### PR TITLE
docs(ops.toml): refresh comments for ccmux-peers MCP era (closes #27)

### DIFF
--- a/ccmux-layouts/ops.toml
+++ b/ccmux-layouts/ops.toml
@@ -4,8 +4,9 @@
 #   ccmux --layout ops
 #
 # Additional panes (Foreman / Curator / Workers) are spawned
-# dynamically via `ccmux split --role ... --command ...` from the
-# Secretary's `/org-start` flow.
+# dynamically via `mcp__ccmux-peers__spawn_pane` from the Secretary's
+# `/org-start` flow. (Historical note: pre-#22 the same flow used
+# `ccmux split` CLI; the new MCP path is functionally equivalent.)
 #
 # Override the Secretary startup command by editing `command` below
 # or setting a shell alias pointing at your preferred `claude` invocation.
@@ -18,14 +19,27 @@
 # Secretary looks "alive but deaf"). Matches the same flag already
 # passed to Foreman / Curator / workers in org-start / org-delegate.
 #
+# The `ccmux-peers` MCP server (registered via `ccmux mcp install` in
+# user scope) is independent of this layout and is auto-loaded by
+# Claude Code regardless of the channel flag. MCP tool calls
+# (`mcp__ccmux-peers__*`) work from Secretary without extra config;
+# push notifications via `<channel source="ccmux-peers">` only arrive
+# if ccmux's own auto-upgrade path adds `server:ccmux-peers` to the
+# command line, which it does for `spawn_pane` / `new_tab`-started
+# claudes with a bare `claude` command. For this layout the command
+# has an explicit `--dangerously-load-development-channels` flag so
+# the auto-upgrade is skipped; if Secretary needs ccmux-peers push
+# delivery, add `server:ccmux-peers` to the channels flag below.
+#
 # With the flag on first launch Claude Code shows a one-off
 # "Load development channel: claude-peers?" prompt. Foreman /
 # Curator / workers bypass it via `ccmux send --name <id> --enter ""`
-# in org-start, but the Secretary is the initial pane that bootstraps
-# everything else, so that automated Enter isn't available yet —
-# the human operator has to press Enter manually the first time the
-# layout launches (and subsequently when Claude Code's session cache
-# gets invalidated).
+# in org-start (raw-key send is CLI-only until upstream
+# happy-ryo/ccmux#118 lands `send_keys` MCP). The Secretary is the
+# initial pane that bootstraps everything else, so that automated
+# Enter isn't available yet — the human operator has to press Enter
+# manually the first time the layout launches (and subsequently when
+# Claude Code's session cache gets invalidated).
 
 version = 1
 name = "ops"


### PR DESCRIPTION
## Summary
親 Epic #20 の子 [7]。`ccmux-layouts/ops.toml` の存廃判断と、それに伴うコメント更新。

## 判断: 存続

理由:
- `ccmux --layout ops` は README クイックスタートで案内されており、ユーザー体験の入口として価値がある
- ops.toml 自体は薄く（有意な設定は 4 行）、廃止メリットが小さい
- MCP 化後の起動フロー「レイアウト起動 → Secretary ペイン → `/org-start` → `spawn_pane` で Foreman/Curator」は従来通り破綻なし

代替案（廃止 + `ccmux` 無引数起動 + Secretary 自走 spawn）はユーザー初期コマンドの負担を増やすので不採用。

## コメント更新の内容
- `ccmux split --role ... --command ...` → `mcp__ccmux-peers__spawn_pane`
- ccmux-peers MCP サーバーは `ccmux mcp install` で user-scope に登録され、channel flag と独立して auto-load される旨を明記
- Secretary が `<channel source=\"ccmux-peers\">` push 通知を受けたい場合の手順（channels flag に `server:ccmux-peers` 追加）を注記
- raw キー送信（`ccmux send --enter`）が CLI 限定な現状、upstream happy-ryo/ccmux#118 (`send_keys` MCP) merge で MCP 化できる点を追記

`command` の値自体は現状維持（`claude --dangerously-load-development-channels server:claude-peers`）。Secretary で ccmux-peers push 通知が実用要件になった時点で後続 Issue で再検討する。

## Scope out
- `org-start` / `org-resume` の起動手順の反映 — `/org-start` の `ccmux --layout ops` 記述は #22 で MCP 化済みのファイルに既に残っており、存続判断と整合するため追加変更不要
- Secretary の `command` に `server:ccmux-peers` を追加するかの判断は、実運用で push 通知が必要になった時に別 Issue で対応

## Test plan
- [ ] `ccmux --layout ops` 実行で Secretary ペインが従来通り立ち上がる
- [ ] 初回 `--dangerously-load-development-channels server:claude-peers` プロンプトに手動 Enter で先に進める
- [ ] 起動後 `mcp__ccmux-peers__list_panes` が疎通する（`ccmux mcp install` 済み前提）
- [ ] README / `/org-start` の案内との整合が取れている

## Review
親 Epic #20 の共通ポリシーに従い merge 前に **Codex レビュー** を受ける。

## Refs
- Closes #27
- Parent Epic #20
- Upstream 参照: happy-ryo/ccmux#118