### PR TITLE
refactor(org-delegate): migrate balanced split to ccmux-peers MCP (closes #23)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -254,93 +254,95 @@ DELEGATE: 以下のワーカーを派遣してください。
 
 ### 3-1. balanced split で target / direction を決める
 
-旧設計は序数 `k` ベースの lookup table で target を決めていたが、ワーカーが途中で閉じた後の再派遣や想定外の退役順でテーブル前提と実レイアウトが乖離し、`[split_refused]` を誘発しやすかった。ccmux v0.5.x から `ccmux list --format json` が各ペインの `x / y / width / height` (u16, cell 単位) を返すため、**現在のレイアウト (rect) から動的に target と direction を選ぶ方式**に差し替えた。詳細ルールは `references/pane-layout.md` の「ワーカーの balanced split 戦略」セクションを参照。
+旧設計は序数 `k` ベースの lookup table で target を決めていたが、ワーカーが途中で閉じた後の再派遣や想定外の退役順でテーブル前提と実レイアウトが乖離し、`[split_refused]` を誘発しやすかった。ccmux-peers MCP の `mcp__ccmux-peers__list_panes` が各ペインの `id / name / role / focused / x / y / width / height` (cell 単位) を返すため、**現在のレイアウト (rect) から動的に target と direction を選ぶ方式**を取る。詳細ルールは `references/pane-layout.md` の「ワーカーの balanced split 戦略」セクションを参照。
 
-フォアマンは `ccmux split` を呼ぶ前に、以下のシェルスニペットで target と direction を算出する:
+#### 3-1a. レイアウト取得
 
-```bash
-# MIN_PANE_WIDTH=20 / MIN_PANE_HEIGHT=5: ccmux 側の分割下限 (findings: ccmux-split-inv)
-# SECRETARY_MIN_WIDTH=100:               secretary を分割候補にしてよい最小幅 (保険条項、実運用ではほぼ不発動)
-layout=$(ccmux list --format json)
-read -r target direction < <(
-  jq -r '
-    # rect 隣接判定: 辺共有 + その軸に直交する方向の区間 overlap
-    def adj($a; $b):
-      ((($a.x + $a.width) == $b.x or ($b.x + $b.width) == $a.x)
-        and ([$a.y, $b.y] | max) < ([$a.y + $a.height, $b.y + $b.height] | min))
-      or ((($a.y + $a.height) == $b.y or ($b.y + $b.height) == $a.y)
-        and ([$a.x, $b.x] | max) < ([$a.x + $a.width, $b.x + $b.width] | min));
-    (.panes | map(select(.role == "curator")) | first) as $cur
-    | .panes
-      # 候補は worker / foreman / secretary のみ (curator は常に除外)
-      | map(select(.role == "worker" or .role == "foreman" or .role == "secretary"))
-      # foreman-curator 隣接維持: foreman は curator と rect 隣接しているときのみ候補
-      | map(select(.role != "foreman" or ($cur != null and adj(.; $cur))))
-      | map(
-          # ターミナルセルは縦横比 ≈ 2:1 (文字が縦長) なので、文字単位で
-          # width = 2*height のとき物理的にほぼ正方形。width > height*2 を
-          # 「物理的に横長」判定とし、横長なら vertical (左右分割)、
-          # そうでなければ horizontal (上下分割) を選ぶ。
-          (if .width > .height * 2 then "vertical" else "horizontal" end) as $d
-          | (if $d == "vertical"   then (.width  / 2 | floor) else .width  end) as $nw
-          | (if $d == "horizontal" then (.height / 2 | floor) else .height end) as $nh
-          | . + {dir:$d, nw:$nw, nh:$nh,
-                 metric: (if $d == "vertical" then $nw else $nh end)})
-      # MIN_PANE 制約 + secretary 保険条項 (secretary は new_w >= 100 のときだけ候補に残る)
-      | map(select(.nw >= 20 and .nh >= 5))
-      | map(select(.role != "secretary" or .nw >= 100))
-      # 分割軸方向の新サイズ (vertical なら new_w、horizontal なら new_h) が最大のペインを選ぶ。
-      # tie-break はその時点の pane id 昇順 (スナップショット内で再現可能)。
-      | sort_by(-.metric, .id)
-      | if length == 0 then "" else (.[0] | "\(.name) \(.dir)") end
-  ' <<<"$layout"
-)
-```
+`mcp__ccmux-peers__list_panes` を呼び、返却テキストから全ペインの属性を抽出する。各ペインは以下のフィールドを持つ:
 
-- 初回 (ワーカー 0 人) は foreman が唯一の候補として残り、direction は foreman の aspect ratio から決まる (典型的に横長なので vertical)
-- **候補が空だった場合の扱い**: `$target` / `$direction` が空のまま 3-2 に進むので、フォアマン Claude は **`ccmux split` を発行せず**、代わりに claude-peers で窓口 (Secretary) に escalate メッセージを送信する:
-  1. `mcp__claude-peers__list_peers` (scope: `machine`) を呼び、`summary` に `Secretary` を含む peer を特定して `id` を取得する (通常は 1 件だが、複数あれば最新の last_seen を選ぶ)
-  2. `mcp__claude-peers__send_message` を `to_id=<Secretary id>` で呼び、本文を以下にする:
-     ```
-     SPLIT_CAPACITY_EXCEEDED: {task_id} のワーカー分割対象が見つからない。
-     rect ベース balanced split の MIN_PANE / 隣接条件を満たす候補が 0。
-     ターミナルサイズ不足または想定外のレイアウトが疑われる。人間判断が必要です。
-     ```
-  3. 3-3 以降（`ccmux events` 待機、`list_peers` 待ち、instruction 送信）は **skip** する。該当ワーカー 1 件だけ派遣を中止し、フォアマン本体の監視ループは **継続**させる。`exit` / `return` などでフォアマンを落とさないこと
+- `id`: 整数
+- `name`: 文字列（`spawn_pane` / `new_tab` で明示指定されたペインのみ、未設定なら省略）
+- `role`: 文字列 ("secretary" / "foreman" / "curator" / "worker" のいずれか。未設定なら省略)
+- `focused`: bool（出力行に `(focused)` が付くかで判断）
+- `x / y / width / height`: cell 単位の整数
+
+#### 3-1b. balanced split アルゴリズム（Claude が判定ロジックを実行）
+
+**定数**:
+- `MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5`: ccmux 側の分割下限（findings: ccmux-split-inv）
+- `SECRETARY_MIN_WIDTH = 100`: secretary を分割候補にしてよい最小幅（保険条項、実運用ではほぼ不発動）
+
+**Step 1. curator を特定**: `role == "curator"` のペインを 1 つ選ぶ（複数あれば先頭）。以降 `$curator` と呼ぶ。存在しなければ `$curator = null`。
+
+**Step 2. 候補を絞り込む**:
+- `role ∈ {"secretary", "foreman", "worker"}` のペインのみ候補
+- `role == "foreman"` のペインは、**`$curator` と rect 隣接している場合のみ**残す（`$curator = null` なら foreman も除外）
+  - rect 隣接の定義（どちらかを満たす）:
+    - **縦辺共有 + y 区間重なり**: `a.x + a.width == b.x` または `b.x + b.width == a.x`、かつ `max(a.y, b.y) < min(a.y + a.height, b.y + b.height)`
+    - **横辺共有 + x 区間重なり**: `a.y + a.height == b.y` または `b.y + b.height == a.y`、かつ `max(a.x, b.x) < min(a.x + a.width, b.x + b.width)`
+
+**Step 3. 各候補に direction / new_w / new_h / metric を付与**:
+- `direction = (width > height * 2) ? "vertical" : "horizontal"`
+  - ターミナル cell は縦:横 ≈ 2:1（文字が縦長）。`width > height*2` は物理的に横長 → vertical（左右分割）で綺麗に割れる
+  - それ以外は horizontal（上下分割）
+- `new_w = (direction == "vertical") ? floor(width / 2) : width`
+- `new_h = (direction == "horizontal") ? floor(height / 2) : height`
+- `metric = (direction == "vertical") ? new_w : new_h`（分割軸方向の新サイズ）
+
+**Step 4. MIN_PANE 制約**:
+- `new_w >= MIN_PANE_WIDTH` かつ `new_h >= MIN_PANE_HEIGHT` のペインのみ残す
+
+**Step 5. secretary 保険条項**:
+- `role == "secretary"` のペインは `new_w >= SECRETARY_MIN_WIDTH` のときだけ残す
+
+**Step 6. ソート & 選択**:
+- `metric` の降順、tie-break は `id` の昇順
+- 先頭要素の `name` を `$target`、`direction` を `$direction` として使用
+
+初回（ワーカー 0 人）は foreman が唯一の候補として残り、direction は foreman の aspect ratio から決まる（典型的に横長なので vertical）。
+
+#### 3-1c. 候補が空だった場合
+
+`$target` が空（候補セットが空）の場合、フォアマン Claude は **`spawn_pane` を発行せず**、代わりに claude-peers で窓口 (Secretary) に escalate メッセージを送信する:
+
+1. `mcp__claude-peers__list_peers` (scope: `machine`) を呼び、`summary` に `Secretary` を含む peer を特定して `id` を取得する（通常は 1 件、複数あれば最新の last_seen を選ぶ）
+2. `mcp__claude-peers__send_message` を `to_id=<Secretary id>` で呼び、本文を以下にする:
+   ```
+   SPLIT_CAPACITY_EXCEEDED: {task_id} のワーカー分割対象が見つからない。
+   rect ベース balanced split の MIN_PANE / 隣接条件を満たす候補が 0。
+   ターミナルサイズ不足または想定外のレイアウトが疑われる。人間判断が必要です。
+   ```
+3. 3-2 以降（`spawn_pane` / 起動確認 / `list_peers` 待ち / instruction 送信）は **skip** する。該当ワーカー 1 件だけ派遣を中止し、フォアマン本体の監視ループは **継続**させる。`exit` / `return` などでフォアマンを落とさないこと
 
 ### 3-2. ワーカーペインを起動する
 
-3-1 で算出した `$target` / `$direction` を使って `ccmux split` を呼ぶ。**`$target` が空なら split を発行せず 3-1 末尾の escalate 手順に従う**:
+3-1 で算出した `$target` / `$direction` を使って `mcp__ccmux-peers__spawn_pane` を呼ぶ。**`$target` が空なら spawn せず 3-1c の escalate 手順に従う**:
 
-```bash
-if [ -z "$target" ] || [ -z "$direction" ]; then
-  # 3-1 で balanced split 候補が空。claude-peers で窓口に SPLIT_CAPACITY_EXCEEDED を送信して
-  # このワーカーの派遣を中止する (フォアマン本体は継続)
-  :  # ccmux split を発行しない
-else
-  ccmux split \
-    --target-name "$target" \
-    --direction "$direction" \
-    --role worker \
-    --id worker-{task_id} \
-    --command "cd '{workers_dir}/{task_id}' && claude --dangerously-load-development-channels server:claude-peers --permission-mode {default_permission_mode}"
-fi
+```
+mcp__ccmux-peers__spawn_pane(
+  target=$target,                         # 3-1 で算出した既存ペイン名
+  direction=$direction,                   # "vertical" or "horizontal"
+  role="worker",
+  name="worker-{task_id}",                # 後続操作で参照する安定名。英字含む前提
+  command="cd '{workers_dir}/{task_id}' && claude --dangerously-load-development-channels server:claude-peers --permission-mode {default_permission_mode}"
+)
 ```
 
-> **`$target` / `$direction` が空だった場合の後続フロー**: このワーカーの起動フローはここで終了。3-3 (`ccmux events` 待機)、3-4 (`list_peers` 待ち)、3-5 (instruction 送信) のいずれも **skip** する。claude-peers での escalate（3-1 の手順参照）を行ったらフォアマン本体は次のサイクルへ。次タスクが控えているなら 3-6 で次の派遣へ進む。
+- ペイン配置ルールは `references/pane-layout.md` を参照。rect ベースの target / direction 選出ルールはそちらに集約
+- **同一タブ内 spawn で起動する理由**: ccmux の `list_panes` / `focus_pane` / `send_message` / `inspect`（CLI） は現在フォーカス中のタブのペインしか見えない。`new_tab` で別タブに置くとフォアマンからの監視・指示送信が不能になる（ccmux 側 issue: happy-ryo/ccmux#71）
+- `name="worker-{task_id}"`: 後続の `mcp__ccmux-peers__send_message(to_id="worker-{task_id}", ...)` や `close_pane(target="worker-{task_id}")` で addressable にする安定名。**全桁数字は id 扱いになる** ので、`worker-` プレフィックス等で英字を必ず含める
+- `role="worker"`: `list_panes` の結果で役割識別（次回以降の balanced split の target 選出にも使われる）
+- 起動コマンドは `.claude/skills/org-start/SKILL.md` の「ClaudeCode 起動コマンド（役割別）」セクションを参照
+- Planモード要の場合は `command` に `--permission-mode plan` を含める（org-config の値を上書き）
+- 開発チャネルの確認プロンプトが表示されるので、`ccmux send --name worker-{task_id} --enter ""` で Enter を送信する（raw キー入力は ccmux-peers MCP 未対応のため CLI 併用。upstream happy-ryo/ccmux#118 の `send_keys` MCP merge 後に MCP 化 — #30 の cleanup 事項）
+- **エラーハンドリング**: MCP 結果テキストに `[<code>] <msg>` 形式でエラーが埋まる。主な code:
+  - `[split_refused]` (MAX_PANES / too small): `references/ccmux-error-codes.md` の手順に従いキュレーター → 窓口に escalate。balanced split は best-effort の配置ヒントであり、想定外のレイアウト（途中でワーカーが閉じた後の再派遣など）では拒否され得る
+  - `[pane_not_found]`: `$target` に選んだ既存ペインが spawn 発行直前に閉じたレース。同じくエラーコード経路で escalate
+  - その他の code は `references/ccmux-error-codes.md` 参照
 
-   - ペイン配置ルールは `references/pane-layout.md` (ccmux 版) を参照。rect ベースの target / direction 選出ルールはそちらに集約
-   - **同一タブ内 split で起動する理由**: ccmux の `list` / `focus` / `send` / `inspect` は現在フォーカス中のタブのペインしか見えない。`new-tab` で別タブに置くとフォアマンからの監視・指示送信が不能になる (2026-04-20 判明。ccmux 側 issue: happy-ryo/ccmux#71)
-   - `--target-name "$target"`: balanced split で算出した既存ペイン名 (`foreman` もしくは `worker-*`) を分割対象にする
-   - `--direction "$direction"`: balanced split で算出した `vertical` / `horizontal`
-   - `--id worker-{task_id}`: 後続の `ccmux send --name worker-{task_id} ...` で addressable にする安定名
-   - `--role worker`: `ccmux list` の JSON で役割識別 (balanced split の target 選出にも使われる)
-   - 起動コマンドは `.claude/skills/org-start/SKILL.md` の「ClaudeCode 起動コマンド（役割別）」セクションを参照
-   - Planモード要の場合は `--permission-mode plan` を使用する（org-config の値を上書き）
-   - 開発チャネルの確認プロンプトが表示されるので、`ccmux send --name worker-{task_id} --enter ""` で Enter を送信する
-   - `[split_refused]` (MAX_PANES / too small) が返った場合は `references/ccmux-error-codes.md` の手順に従いキュレーター → 窓口に escalate する。balanced split は best-effort の配置ヒントであり、想定外のレイアウト (途中でワーカーが閉じた後の再派遣など) では拒否され得る
-   - `[pane_not_found]` が返った場合は `$target` に選んだワーカーが split 発行直前に閉じたレース。同じく既存エラーコード経路で escalate
-### 3-3. ペインが起動したことを確認 (`ccmux events`、推奨)
+### 3-3. ペインが起動したことを確認
+
+現状は `ccmux events` CLI 併用で確認（upstream happy-ryo/ccmux#117 / ccmux PR #120 の `poll_events` MCP が merge されたら後続 Issue で切り替え）:
 
 ```bash
 ccmux events --timeout 3s \
@@ -350,22 +352,22 @@ ccmux events --timeout 3s \
 ```
 
 - `ccmux events` は 3 秒経過で勝手に exit するので全体で最大 3 秒待機
-- `jq` で `pane_started` かつ `name == "worker-{task_id}"` の行だけに絞る (別タスクの同時 spawn 由来イベントを取りこぼさない、誤マッチしない)
+- `jq` で `pane_started` かつ `name == "worker-{task_id}"` の行だけに絞る（別タスクの同時 spawn 由来イベントを取りこぼさない、誤マッチしない）
 - `head -n 1` で最初の該当行で pipeline を終了させる
-- 出力が 1 行あれば OK。空なら 3 秒以内に起動イベントが来なかったということなので、`ccmux list` で状態を確認して窓口にエスカレーションする
+- 出力が 1 行あれば OK。空なら 3 秒以内に起動イベントが来なかったということなので、`mcp__ccmux-peers__list_panes` で状態を確認して窓口にエスカレーションする
 - **注意**: 直接 `--count 1` にすると、別ワーカーの起動イベント等の無関係な 1 件で exit してしまい、target ワーカーの起動確認ができない
 
-### 3-4. claude-peers の `list_peers` で新ピア出現を待機
+### 3-4. claude-peers の `mcp__claude-peers__list_peers` で新ピア出現を待機
 
-pane は live でも Claude がまだ起動中の場合があるため二重確認。
+pane は live でも Claude がまだ起動中の場合があるため二重確認。`ccmux-peers` 側の `list_peers` ではなく、必ず **`claude-peers` 側**を使う（広域 peer 空間は claude-peers が正本）。
 
-### 3-5. claude-peers の `send_message` でワーカーに指示を送信
+### 3-5. `mcp__claude-peers__send_message` でワーカーに指示を送信
 
-`references/instruction-template.md` のフォーマットに従う。
+`references/instruction-template.md` のフォーマットに従う。こちらも `claude-peers` 側を使用。
 
 ### 3-6. 複数ワーカーの順次起動
 
-複数ワーカーがある場合は 3-1〜3-5 を順次繰り返す。`ccmux list` の結果が毎回変わるので、都度 `active_workers` を再取得して `k` を計算し直す (前ワーカーの起動が完了するのを 3-3 / 3-4 で待ってから次に進むこと)。
+複数ワーカーがある場合は 3-1〜3-5 を順次繰り返す。`list_panes` の結果が毎回変わるので、**都度再取得して** balanced split 判定をし直す（前ワーカーの起動が完了するのを 3-3 / 3-4 で待ってから次に進むこと）。
 
 ### 3-7. Planモード要の場合 — Plan承認前のモード切替（重要: 順序厳守）
 

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -1,6 +1,7 @@
-# Pane Layout Specification (ccmux)
+# Pane Layout Specification (ccmux-peers MCP)
 
-ccmux のペイン / タブ配置ルール。org-start と org-delegate が参照する。
+ccmux のペイン / タブ配置ルール。`org-start` と `org-delegate` が参照する。
+ペイン制御は `mcp__ccmux-peers__*` MCP ツール経由で行う（一部の raw キー入力とイベント購読のみ `ccmux` CLI 併用、upstream happy-ryo/ccmux#117 / #118 merge まで）。
 
 ## 初期レイアウト (`ccmux --layout ops` の結果 + フォアマン・キュレーター起動後)
 
@@ -25,9 +26,9 @@ Tab 1: ops (ワーカー 0 人)
 
 | 対象 | 操作 | 備考 |
 |---|---|---|
-| フォアマン | 窓口ペインを水平分割して下半分 | `ccmux split --target-focused --direction horizontal --role foreman --id foreman --command "cd .foreman && claude ..."` (org-start Step 2) |
-| キュレーター | フォアマンペインを垂直分割して右半分 | `ccmux split --target-name foreman --direction vertical --role curator --id curator --command "cd .curator && claude ..."` (org-start Step 3) |
-| 各ワーカー | **balanced split**: `ccmux list` が返す現在の rect から target と direction を動的に選び、同一タブ内に積む | 詳細は下記「ワーカーの balanced split 戦略」セクション。`ccmux split --target-name {target} --direction {direction} --role worker --id worker-{task_id} --command "cd {workers_dir}/{task_id} && claude ..."` (org-delegate Step 3) |
+| フォアマン | 窓口ペインを水平分割して下半分 | `mcp__ccmux-peers__spawn_pane(target="focused", direction="horizontal", role="foreman", name="foreman", command="cd .foreman && claude ...")` (org-start Step 2) |
+| キュレーター | フォアマンペインを垂直分割して右半分 | `mcp__ccmux-peers__spawn_pane(target="foreman", direction="vertical", role="curator", name="curator", command="cd .curator && claude ...")` (org-start Step 3) |
+| 各ワーカー | **balanced split**: `list_panes` が返す現在の rect から target と direction を動的に選び、同一タブ内に積む | 詳細は下記「ワーカーの balanced split 戦略」セクション。`mcp__ccmux-peers__spawn_pane(target={target}, direction={direction}, role="worker", name="worker-{task_id}", command="cd {workers_dir}/{task_id} && claude ...")` (org-delegate Step 3) |
 
 ## ワーカーの balanced split 戦略
 
@@ -35,15 +36,15 @@ Tab 1: ops (ワーカー 0 人)
 
 ccmux は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5` の下限を割り込むと `[split_refused]` で拒否される (調査: `C:/Users/iwama/working/workers/ccmux-split-inv/findings.md`)。
 
-固定 target (`--target-name foreman --direction vertical`) や序数 `k` ベースの lookup table では、foreman 幅の累積半減や、ワーカーが途中で閉じた後の再派遣で想定レイアウトと実レイアウトが乖離し、早期に `split_refused` を誘発していた。
+固定 target や序数 `k` ベースの lookup table では、foreman 幅の累積半減や、ワーカーが途中で閉じた後の再派遣で想定レイアウトと実レイアウトが乖離し、早期に `split_refused` を誘発していた。
 
-現設計は ccmux v0.5.x から `ccmux list --format json` が返す各ペインの **rect 情報 (`x / y / width / height`, u16, cell 単位)** を使い、**現状のレイアウトから動的に target と direction を選ぶ**。ワーカー退役順の揺れや途中クローズに強く、固定的な「N 並列上限」は持たず、ターミナルサイズと MIN_PANE 制約が許す限り分割し続け、限界に達したら自動 escalate する。
+現設計は `mcp__ccmux-peers__list_panes` が返す各ペインの **rect 情報 (`x / y / width / height`, cell 単位)** を使い、**現状のレイアウトから動的に target と direction を選ぶ**。ワーカー退役順の揺れや途中クローズに強く、固定的な「N 並列上限」は持たず、ターミナルサイズと MIN_PANE 制約が許す限り分割し続け、限界に達したら自動 escalate する。
 
 ### アルゴリズム
 
-新規ワーカーを起動するフォアマンは、`ccmux split` を呼ぶ前に以下を実行する。bash + jq 実装は `SKILL.md` Step 3-1 を参照。
+新規ワーカーを起動するフォアマンは、`spawn_pane` を呼ぶ前に以下を実行する。判定ステップの詳細は `SKILL.md` Step 3-1 を参照（Claude が `list_panes` の結果テキストを解釈してロジックを実行する）。
 
-1. `ccmux list --format json` で全ペインと rect を取得する
+1. `mcp__ccmux-peers__list_panes` で全ペインと属性 (id / name / role / focused / x / y / width / height) を取得する
 2. **候補集合**: `role ∈ {worker, foreman, secretary}` のペイン (curator は常に除外)
 3. **候補の絞り込み**:
    - **foreman-curator 隣接維持**: foreman は curator と rect 隣接 (後述) しているときのみ候補に入れる。組織運営上 foreman と curator の隣接配置は前提。foreman を分割すると隣接が崩れ得るので、既に非隣接な foreman は候補から外す
@@ -56,7 +57,7 @@ ccmux は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 
    - vertical 分割: `(new_w, new_h) = (floor(width / 2), height)`
    - horizontal 分割: `(new_w, new_h) = (width, floor(height / 2))`
 6. **target 選出**: 残った候補から **「分割軸方向の新サイズ」** (vertical なら `new_w`、horizontal なら `new_h`) が最大のペインを target にする。tie-break はその時点の pane id 昇順 (スナップショット内で再現可能。セッション跨ぎの安定性までは保証しない)
-7. **候補が空なら escalate**: `SKILL.md` Step 3-1 末尾の `SPLIT_CAPACITY_EXCEEDED` 経路で窓口に escalate (`ccmux split` は発行せず、該当ワーカー 1 件だけ派遣中止、フォアマン本体は継続)
+7. **候補が空なら escalate**: `SKILL.md` Step 3-1c の `SPLIT_CAPACITY_EXCEEDED` 経路で窓口に escalate (`spawn_pane` は発行せず、該当ワーカー 1 件だけ派遣中止、フォアマン本体は継続)
 
 ### rect 隣接判定の定義
 
@@ -76,35 +77,38 @@ ccmux の cell 座標は整数なので tolerance なし完全一致で判定す
 ### Edge cases / 運用時の注意
 
 - **ワーカーが途中で閉じた後の再派遣**: 旧 k-table 方式で問題になった「閉じた slot を詰めるとテーブル前提と乖離」は rect ベースでは発生しない。常に実レイアウトから target を選ぶため、ccmux のレイアウト tree と判断が一致する
-- **`ccmux split` エラー**: `[split_refused]` / `[pane_not_found]` が返った場合は `references/ccmux-error-codes.md` の手順でキュレーター → 窓口にエスカレーション (方針は旧設計と同じ)
-- **レース**: `ccmux list` 実行から `ccmux split` 実行までに他ワーカーが増減した場合、target 不整合は `[pane_not_found]` として顕在化する。既存のエラーハンドリング経路で吸収する
-- **target 選出の責務**: 計算はフォアマンが `ccmux list` の rect ベースで行う。窓口は DELEGATE メッセージに task_id だけを渡せばよく、target は指定しない
+- **`spawn_pane` エラー**: `[split_refused]` / `[pane_not_found]` が MCP 結果テキストで返る。`references/ccmux-error-codes.md` の手順でキュレーター → 窓口にエスカレーション (方針は旧設計と同じ)
+- **レース**: `list_panes` 実行から `spawn_pane` 実行までに他ワーカーが増減した場合、target 不整合は `[pane_not_found]` として顕在化する。既存のエラーハンドリング経路で吸収する
+- **target 選出の責務**: 計算はフォアマンが `list_panes` の rect ベースで行う。窓口は DELEGATE メッセージに task_id だけを渡せばよく、target は指定しない
 
 ## 運用メモ
 
-- **全ペインを同一タブ内に配置する**: ccmux の `list` / `focus` / `send` / `inspect` は現在フォーカス中のタブのペインしか扱えないため、フォアマン・キュレーター・全ワーカーを同一タブ内に split で積む。`ccmux new-tab` でワーカーを別タブに置くとフォアマン側から addressable でなくなる (2026-04-20 判明。ccmux 本体での解決は happy-ryo/ccmux#71)
+- **全ペインを同一タブ内に配置する**: ccmux の `list_panes` / `focus_pane` / `send_message` / `inspect`（CLI） は現在フォーカス中のタブのペインしか扱えないため、フォアマン・キュレーター・全ワーカーを同一タブ内に split で積む。`new_tab` でワーカーを別タブに置くとフォアマン側から addressable でなくなる (2026-04-20 判明。ccmux 本体での解決は happy-ryo/ccmux#71)
 - **命名規約**:
   - 窓口 → `secretary`
   - フォアマン → `foreman`
   - キュレーター → `curator`
   - ワーカー → `worker-{task_id}` (task_id は kebab-case の一意識別子)
-- **役割ラベル (`--role`)**: `secretary` / `foreman` / `curator` / `worker` の 4 種
-  - `ccmux list` の JSON 出力で `role` フィールドが取得でき、組織状態の集計や balanced split の target 選出に使える
+  - **ccmux-peers の target 解決ルール**: 全桁数字の name は id として解釈されるため、name には英字を必ず含める (`worker-1` は OK、`1` は id 扱いになるので NG)
+- **役割ラベル (`role`)**: `secretary` / `foreman` / `curator` / `worker` の 4 種
+  - `list_panes` の出力で `role` フィールドが取得でき、組織状態の集計や balanced split の target 選出に使える
 - **ワーカー完了時**:
   1. 窓口がフォアマンに `CLOSE_PANE` を依頼
-  2. フォアマンは `ccmux close --name worker-{task_id}` でペインを明示破棄する (ccmux v0.5.8+)
-     (ccmux が pane を撤去 → `Event::PaneExited` を 1 回 emit → `ccmux list` からも消える。
+  2. フォアマンは `mcp__ccmux-peers__close_pane(target="worker-{task_id}")` でペインを明示破棄する
+     (ccmux が pane を撤去 → `Event::PaneExited` を 1 回 emit → `list_panes` からも消える。
      `[pane_not_found]` / `[pane_vanished]` は「既に閉じた扱い」として skip する)
-- **org-suspend 時の停止順**: ワーカー → フォアマン → キュレーター (いずれも `ccmux close --name ...` で破棄。最後の 1 ペインを閉じるときだけ `[last_pane]` が返るので、そのペインは自分自身で `exit` させる)
+- **org-suspend 時の停止順**: ワーカー → フォアマン → キュレーター (いずれも `mcp__ccmux-peers__close_pane` で破棄。最後の 1 ペインを閉じるときだけ `[last_pane]` が返るので、そのペインは自分自身で `exit` させる)
 
-## ccmux split の direction 慣習
+## spawn_pane の direction 慣習
 
-ccmux の分割方向は以下の定義:
-- `--direction vertical` = 左右分割 (既存ペイン=左、新ペイン=右)
-- `--direction horizontal` = 上下分割 (既存ペイン=上、新ペイン=下)
+ccmux の分割方向は以下の定義（旧 `ccmux split --direction` と同じ）:
+- `direction="vertical"` = 左右分割 (既存ペイン=左、新ペイン=右)
+- `direction="horizontal"` = 上下分割 (既存ペイン=上、新ペイン=下)
 
-## 将来機能 (Phase 2 待ち)
+## 将来機能 / upstream 追跡
 
-- `ccmux events` によるペイン lifecycle 購読 (現在は claude-peers 経由で補完)
-- `ccmux split --ratio 0.2` 等の比率指定 (現状は 50/50 固定)
-- `ccmux split --target-largest` / `--direction auto` 等の ccmux 側自動 target 選出 (現状はフォアマン側で `ccmux list` rect から算出。upstream に移譲できれば lookup ロジックを ccmux CLI 1 行に畳める)
+- **ペイン lifecycle 購読**: 現在は `ccmux events` CLI 併用（フォアマン監視ループなど）。upstream happy-ryo/ccmux#117 / ccmux PR #120 で `mcp__ccmux-peers__poll_events` が追加されたら後続 Issue で MCP に切替
+- **画面スクレイプ**: `ccmux inspect` CLI 併用。upstream happy-ryo/ccmux#116 / ccmux PR #121 で `mcp__ccmux-peers__inspect_pane` が追加されたら後続 Issue で MCP に切替
+- **raw キー送信**: `ccmux send --text` CLI 併用（開発チャネル Enter / Plan モード切替 Shift+Tab 等）。upstream happy-ryo/ccmux#118 で `send_keys` MCP が設計中。追加されたら後続 Issue で MCP に切替
+- `spawn_pane --ratio 0.2` 等の比率指定 (現状は 50/50 固定)
+- `spawn_pane --target-largest` / `--direction auto` 等の ccmux 側自動 target 選出 (現状はフォアマン側で `list_panes` rect から算出。upstream に移譲できれば balanced split ロジックを MCP 側に畳める)


### PR DESCRIPTION
## Summary
親 Epic #20 の子 [3]。本丸の `org-delegate` SKILL.md / references/pane-layout.md を MCP ベースに書き直す。balanced split の rect ベース判定ロジック自体は**完全に不変**、計算主体を bash + jq から Claude に移す点が最大の変更。

## 主な変更
### SKILL.md Step 3
- **3-1a**: `ccmux list --format json` → `mcp__ccmux-peers__list_panes` で全ペイン (id / name / role / focused / x / y / width / height) 取得
- **3-1b**: bash + jq パイプライン削除、**Claude が `list_panes` 結果テキストを解釈してロジック実行**する手順に変更。疑似コード風に記述。アルゴリズム（curator 特定 → role filter → foreman-curator 隣接 → direction / MIN_PANE / SECRETARY 保険条項 → metric sort）は完全不変
- **3-1c**: 候補空時の escalate (SPLIT_CAPACITY_EXCEEDED) は不変、`spawn_pane を発行しない`ことを明記
- **3-2**: `ccmux split` → `mcp__ccmux-peers__spawn_pane`。target は name 指定（英字含む必須、全桁数字は id 扱いになる仕様を注記）。raw キー入力 (開発チャネル Enter) は `ccmux send --enter` CLI 併用残置（upstream ccmux#118 merge 後に MCP 化）
- **3-3 (起動確認)**: `ccmux events` CLI 併用継続（upstream ccmux#117 / PR #120 の `poll_events` MCP merge 後に後続 Issue で切替）
- **3-4 / 3-5 (ピア同期 / 指示送信)**: `mcp__claude-peers__*` 側を使う旨を明示（ccmux-peers 側の同名ツールと取り違えないよう）

### references/pane-layout.md
- 配置ルール表の `ccmux split` コマンド例を `mcp__ccmux-peers__spawn_pane` 呼び出しに差し替え
- balanced split アルゴリズムの入口を `list_panes` 経由に
- 運用メモ: `ccmux close` → `mcp__ccmux-peers__close_pane`、`ccmux new-tab` → `new_tab` 等 CLI 参照を MCP 置換
- 命名規約に **「ccmux-peers は全桁数字 name を id 扱い」** ルールを追記
- 将来機能セクションを upstream 追跡に刷新（ccmux PR #120 / #121 / #118）

## 不変（動作互換性の保証）
- balanced split のロジック本体（`MIN_PANE_WIDTH=20` / `MIN_PANE_HEIGHT=5` / `SECRETARY_MIN_WIDTH=100` / rect 隣接判定 / metric sort / tie-break）
- 候補空時の escalate 経路（`SPLIT_CAPACITY_EXCEEDED`）
- ワーカー命名 (`worker-{task_id}`) と role label (`worker`)
- 同一タブ内 split 配置ルール（happy-ryo/ccmux#71 待ち）

## Scope out
- 3-3 の `ccmux events` → `poll_events` MCP 置換: upstream ccmux PR #120 merge 後に #24 / #25 で対応
- 3-7 (Plan モード切替) の raw キー送信 `ccmux send $'\x1b[Z'`: upstream ccmux#118 に基づいて #28 で対応
- org-suspend / Foreman 監視ループの MCP 化: それぞれ #24 / #25 で対応

## Test plan
- [ ] `/org-delegate` でワーカー派遣を実行し、Foreman が `list_panes` → 候補判定 → `spawn_pane` を成功させる
- [ ] 派遣されたワーカーペインが `worker-{task_id}` の name で存在する（`list_panes` で確認）
- [ ] balanced split の判定で、正しい target / direction が選ばれる（初回は `foreman` + `vertical`、複数ワーカー時は metric 最大が選ばれる）
- [ ] 候補空時の escalate（ターミナルサイズ不足を再現）で `spawn_pane` が呼ばれず `SPLIT_CAPACITY_EXCEEDED` メッセージが窓口に届く
- [ ] `[split_refused]` / `[pane_not_found]` を意図的に再現した際に、既存のエラーコード経路（`references/ccmux-error-codes.md`）に沿って escalate する
- [ ] 開発チャネルの確認プロンプト Enter 送信（`ccmux send --enter ""`）が従来通り動く

## Review
親 Epic #20 の共通ポリシーに従い merge 前に **Codex レビュー** を受ける。CI 通過したら merge。

## Refs
- Closes #23
- Parent Epic #20
- Upstream: happy-ryo/ccmux#117 (PR #120 poll_events) / #116 (PR #121 inspect_pane) / #118 (send_keys)