### PR TITLE
feat(foreman): code-based ccmux error handling + document Heartbeat

### DIFF
--- a/.claude/skills/org-delegate/references/ccmux-error-codes.md
+++ b/.claude/skills/org-delegate/references/ccmux-error-codes.md
@@ -1,0 +1,93 @@
+# ccmux IPC error codes — Foreman / Secretary reference
+
+ccmux 0.5.7+ は IPC エラー応答に `[code] human message` 形式で安定した
+machine-readable コードを載せる。フォアマン / キュレーター / 窓口は
+message の substring match ではなく **code で分岐する**のを推奨する。
+
+Wire format (実挙動):
+
+```
+$ ccmux send --name worker-nonexistent hi
+Error: [pane_not_found] pane not found: Name("worker-nonexistent")
+```
+
+stderr に上記 1 行、exit status は非ゼロ。
+
+## Known codes
+
+| Code | 意味 | Foreman の推奨挙動 |
+|---|---|---|
+| `pane_not_found` | 指定した pane 名 / id / Focused が存在しない | そのワーカーは既に閉じた扱い。`.state/workers/worker-*.md` の status を `pane_closed` に遷移、`WORKER_PANE_EXITED` を窓口に通知。リトライしない |
+| `pane_vanished` | resolve 成功後に消えたレース | `pane_not_found` と同等扱い |
+| `split_refused` | `ccmux split` が MAX_PANES / too small で拒否 | `org-delegate` では `new-tab` を優先しているので実際には出にくい。出た場合はキュレーターに escalate |
+| `io_error` | PTY write / spawn / OS レベル失敗 | 1 サイクル spin して再試行。2 連続で同じ worker に出たら窓口に `IO_ERROR_DETECTED` で escalate |
+| `shutting_down` | ccmux 本体がシャットダウン中 | 監視ループを **即停止** する。claude-peers に `FOREMAN_STOPPING` を通知 |
+| `app_timeout` | ccmux 内部 App スレッドが応答しなかった | 1 サイクル spin (ccmux 再起動は管理者判断)。連続発生なら窓口にログ |
+| `parse` / `protocol` | 通常出ない (ccmux CLI が正しく組み立てる前提) | 発生時はバグ。stderr を journal に記録して窓口に `IPC_PROTOCOL_ERROR` で報告 |
+| `internal` | ccmux 内部不変条件違反 (parser lock poison 等) | `app_timeout` と同じ扱い |
+
+## シェル側のハンドリング例
+
+```bash
+out=$(ccmux send --name worker-foo --enter "ping" 2>&1)
+status=$?
+if [ $status -ne 0 ]; then
+  case "$out" in
+    *"[pane_not_found]"*|*"[pane_vanished]"*)
+      # worker 既に閉じた — lifecycle 処理に回す
+      mark_worker_pane_closed worker-foo
+      ;;
+    *"[shutting_down]"*)
+      echo "ccmux halting — foreman stopping"
+      exit 0
+      ;;
+    *"[io_error]"*|*"[app_timeout]"*|*"[internal]"*)
+      log_journal "transient ccmux error: $out"
+      ;;
+    *)
+      log_journal "unexpected ccmux error: $out"
+      ;;
+  esac
+fi
+```
+
+## なぜ code か、substring ではなく
+
+- メッセージ本文は human-facing。リワードなしで変更される可能性がある
+  (e.g. "pane not found: Id(3)" → "pane 3 does not exist")
+- ccmux 側は `err_code` module で code 値を wire ABI として扱う。
+  rename は deprecation window 付き (詳細は ccmux `src/ipc/mod.rs::err_code`
+  の doc コメント参照)
+- 未知の code は必ず非致命扱いにする — 将来 ccmux が新 code を追加しても
+  フォアマンが落ちないようにデフォルトブランチ必須
+
+## 後方互換
+
+- pre-0.5.7 の ccmux では code が省略される (wire Response に `code`
+  フィールドなし)。その場合は従来通り substring match にフォールバック。
+- aainc-ops 側で code を扱う新しいコードは **両方** をサポートすべき
+  (最低でも unknown code を無視しないロジック)。
+
+## Event stream 側
+
+`ccmux events --timeout 5s` が返す JSON 行のうち、フォアマンが扱う `type`:
+
+| type | 扱い |
+|---|---|
+| `pane_started` | 現状 skip (将来必要になれば追加) |
+| `pane_exited` | `role == "worker"` に絞って `WORKER_PANE_EXITED` 通知 |
+| `events_dropped` | `.state/journal.jsonl` に drop 件数を記録 |
+| `heartbeat` | skip (30 秒おきの keep-alive。ccmux 0.5.7+ が emit) |
+
+`jq -c 'select(.type == "pane_exited" and .role == "worker")'` は
+heartbeat / pane_started / events_dropped を暗黙に落とすので、
+**既存のフィルタ式は 0.5.7 以降も無修正で動く**。ただし
+`events_dropped` を journal に記録したいなら select 式を拡張する:
+
+```bash
+ccmux events --timeout 5s \
+  | jq -c 'select(
+      (.type == "pane_exited" and .role == "worker")
+      or .type == "events_dropped"
+    )'
+```

