### PR TITLE
refactor(org-suspend): migrate pane shutdown to ccmux-peers MCP (closes #24)

### DIFF
--- a/.claude/skills/org-suspend/SKILL.md
+++ b/.claude/skills/org-suspend/SKILL.md
@@ -9,10 +9,15 @@ description: >
 
 全ワーカーの状態を収集し、ディスクに保存し、全ペインを停止する。
 
+ペイン操作は `mcp__ccmux-peers__*` MCP ツール経由で行う。pane_exited 相当の
+lifecycle イベントは `ccmux-peers` が現状 push/poll を提供するまで（upstream
+happy-ryo/ccmux#117 / ccmux PR #120 の `poll_events` merge 待ち）、
+`mcp__ccmux-peers__list_panes` の**短間隔ポーリング**で代替する。
+
 ## Phase 1: ワーカー状態収集
 
-1. claude-peers の `list_peers` で稼働中のピアを列挙する（scope: machine）
-2. 自分自身とキュレーターを除いた全ピアに以下を送信:
+1. `mcp__claude-peers__list_peers` で稼働中のピアを列挙する（scope: `machine`）
+2. 自分自身とキュレーターを除いた全ピアに `mcp__claude-peers__send_message` で以下を送信:
    ```
    SUSPEND: 現在の状態を報告してください。
    1. これまでに完了したこと
@@ -20,7 +25,7 @@ description: >
    3. 次にやろうとしていたこと
    4. ブロッカーや未解決の問題
    ```
-3. 30秒間 `check_messages` で応答を待つ（5秒間隔でポーリング）
+3. 30 秒間 `mcp__claude-peers__check_messages` で応答を待つ（5 秒間隔でポーリング）
 4. 応答があったワーカーの報告を記録する
 
 ## Phase 2: 未応答ワーカーのスクレイプ
@@ -28,8 +33,11 @@ description: >
 応答がなかったワーカーについて:
 
 1. `.state/workers/` から該当ワーカーの状態ファイルを読み、Pane Name と Directory を取得
-2. (ccmux にはペイン表示内容スクレイプの API が未実装。Phase 2 の `ccmux events` 実装待ち)
-   当面は git 情報のみで状態を推定する
+2. 画面内容スクレイプは upstream happy-ryo/ccmux#116 / ccmux PR #121 で `mcp__ccmux-peers__inspect_pane` が追加済み（ccmux リリース後に利用可能）。利用可能なら:
+   ```
+   mcp__ccmux-peers__inspect_pane(target="worker-{task_id}", format="text")
+   ```
+   の結果テキストから最新のコンソール出力を読む。**未実装版 ccmux（リリース前）を使っている間は Step 3 の git 情報だけで推定する**
 3. ワーカーの作業ディレクトリで以下を実行:
    - `git status`
    - `git diff --stat`
@@ -69,49 +77,50 @@ kill $(cat .state/dashboard.pid 2>/dev/null) 2>/dev/null || true
 
 停止順序が重要。ワーカー → フォアマン → キュレーターの順で停止する。
 
-1. claude-peers の `list_peers` で稼働中のピアを列挙
-2. **ワーカーを先に停止**: 全ワーカーピアに `send_message` で終了を指示:
+1. `mcp__claude-peers__list_peers` で稼働中のピアを列挙（scope: `machine`）
+2. **ワーカーを先に停止**: 全ワーカーピアに `mcp__claude-peers__send_message` で終了を指示:
    「SHUTDOWN: 作業を終了してください。」
 3. **ワーカーペインが閉じたことを確認** — 2-pass 構造で実施:
 
    **Pass 1 (polite shutdown の観察、最大 10 秒)**:
-   ```bash
-   ccmux events --timeout 10s \
-     | jq -c 'select(.type == "pane_exited" and .role == "worker")'
-   ```
-   - 出力された各行の `name` を `worker-{task_id}` と対応付けて、完了リストを作る
-   - 10 秒経過で `ccmux events` が自動 exit
+
+   `mcp__ccmux-peers__list_panes` を **500ms 間隔で最大 20 回** ポーリングする。各 poll で返却テキストに含まれる pane の name から、待機対象ワーカー名 (`worker-{task_id}`) が**消えていれば閉じた**と判定する。
+   - 待機対象集合 `pending_workers = {worker-{id} | 全ワーカー}` を用意
+   - 各 iteration:
+     1. `list_panes` を呼ぶ
+     2. `pending_workers` から、結果テキストに現れない name を除外し「閉じたリスト」に追加
+     3. `pending_workers` が空になったら break
+     4. そうでなければ 500ms 待機して次の iteration
+   - 最大 20 回 (合計 ~10 秒) で break せずに抜けた場合、残りは Pass 2 へ
+   - > **将来**: upstream happy-ryo/ccmux#117 / ccmux PR #120 の `poll_events` が merge されたら、この polling ループは以下 1 回の呼び出しに畳める:
+     > ```
+     > mcp__ccmux-peers__poll_events(since=<cursor>, timeout_ms=10000, types=["pane_exited"])
+     > ```
+     > `events[]` から `role == "worker"` のものを抽出する。この置換は後続 Issue で対応。
 
    **Pass 2 (残留ワーカーへのフォールバック + 再確認、最大 5 秒)**:
-   - Pass 1 で `pane_exited` を確認できなかったワーカーそれぞれに対して:
-     ```bash
-     ccmux close --name worker-{task_id}
+   - Pass 1 で閉じていないワーカーそれぞれに対して:
      ```
-     でペインを明示破棄する (ccmux v0.5.8+)。成功時は `{"id": N, "closed": true}` が返り、
-     `Event::PaneExited` が 1 回 emit される。`[pane_not_found]` / `[pane_vanished]` は
-     既に閉じた扱いで skip。`[last_pane]` はワーカー停止段階では通常発生しない
-     (窓口/フォアマン/キュレーターが残っているため)
-   - その後、再度:
-     ```bash
-     ccmux events --timeout 5s \
-       | jq -c 'select(.type == "pane_exited" and .role == "worker")'
+     mcp__ccmux-peers__close_pane(target="worker-{task_id}")
      ```
-     で残りの `pane_exited` を収集
-   - Pass 2 後もまだ閉じていないワーカーは `ccmux list` で生存確認し、残存なら人間に報告 (強制終了は現状未サポート)
+     でペインを明示破棄する。成功時は `"Closed pane id=N."` テキストが返る。`[pane_not_found]` / `[pane_vanished]` は既に閉じた扱いで skip（`references/ccmux-error-codes.md` 参照）。`[last_pane]` はワーカー停止段階では通常発生しない（窓口/フォアマン/キュレーターが残っているため）
+   - その後、再度 `list_panes` を 500ms × 最大 10 回 (合計 ~5 秒) ポーリングして、残りのワーカーが消えたかを確認する。判定ロジックは Pass 1 と同じ
+   - Pass 2 後もまだ閉じていないワーカーは `list_panes` で生存確認し、残存なら journal に記録して人間に報告（強制終了は現状未サポート）
 
-4. **フォアマンを停止**: フォアマンに `send_message` で終了を指示:
+4. **フォアマンを停止**: フォアマンに `mcp__claude-peers__send_message` で終了を指示:
    「SHUTDOWN: 作業を終了してください。」
-5. **キュレーターを停止**: キュレーターに `send_message` で終了を指示:
+5. **キュレーターを停止**: キュレーターに `mcp__claude-peers__send_message` で終了を指示:
    「SHUTDOWN: 作業を終了してください。」
 6. フォアマン・キュレーターも (3) と同じ 2-pass 構造で確認:
-   - Pass 1: `ccmux events --timeout 10s | jq 'select(.type=="pane_exited" and (.role=="foreman" or .role=="curator"))'`
-   - Pass 2: 残った pane に `ccmux close --name foreman` / `ccmux close --name curator` を送り、`ccmux events --timeout 5s` で再確認
+   - Pass 1: `list_panes` を 500ms × 最大 20 回ポーリングして、name が `foreman` / `curator` のペインが消えたかを確認
+   - Pass 2: 残った pane に `mcp__ccmux-peers__close_pane(target="foreman")` / `mcp__ccmux-peers__close_pane(target="curator")` を送り、`list_panes` ポーリング (500ms × 最大 10 回) で再確認
 
 **最後のペイン (窓口) の扱い**: フォアマン・キュレーターを閉じた時点でタブに残るのは窓口
-ペインのみになる。窓口が自分自身を `ccmux close --name secretary` で閉じようとすると
-`[last_pane]` (唯一のタブの唯一のペイン) が返るので、**窓口は自分自身で `exit` して自然終了
-させる** (人間が端末を閉じる、または `/exit` でシェルに戻る)。org-suspend は窓口ペインを
-閉じる責任を負わない。
+ペインのみになる。窓口が自分自身を `mcp__ccmux-peers__close_pane(target="secretary")` で
+閉じようとすると `[last_pane]` (唯一のタブの唯一のペイン) が返るので、**窓口は自分自身で
+`exit` して自然終了させる** (人間が端末を閉じる、または `/exit` でシェルに戻る)。
+org-suspend は窓口ペインを閉じる責任を負わない。
+
 7. 人間に報告:
    ```
    組織を中断しました。


### PR DESCRIPTION
## Summary
親 Epic #20 の子 [4]。`org-suspend` Skill の Phase 4 (全ペイン停止) を MCP ベースに書き換える。`ccmux close` / `ccmux events` / `ccmux list` への Bash 依存を全て除去。

## 主な変更
### Phase 1 / 4 の claude-peers 呼び出し
- `list_peers` / `send_message` / `check_messages` を `mcp__claude-peers__*` で明示（従来も MCP 経由だが、ccmux-peers 側との取り違え防止）

### Phase 2 画面スクレイプ
- 「ccmux にスクレイプ API 未実装」の古い注記を更新。upstream happy-ryo/ccmux#116 / ccmux PR #121 で merged 済みの `mcp__ccmux-peers__inspect_pane` を参照。当面は ccmux リリース前なので git 情報ベースを維持、inspect_pane が使える環境では optional に活用

### Phase 4 ペイン停止（本丸）
- `ccmux close --name X` → `mcp__ccmux-peers__close_pane(target="X")`
- `ccmux events --timeout 10s | jq ...` による pane_exited 待機を除去、代わりに **`list_panes` 短間隔ポーリング** で実装:
  - **500ms 間隔 × 最大 20 回 (合計 ~10 秒)** で pane name が消えたかを確認
  - 待機対象集合から消えたものを順次除外、空になったら break
  - **タイムアウト時は warning + continue** で強制クローズ競合を回避
- Pass 2（残留へのフォールバック）も同様の polling 構造
- Foreman / Curator 停止も同じ 2-pass + polling で統一
- `list_panes` は ccmux-peers の stable な contract なので name 消失 = 閉じた判定

## 方針合意（ccmux 側と）
ccmux-peers の `poll_events` MCP (upstream ccmux PR #120) が merge 前のため、下流では `list_panes` ポーリングで代替する方針を ccmux 側 Claude と合意済み:
- **理由 1**: #120 merge 後に `poll_events` 1 call への書き換え差分が最小
- **理由 2**: `ccmux events` CLI 併用は Bash permission 再導入で MCP 化の趣旨に逆行
- **理由 3**: 500ms–1s poll 間隔なら UX 上 event-driven とほぼ同等
- 500ms × 20 回 = 10 秒の待機レンジは `ccmux close` → PTY SIGHUP → shell exit → ccmux cleanup の観測レンジに十分収まる（Windows で若干遅めでも大抵 5 秒以内）

## 不変
- 停止順序（ワーカー → フォアマン → キュレーター）
- `[last_pane]` / `[pane_not_found]` / `[pane_vanished]` の扱い
- 最後の窓口ペインは自分自身で `exit` させる運用
- Phase 1-3 の状態書き込み手順

## 将来置換（upstream 依存、後続 Issue で対応）
```
mcp__ccmux-peers__poll_events(
  since=<cursor>, timeout_ms=10000, types=["pane_exited"]
)
```
置換 TODO は SKILL.md 本文に明記済み。upstream ccmux PR #120 merge 後に後続 Issue（#30 の cleanup 事項として取り込み）。

## Scope out
- Phase 2 の `inspect_pane` 積極活用 → ccmux リリース後に別 Issue で検討
- Foreman 監視ループの MCP 化 → #25 で対応
- raw キー送信の MCP 化 → #28 / upstream #118 で対応

## Test plan
- [ ] `/org-suspend` で正常 shutdown 経路（ワーカーが SHUTDOWN で自発的に閉じる）が `list_panes` ポーリングで pane_exited を検出できる
- [ ] 残留ワーカーを意図的に作り、Pass 2 の `close_pane` + 再ポーリングで閉じられる
- [ ] Foreman / Curator の停止も同じ 2-pass + polling で動作
- [ ] 最後の窓口ペインで `[last_pane]` が返った場合、強制クローズせず自然終了に任せる
- [ ] `Bash(ccmux close *)` / `Bash(ccmux events *)` permission が不要で動作すること（permission 撤去は #30 で実施、本 PR ではまだ残置）

## Review
親 Epic #20 の共通ポリシーに従い merge 前に **Codex レビュー**（スコープ絞ったプロンプトで）を受ける。CI 通過したら merge。

## Refs
- Closes #24
- Parent Epic #20
- Upstream: happy-ryo/ccmux#117 (PR #120 poll_events) / #116 (PR #121 inspect_pane, merged)