### PR TITLE
fix(layout): pass --dangerously-load-development-channels to Secretary

### DIFF
--- a/ccmux-layouts/ops.toml
+++ b/ccmux-layouts/ops.toml
@@ -9,6 +9,14 @@
 #
 # Override the Secretary startup command by editing `command` below
 # or setting a shell alias pointing at your preferred `claude` invocation.
+#
+# The `--dangerously-load-development-channels server:claude-peers`
+# flag is required: without it the Claude Code session silently
+# drops incoming claude-peers channel notifications (the peer is
+# still registered and list_peers / send_message work one-way, but
+# pushes from Foreman / Curator / workers never surface, and the
+# Secretary looks "alive but deaf"). Matches the same flag already
+# passed to Foreman / Curator / workers in org-start / org-delegate.
 
 version = 1
 name = "ops"
@@ -17,4 +25,4 @@ name = "ops"
 type = "pane"
 id = "secretary"
 role = "secretary"
-command = "claude"
+command = "claude --dangerously-load-development-channels server:claude-peers"

--- a/ccmux-layouts/ops.toml
+++ b/ccmux-layouts/ops.toml
@@ -17,6 +17,15 @@
 # pushes from Foreman / Curator / workers never surface, and the
 # Secretary looks "alive but deaf"). Matches the same flag already
 # passed to Foreman / Curator / workers in org-start / org-delegate.
+#
+# With the flag on first launch Claude Code shows a one-off
+# "Load development channel: claude-peers?" prompt. Foreman /
+# Curator / workers bypass it via `ccmux send --name <id> --enter ""`
+# in org-start, but the Secretary is the initial pane that bootstraps
+# everything else, so that automated Enter isn't available yet —
+# the human operator has to press Enter manually the first time the
+# layout launches (and subsequently when Claude Code's session cache
+# gets invalidated).
 
 version = 1
 name = "ops"


### PR DESCRIPTION
## Summary
Secretary (窓口) が claude-peers の channel push を受信できない問題の修正。

## Root cause
\`ccmux-layouts/ops.toml\` の Secretary pane の起動コマンドが \`claude\` のみで、\`--dangerously-load-development-channels server:claude-peers\` が抜けていた。そのため Claude Code 側が incoming channel notifications を丸ごと drop していた。

MCP ログの証拠:
\`\`\`
%LOCALAPPDATA%/claude-cli-nodejs/Cache/...aainc-ops/mcp-logs-claude-peers/<latest>.jsonl
...
Channel notifications skipped: server claude-peers not in --channels list for this session
\`\`\`

Secretary は outbound (list_peers / send_message / set_summary) は動くが inbound push は届かない "alive but deaf" 状態だった。check_messages ポーリングでのみ拾えていたはずだが、ループは組まれていなかった。

## Fix
\`ccmux-layouts/ops.toml\` の \`command\` を \`claude --dangerously-load-development-channels server:claude-peers\` に変更。org-start / org-delegate の Foreman / Curator / worker 起動と同じフラグ。

コメントで理由を書き残し (将来誰かが \`claude\` だけに戻さないよう)。

## Verification
マージ後:
1. 現在の Secretary pane を閉じる (`ccmux` セッションごと exit でも可)
2. \`ccmux --layout ops\` で再起動
3. MCP ログの新ファイルを確認、"Channel notifications skipped" が消えていること
4. 別 peer (Foreman / Curator / 別 Claude) から \`send_message\` → Secretary に即座に届くこと

## Non-goals
- Foreman / Curator の起動コマンドは既に正しい (org-start の SKILL.md 記述) ので変更なし
- 手動で \`claude\` を入力するケース (alias / 直接入力) の flag 強制は別課題