--- a/.claude/skills/org-delegate/references/ccmux-error-codes.md
+++ b/.claude/skills/org-delegate/references/ccmux-error-codes.md
@@ -55,17 +55,23 @@ fi
 
 - メッセージ本文は human-facing。リワードなしで変更される可能性がある
   (e.g. "pane not found: Id(3)" → "pane 3 does not exist")
-- ccmux 側は `err_code` module で code 値を wire ABI として扱う。
-  rename は deprecation window 付き (詳細は ccmux `src/ipc/mod.rs::err_code`
-  の doc コメント参照)
+- ccmux 側の契約については、以下を正本として参照する (このリポジトリ
+  内では検証不能な前提なので **外部依存** として扱うこと):
+  - `ccmux/src/ipc/mod.rs::err_code` の doc コメント — 公開 code の一覧
+    と ABI 安定性 (rename は deprecation window 付き) の明文
+  - ccmux `Response::Err { message, code }` の wire schema — `code`
+    は `Option<String>` で、`skip_serializing_if = "Option::is_none"`
 - 未知の code は必ず非致命扱いにする — 将来 ccmux が新 code を追加しても
   フォアマンが落ちないようにデフォルトブランチ必須
 
 ## 後方互換
 
-- pre-0.5.7 の ccmux では code が省略される (wire Response に `code`
-  フィールドなし)。その場合は従来通り substring match にフォールバック。
-- aainc-ops 側で code を扱う新しいコードは **両方** をサポートすべき
+- **想定**: pre-0.5.7 の ccmux では wire Response に `code` フィールド
+  が載らず、CLI 側も `[code]` prefix なしでメッセージだけを stderr に
+  吐く。この想定はこのリポジトリでは検証できないので ccmux 本体の
+  リリースノート (v0.5.7) で裏取りしてから運用する。
+- code 無しで受けた場合は従来 substring match にフォールバック。
+  aainc-ops 側で code を扱う新しいコードは **両方** をサポートすべき
   (最低でも unknown code を無視しないロジック)。
 
 ## Event stream 側

--- a/.foreman/CLAUDE.md
+++ b/.foreman/CLAUDE.md
@@ -43,9 +43,12 @@
 1. **`ccmux events` で直近のペイン lifecycle を drain** (タイムアウト付きで 1 回だけ):
    ```bash
    ccmux events --timeout 5s \
-     | jq -c 'select(.type == "pane_exited" and .role == "worker")'
+     | jq -c 'select(
+         (.type == "pane_exited" and .role == "worker")
+         or .type == "events_dropped"
+       )'
    ```
