### PR TITLE
chore(org): switch default_permission_mode to auto

### DIFF
--- a/registry/org-config.md
+++ b/registry/org-config.md
@@ -1,7 +1,7 @@
 # Organization Config
 
 ## Permission Mode
-default_permission_mode: bypassPermissions
+default_permission_mode: auto
 
 選択肢:
 - bypassPermissions: 全許可、確認なし（デフォルト）


### PR DESCRIPTION
## Summary

Switch the organization's `default_permission_mode` from `bypassPermissions` to `auto` in `registry/org-config.md`. `auto` provides classifier-based safety checks (Team/Enterprise/API plans only) and is a safer default for new panes.

## Scope

- This change affects **new panes launched after this is merged**: next `/org-start` and next worker via org-delegate will inherit `auto`.
- Currently running panes (secretary / foreman / curator / active workers) keep `bypassPermissions` until they are relaunched, because the mode is passed as a CLI arg at pane spawn time.

## Files

- `registry/org-config.md`: 1 line changed

## Test plan

- Next session's `/org-start` should launch foreman / curator with `--permission-mode auto`
- Next `org-delegate` should pass `auto` to new worker panes