### PR TITLE
refactor(docs): cleanup error-codes / permissions for MCP-only era (part of #30)

### DIFF
--- a/.claude/skills/org-delegate/references/ccmux-error-codes.md
+++ b/.claude/skills/org-delegate/references/ccmux-error-codes.md
@@ -1,51 +1,30 @@
-# ccmux error codes — Foreman / Secretary reference (MCP + CLI fallback)
+# ccmux-peers MCP error codes — Foreman / Secretary reference
 
-ccmux 0.5.7+ および ccmux-peers MCP 0.12.0+ は、エラー応答に安定した
-machine-readable な code を載せる。フォアマン / キュレーター / 窓口は
-message 文字列の substring match ではなく **code で分岐する**のを推奨する。
-
-伝達経路は呼び出し手段で 2 通り:
-
-| 呼び出し手段 | エラー表現 | 抽出方法 |
-|---|---|---|
-| MCP (`mcp__ccmux-peers__*`) | JSON-RPC error の result テキストに `[<code>] <message>` を埋め込み | tool result text を正規表現 / substring で `[<code>]` 抽出 |
-| CLI (`ccmux send / inspect / events`, upstream #116/#117/#118 merge まで併用) | stderr に `Error: [<code>] <message>` 形式、exit status 非ゼロ | `grep '\[<code>\]'` or case 分岐 |
-
-code 語彙は両経路共通なので、抽出後のハンドリング分岐は同じテーブルを使える。
+ccmux 0.14.0+ の `ccmux-peers` MCP サーバは、エラー応答に安定した machine-readable な code を載せる。フォアマン / キュレーター / 窓口は message 文字列の substring match ではなく **code で分岐する**のを推奨する。
 
 ## Wire format
 
-### MCP (`mcp__ccmux-peers__*`) 失敗例
+MCP ツール（`mcp__ccmux-peers__*`）が失敗すると、JSON-RPC error の human-readable message 先頭に `[<code>] <human message>` が埋まる。ccmux 側の `fmt_code` 関数がこの形式を保証。
 
 ```
 mcp__ccmux-peers__send_message(to_id="worker-nonexistent", message="hi")
 → ccmux refused send: [pane_not_found] pane not found: Name("worker-nonexistent")
 ```
 
-MCP ツールの result テキスト（JSON-RPC error の human-readable message）の先頭に
-`[<code>] <human message>` が埋まる。ccmux 側の `fmt_code` 関数がこの形式を保証。
-
-### CLI 失敗例（併用中の経路）
-
-```
-$ ccmux send --name worker-nonexistent hi
-Error: [pane_not_found] pane not found: Name("worker-nonexistent")
-```
-
-stderr に上記 1 行、exit status 非ゼロ。
+抽出方法: tool result text を substring match（`[pane_not_found]` 等で case 分岐）。
 
 ## Known codes
 
 | Code | 意味 | Foreman の推奨挙動 |
 |---|---|---|
-| `pane_not_found` | 指定した pane 名 / id / Focused が存在しない | そのワーカーは既に閉じた扱い。`.state/workers/worker-*.md` の status を `pane_closed` に遷移、`WORKER_PANE_EXITED` を窓口に通知。リトライしない。**注意**: ccmux の `list_panes` / `focus_pane` / `send_message` / `inspect`（CLI） は現在フォーカス中のタブのペインしか見えない。別タブ (`new_tab` 由来) のワーカーは本 code で返るので、org-delegate では全ワーカーを同一タブ内 `spawn_pane` で起動する (happy-ryo/ccmux#71) |
+| `pane_not_found` | 指定した pane 名 / id / Focused が存在しない | そのワーカーは既に閉じた扱い。`.state/workers/worker-*.md` の status を `pane_closed` に遷移、`WORKER_PANE_EXITED` を窓口に通知。リトライしない。**注意**: `list_panes` / `focus_pane` / `send_message` / `inspect_pane` は現在フォーカス中のタブのペインしか見えない。別タブ (`new_tab` 由来) のワーカーは本 code で返るので、org-delegate では全ワーカーを同一タブ内 `spawn_pane` で起動する (happy-ryo/ccmux#71) |
 | `pane_vanished` | resolve 成功後に消えたレース | `pane_not_found` と同等扱い |
-| `last_pane` | `close_pane` / `ccmux close` で唯一のタブの唯一のペインを閉じようとした | 通常のワーカー停止では発生しない (窓口/フォアマン/キュレーターが同タブに同居するため)。`org-suspend` 末端で残った最後のペイン (通常は窓口) に対して発生した場合、そのペインは自分自身で `exit` して自然終了させる。強制再試行はしない |
-| `split_refused` | `spawn_pane` / `ccmux split` が MAX_PANES / too small で拒否 | ワーカー起動 (`org-delegate` Step 3) で balanced split のいずれかのステップが 16 ペイン上限 / `MIN_PANE_WIDTH` / `MIN_PANE_HEIGHT` で拒否された場合、キュレーター → 窓口に escalate。典型シナリオは (a) 9 並列以上に到達、(b) ターミナル幅が balanced split の要件 (W ≥ 160) を満たさない、(c) ワーカー退役後の再派遣でレイアウト tree が想定と乖離。`new_tab` フォールバックは tab-scoped 制約のため不可 (happy-ryo/ccmux#71) |
+| `last_pane` | `close_pane` で唯一のタブの唯一のペインを閉じようとした | 通常のワーカー停止では発生しない (窓口/フォアマン/キュレーターが同タブに同居するため)。`org-suspend` 末端で残った最後のペイン (通常は窓口) に対して発生した場合、そのペインは自分自身で `exit` して自然終了させる。強制再試行はしない |
+| `split_refused` | `spawn_pane` が MAX_PANES / too small で拒否 | ワーカー起動 (`org-delegate` Step 3) で balanced split のいずれかのステップが 16 ペイン上限 / `MIN_PANE_WIDTH` / `MIN_PANE_HEIGHT` で拒否された場合、キュレーター → 窓口に escalate。典型シナリオは (a) 9 並列以上に到達、(b) ターミナル幅が balanced split の要件 (W ≥ 160) を満たさない、(c) ワーカー退役後の再派遣でレイアウト tree が想定と乖離。`new_tab` フォールバックは tab-scoped 制約のため不可 (happy-ryo/ccmux#71) |
 | `io_error` | PTY write / spawn / OS レベル失敗 | 1 サイクル spin して再試行。2 連続で同じ worker に出たら窓口に `IO_ERROR_DETECTED` で escalate |
 | `shutting_down` | ccmux 本体がシャットダウン中 | 監視ループを **即停止** する。claude-peers に `FOREMAN_STOPPING` を通知 |
 | `app_timeout` | ccmux 内部 App スレッドが応答しなかった | 1 サイクル spin (ccmux 再起動は管理者判断)。連続発生なら窓口にログ |
-| `parse` / `protocol` | 通常出ない (MCP / CLI が正しく組み立てる前提) | 発生時はバグ。journal に記録して窓口に `IPC_PROTOCOL_ERROR` で報告 |
+| `parse` / `protocol` | 通常出ない (MCP が正しく組み立てる前提) | 発生時はバグ。journal に記録して窓口に `IPC_PROTOCOL_ERROR` で報告 |
 | `internal` | ccmux 内部不変条件違反 (parser lock poison 等) | `app_timeout` と同じ扱い |
 
 ## MCP ツール特有の ok-return ルール
@@ -56,16 +35,11 @@ stderr に上記 1 行、exit status 非ゼロ。
 - `mcp__ccmux-peers__send_message`: 同上 → `"(message dropped — ccmux not reachable: <reason>)"`
 
 他の ccmux-peers ツール (`spawn_pane` / `close_pane` / `list_panes` / `focus_pane` / `new_tab` /
-`check_messages` / `set_summary` / `poll_events` / `inspect_pane`) は `require_connected` で
-非接続時に JSON-RPC error になる。この 2 つだけは**ハンドリング分岐を `[code]` パターンだけでなく
-`(no peers` / `(message dropped` 接頭辞**でも見るべき。
+`check_messages` / `set_summary` / `poll_events` / `inspect_pane` / `send_keys`) は `require_connected` で非接続時に JSON-RPC error になる。この 2 つだけは**ハンドリング分岐を `[code]` パターンだけでなく `(no peers` / `(message dropped` 接頭辞**でも見るべき。
 
 ## シェル側のハンドリング例
 
-### MCP ツール結果のパターンマッチ
-
-Claude Code 内で MCP ツール呼び出しを行い、結果テキストを受け取ったあと。典型的には tool result
-の `content[0].text` または JSON-RPC error message:
+MCP ツール呼び出し結果テキスト (`content[0].text` or JSON-RPC error message) に対する case 分岐:
 
 ```
 # MCP ツール呼び出し後、返ってきたテキストを $out に入れた状態を想定
@@ -96,111 +70,61 @@ case "$out" in
 esac
 ```
 
-### CLI 経路のハンドリング例（upstream merge まで使う）
-
-```bash
-out=$(ccmux send --name worker-foo --enter "ping" 2>&1)
-status=$?
-if [ $status -ne 0 ]; then
-  case "$out" in
-    *"[pane_not_found]"*|*"[pane_vanished]"*) mark_worker_pane_closed worker-foo ;;
-    *"[last_pane]"*) echo "last pane — leave for self-exit" ;;
-    *"[shutting_down]"*) echo "ccmux halting — foreman stopping"; exit 0 ;;
-    *"[io_error]"*|*"[app_timeout]"*|*"[internal]"*) log_journal "transient ccmux error: $out" ;;
-    *) log_journal "unexpected ccmux error: $out" ;;
-  esac
-fi
-```
-
-MCP / CLI で分岐テーブルは実質同一。違いは入力の取り方のみ。
-
 ## なぜ code か、substring ではなく
 
 - メッセージ本文は human-facing。理由なしで変更される可能性がある
   (e.g. "pane not found: Id(3)" → "pane 3 does not exist")
-- ccmux 側の契約については、以下を正本として参照する (このリポジトリ
-  内では検証不能な前提なので **外部依存** として扱うこと):
-  - `ccmux/src/ipc/mod.rs::err_code` の doc コメント — 公開 code の一覧
-    と ABI 安定性 (rename は deprecation window 付き) の明文
+- ccmux 側の契約については、以下を正本として参照する (このリポジトリ内では検証不能な前提なので **外部依存** として扱うこと):
+  - `ccmux/src/ipc/mod.rs::err_code` の doc コメント — 公開 code の一覧と ABI 安定性 (rename は deprecation window 付き) の明文
   - `ccmux/src/mcp_peer/mod.rs::fmt_code` — MCP 経由の `[<code>] <message>` 成形ロジック
-  - ccmux `Response::Err { message, code }` の wire schema — `code` は
-    `Option<String>` で、`skip_serializing_if = "Option::is_none"`
-- 未知の code は必ず非致命扱いにする — 将来 ccmux が新 code を追加しても
-  フォアマンが落ちないようにデフォルトブランチ必須
+  - ccmux `Response::Err { message, code }` の wire schema — `code` は `Option<String>` で、`skip_serializing_if = "Option::is_none"`
+- 未知の code は必ず非致命扱いにする — 将来 ccmux が新 code を追加してもフォアマンが落ちないようにデフォルトブランチ必須
 
-## 後方互換
+## Event stream — `poll_events` MCP
 
-MCP 経路 (`ccmux-peers` 0.12.0+) では常に `[<code>] <message>` が取れる前提で良い。
-CLI 経路の pre-0.5.7 後方互換は以下の通り:
-
-- **想定**: pre-0.5.7 の ccmux では wire Response に `code` フィールドが載らず、CLI 側も
-  `[<code>]` prefix なしでメッセージだけを stderr に吐く。この想定はこのリポジトリでは検証
-  できないので ccmux 本体のリリースノート (v0.5.7) で裏取りしてから運用する
-- code 無しで受けた場合は従来 substring match にフォールバック。aainc-ops 側で code を
-  扱う新しいコードは **両方** をサポートすべき (最低でも unknown code を無視しないロジック)
-
-## Event stream 側（CLI 併用、upstream #117 merge まで）
-
-MCP に `poll_events` tool が追加された (upstream happy-ryo/ccmux#117 / PR #120)。
-以降のスキル改修で `ccmux events` CLI から `mcp__ccmux-peers__poll_events` に切替予定
-（下流 Issue #24 / #25 で対応）。cleanup までは CLI 併用経路で扱う:
-
-`ccmux events --timeout 5s` が返す JSON 行のうち、フォアマンが扱う `type`:
-
-| type | 扱い |
-|---|---|
-| `pane_started` | 現状 skip (将来必要になれば追加) |
-| `pane_exited` | `role == "worker"` に絞って `WORKER_PANE_EXITED` 通知 |
-| `events_dropped` | `.state/journal.jsonl` に drop 件数を記録 |
-| `heartbeat` | skip (30 秒おきの keep-alive。ccmux 0.5.7+ が emit) |
-
-`jq -c 'select(.type == "pane_exited" and .role == "worker")'` は
-heartbeat / pane_started / events_dropped を暗黙に落とすので、
-**既存のフィルタ式は 0.5.7 以降も無修正で動く**。ただし
-`events_dropped` を journal に記録したいなら select 式を拡張する:
-
-```bash
-ccmux events --timeout 5s \
-  | jq -c 'select(
-      (.type == "pane_exited" and .role == "worker")
-      or .type == "events_dropped"
-    )'
-```
-
-### MCP 化後の等価ハンドリング（参考、#24 / #25 で実装）
-
-`poll_events` の types フィルタで同じ選別ができる:
+pane lifecycle (`pane_started` / `pane_exited` / `events_dropped` / `heartbeat` / forward-compat variants) は `mcp__ccmux-peers__poll_events` で cursor-based long-poll する:
 
 ```
 mcp__ccmux-peers__poll_events(
-  since=<cursor>,
+  since=<前回の next_since、初回は省略>,
   timeout_ms=5000,
   types=["pane_exited", "events_dropped"]
 )
 ```
 
-戻り値の `events[]` は role フィールドを含むので、さらに `role == "worker"` で絞る。
-`next_since` は次回呼び出しの `since` に流用する（idempotent resume）。
+戻り値の `events[]` は `type` / `role` / `name` / `id` / `ts` を含む。フォアマンは `role == "worker"` で絞り込んで `WORKER_PANE_EXITED` 通知する。`next_since` を次回 `since` に流用して idempotent resume。
 
-注: `poll_events` は **filter 不一致イベントが到着しても long-poll を中断して empty 返却する**
-挙動（ccmux PR #120 のドキュメント参照）。Foreman 監視ループでは空応答時に spin せず、
-`next_since` を保持したまま次のサイクルで再呼び出しする。
+### type 別の扱い
 
-## raw キー入力 (`send_keys` MCP、ccmux PR #122 / リリース後に利用可能)
+| type | 扱い |
+|---|---|
+| `pane_started` | 現状 skip (将来必要になれば追加) |
+| `pane_exited` | `role == "worker"` に絞って `WORKER_PANE_EXITED` 通知 |
+| `events_dropped` | `.state/journal.jsonl` に drop 件数を記録 (監視が追いついていないシグナル) |
+| `heartbeat` | 通常 `poll_events` のバッファに入らない (subscribe 内部で消化される) |
 
-現状 `ccmux send --text` / `ccmux send --enter` CLI で送っている raw キー送信は、
-ccmux PR #122（`send_keys` MCP、upstream CI green 待ち）で置換する。API 形状:
+### `types` フィルタの挙動
+
+`types` filter は cursor を全 type で advance させるので重複 scan なし。ただし **filter 不一致イベント到着で long-poll が early return** し、`events: []` + 進んだ cursor が返る (ccmux PR #120 参照)。Foreman 監視ループでは空応答時に spin せず、`next_since` を保持したまま次のサイクルで再呼び出しする。
+
+### 初回呼び出しのセマンティクス
+
+`since` 省略で「今以降のイベントだけ」を返す（過去の履歴を flood しない）。旧 `ccmux events --timeout` と同じ契約。
+
+## Raw キー入力 — `send_keys` MCP
+
+raw PTY キー送信は `mcp__ccmux-peers__send_keys` を使う。論理メッセージ配送の `send_message` とは**別物**（PTY に生バイトを書き込むので、そのペインで走っているアプリケーション側に見える）:
 
 ```
 mcp__ccmux-peers__send_keys(
-  target: string,           // pane name or id (list_panes と同じ解決規則)
-  text?: string,            // 送信するテキスト（optional）
-  keys?: string[],          // 特殊キー名の配列（optional、text と併用可）
-  enter?: boolean           // 末尾に Enter (CR, 0x0D) を付ける（optional）
+  target: string,           # pane name or id (list_panes と同じ解決規則)
+  text?: string,            # 送信するテキスト（optional）
+  keys?: string[],          # 特殊キー名の配列（optional、text と併用可、text の後に送られる）
+  enter?: boolean           # 末尾に Enter (CR, 0x0D) を付ける（optional、keys の後に送られる）
 )
 ```
 
-**対応キー語彙**（ccmux PR #122 より）:
+### 対応キー語彙
 
 - `Enter` / `Return` (CR, `\r` = 0x0D。`enter: true` と byte-identical)
 - `Tab`
@@ -214,12 +138,14 @@ mcp__ccmux-peers__send_keys(
 - `Space`
 - `Ctrl+<A-Z>`（例: `Ctrl+C`）
 
-**置換例**:
+未知の key 名は `-32602 invalid-params` error が返る。
 
-| 現行 CLI | upstream merge + リリース後の MCP 置換 |
+### 典型的な呼び出しパターン
+
+| 用途 | 呼び出し |
 |---|---|
-| `ccmux send --name X --enter ""` | `mcp__ccmux-peers__send_keys(target="X", enter=true)` |
-| `ccmux send --name X --enter "yes"` | `mcp__ccmux-peers__send_keys(target="X", text="yes", enter=true)` |
-| `ccmux send --name X $'\x1b[Z'` | `mcp__ccmux-peers__send_keys(target="X", keys=["Shift+Tab"])` |
-
-実際の置換は Issue #30 cleanup で ccmux リリース後に一括で実施する。現行 CLI 経路はそれまで維持。
+| 空 Enter（プロンプトへの返答） | `send_keys(target="X", enter=true)` |
+| "yes" + Enter（Plan 承認など） | `send_keys(target="X", text="yes", enter=true)` |
+| Shift+Tab（permission mode 切替） | `send_keys(target="X", keys=["Shift+Tab"])` |
+| Esc（モーダル escape） | `send_keys(target="X", keys=["Esc"])` |
+| Ctrl+C（走行中プロセス中断） | `send_keys(target="X", keys=["Ctrl+C"])` |

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -10,7 +10,13 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 {
   "permissions": {
     "allow": [
-      "Bash(ccmux:*)",
+      "Bash(ccmux --version)",
+      "Bash(ccmux --help)",
+      "Bash(ccmux --layout:*)",
+      "Bash(ccmux mcp install:*)",
+      "Bash(ccmux mcp uninstall:*)",
+      "Bash(ccmux mcp status:*)",
+      "Bash(ccmux mcp --help)",
       "mcp__claude-peers__set_summary",
       "mcp__claude-peers__list_peers",
       "mcp__claude-peers__send_message",
@@ -23,7 +29,10 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
       "mcp__ccmux-peers__spawn_pane",
       "mcp__ccmux-peers__close_pane",
       "mcp__ccmux-peers__focus_pane",
-      "mcp__ccmux-peers__new_tab"
+      "mcp__ccmux-peers__new_tab",
+      "mcp__ccmux-peers__inspect_pane",
+      "mcp__ccmux-peers__poll_events",
+      "mcp__ccmux-peers__send_keys"
     ]
   },
   "env": {
@@ -32,7 +41,15 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 }
 ```
 
-**注意**: `ccmux-peers` MCP ツールは `ccmux mcp install` を一度実行して user-scope に MCP サーバーを登録した後に利用可能になる。登録手順は README「ccmux MCP サーバーの登録」を参照。旧 `Bash(ccmux:*)` は段階移行中の併用（撤去時期は Issue #30 で管理）。
+**Bash permission 方針**: 旧 `Bash(ccmux:*)` glob は撤去済み（ccmux 0.14.0+ でペイン操作・ピア通信・event 購読・スクレイプ・raw キー送信がすべて MCP 化されたため）。残している `Bash(ccmux …)` は **運用コマンド限定**:
+
+- `ccmux --version` / `ccmux --help`: 環境確認
+- `ccmux --layout ops` 相当 (`--layout:*`): 初回レイアウト起動（`ccmux-layouts/ops.toml` 参照）
+- `ccmux mcp install` / `uninstall` / `status` / `--help`: MCP サーバー登録管理（`mcp__ccmux-peers__*` を使えるようにするための bootstrap）
+
+ペイン操作（`ccmux split` / `close` / `list` / `send` / `events` / `inspect` / `new-tab` 等）は MCP ツール (`mcp__ccmux-peers__*`) 経由で実施する。該当 Bash permission は含めない。
+
+**注意**: `ccmux-peers` MCP ツール 12 種は `ccmux mcp install` を一度実行して user-scope に MCP サーバーを登録した後に利用可能になる。登録手順は README「ccmux MCP サーバーの登録」を参照。
 
 ## 窓口 (`<repo>/.claude/settings.local.json`)
 


### PR DESCRIPTION
## Summary
親 Epic #20 子 [10] (#30) の **PR 2/N**（PR #40 に続く）。ccmux 0.14.0+ で全機能 MCP 化された前提で、references を MCP 単一経路に書き直し、Bash permission を運用コマンド限定に絞り込む。

## 変更ファイル

### `.claude/skills/org-delegate/references/ccmux-error-codes.md`
- タイトルから「(MCP + CLI fallback)」を削除 → MCP 単一経路 reference に
- Wire format セクション: MCP のみ（CLI 失敗例セクション削除）
- 伝達経路の 2 通り表を削除、MCP `[<code>] <msg>` の 1 経路で統一
- シェル側ハンドリング例: MCP のみ（CLI 経路の case 分岐例を削除）
- 「後方互換」pre-0.5.7 セクション削除（0.14.0+ 前提のため不要）
- **Event stream — `poll_events` MCP** セクションで置換:
  - type 別の扱い、types filter の early return 挙動、初回 since 省略のセマンティクスを整理
- **Raw キー入力 — `send_keys` MCP** セクションを primary 記述に:
  - 「ccmux リリース後に利用可能」「実置換は #30 cleanup で一括」等の未来形記述を全削除
  - 典型的な呼び出しパターン 5 ケース (空 Enter / yes+Enter / Shift+Tab / Esc / Ctrl+C) を明示

### `.claude/skills/org-setup/references/permissions.md`
- ユーザー共通 allow の `Bash(ccmux:*)` glob を削除、運用コマンド限定に細粒度化:
  - `Bash(ccmux --version)` / `Bash(ccmux --help)`
  - `Bash(ccmux --layout:*)` （`ccmux --layout ops` 起動）
  - `Bash(ccmux mcp install:*)` / `uninstall:*` / `status:*` / `--help`
- `mcp__ccmux-peers__*` に `inspect_pane` / `poll_events` / `send_keys` の 3 ツールを追加（計 12 ツール allow）
- ペイン操作（split / close / list / send / events / inspect / new-tab）は MCP 経由に統一され、該当 Bash permission は含めない旨を明記

## 不変
- error code 語彙（`pane_not_found` / `pane_vanished` / `last_pane` / `split_refused` / `io_error` / `shutting_down` / `app_timeout` / `parse` / `protocol` / `internal`）
- 推奨 Foreman 挙動テーブル
- MCP ok-return ルール (`list_peers` / `send_message` のみ例外)
- `mcp__claude-peers__*` 4 ツール allow
- `CLAUDE_CODE_NO_FLICKER=1` env

## Test plan
- [ ] `claude mcp list` で `ccmux-peers` が Connected、12 ツール呼び出し可
- [ ] `Bash(ccmux --version)` / `Bash(ccmux mcp install --force)` が permission プロンプトなしで実行できる
- [ ] `Bash(ccmux split)` / `Bash(ccmux close)` など旧 CLI は permission で拒否される（細粒度化の狙い）
- [ ] error-codes.md の code 分岐が MCP tool result text に対して機能する（実呼び出しで `[pane_not_found]` / `[split_refused]` を再現）

## Review
親 Epic #20 の共通ポリシーに従い merge 前に **Codex レビュー**（制約プロンプト）。CI 通過したら merge。

## Refs
- Part of #30, Parent Epic #20
- Depends on: ccmux-fork@0.14.0 (published 2026-04-22T06:06Z)
- 先行 PR: #40 (skills / .foreman の CLI→MCP 実置換, merged)