-   - `jq` で **ワーカーペイン (`role == "worker"`) に限定**してフィルタ。フォアマン/キュレーター/窓口の終了を誤ってワーカー終了として扱わないこと
+   - `jq` で **ワーカーペインの `pane_exited` と `events_dropped` のみ**を通す。フォアマン/キュレーター/窓口の終了や heartbeat を誤ってワーカー終了として扱わないこと。`type` で出力先を分岐する (`pane_exited` → 窓口通知、`events_dropped` → journal)
    - 絞り込んだ `pane_exited` 行の `name` (例: `worker-foo`) を拾い、窓口に claude-peers で **ペインが閉じた** という事実だけを通知する:
      ```
      WORKER_PANE_EXITED: {name} (id={id}) のペインが閉じました。リコンサイル要。
@@ -135,7 +138,7 @@
       - **de-dup チェック**: 直近 30 秒以内の journal に **`event == "notify_sent"`** かつ `(worker, kind)` 一致のエントリが存在しない
         - `anomaly_observed` エントリは de-dup キーに **含めない** (低 confidence や observation-only record が将来の通知を抑制しないため)
         - 今サイクルの step (1) で書いた `anomaly_observed` も de-dup 対象にならない
-   3. **通知送信** (step 2 を通過した場合): claude-peers で窓口に通知 (フォーマットは (g) 参照)
+   3. **通知送信** (step 2 を通過した場合): claude-peers で窓口に通知 (フォーマットは (f) 参照)
    4. **notify_sent 記録** (通知送信成功時): `confidence` は kind と source に一致させる (APPROVAL_BLOCKED かつ source=inspect のみ `"high"`、それ以外は `"n/a"`):
       ```json
       // APPROVAL_BLOCKED + source=inspect
@@ -157,7 +160,7 @@
    ERROR は cursor 補強を使わないため confidence は便宜上 `n/a`。
 
    #### (g) worker 自己申告 (Step 2) と inspect (Step 4) の併用設計
-   両チャネルが同じ anomaly を通知しても de-dup (f) が 30 秒窓で合算するので、窓口は重複通知を受け取らない。self-report は先に届けば inspect を抑制、inspect は worker が通知を忘れていれば self-report を補完する。両方独立稼働で OK。
+   両チャネルが同じ anomaly を通知しても de-dup ((e) の step 2) が 30 秒窓で合算するので、窓口は重複通知を受け取らない。self-report は先に届けば inspect を抑制、inspect は worker が通知を忘れていれば self-report を補完する。両方独立稼働で OK。
 
 5. **重要**: フォアマンが自動で承認・拒否することはしない (ユーザー判断が必要)
    - **例外**: Plan モードワーカーの Plan 承認後、permission mode がまだ plan のままの場合、Shift+Tab を送信して acceptEdits に切り替える (下記「Plan 承認後のモード切替」参照)

--- a/.foreman/CLAUDE.md
+++ b/.foreman/CLAUDE.md
@@ -18,6 +18,7 @@
 - **ペイン配置ルール**: `.claude/skills/org-delegate/references/pane-layout.md`
 - **ワーカーへの指示フォーマット**: `.claude/skills/org-delegate/references/instruction-template.md`
 - **ClaudeCode 起動コマンド**: `.claude/skills/org-start/SKILL.md` の「ClaudeCode 起動コマンド（役割別）」セクション
+- **ccmux IPC エラーコードと event 種別**: `.claude/skills/org-delegate/references/ccmux-error-codes.md` — `ccmux send` / `inspect` / `list` が失敗した時のハンドリング、`ccmux events` の type 分岐
 
 ## ワーカーへの報告先ルール（重要）
 
@@ -57,6 +58,7 @@
      のプロセスで判定する
    - `type == "pane_started"` は現状 use case なしなので無視して良い (将来必要になれば追加)
    - `type == "events_dropped"` は drop 件数を `.state/journal.jsonl` に記録 (監視が追いついていないシグナル)
+   - `type == "heartbeat"` は 30 秒おきの keep-alive (ccmux 0.5.7+)。既存 jq フィルタで暗黙に skip されるので何もしなくてよい
    - 5 秒以内に 1 件も来なければ次の Step へ進む (Phase 2.1 の `--timeout` で勝手に exit する)
 
 2. **`claude-peers` の `check_messages` でワーカーからの自己報告を受信**:
