### PR TITLE
refactor(org-delegate): rect-based balanced split (closes #18)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -254,56 +254,57 @@ DELEGATE: 以下のワーカーを派遣してください。
 
 ### 3-1. balanced split で target / direction を決める
 
-旧設計は `--target-name foreman --direction vertical` 固定だったが、これは foreman 幅を毎回半減させるため、典型的なターミナル幅 (W≈200〜300 cols) で 4 人目以降 `[split_refused]` が発生していた (`MIN_PANE_WIDTH=20` 制約、調査: `C:/Users/iwama/working/workers/ccmux-split-inv/findings.md`)。
-
-現設計では **balanced split** により、新規ワーカーの序数 `k` に応じて target と direction を動的に選ぶ。詳細ルールは `references/pane-layout.md` の「ワーカーの balanced split 戦略」セクションを参照。
+旧設計は序数 `k` ベースの lookup table で target を決めていたが、ワーカーが途中で閉じた後の再派遣や想定外の退役順でテーブル前提と実レイアウトが乖離し、`[split_refused]` を誘発しやすかった。ccmux v0.5.x から `ccmux list --format json` が各ペインの `x / y / width / height` (u16, cell 単位) を返すため、**現在のレイアウト (rect) から動的に target と direction を選ぶ方式**に差し替えた。詳細ルールは `references/pane-layout.md` の「ワーカーの balanced split 戦略」セクションを参照。
 
 フォアマンは `ccmux split` を呼ぶ前に、以下のシェルスニペットで target と direction を算出する:
 
 ```bash
-# 生きている worker ペインを作成順 (pane id 昇順) に並べた name 配列を取得
-# ccmux close で撤去されたペインは list に載らないため、role フィルタのみで live 扱い
-# (PaneInfo JSON に .exited フィールドは存在しない。ccmux/src/ipc/mod.rs:157-167 参照)
-#
-# bash 4+ 専用の配列展開ビルトインと非互換のため、macOS デフォルト bash 3.2 でも動く
-# while-read ループで実装する
-active_workers=()
-while IFS= read -r name; do
-  active_workers+=("$name")
-done < <(
-  ccmux list --format json \
-    | jq -r '.panes | map(select(.role == "worker")) | sort_by(.id) | .[].name'
+# MIN_PANE_WIDTH=20 / MIN_PANE_HEIGHT=5: ccmux 側の分割下限 (findings: ccmux-split-inv)
+# SECRETARY_MIN_WIDTH=100:               secretary を分割候補にしてよい最小幅 (保険条項、実運用ではほぼ不発動)
+layout=$(ccmux list --format json)
+read -r target direction < <(
+  jq -r '
+    # rect 隣接判定: 辺共有 + その軸に直交する方向の区間 overlap
+    def adj($a; $b):
+      ((($a.x + $a.width) == $b.x or ($b.x + $b.width) == $a.x)
+        and ([$a.y, $b.y] | max) < ([$a.y + $a.height, $b.y + $b.height] | min))
+      or ((($a.y + $a.height) == $b.y or ($b.y + $b.height) == $a.y)
+        and ([$a.x, $b.x] | max) < ([$a.x + $a.width, $b.x + $b.width] | min));
+    (.panes | map(select(.role == "curator")) | first) as $cur
+    | .panes
+      # 候補は worker / foreman / secretary のみ (curator は常に除外)
+      | map(select(.role == "worker" or .role == "foreman" or .role == "secretary"))
+      # foreman-curator 隣接維持: foreman は curator と rect 隣接しているときのみ候補
+      | map(select(.role != "foreman" or ($cur != null and adj(.; $cur))))
+      | map(
+          # ターミナルセルは縦横比 ≈ 2:1 (文字が縦長) なので、文字単位で
+          # width = 2*height のとき物理的にほぼ正方形。width > height*2 を
+          # 「物理的に横長」判定とし、横長なら vertical (左右分割)、
+          # そうでなければ horizontal (上下分割) を選ぶ。
+          (if .width > .height * 2 then "vertical" else "horizontal" end) as $d
+          | (if $d == "vertical"   then (.width  / 2 | floor) else .width  end) as $nw
+          | (if $d == "horizontal" then (.height / 2 | floor) else .height end) as $nh
+          | . + {dir:$d, nw:$nw, nh:$nh,
+                 metric: (if $d == "vertical" then $nw else $nh end)})
+      # MIN_PANE 制約 + secretary 保険条項 (secretary は new_w >= 100 のときだけ候補に残る)
+      | map(select(.nw >= 20 and .nh >= 5))
+      | map(select(.role != "secretary" or .nw >= 100))
+      # 分割軸方向の新サイズ (vertical なら new_w、horizontal なら new_h) が最大のペインを選ぶ。
+      # tie-break は pane id 昇順で決定的に。
+      | sort_by(-.metric, .id)
+      | if length == 0 then "" else (.[0] | "\(.name) \(.dir)") end
+  ' <<<"$layout"
 )
-
-k=$(( ${#active_workers[@]} + 1 ))  # この新規ワーカーの序数 (1-indexed)
-
-target=""
-direction=""
-if [ "$k" -ge 9 ]; then
-  # k >= 9 は balanced split table 未定義。target / direction を空のまま残し、
-  # フォアマン Claude 側で ccmux split を発行せず claude-peers で escalate する
-  echo "SPLIT_CAPACITY_EXCEEDED: ${k} 人目のワーカーは balanced split table 未定義" >&2
-else
-  case "$k" in
-    1) target="foreman";                direction="vertical"   ;;
-    2) target="${active_workers[0]}";   direction="horizontal" ;;
-    3) target="${active_workers[0]}";   direction="vertical"   ;;
-    4) target="${active_workers[1]}";   direction="vertical"   ;;
-    5) target="${active_workers[0]}";   direction="horizontal" ;;
-    6) target="${active_workers[2]}";   direction="horizontal" ;;
-    7) target="${active_workers[1]}";   direction="horizontal" ;;
-    8) target="${active_workers[3]}";   direction="horizontal" ;;
-  esac
-fi
 ```
 
-- active_workers が空 (最初のワーカー) なら k=1 に落ちて target=foreman / direction=vertical が選ばれる
-- **k >= 9 もしくは算出不能時の扱い**: `$target` / `$direction` が空のまま 3-2 に進むので、フォアマン Claude は **`ccmux split` を発行せず**、代わりに claude-peers で窓口 (Secretary) に escalate メッセージを送信する:
+- 初回 (ワーカー 0 人) は foreman が唯一の候補として残り、direction は foreman の aspect ratio から決まる (典型的に横長なので vertical)
+- **候補が空だった場合の扱い**: `$target` / `$direction` が空のまま 3-2 に進むので、フォアマン Claude は **`ccmux split` を発行せず**、代わりに claude-peers で窓口 (Secretary) に escalate メッセージを送信する:
   1. `mcp__claude-peers__list_peers` (scope: `machine`) を呼び、`summary` に `Secretary` を含む peer を特定して `id` を取得する (通常は 1 件だが、複数あれば最新の last_seen を選ぶ)
   2. `mcp__claude-peers__send_message` を `to_id=<Secretary id>` で呼び、本文を以下にする:
      ```
-     SPLIT_CAPACITY_EXCEEDED: {task_id} は {k} 人目のワーカーで balanced split table 未定義。
-     ターミナル幅不足 or 想定外の退役順が疑われる。人間判断が必要です。
+     SPLIT_CAPACITY_EXCEEDED: {task_id} のワーカー分割対象が見つからない。
+     rect ベース balanced split の MIN_PANE / 隣接条件を満たす候補が 0。
+     ターミナルサイズ不足または想定外のレイアウトが疑われる。人間判断が必要です。
      ```
   3. 3-3 以降（`ccmux events` 待機、`list_peers` 待ち、instruction 送信）は **skip** する。該当ワーカー 1 件だけ派遣を中止し、フォアマン本体の監視ループは **継続**させる。`exit` / `return` などでフォアマンを落とさないこと
 

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -290,7 +290,7 @@ read -r target direction < <(
       | map(select(.nw >= 20 and .nh >= 5))
       | map(select(.role != "secretary" or .nw >= 100))
       # 分割軸方向の新サイズ (vertical なら new_w、horizontal なら new_h) が最大のペインを選ぶ。
-      # tie-break は pane id 昇順で決定的に。
+      # tie-break はその時点の pane id 昇順 (スナップショット内で再現可能)。
       | sort_by(-.metric, .id)
       | if length == 0 then "" else (.[0] | "\(.name) \(.dir)") end
   ' <<<"$layout"
@@ -314,7 +314,7 @@ read -r target direction < <(
 
 ```bash
 if [ -z "$target" ] || [ -z "$direction" ]; then
-  # 3-1 の k >= 9 分岐を経由。claude-peers で窓口に SPLIT_CAPACITY_EXCEEDED を送信して
+  # 3-1 で balanced split 候補が空。claude-peers で窓口に SPLIT_CAPACITY_EXCEEDED を送信して
   # このワーカーの派遣を中止する (フォアマン本体は継続)
   :  # ccmux split を発行しない
 else
@@ -329,7 +329,7 @@ fi
 
 > **`$target` / `$direction` が空だった場合の後続フロー**: このワーカーの起動フローはここで終了。3-3 (`ccmux events` 待機)、3-4 (`list_peers` 待ち)、3-5 (instruction 送信) のいずれも **skip** する。claude-peers での escalate（3-1 の手順参照）を行ったらフォアマン本体は次のサイクルへ。次タスクが控えているなら 3-6 で次の派遣へ進む。
 
-   - ペイン配置ルールは `references/pane-layout.md` (ccmux 版) を参照。`k` に対する target / direction のマッピングと 4 並列 / 8 並列の ASCII 図もそちらに集約
+   - ペイン配置ルールは `references/pane-layout.md` (ccmux 版) を参照。rect ベースの target / direction 選出ルールはそちらに集約
    - **同一タブ内 split で起動する理由**: ccmux の `list` / `focus` / `send` / `inspect` は現在フォーカス中のタブのペインしか見えない。`new-tab` で別タブに置くとフォアマンからの監視・指示送信が不能になる (2026-04-20 判明。ccmux 側 issue: happy-ryo/ccmux#71)
    - `--target-name "$target"`: balanced split で算出した既存ペイン名 (`foreman` もしくは `worker-*`) を分割対象にする
    - `--direction "$direction"`: balanced split で算出した `vertical` / `horizontal`

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -35,96 +35,50 @@ Tab 1: ops (ワーカー 0 人)
 
 ccmux は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5` の下限を割り込むと `[split_refused]` で拒否される (調査: `C:/Users/iwama/working/workers/ccmux-split-inv/findings.md`)。
 
-旧設計は全ワーカーを `--target-name foreman --direction vertical` で追加しており、`foreman` 幅が毎回半減するため、典型的なターミナル幅 (W≈200 cols) では **4 人目で `split_refused`** になっていた。
+固定 target (`--target-name foreman --direction vertical`) や序数 `k` ベースの lookup table では、foreman 幅の累積半減や、ワーカーが途中で閉じた後の再派遣で想定レイアウトと実レイアウトが乖離し、早期に `split_refused` を誘発していた。
 
-新設計 (balanced split) では「新規ワーカーの序数 `k` に応じて既存ワーカーを動的に target に選ぶ」ことで、ワーカー zone を準 balanced binary tree にする。これにより **W ≥ 160 cols で 8 並列**まで収まる。
+現設計は ccmux v0.5.x から `ccmux list --format json` が返す各ペインの **rect 情報 (`x / y / width / height`, u16, cell 単位)** を使い、**現状のレイアウトから動的に target と direction を選ぶ**。ワーカー退役順の揺れや途中クローズに強く、固定的な「N 並列上限」は持たず、ターミナルサイズと MIN_PANE 制約が許す限り分割し続け、限界に達したら自動 escalate する。
 
 ### アルゴリズム
 
-新規ワーカーを起動するフォアマンは、`ccmux split` を呼ぶ前に以下を計算する:
+新規ワーカーを起動するフォアマンは、`ccmux split` を呼ぶ前に以下を実行する。bash + jq 実装は `SKILL.md` Step 3-1 を参照。
 
-1. `ccmux list --format json` を実行し、`.panes | map(select(.role == "worker")) | sort_by(.id)` で **生きている worker ペインを作成順 (pane id 昇順) に並べた配列** `active_workers` を得る。要素は `{id, name, role, focused}` で、以降は `name` (例: `worker-foo-bar`) のみ使う。なお `PaneInfo` JSON schema には `.exited` フィールドは存在しない (`ccmux/src/ipc/mod.rs:157-167` 参照)。ccmux は `ccmux close` で撤去されたペインを list から外すので、`role == "worker"` を満たすものはすべて live。
-2. 序数 `k = len(active_workers) + 1` を決める。
-3. 下表から `k` に対応する `target` ペイン名と `direction` を取得する。
+1. `ccmux list --format json` で全ペインと rect を取得する
+2. **候補集合**: `role ∈ {worker, foreman, secretary}` のペイン (curator は常に除外)
+3. **候補の絞り込み**:
+   - **foreman-curator 隣接維持**: foreman は curator と rect 隣接 (後述) しているときのみ候補に入れる。組織運営上 foreman と curator の隣接配置は前提。foreman を分割すると隣接が崩れ得るので、既に非隣接な foreman は候補から外す
+   - **secretary 保護**: secretary は分割後の新ペイン幅 `new_w >= 100` を満たす場合のみ候補化 (保険条項、実運用では通常発動しない)
+4. **direction 決定** (各候補の aspect ratio から):
+   - `width > height * 2` → `vertical` (左右分割)
+   - それ以外 → `horizontal` (上下分割)
+   - ターミナルセルは縦長 (縦横比 ≈ 2:1) なので、文字単位で `width = 2 * height` のとき物理的にほぼ正方形。`width > height * 2` は「物理的に横長」判定として妥当
+5. **MIN_PANE 制約**: 分割後の新ペインサイズ `(new_w, new_h)` が `new_w >= 20` かつ `new_h >= 5` を満たさない候補は除外
+   - vertical 分割: `(new_w, new_h) = (floor(width / 2), height)`
+   - horizontal 分割: `(new_w, new_h) = (width, floor(height / 2))`
+6. **target 選出**: 残った候補から **「分割軸方向の新サイズ」** (vertical なら `new_w`、horizontal なら `new_h`) が最大のペインを target にする。tie-break は pane id 昇順で決定的に
+7. **候補が空なら escalate**: `SKILL.md` Step 3-1 末尾の `SPLIT_CAPACITY_EXCEEDED` 経路で窓口に escalate (`ccmux split` は発行せず、該当ワーカー 1 件だけ派遣中止、フォアマン本体は継続)
 
-### 序数 `k` → target / direction テーブル
+### rect 隣接判定の定義
 
-| k | target pane name | direction | 備考 |
-|---|---|---|---|
-| 1 | `foreman` | `vertical` | 唯一の foreman 分割。以降 foreman 幅は固定 |
-| 2 | `active_workers[0]` | `horizontal` | worker zone を 2 行化 |
-| 3 | `active_workers[0]` | `vertical` | 2×1 から 2×2 グリッド化 (上段) |
-| 4 | `active_workers[1]` | `vertical` | 2×2 グリッド化完了 (下段) |
-| 5 | `active_workers[0]` | `horizontal` | 2×2 各セルを 2 段化開始 (top-left セル) |
-| 6 | `active_workers[2]` | `horizontal` | (top-right セル) |
-| 7 | `active_workers[1]` | `horizontal` | (bottom-left セル) |
-| 8 | `active_workers[3]` | `horizontal` | (bottom-right セル) → 2×4 の 8 セル完成 |
-| 9+ | escalate to 窓口 | — | `ccmux` 本体の `MIN_PANE_WIDTH` を下げるか Phase 2 機能 (`--target-largest` 相当) が必要 |
+rect `A, B` が隣接するとは以下のいずれかを満たすこと:
 
-### 幅・高さ要件
+- **左右隣接**: `A.x + A.width == B.x` または `B.x + B.width == A.x`、かつ y 区間が overlap (`max(A.y, B.y) < min(A.y + A.height, B.y + B.height)`)
+- **上下隣接**: `A.y + A.height == B.y` または `B.y + B.height == A.y`、かつ x 区間が overlap (`max(A.x, B.x) < min(A.x + A.width, B.x + B.width)`)
 
-初期 foreman 領域を `W_f × H_f` とする (典型: `W_f = W/2`, `H_f = H/2`、file-tree / preview が表示中ならさらに縮む)。上表適用後の最小ペインサイズは:
+ccmux の cell 座標は整数なので tolerance なし完全一致で判定する。
 
-| 並列数 | 最小 worker 幅 | 最小 worker 高 | 必要 `W_f` | 必要 `H_f` |
-|---|---|---|---|---|
-| 4 | `W_f/4` | `H_f/2` | 80 (W ≥ 160) | 10 |
-| 8 | `W_f/4` | `H_f/4` | 80 (W ≥ 160) | 20 |
+### 初期状態と典型的な挙動
 
-各 split ステップで satisfying するのは「target の分割軸幅 ÷ 2 ≥ MIN」。上表の最悪ケースは k=3 の `W_f/2 → W_f/4` (必要 `W_f/2 ≥ 40`) と k=5〜8 の `H_f/2 → H_f/4` (必要 `H_f/2 ≥ 10`)。
+ワーカー 0 人の時点では、候補は `foreman` のみ (secretary は `new_w >= 100` 条件または隣接条件で除外されるのが通常。curator は常に除外)。foreman は典型的に横長なので vertical 分割され、最初のワーカー zone が foreman の右側に作られる。
 
-### ペイン配置図
-
-#### 4 並列時 (k=4 まで適用)
-
-foreman 領域を `2×2` のワーカー zone + 左側の foreman に分ける:
-
-```
-foreman 領域 (W_f × H_f)
-┌──────────┬─────────────────────┐
-│          │                     │
-│          │  worker-1 │ worker-3│
-│          │  (W_f/4 × H_f/2)    │
-│ foreman  │                     │
-│ (W_f/2 × ├──────────┬──────────┤
-│  H_f)    │          │          │
-│          │ worker-2 │ worker-4 │
-│          │ (W_f/4 × H_f/2)     │
-└──────────┴─────────────────────┘
-```
-
-#### 8 並列時 (k=8 まで適用)
-
-2×2 の各セルをさらに上下 2 段に割って `2×4` の 8 セルに:
-
-```
-foreman 領域 (W_f × H_f)
-┌──────────┬──────────┬──────────┐
-│          │ worker-1 │ worker-3 │
-│          │ W_f/4 ×  │ W_f/4 ×  │
-│          │ H_f/4    │ H_f/4    │
-│          ├──────────┼──────────┤
-│          │ worker-5 │ worker-6 │
-│ foreman  │ W_f/4 ×  │ W_f/4 ×  │
-│ (W_f/2 × │ H_f/4    │ H_f/4    │
-│  H_f)    ├──────────┼──────────┤
-│          │ worker-2 │ worker-4 │
-│          │ W_f/4 ×  │ W_f/4 ×  │
-│          │ H_f/4    │ H_f/4    │
-│          ├──────────┼──────────┤
-│          │ worker-7 │ worker-8 │
-│          │ W_f/4 ×  │ W_f/4 ×  │
-│          │ H_f/4    │ H_f/4    │
-└──────────┴──────────┴──────────┘
-```
-
-図中の `worker-N` は `active_workers[N-1]` の位置関係を表す (task_id kebab-case は描画上省略)。
+以降は既存ペインの中で「分割後サイズが最大」のものが選ばれ、direction が rect に応じて自然に交替することで準 balanced な配置になる。固定的な 4 並列 / 8 並列の図は意味を持たないため割愛する (動的で決まるため)。
 
 ### Edge cases / 運用時の注意
 
-- **ワーカーが途中で閉じた後の再派遣**: `active_workers` は「現在生きている」worker のリストなので、閉じた slot を詰めて上表を再適用すると、ccmux のレイアウト tree 実状と表の想定が乖離し得る。**この場合、`ccmux split` が `[split_refused]` / `[pane_not_found]` を返したら `references/ccmux-error-codes.md` の手順でキュレーター → 窓口にエスカレーション**する。balanced split は best-effort の配置ヒントであり、正確な木構造復元ではない。
-- **9 並列以上**: 上表は k=8 までしか定義しない。k=9 以降は ccmux 本体の機能拡張 (`MIN_PANE_WIDTH` 下げ、`--target-largest` フラグ等) 待ち。フォアマンは即座に窓口へエスカレーションする。
-- **レース**: `ccmux list` 実行から `ccmux split` 実行までに他ワーカーが増減した場合、target 不整合は `[pane_not_found]` として顕在化する。通常のエラーハンドリング経路で吸収する。
-- **target 選出の責務**: 計算はフォアマンが `ccmux list` ベースで行う。窓口は DELEGATE メッセージに task_id だけを渡せばよく、target は指定しない。
+- **ワーカーが途中で閉じた後の再派遣**: 旧 k-table 方式で問題になった「閉じた slot を詰めるとテーブル前提と乖離」は rect ベースでは発生しない。常に実レイアウトから target を選ぶため、ccmux のレイアウト tree と判断が一致する
+- **`ccmux split` エラー**: `[split_refused]` / `[pane_not_found]` が返った場合は `references/ccmux-error-codes.md` の手順でキュレーター → 窓口にエスカレーション (方針は旧設計と同じ)
+- **レース**: `ccmux list` 実行から `ccmux split` 実行までに他ワーカーが増減した場合、target 不整合は `[pane_not_found]` として顕在化する。既存のエラーハンドリング経路で吸収する
+- **target 選出の責務**: 計算はフォアマンが `ccmux list` の rect ベースで行う。窓口は DELEGATE メッセージに task_id だけを渡せばよく、target は指定しない
 
 ## 運用メモ
 
@@ -153,7 +107,4 @@ ccmux の分割方向は以下の定義:
 
 - `ccmux events` によるペイン lifecycle 購読 (現在は claude-peers 経由で補完)
 - `ccmux split --ratio 0.2` 等の比率指定 (現状は 50/50 固定)
-- `ccmux split --target-largest` 等の自動 target 選出 (現状は balanced split table を `k` ベースで適用)
-- `ccmux list` の JSON に `rect` 情報を含める拡張 (現状は rect 不明のため table-driven の近似)
-
-> **暫定対応の位置付け**: 本ドキュメントの balanced split 戦略は、ccmux 本体で上記の `--target-largest` / rect 情報 / `MIN_PANE_WIDTH` 調整が整うまでの **暫定運用** である。upstream 追跡 issue は別途 `happy-ryo/ccmux` に起票後 `ccmux#78` を参照する想定。issue 作成までは本ドキュメントを balanced split workaround の一次情報とする。`ccmux#78` がマージされ次第、本スキルの lookup table を撤去して `--target-largest --direction auto` 1 行に差し替える。
+- `ccmux split --target-largest` / `--direction auto` 等の ccmux 側自動 target 選出 (現状はフォアマン側で `ccmux list` rect から算出。upstream に移譲できれば lookup ロジックを ccmux CLI 1 行に畳める)

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -27,7 +27,7 @@ Tab 1: ops (ワーカー 0 人)
 |---|---|---|
 | フォアマン | 窓口ペインを水平分割して下半分 | `ccmux split --target-focused --direction horizontal --role foreman --id foreman --command "cd .foreman && claude ..."` (org-start Step 2) |
 | キュレーター | フォアマンペインを垂直分割して右半分 | `ccmux split --target-name foreman --direction vertical --role curator --id curator --command "cd .curator && claude ..."` (org-start Step 3) |
-| 各ワーカー | **balanced split**: 既存のペイン数 `k` に応じた target と direction を `ccmux list` の結果から動的に選び、同一タブ内に積む | 詳細は下記「ワーカーの balanced split 戦略」セクション。`ccmux split --target-name {target} --direction {direction} --role worker --id worker-{task_id} --command "cd {workers_dir}/{task_id} && claude ..."` (org-delegate Step 3) |
+| 各ワーカー | **balanced split**: `ccmux list` が返す現在の rect から target と direction を動的に選び、同一タブ内に積む | 詳細は下記「ワーカーの balanced split 戦略」セクション。`ccmux split --target-name {target} --direction {direction} --role worker --id worker-{task_id} --command "cd {workers_dir}/{task_id} && claude ..."` (org-delegate Step 3) |
 
 ## ワーカーの balanced split 戦略
 
@@ -55,7 +55,7 @@ ccmux は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 
 5. **MIN_PANE 制約**: 分割後の新ペインサイズ `(new_w, new_h)` が `new_w >= 20` かつ `new_h >= 5` を満たさない候補は除外
    - vertical 分割: `(new_w, new_h) = (floor(width / 2), height)`
    - horizontal 分割: `(new_w, new_h) = (width, floor(height / 2))`
-6. **target 選出**: 残った候補から **「分割軸方向の新サイズ」** (vertical なら `new_w`、horizontal なら `new_h`) が最大のペインを target にする。tie-break は pane id 昇順で決定的に
+6. **target 選出**: 残った候補から **「分割軸方向の新サイズ」** (vertical なら `new_w`、horizontal なら `new_h`) が最大のペインを target にする。tie-break はその時点の pane id 昇順 (スナップショット内で再現可能。セッション跨ぎの安定性までは保証しない)
 7. **候補が空なら escalate**: `SKILL.md` Step 3-1 末尾の `SPLIT_CAPACITY_EXCEEDED` 経路で窓口に escalate (`ccmux split` は発行せず、該当ワーカー 1 件だけ派遣中止、フォアマン本体は継続)
 
 ### rect 隣接判定の定義


### PR DESCRIPTION
## Summary
- org-delegate の balanced split を ccmux v0.5.x の rect 付き `list` をベースにしたロジックに置き換え（Issue #18）
- 旧 k-table 方式（序数ベース）を削除し、ペインの実際の rect から target / direction を動的に決定

## 変更内容

### `.claude/skills/org-delegate/SKILL.md` (Step 3-1)
- bash + jq で `ccmux list --format json` の rect 情報から target を選ぶロジックに書き換え
- 候補集合: role が `worker` / `foreman` / `secretary`
- **foreman**: curator と rect 上で隣接（辺共有 + 直交軸 overlap）していなければ候補除外
- **secretary**: 分割後 new_w ≥ 100 のときのみ候補（保険条項、実運用ではほぼ発動しない）
- **direction**: `width > height * 2` → `vertical`、それ以外 → `horizontal`（ターミナルセルの縦横比 ≈ 2:1 根拠）
- **MIN_PANE 制約**: 分割後 new_w ≥ 20 / new_h ≥ 5 で絞り込み
- **tie-break**: metric 最大 → pane id 昇順で決定的
- 候補 0 → `$target` / `$direction` 空のまま既存の SPLIT_CAPACITY_EXCEEDED escalate 経路へ

### `.claude/skills/org-delegate/references/pane-layout.md`
- balanced split 戦略を rect 方式で書き直し
- 旧 k-table / 4・8 並列 ASCII 図 / 並列数上限表を削除（rect 方式では動的なので固定図は誤誘導）
- Phase 2 セクションの rect 関連項目も削除（実装済み扱い）

## コミット
- `5eba224` refactor(org-delegate): switch balanced split to rect-based target selection
- `e2bdafe` docs(org-delegate): fix stale k-table wording flagged by codex review

## Codex レビュー
- 実施済み。Blocker なし。指摘された旧表現 3+1 件は `e2bdafe` で修正済み
- Out-of-scope: `references/ccmux-error-codes.md` の旧 k-table 残骸（別 PR で対応）

## Test plan
- [ ] 既存の k-table 参照が SKILL.md / pane-layout.md から消えていることを目視確認
- [ ] jq スニペットを手元で 2-3 パターンの layout で動作確認
- [ ] Worker 新規派遣で target/direction が期待通り選ばれることを次セッションで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)