@@ -87,6 +89,11 @@
      ccmux inspect --name worker-{task_id} --lines 10 --cursor
      ```
      を順次実行 (16 ワーカー並列でも合計 1 秒未満)
+   - **エラー時の挙動**: stderr の先頭が `Error: [<code>] ...` のとき、code で分岐する (詳細は `references/ccmux-error-codes.md`):
+     - `[pane_not_found]` / `[pane_vanished]` — ワーカーが既に閉じた。そのワーカーの inspect を skip して Step 3 の list 結果で `WORKER_PANE_EXITED` 経路に回す (二重検出は de-dup で吸収される)
+     - `[shutting_down]` — ccmux 停止中。監視ループを即停止し、claude-peers で `FOREMAN_STOPPING` を窓口に通知
+     - `[io_error]` / `[app_timeout]` / `[internal]` — 一過性の可能性。`.state/journal.jsonl` に記録して次サイクルで再試行
+     - 未知 code (将来の ccmux が追加) — journal 記録のみで続行
 
    #### (a) マッチ対象の定義
    返却された `lines` 配列 (各要素 `{row, text}`) の中で、**`text != ""` を満たす最後の 1 要素** だけを APPROVAL_BLOCKED パターンの match 対象とする (複数行を対象にしない)。
@@ -166,6 +173,7 @@
 - **events と list の二重カバー**: events は best-effort (EventsDropped あり得る) なので、list による突き合わせを保険として併用
 - **inspect を独立した観測チャネルにする理由**: ワーカーが承認待ちで止まった時、worker 自己申告 (claude-peers) だけに頼ると worker が通知を送る前に停止してしまう。inspect は fore man 側から能動的に観測するので、worker 側の通知忘れ/遅延を補完する。自己申告と inspect は「同じ事象を 2 チャネルで観測できれば確度が上がる」という冗長性設計
 - **anchored regex の意図**: 本文中に "Allow this tool use" が偶然出てもプロンプト自体の行フォーマット (末尾に `(y/n)`) まで揃うことは稀。末尾 non-empty 行に絞ることで誤検出をさらに減らす
+- **ccmux コマンドの失敗は message ではなく code で分岐する**: `ccmux send` / `inspect` / `list` は stderr に `Error: [<code>] ...` の形でエラーを返す (ccmux 0.5.7+)。message 文字列は human-facing で将来変更あり得るので、`[pane_not_found]` / `[shutting_down]` 等の code で case 分岐する。code なしで受けた場合 (pre-0.5.7) は substring fallback。詳細は `.claude/skills/org-delegate/references/ccmux-error-codes.md`
 
 ## Plan承認後のモード切替
 


### PR DESCRIPTION
## Summary
ccmux 0.5.7+ で `Response::Err.code` が wire ABI として確立し、CLI は stderr に `Error: [<code>] <message>` 形式で吐くようになった。Foreman 側は現状 substring match かエラー放置で運用していたので、code 分岐への移行ガイドを整備する。

## 変更

### 新規 `.claude/skills/org-delegate/references/ccmux-error-codes.md`
- 全 known code (pane_not_found / pane_vanished / split_refused / io_error / shutting_down / app_timeout / parse / protocol / internal) のセマンティクスと Foreman 推奨挙動 (retry / escalate / loop 停止 / pane_closed 遷移) を表で整理
- shell 側のハンドリング例 (`case "$out" in *\"[pane_not_found]\"*)` パターン)
- pre-0.5.7 fallback ルール (code 無しなら従来 substring)
- Event stream (`ccmux events`) の type 分岐 (heartbeat / events_dropped / pane_* の処理)

### `.foreman/CLAUDE.md`
- スキル参照セクションに上記 doc を追加
- Step 1 (`ccmux events`): `type == "heartbeat"` は既存 jq filter で skip 済だが明示
- Step 4 (`ccmux inspect`): エラー時の code 分岐を展開 (pane_not_found → pane_closed 経路、shutting_down → loop 停止、io_error → journal + retry、未知 code → 記録のみ)
- 設計メモ: 「message ではなく code で分岐する」一般ルール追記

## Runtime impact
ハッピーパスは無変更。jq filter は heartbeat を暗黙 skip していたので event 列は既に正しい。エラー分岐は従来未実装だったので新規挙動追加。

## Refs
- ccmux PR #42: wire の code フィールド導入
- ccmux PR #46: App 由来エラー (pane_not_found 等) にも code 付与
- ccmux 本体の安定性ガイド: `ccmux/src/ipc/mod.rs::err_code` doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)