### PR TITLE
docs(verification): rewrite for ccmux-peers MCP-only era (closes #30)

### DIFF
--- a/.claude/skills/org-delegate/references/ccmux-error-codes.md
+++ b/.claude/skills/org-delegate/references/ccmux-error-codes.md
@@ -1,51 +1,30 @@
-# ccmux error codes — Foreman / Secretary reference (MCP + CLI fallback)
+# ccmux-peers MCP error codes — Foreman / Secretary reference
 
-ccmux 0.5.7+ および ccmux-peers MCP 0.12.0+ は、エラー応答に安定した
-machine-readable な code を載せる。フォアマン / キュレーター / 窓口は
-message 文字列の substring match ではなく **code で分岐する**のを推奨する。
-
-伝達経路は呼び出し手段で 2 通り:
-
-| 呼び出し手段 | エラー表現 | 抽出方法 |
-|---|---|---|
-| MCP (`mcp__ccmux-peers__*`) | JSON-RPC error の result テキストに `[<code>] <message>` を埋め込み | tool result text を正規表現 / substring で `[<code>]` 抽出 |
-| CLI (`ccmux send / inspect / events`, upstream #116/#117/#118 merge まで併用) | stderr に `Error: [<code>] <message>` 形式、exit status 非ゼロ | `grep '\[<code>\]'` or case 分岐 |
-
-code 語彙は両経路共通なので、抽出後のハンドリング分岐は同じテーブルを使える。
+ccmux 0.14.0+ の `ccmux-peers` MCP サーバは、エラー応答に安定した machine-readable な code を載せる。フォアマン / キュレーター / 窓口は message 文字列の substring match ではなく **code で分岐する**のを推奨する。
 
 ## Wire format
 
-### MCP (`mcp__ccmux-peers__*`) 失敗例
+MCP ツール（`mcp__ccmux-peers__*`）が失敗すると、JSON-RPC error の human-readable message 先頭に `[<code>] <human message>` が埋まる。ccmux 側の `fmt_code` 関数がこの形式を保証。
 
 ```
 mcp__ccmux-peers__send_message(to_id="worker-nonexistent", message="hi")
 → ccmux refused send: [pane_not_found] pane not found: Name("worker-nonexistent")
 ```
 
-MCP ツールの result テキスト（JSON-RPC error の human-readable message）の先頭に
-`[<code>] <human message>` が埋まる。ccmux 側の `fmt_code` 関数がこの形式を保証。
-
-### CLI 失敗例（併用中の経路）
-
-```
-$ ccmux send --name worker-nonexistent hi
-Error: [pane_not_found] pane not found: Name("worker-nonexistent")
-```
-
-stderr に上記 1 行、exit status 非ゼロ。
+抽出方法: tool result text を substring match（`[pane_not_found]` 等で case 分岐）。
 
 ## Known codes
 
 | Code | 意味 | Foreman の推奨挙動 |
 |---|---|---|
-| `pane_not_found` | 指定した pane 名 / id / Focused が存在しない | そのワーカーは既に閉じた扱い。`.state/workers/worker-*.md` の status を `pane_closed` に遷移、`WORKER_PANE_EXITED` を窓口に通知。リトライしない。**注意**: ccmux の `list_panes` / `focus_pane` / `send_message` / `inspect`（CLI） は現在フォーカス中のタブのペインしか見えない。別タブ (`new_tab` 由来) のワーカーは本 code で返るので、org-delegate では全ワーカーを同一タブ内 `spawn_pane` で起動する (happy-ryo/ccmux#71) |
+| `pane_not_found` | 指定した pane 名 / id / Focused が存在しない | そのワーカーは既に閉じた扱い。`.state/workers/worker-*.md` の status を `pane_closed` に遷移、`WORKER_PANE_EXITED` を窓口に通知。リトライしない。**注意**: `list_panes` / `focus_pane` / `send_message` / `inspect_pane` は現在フォーカス中のタブのペインしか見えない。別タブ (`new_tab` 由来) のワーカーは本 code で返るので、org-delegate では全ワーカーを同一タブ内 `spawn_pane` で起動する (happy-ryo/ccmux#71) |
 | `pane_vanished` | resolve 成功後に消えたレース | `pane_not_found` と同等扱い |
-| `last_pane` | `close_pane` / `ccmux close` で唯一のタブの唯一のペインを閉じようとした | 通常のワーカー停止では発生しない (窓口/フォアマン/キュレーターが同タブに同居するため)。`org-suspend` 末端で残った最後のペイン (通常は窓口) に対して発生した場合、そのペインは自分自身で `exit` して自然終了させる。強制再試行はしない |
-| `split_refused` | `spawn_pane` / `ccmux split` が MAX_PANES / too small で拒否 | ワーカー起動 (`org-delegate` Step 3) で balanced split のいずれかのステップが 16 ペイン上限 / `MIN_PANE_WIDTH` / `MIN_PANE_HEIGHT` で拒否された場合、キュレーター → 窓口に escalate。典型シナリオは (a) 9 並列以上に到達、(b) ターミナル幅が balanced split の要件 (W ≥ 160) を満たさない、(c) ワーカー退役後の再派遣でレイアウト tree が想定と乖離。`new_tab` フォールバックは tab-scoped 制約のため不可 (happy-ryo/ccmux#71) |
+| `last_pane` | `close_pane` で唯一のタブの唯一のペインを閉じようとした | 通常のワーカー停止では発生しない (窓口/フォアマン/キュレーターが同タブに同居するため)。`org-suspend` 末端で残った最後のペイン (通常は窓口) に対して発生した場合、そのペインは自分自身で `exit` して自然終了させる。強制再試行はしない |
+| `split_refused` | `spawn_pane` が MAX_PANES / too small で拒否 | ワーカー起動 (`org-delegate` Step 3) で balanced split のいずれかのステップが 16 ペイン上限 / `MIN_PANE_WIDTH` / `MIN_PANE_HEIGHT` で拒否された場合、キュレーター → 窓口に escalate。典型シナリオは (a) 9 並列以上に到達、(b) ターミナル幅が balanced split の要件 (W ≥ 160) を満たさない、(c) ワーカー退役後の再派遣でレイアウト tree が想定と乖離。`new_tab` フォールバックは tab-scoped 制約のため不可 (happy-ryo/ccmux#71) |
 | `io_error` | PTY write / spawn / OS レベル失敗 | 1 サイクル spin して再試行。2 連続で同じ worker に出たら窓口に `IO_ERROR_DETECTED` で escalate |
 | `shutting_down` | ccmux 本体がシャットダウン中 | 監視ループを **即停止** する。claude-peers に `FOREMAN_STOPPING` を通知 |
 | `app_timeout` | ccmux 内部 App スレッドが応答しなかった | 1 サイクル spin (ccmux 再起動は管理者判断)。連続発生なら窓口にログ |
-| `parse` / `protocol` | 通常出ない (MCP / CLI が正しく組み立てる前提) | 発生時はバグ。journal に記録して窓口に `IPC_PROTOCOL_ERROR` で報告 |
+| `parse` / `protocol` | 通常出ない (MCP が正しく組み立てる前提) | 発生時はバグ。journal に記録して窓口に `IPC_PROTOCOL_ERROR` で報告 |
 | `internal` | ccmux 内部不変条件違反 (parser lock poison 等) | `app_timeout` と同じ扱い |
 
 ## MCP ツール特有の ok-return ルール
@@ -56,16 +35,11 @@ stderr に上記 1 行、exit status 非ゼロ。
 - `mcp__ccmux-peers__send_message`: 同上 → `"(message dropped — ccmux not reachable: <reason>)"`
 
 他の ccmux-peers ツール (`spawn_pane` / `close_pane` / `list_panes` / `focus_pane` / `new_tab` /
-`check_messages` / `set_summary` / `poll_events` / `inspect_pane`) は `require_connected` で
-非接続時に JSON-RPC error になる。この 2 つだけは**ハンドリング分岐を `[code]` パターンだけでなく
-`(no peers` / `(message dropped` 接頭辞**でも見るべき。
+`check_messages` / `set_summary` / `poll_events` / `inspect_pane` / `send_keys`) は `require_connected` で非接続時に JSON-RPC error になる。この 2 つだけは**ハンドリング分岐を `[code]` パターンだけでなく `(no peers` / `(message dropped` 接頭辞**でも見るべき。
 
 ## シェル側のハンドリング例
 
-### MCP ツール結果のパターンマッチ
-
-Claude Code 内で MCP ツール呼び出しを行い、結果テキストを受け取ったあと。典型的には tool result
-の `content[0].text` または JSON-RPC error message:
+MCP ツール呼び出し結果テキスト (`content[0].text` or JSON-RPC error message) に対する case 分岐:
 
 ```
 # MCP ツール呼び出し後、返ってきたテキストを $out に入れた状態を想定
@@ -96,111 +70,61 @@ case "$out" in
 esac
 ```
 
-### CLI 経路のハンドリング例（upstream merge まで使う）
-
-```bash
-out=$(ccmux send --name worker-foo --enter "ping" 2>&1)
-status=$?
-if [ $status -ne 0 ]; then
-  case "$out" in
-    *"[pane_not_found]"*|*"[pane_vanished]"*) mark_worker_pane_closed worker-foo ;;
-    *"[last_pane]"*) echo "last pane — leave for self-exit" ;;
-    *"[shutting_down]"*) echo "ccmux halting — foreman stopping"; exit 0 ;;
-    *"[io_error]"*|*"[app_timeout]"*|*"[internal]"*) log_journal "transient ccmux error: $out" ;;
-    *) log_journal "unexpected ccmux error: $out" ;;
-  esac
-fi
-```
-
-MCP / CLI で分岐テーブルは実質同一。違いは入力の取り方のみ。
-
 ## なぜ code か、substring ではなく
 
 - メッセージ本文は human-facing。理由なしで変更される可能性がある
   (e.g. "pane not found: Id(3)" → "pane 3 does not exist")
-- ccmux 側の契約については、以下を正本として参照する (このリポジトリ
-  内では検証不能な前提なので **外部依存** として扱うこと):
-  - `ccmux/src/ipc/mod.rs::err_code` の doc コメント — 公開 code の一覧
-    と ABI 安定性 (rename は deprecation window 付き) の明文
+- ccmux 側の契約については、以下を正本として参照する (このリポジトリ内では検証不能な前提なので **外部依存** として扱うこと):
+  - `ccmux/src/ipc/mod.rs::err_code` の doc コメント — 公開 code の一覧と ABI 安定性 (rename は deprecation window 付き) の明文
   - `ccmux/src/mcp_peer/mod.rs::fmt_code` — MCP 経由の `[<code>] <message>` 成形ロジック
-  - ccmux `Response::Err { message, code }` の wire schema — `code` は
-    `Option<String>` で、`skip_serializing_if = "Option::is_none"`
-- 未知の code は必ず非致命扱いにする — 将来 ccmux が新 code を追加しても
-  フォアマンが落ちないようにデフォルトブランチ必須
+  - ccmux `Response::Err { message, code }` の wire schema — `code` は `Option<String>` で、`skip_serializing_if = "Option::is_none"`
+- 未知の code は必ず非致命扱いにする — 将来 ccmux が新 code を追加してもフォアマンが落ちないようにデフォルトブランチ必須
 
-## 後方互換
+## Event stream — `poll_events` MCP
 
-MCP 経路 (`ccmux-peers` 0.12.0+) では常に `[<code>] <message>` が取れる前提で良い。
-CLI 経路の pre-0.5.7 後方互換は以下の通り:
-
-- **想定**: pre-0.5.7 の ccmux では wire Response に `code` フィールドが載らず、CLI 側も
-  `[<code>]` prefix なしでメッセージだけを stderr に吐く。この想定はこのリポジトリでは検証
-  できないので ccmux 本体のリリースノート (v0.5.7) で裏取りしてから運用する
-- code 無しで受けた場合は従来 substring match にフォールバック。aainc-ops 側で code を
-  扱う新しいコードは **両方** をサポートすべき (最低でも unknown code を無視しないロジック)
-
-## Event stream 側（CLI 併用、upstream #117 merge まで）
-
-MCP に `poll_events` tool が追加された (upstream happy-ryo/ccmux#117 / PR #120)。
-以降のスキル改修で `ccmux events` CLI から `mcp__ccmux-peers__poll_events` に切替予定
-（下流 Issue #24 / #25 で対応）。cleanup までは CLI 併用経路で扱う:
-
-`ccmux events --timeout 5s` が返す JSON 行のうち、フォアマンが扱う `type`:
-
-| type | 扱い |
-|---|---|
-| `pane_started` | 現状 skip (将来必要になれば追加) |
-| `pane_exited` | `role == "worker"` に絞って `WORKER_PANE_EXITED` 通知 |
-| `events_dropped` | `.state/journal.jsonl` に drop 件数を記録 |
-| `heartbeat` | skip (30 秒おきの keep-alive。ccmux 0.5.7+ が emit) |
-
-`jq -c 'select(.type == "pane_exited" and .role == "worker")'` は
-heartbeat / pane_started / events_dropped を暗黙に落とすので、
-**既存のフィルタ式は 0.5.7 以降も無修正で動く**。ただし
-`events_dropped` を journal に記録したいなら select 式を拡張する:
-
-```bash
-ccmux events --timeout 5s \
-  | jq -c 'select(
-      (.type == "pane_exited" and .role == "worker")
-      or .type == "events_dropped"
-    )'
-```
-
-### MCP 化後の等価ハンドリング（参考、#24 / #25 で実装）
-
-`poll_events` の types フィルタで同じ選別ができる:
+pane lifecycle (`pane_started` / `pane_exited` / `events_dropped` / `heartbeat` / forward-compat variants) は `mcp__ccmux-peers__poll_events` で cursor-based long-poll する:
 
 ```
 mcp__ccmux-peers__poll_events(
-  since=<cursor>,
+  since=<前回の next_since、初回は省略>,
   timeout_ms=5000,
   types=["pane_exited", "events_dropped"]
 )
 ```
 
-戻り値の `events[]` は role フィールドを含むので、さらに `role == "worker"` で絞る。
-`next_since` は次回呼び出しの `since` に流用する（idempotent resume）。
+戻り値の `events[]` は `type` / `role` / `name` / `id` / `ts` を含む。フォアマンは `role == "worker"` で絞り込んで `WORKER_PANE_EXITED` 通知する。`next_since` を次回 `since` に流用して idempotent resume。
 
-注: `poll_events` は **filter 不一致イベントが到着しても long-poll を中断して empty 返却する**
-挙動（ccmux PR #120 のドキュメント参照）。Foreman 監視ループでは空応答時に spin せず、
-`next_since` を保持したまま次のサイクルで再呼び出しする。
+### type 別の扱い
 
-## raw キー入力 (`send_keys` MCP、ccmux PR #122 / リリース後に利用可能)
+| type | 扱い |
+|---|---|
+| `pane_started` | 現状 skip (将来必要になれば追加) |
+| `pane_exited` | `role == "worker"` に絞って `WORKER_PANE_EXITED` 通知 |
+| `events_dropped` | `.state/journal.jsonl` に drop 件数を記録 (監視が追いついていないシグナル) |
+| `heartbeat` | 通常 `poll_events` のバッファに入らない (subscribe 内部で消化される) |
 
-現状 `ccmux send --text` / `ccmux send --enter` CLI で送っている raw キー送信は、
-ccmux PR #122（`send_keys` MCP、upstream CI green 待ち）で置換する。API 形状:
+### `types` フィルタの挙動
+
+`types` filter は cursor を全 type で advance させるので重複 scan なし。ただし **filter 不一致イベント到着で long-poll が early return** し、`events: []` + 進んだ cursor が返る (ccmux PR #120 参照)。Foreman 監視ループでは空応答時に spin せず、`next_since` を保持したまま次のサイクルで再呼び出しする。
+
+### 初回呼び出しのセマンティクス
+
+`since` 省略で「今以降のイベントだけ」を返す（過去の履歴を flood しない）。旧 `ccmux events --timeout` と同じ契約。
+
+## Raw キー入力 — `send_keys` MCP
+
+raw PTY キー送信は `mcp__ccmux-peers__send_keys` を使う。論理メッセージ配送の `send_message` とは**別物**（PTY に生バイトを書き込むので、そのペインで走っているアプリケーション側に見える）:
 
 ```
 mcp__ccmux-peers__send_keys(
-  target: string,           // pane name or id (list_panes と同じ解決規則)
-  text?: string,            // 送信するテキスト（optional）
-  keys?: string[],          // 特殊キー名の配列（optional、text と併用可）
-  enter?: boolean           // 末尾に Enter (CR, 0x0D) を付ける（optional）
+  target: string,           # pane name or id (list_panes と同じ解決規則)
+  text?: string,            # 送信するテキスト（optional）
+  keys?: string[],          # 特殊キー名の配列（optional、text と併用可、text の後に送られる）
+  enter?: boolean           # 末尾に Enter (CR, 0x0D) を付ける（optional、keys の後に送られる）
 )
 ```
 
-**対応キー語彙**（ccmux PR #122 より）:
+### 対応キー語彙
 
 - `Enter` / `Return` (CR, `\r` = 0x0D。`enter: true` と byte-identical)
 - `Tab`
@@ -214,12 +138,14 @@ mcp__ccmux-peers__send_keys(
 - `Space`
 - `Ctrl+<A-Z>`（例: `Ctrl+C`）
 
-**置換例**:
+未知の key 名は `-32602 invalid-params` error が返る。
 
-| 現行 CLI | upstream merge + リリース後の MCP 置換 |
+### 典型的な呼び出しパターン
+
+| 用途 | 呼び出し |
 |---|---|
-| `ccmux send --name X --enter ""` | `mcp__ccmux-peers__send_keys(target="X", enter=true)` |
-| `ccmux send --name X --enter "yes"` | `mcp__ccmux-peers__send_keys(target="X", text="yes", enter=true)` |
-| `ccmux send --name X $'\x1b[Z'` | `mcp__ccmux-peers__send_keys(target="X", keys=["Shift+Tab"])` |
-
-実際の置換は Issue #30 cleanup で ccmux リリース後に一括で実施する。現行 CLI 経路はそれまで維持。
+| 空 Enter（プロンプトへの返答） | `send_keys(target="X", enter=true)` |
+| "yes" + Enter（Plan 承認など） | `send_keys(target="X", text="yes", enter=true)` |
+| Shift+Tab（permission mode 切替） | `send_keys(target="X", keys=["Shift+Tab"])` |
+| Esc（モーダル escape） | `send_keys(target="X", keys=["Esc"])` |
+| Ctrl+C（走行中プロセス中断） | `send_keys(target="X", keys=["Ctrl+C"])` |

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -10,7 +10,13 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 {
   "permissions": {
     "allow": [
-      "Bash(ccmux:*)",
+      "Bash(ccmux --version)",
+      "Bash(ccmux --help)",
+      "Bash(ccmux --layout:*)",
+      "Bash(ccmux mcp install:*)",
+      "Bash(ccmux mcp uninstall:*)",
+      "Bash(ccmux mcp status:*)",
+      "Bash(ccmux mcp --help)",
       "mcp__claude-peers__set_summary",
       "mcp__claude-peers__list_peers",
       "mcp__claude-peers__send_message",
@@ -23,7 +29,10 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
       "mcp__ccmux-peers__spawn_pane",
       "mcp__ccmux-peers__close_pane",
       "mcp__ccmux-peers__focus_pane",
-      "mcp__ccmux-peers__new_tab"
+      "mcp__ccmux-peers__new_tab",
+      "mcp__ccmux-peers__inspect_pane",
+      "mcp__ccmux-peers__poll_events",
+      "mcp__ccmux-peers__send_keys"
     ]
   },
   "env": {
@@ -32,7 +41,15 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 }
 ```
 
-**注意**: `ccmux-peers` MCP ツールは `ccmux mcp install` を一度実行して user-scope に MCP サーバーを登録した後に利用可能になる。登録手順は README「ccmux MCP サーバーの登録」を参照。旧 `Bash(ccmux:*)` は段階移行中の併用（撤去時期は Issue #30 で管理）。
+**Bash permission 方針**: 旧 `Bash(ccmux:*)` glob は撤去済み（ccmux 0.14.0+ でペイン操作・ピア通信・event 購読・スクレイプ・raw キー送信がすべて MCP 化されたため）。残している `Bash(ccmux …)` は **運用コマンド限定**:
+
+- `ccmux --version` / `ccmux --help`: 環境確認
+- `ccmux --layout ops` 相当 (`--layout:*`): 初回レイアウト起動（`ccmux-layouts/ops.toml` 参照）
+- `ccmux mcp install` / `uninstall` / `status` / `--help`: MCP サーバー登録管理（`mcp__ccmux-peers__*` を使えるようにするための bootstrap）
+
+ペイン操作（`ccmux split` / `close` / `list` / `send` / `events` / `inspect` / `new-tab` 等）は MCP ツール (`mcp__ccmux-peers__*`) 経由で実施する。該当 Bash permission は含めない。
+
+**注意**: `ccmux-peers` MCP ツール 12 種は `ccmux mcp install` を一度実行して user-scope に MCP サーバーを登録した後に利用可能になる。登録手順は README「ccmux MCP サーバーの登録」を参照。
 
 ## 窓口 (`<repo>/.claude/settings.local.json`)
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -86,15 +86,15 @@ mcp__ccmux-peers__list_panes    # 現在のペイン一覧
    - a. フォアマンの `mcp__ccmux-peers__spawn_pane` 呼び出し結果テキストに `[split_refused]` が含まれない
    - b. Step 3-1b のアルゴリズムが選出した `target` / `direction` が、`list_panes` の直前スナップショットから rect ベースで再現可能
    - c. 起動直後の `mcp__ccmux-peers__list_panes` を **別ログファイル (例: `.state/verification/balanced-split-{timestamp}.log`)** に保存するか、その場で `role == "worker"` の `name` / `id` を記録し、`.state/journal.jsonl` の `worker_spawned` イベントと事後照合する
-3. k=4 到達時点でペイン配置を目視し、`pane-layout.md` 末尾の balanced split 典型挙動と一致するか確認（`foreman` 幅 ≈ W_f/2、ワーカー 4 個が 2×2 のグリッド近傍）。
-4. k=8 到達時点で同じく 8 並列の準 balanced な tree と一致するか確認。
-5. 9 人目のダミータスクを試し、フォアマンが claude-peers で窓口に `SPLIT_CAPACITY_EXCEEDED` を送信することを確認。**当該 9 人目のワーカーのみ派遣を中止し、フォアマン本体の監視ループは継続稼働**すること（`spawn_pane` は発行されず、`exit` などでフォアマンが落ちない）。
+3. 各 k 到達時点でペイン配置を `list_panes` で取得し、Step 3-1b のアルゴリズム（curator 特定 → role filter → foreman-curator 隣接判定 → direction 判定 → `new_w / new_h` 計算 → MIN_PANE 制約 → SECRETARY 保険条項 → metric sort）をスナップショットに対して手計算で再現できることを確認する。`pane-layout.md` の「ワーカーの balanced split 戦略」で述べている通り、rect ベース動的配置なので 2×2 や 2×4 のような固定グリッド形状は成功基準にしない。
+4. 9 人目のダミータスクを試し、フォアマンが claude-peers で窓口に `SPLIT_CAPACITY_EXCEEDED` を送信することを確認。**当該 9 人目のワーカーのみ派遣を中止し、フォアマン本体の監視ループは継続稼働**すること（`spawn_pane` は発行されず、`exit` などでフォアマンが落ちない）。
 
 > **注**: `.state/verification/balanced-split-{timestamp}.log` 等の検証用ログは一時ファイルなのでコミット対象外。`.state/*` は既存の `.gitignore` で除外済み。
 
 **期待結果**:
 - k=1〜8 で `[split_refused]` ゼロ
-- 8 並列時のワーカー最小幅 ≈ W_f/4、最小高 ≈ H_f/4
+- 各 k の配置が Step 3-1b の判定結果と一致（固定グリッド形状は要求しない、rect 動的配置が正しく動くこと）
+- MIN_PANE 制約（`new_w ≥ 20` / `new_h ≥ 5`）に触れない範囲で候補が空にならない
 - k=9 で明示的 escalate（silently fail しない）
 
 **確認コマンド**:
@@ -334,11 +334,18 @@ head -1 knowledge/raw/*.md  # <!-- curated --> マーカー確認
 
 ## 11. MCP 疎通テスト（環境確認）
 
-**目的**: ccmux-peers MCP の 12 ツールすべてが呼び出せるかを確認。
+**目的**: `ccmux-peers` MCP サーバが Claude Code に接続済みで、12 ツール全てが tool surface として登録されていることを確認し、副作用なしで呼び出せる 7 ツールについてはサンプル呼び出しで応答を検証する。副作用の大きい 5 ツール（`send_keys` / `spawn_pane` / `close_pane` / `focus_pane` / `new_tab`）の実動作確認は Test 1-10 の E2E フローでカバーされるため、本テストでは登録確認のみに留める。
 
 **手順**:
+
+### 11-a. 登録確認（12 ツール）
 1. `claude mcp list` で `ccmux-peers` が Connected を表示することを確認
-2. 以下の MCP ツールを順次呼び出し、エラーなく応答が返るか確認:
+2. 以下 12 ツールが Claude Code の tool surface に出現するか確認（MCP サーバが tools/list で返すツール名と一致する）:
+   - 副作用なし / 軽 side-effect: `list_panes` / `list_peers` / `set_summary` / `check_messages` / `send_message` / `poll_events` / `inspect_pane`
+   - 副作用大（ペイン / PTY 操作）: `spawn_pane` / `close_pane` / `focus_pane` / `new_tab` / `send_keys`
+
+### 11-b. 副作用なしツールの応答確認（7 ツール）
+以下の 7 ツールを順次呼び出し、エラーなく応答が返るか確認:
 
 | ツール | 呼び出し例 | 期待応答 |
 |---|---|---|
@@ -346,15 +353,17 @@ head -1 knowledge/raw/*.md  # <!-- curated --> マーカー確認
 | `list_peers` | 引数なし | 同タブ内 peer 一覧 or `(no peers — …)` |
 | `set_summary` | `summary="test"` | `Summary accepted (v1 stub: …)` |
 | `check_messages` | 引数なし | `No queued messages.` |
-| `send_message` | `to_id=<self>, message="ping"` | `Delivered to <self>.` or `(message dropped — …)` |
+| `send_message` | `to_id=<self の pane id or name>, message="ping"` | `Delivered to <target>.` or `(message dropped — …)` |
 | `poll_events` | `timeout_ms=0`（非ブロッキング drain） | `{next_since, events}` の JSON |
-| `inspect_pane` | `target="focused", lines=5, format="text"` | 画面末尾 5 行 |
-| `send_keys` | 疎通確認のため省略（副作用あり） | — |
-| `spawn_pane` / `close_pane` / `focus_pane` / `new_tab` | 疎通確認のため省略（副作用あり） | — |
+| `inspect_pane` | `target="focused", lines=5, format="text"` | 画面末尾 5 行 + `structuredContent` |
+
+### 11-c. 副作用大ツールは E2E テストに委譲
+`spawn_pane` / `close_pane` / `focus_pane` / `new_tab` は Test 1 / 2 / 3 / 4 の中で実動作確認される。`send_keys` は Test 1（開発チャネル確認 Enter 注入）と Test 2（Plan モード切替時の Shift+Tab / yes 送信）で確認される。
 
 **期待結果**:
-- 9 ツール（副作用なし + 軽 side-effect）がすべてエラーなく応答
-- エラー時は `[<code>] <msg>` 形式のテキストが得られる（例: `list_panes` が ccmux 未起動なら `[shutting_down]` 等）
+- 11-a: `claude mcp list` の出力に `ccmux-peers: … ✓ Connected` があり、12 ツールすべてが Claude Code の tool list に登録されている
+- 11-b: 7 ツールがすべてエラーなく応答、エラー時は `[<code>] <msg>` 形式のテキストが得られる（例: `list_panes` が ccmux 未起動なら `[shutting_down]` 等）
+- 11-c: 副作用大ツールは本テストでは実行せず、E2E テストでのカバレッジに委ねる
 
 **失敗パターンと対処**:
 - `claude mcp list` に `ccmux-peers` が出ない → `ccmux mcp install --force` 再実行

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -19,6 +19,7 @@
 **期待結果**:
 - `.state/org-state.md` が存在しないので、初回起動と判断される
 - `mcp__ccmux-peers__spawn_pane` でフォアマンペインが窓口の下に開き、その右にキュレーターペインが開く
+- Foreman / Curator 起動直後の「開発チャネル確認プロンプト」を `mcp__ccmux-peers__send_keys(target=<pane>, enter=true)` で Enter 注入して通過している（`org-start` SKILL Step 2 / Step 3 の手順）
 - キュレーターに `mcp__claude-peers__send_message` 経由で `/loop 30m /org-curate` の実行が指示される
 - 「初回起動です。何をしましょうか？」と報告される
 
@@ -27,6 +28,7 @@
 - スキルが認識されない → `.claude/skills/*/SKILL.md` のfrontmatter形式を確認
 - `/org-start` が発動しない → スキル名の競合やdescriptionを確認
 - `mcp__ccmux-peers__list_panes` で error → `ccmux mcp install --force` を再実行、`claude mcp list` で登録確認
+- `send_keys(enter=true)` が Enter 注入に失敗 → Foreman / Curator ペインが「Load development channel?」プロンプトで止まっているか確認、手動で Enter
 
 ---
 
@@ -46,6 +48,8 @@
 - 窓口がフォアマンに DELEGATE メッセージを送信し、すぐにユーザーとの対話に戻る
 - フォアマンが `mcp__ccmux-peers__spawn_pane` で同一タブ内にワーカーペインを派生する（`name="worker-{task_id}"`、balanced split 戦略は `pane-layout.md` に従う）
 - フォアマンが `mcp__ccmux-peers__poll_events(types=["pane_started"])` で起動完了を確認
+- ワーカー起動直後の「開発チャネル確認プロンプト」を `mcp__ccmux-peers__send_keys(target="worker-{task_id}", enter=true)` で Enter 注入して通過（`org-delegate` SKILL Step 3-2）
+- **Plan モード要の Worker 派遣時** (DELEGATE に「Plan承認後モード切替: 要」含む場合): Worker が Plan 作成 → APPROVAL_BLOCKED 通知 → 窓口側で **Plan 承認前に** `mcp__ccmux-peers__send_keys(target="worker-{task_id}", keys=["Shift+Tab"])` でモード切替 → `mcp__ccmux-peers__inspect_pane(lines=5, format="grid")` でステータスバーに「auto mode on」表示を確認 → `mcp__ccmux-peers__send_keys(target="worker-{task_id}", text="yes", enter=true)` で Plan 承認（`org-delegate` SKILL Step 3-7 / Step 5）
 - フォアマンが `mcp__claude-peers__send_message` 経由でワーカーに作業指示を送信する
 - フォアマンが `.state/workers/worker-{id}.md` を作成する
 - `.state/org-state.md` が作成/更新される

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -2,6 +2,8 @@
 
 各機能の動作確認手順。問題が見つかったらスキルやCLAUDE.mdを修正し、再テストする。
 
+**前提**: ccmux 0.14.0+ （`npm install -g ccmux-fork@0.14.0` 後、`ccmux mcp install --force` で `ccmux-peers` MCP サーバを user-scope 登録済み）。
+
 ---
 
 ## 1. 基本起動テスト
@@ -11,18 +13,20 @@
 **手順**:
 1. 任意の場所に本リポジトリを `git clone`
 2. clone先で `ccmux --layout ops` を実行 (窓口ペインが立ち上がる)
-3. 窓口の Claude Code で `/org-start` を実行
+3. 窓口の Claude Code で `mcp__ccmux-peers__list_panes` が疎通するか確認（Step 0 の MCP 有効性 chk）
+4. 窓口の Claude Code で `/org-start` を実行
 
 **期待結果**:
 - `.state/org-state.md` が存在しないので、初回起動と判断される
-- フォアマンペインが窓口の下に開き、その右にキュレーターペインが開く
-- キュレーターにclaude-peers経由で `/loop 30m /org-curate` の実行が指示される
+- `mcp__ccmux-peers__spawn_pane` でフォアマンペインが窓口の下に開き、その右にキュレーターペインが開く
+- キュレーターに `mcp__claude-peers__send_message` 経由で `/loop 30m /org-curate` の実行が指示される
 - 「初回起動です。何をしましょうか？」と報告される
 
 **失敗パターンと対処**:
 - CLAUDE.mdが読み込まれない → `.claude/` ディレクトリ配置を確認
 - スキルが認識されない → `.claude/skills/*/SKILL.md` のfrontmatter形式を確認
 - `/org-start` が発動しない → スキル名の競合やdescriptionを確認
+- `mcp__ccmux-peers__list_panes` で error → `ccmux mcp install --force` を再実行、`claude mcp list` で登録確認
 
 ---
 
@@ -30,7 +34,7 @@
 
 **目的**: ワーカーが正しく派遣され、作業を完了し、結果が報告されるか確認。
 
-**前提**: `ccmux --layout ops` で起動していること、claude-peers MCPが有効なこと。テスト1で `/org-start` 済み。
+**前提**: `ccmux --layout ops` で起動していること、claude-peers / ccmux-peers 両 MCP が有効なこと。テスト1で `/org-start` 済み。
 
 **手順**:
 1. 窓口Claudeにタスクを依頼する（例:「ブログに新しい記事を追加して」）
@@ -40,14 +44,15 @@
 **期待結果**:
 - プロジェクトが `registry/projects.md` に自動登録される
 - 窓口がフォアマンに DELEGATE メッセージを送信し、すぐにユーザーとの対話に戻る
-- フォアマンが `ccmux split` で同一タブ内にワーカーペインを派生する（`worker-{task_id}` 名、balanced split 戦略は `pane-layout.md` に従う）
-- フォアマンがclaude-peers経由でワーカーに作業指示を送信する
+- フォアマンが `mcp__ccmux-peers__spawn_pane` で同一タブ内にワーカーペインを派生する（`name="worker-{task_id}"`、balanced split 戦略は `pane-layout.md` に従う）
+- フォアマンが `mcp__ccmux-peers__poll_events(types=["pane_started"])` で起動完了を確認
+- フォアマンが `mcp__claude-peers__send_message` 経由でワーカーに作業指示を送信する
 - フォアマンが `.state/workers/worker-{id}.md` を作成する
 - `.state/org-state.md` が作成/更新される
 - `.state/journal.jsonl` にイベントが記録される
 - ワーカー完了後、claude-peers経由で**窓口に**報告が届く（フォアマンではなく窓口）
 - 窓口が結果を業務言語で人間に伝える（技術用語を避ける）
-- 窓口がフォアマンにペインクローズを依頼する
+- 窓口がフォアマンにペインクローズを依頼する（フォアマンは `mcp__ccmux-peers__close_pane(target="worker-{task_id}")` で破棄）
 
 **確認コマンド**:
 ```bash
@@ -57,28 +62,33 @@ ls .state/workers/
 cat registry/projects.md
 ```
 
+ペイン状態の確認は MCP ツールで:
+```
+mcp__ccmux-peers__list_panes    # 現在のペイン一覧
+```
+
 **失敗パターンと対処**:
-- ペインが開かない → `ccmux list` で現在のペイン状態を確認、`ccmux split --help` が実行できるか確認
-- claude-peersで通信できない → MCPサーバーの起動確認、peer IDの確認
+- ペインが開かない → `mcp__ccmux-peers__list_panes` で現在のペイン状態を確認、tool result の `[split_refused]` / `[pane_not_found]` を `references/ccmux-error-codes.md` で分岐
+- claude-peersで通信できない → `claude mcp list` で claude-peers / ccmux-peers 両方が Connected か確認、peer IDの確認
 - 状態ファイルが作成されない → org-delegateスキルの手順を見直し
 - ワーカーが指示を理解しない → instruction-template.md の記述を改善
 - プロジェクト名前解決が動かない → org-delegate Step 0 を見直し
 
 ### 2.1 balanced split スケール検証（4 並列 / 8 並列）
 
-**目的**: org-delegate Step 3 の balanced split lookup table が、4 並列・8 並列いずれも `[split_refused]` を発生させずに配置図通りの tree を生成することを実機確認する。
+**目的**: org-delegate Step 3 の rect ベース balanced split が、4 並列・8 並列いずれも `[split_refused]` を発生させずに期待通りの tree を生成することを実機確認する。
 
-**前提**: テスト 2 が通っていること。ターミナル幅 `W ≥ 160 cols`（`tput cols` で確認）。`pane-layout.md` の 4 並列 / 8 並列 ASCII 図を手元で開いておく。
+**前提**: テスト 2 が通っていること。ターミナル幅 `W ≥ 160 cols`（`tput cols` で確認）。`pane-layout.md` の「ワーカーの balanced split 戦略」セクションを手元で開いておく。
 
 **手順**:
 1. `tput cols` を実行し W を記録。160 未満なら検証不能としてスキップ or ターミナルを広げる。
 2. 窓口に互いに独立な 8 タスク（ダミーで良い。例: `echo-1` 〜 `echo-8` のような軽量タスク）を順次依頼。k=1〜8 それぞれが以下を満たすことを確認:
-   - a. フォアマンの `ccmux split` 呼び出しが `[split_refused]` を返さない
-   - b. Step 3-1 のシェルスニペットが返す `$target` / `$direction` が `pane-layout.md` の lookup table 通り
-   - c. 起動直後の `ccmux list --format json` を **別ログファイル (例: `.state/verification/balanced-split-{timestamp}.log`)** に保存するか、その場で `role == "worker"` の `name` / `id` を記録し、`.state/journal.jsonl` の `worker_spawned` イベントと事後照合する（`journal.jsonl` の schema に raw list スナップショットは含まれないので、verification 用途の一時ログとして分離する）
-3. k=4 到達時点でペイン配置を目視し、`pane-layout.md` の 4 並列 ASCII 図と一致するか確認（`foreman` 幅 ≈ W_f/2、ワーカー 4 個が 2×2 のグリッド）。
-4. k=8 到達時点で同じく 8 並列 ASCII 図（2×4 グリッド）と一致するか確認。
-5. 9 人目のダミータスクを試し、フォアマンが claude-peers で窓口に `SPLIT_CAPACITY_EXCEEDED` を送信することを確認。**当該 9 人目のワーカーのみ派遣を中止し、フォアマン本体の監視ループは継続稼働**すること（`ccmux split` は発行されず、`exit` などでフォアマンが落ちない）。
+   - a. フォアマンの `mcp__ccmux-peers__spawn_pane` 呼び出し結果テキストに `[split_refused]` が含まれない
+   - b. Step 3-1b のアルゴリズムが選出した `target` / `direction` が、`list_panes` の直前スナップショットから rect ベースで再現可能
+   - c. 起動直後の `mcp__ccmux-peers__list_panes` を **別ログファイル (例: `.state/verification/balanced-split-{timestamp}.log`)** に保存するか、その場で `role == "worker"` の `name` / `id` を記録し、`.state/journal.jsonl` の `worker_spawned` イベントと事後照合する
+3. k=4 到達時点でペイン配置を目視し、`pane-layout.md` 末尾の balanced split 典型挙動と一致するか確認（`foreman` 幅 ≈ W_f/2、ワーカー 4 個が 2×2 のグリッド近傍）。
+4. k=8 到達時点で同じく 8 並列の準 balanced な tree と一致するか確認。
+5. 9 人目のダミータスクを試し、フォアマンが claude-peers で窓口に `SPLIT_CAPACITY_EXCEEDED` を送信することを確認。**当該 9 人目のワーカーのみ派遣を中止し、フォアマン本体の監視ループは継続稼働**すること（`spawn_pane` は発行されず、`exit` などでフォアマンが落ちない）。
 
 > **注**: `.state/verification/balanced-split-{timestamp}.log` 等の検証用ログは一時ファイルなのでコミット対象外。`.state/*` は既存の `.gitignore` で除外済み。
 
@@ -89,17 +99,20 @@ cat registry/projects.md
 
 **確認コマンド**:
 ```bash
-# 各 k 到達時に記録
-ccmux list --format json | jq '.panes | map(select(.role == "worker")) | sort_by(.id) | .[] | {id, name}'
-tput cols  # ターミナル幅の記録
+tput cols                                # ターミナル幅の記録
 cat .state/journal.jsonl | grep worker_spawned
 ```
 
+ペイン状態は MCP で:
+```
+mcp__ccmux-peers__list_panes             # 各 k 到達時のスナップショット
+```
+
 **失敗パターンと対処**:
-- k=4 で `split_refused` → `tput cols` の値を確認。W < 160 なら balanced split table の要件未満。ターミナル拡大で再試行
-- k=3 で既に `split_refused` → foreman 直下に file-tree / preview が居座っていないか確認（これらが表示中だと `W_f` が 20〜40 cols 目減りする）
-- 配置が ASCII 図と乖離 → 前タスクで閉じ残ったワーカーの `ccmux close` 忘れ。`ccmux list` で role=worker の active が 0 からスタートしているか確認
-- k=9 で silently 動く → Step 3-1 の case 文の `*)` ブランチが発火していない。jq スニペットが `.exited` 等存在しないフィールドで全件を抜いていないか確認
+- k=4 で `[split_refused]` → `tput cols` の値を確認。W < 160 なら balanced split の要件未満。ターミナル拡大で再試行
+- k=3 で既に `[split_refused]` → foreman 直下に file-tree / preview が居座っていないか確認（これらが表示中だと `W_f` が 20〜40 cols 目減りする）
+- 配置が期待と乖離 → 前タスクで閉じ残ったワーカーの `close_pane` 忘れ。`list_panes` で role=worker の active が 0 からスタートしているか確認
+- k=9 で silently 動く → Step 3-1c (`SPLIT_CAPACITY_EXCEEDED` escalate) の分岐が発火していない。Step 3-1b の判定ロジックが「候補空」を正しく返しているか確認
 
 ---
 
@@ -114,11 +127,13 @@ cat .state/journal.jsonl | grep worker_spawned
 2. `/org-suspend` が発動するのを確認
 
 **期待結果**:
-- claude-peers経由でワーカーに SUSPEND メッセージが送信される
-- ワーカーが claude-peers 経由で状態を報告する (ccmux には pane text スクレイプ API が未実装なので、未応答ワーカーは git 状態ベースで推定する)
+- `mcp__claude-peers__send_message` 経由でワーカーに SUSPEND メッセージが送信される
+- ワーカーが claude-peers 経由で状態を報告する。未応答ワーカーは `mcp__ccmux-peers__inspect_pane(target="worker-{task_id}", format="text")` で画面内容を読み、git 状態と組み合わせて推定する
 - `.state/org-state.md` の Status が `SUSPENDED` になる
 - `.state/org-state.prev.md` にバックアップが作成される
-- claude-peers経由で全ピアに SHUTDOWN が送信される
+- `mcp__claude-peers__send_message` で全ピアに SHUTDOWN が送信される
+- `mcp__ccmux-peers__poll_events(types=["pane_exited"], timeout_ms=10000)` で pane_exited を待機、`role == "worker"` をまとめて消化
+- 残留ワーカーは `mcp__ccmux-peers__close_pane(target="worker-{task_id}")` でフォールバッククローズ
 - 全ワーカーペインが先に閉じられ、次にフォアマン、最後にキュレーターが閉じられる
 - 窓口が中断完了を報告する
 
@@ -129,8 +144,9 @@ cat .state/journal.jsonl | tail -1  # suspend イベントを確認
 ```
 
 **失敗パターンと対処**:
-- ワーカーがSUSPENDに応答しない → Phase 2のスクレイプが機能するか確認
-- ペインが閉じない → `ccmux close --name X` でペインを明示破棄しているか確認 (ccmux v0.5.8+)
+- ワーカーがSUSPENDに応答しない → `inspect_pane` で画面内容を確認、Phase 2 のスクレイプが機能するか確認
+- ペインが閉じない → `close_pane(target="X")` の結果テキストをチェック。`[pane_not_found]` / `[pane_vanished]` は skip 扱い
+- `[last_pane]` が出た → 最後の窓口ペインは自己 exit で自然終了させる（org-suspend は閉じない）
 - 状態ファイルが不完全 → org-suspendの手順を見直し
 
 ---
@@ -143,7 +159,7 @@ cat .state/journal.jsonl | tail -1  # suspend イベントを確認
 
 **手順**:
 1. 窓口Claudeの端末を**完全に閉じる**
-2. clone先で再度ClaudeCodeを起動する
+2. clone先で再度 `ccmux --layout ops` で起動する
 3. `/org-start` を実行する
 
 **期待結果**:
@@ -152,17 +168,17 @@ cat .state/journal.jsonl | tail -1  # suspend イベントを確認
 - 各作業ディレクトリのgit状態との照合結果が報告される
 - 再開計画が提案される
 - 人間の承認を待つ（勝手にワーカーを派遣しない）
-- フォアマンとキュレーターペインが再起動される（claude-peers経由で指示）
+- フォアマンとキュレーターペインが `mcp__ccmux-peers__spawn_pane` 経由で再起動される
 
 **確認ポイント**:
 - ブリーフィング内容が `.state/org-state.md` と一致するか
 - git状態の照合が正確か
-- フォアマンとキュレーターペインが起動しているか
+- フォアマンとキュレーターペインが起動しているか（`mcp__ccmux-peers__list_panes` で確認）
 
 **失敗パターンと対処**:
 - `/org-start` が状態を読まない → org-start スキルの Step 1 を見直し
 - 状態が不正確 → org-state.md のフォーマットまたはorg-suspendの書き込みを見直し
-- キュレーターが起動しない → org-start Step 2 のclaude-peers送信を確認
+- キュレーターが起動しない → org-start Step 3 の `send_message` / `spawn_pane` を確認
 
 ---
 
@@ -172,7 +188,7 @@ cat .state/journal.jsonl | tail -1  # suspend イベントを確認
 
 **手順**:
 1. テスト2の状態（ワーカー稼働中）で、**suspendせずに**端末を閉じる
-2. 再度ClaudeCodeを起動する
+2. 再度 `ccmux --layout ops` で起動する
 3. `/org-start` を実行する
 
 **期待結果**:
@@ -185,6 +201,7 @@ cat .state/journal.jsonl | tail -1  # suspend イベントを確認
 - ワーカーの自己申告による詳細な進捗情報は失われる
 - journal.jsonl の最後のエントリ以降の情報は失われる
 - git commitされていない作業は状態が不明確になる可能性がある
+- Foreman の `poll_events` cursor (`.state/foreman-event-cursor.txt`) 消失時は過去 5 秒分のイベントを取りこぼす可能性があるが、`list_panes` 突き合わせで回復可能
 
 **失敗パターンと対処**:
 - org-state.md が古すぎる → 定期スナップショットの頻度を上げる（org-delegateの進捗管理を強化）
@@ -248,13 +265,13 @@ head -1 knowledge/raw/*.md  # <!-- curated --> マーカー確認
 
 **手順**:
 1. `/org-start` を実行し、フォアマンとキュレーターのペインが起動されるか確認
-2. フォアマンがclaude-peers経由で役割指示を受け取っているか確認
-3. キュレーターがclaude-peers経由で `/loop 30m /org-curate` を実行しているか確認
+2. フォアマンが `mcp__claude-peers__send_message` 経由で役割指示を受け取っているか確認
+3. キュレーターが `mcp__claude-peers__send_message` 経由で `/loop 30m /org-curate` を実行しているか確認
 4. `knowledge/raw/` に閾値未満のファイルを置き、キュレーターがスキップするか確認
 5. 閾値以上に増やし、次の /loop サイクルで実行されるか確認
 
 **期待結果**:
-- `/org-start` 実行後に窓口の下にフォアマンとキュレーターが横並びで開く
+- `/org-start` 実行後に窓口の下にフォアマンとキュレーターが横並びで開く（`mcp__ccmux-peers__list_panes` で確認）
 - フォアマンが DELEGATE メッセージを待ち受ける状態になる
 - キュレーターが `/loop` を開始する
 - 30分ごとに org-curate が発動する
@@ -295,7 +312,7 @@ head -1 knowledge/raw/*.md  # <!-- curated --> マーカー確認
 **目的**: 起動→作業→中断→再開→知見整理の全サイクルが機能するか確認。
 
 **手順**:
-1. clone先でClaudeCodeを起動
+1. clone先でClaudeCodeを起動（`ccmux --layout ops`）
 2. `/org-start` を実行（初回起動）
 3. タスクを3つ依頼（ワーカー派遣が発生するもの）
 4. 各タスク完了後に振り返りが記録されることを確認
@@ -312,6 +329,37 @@ head -1 knowledge/raw/*.md  # <!-- curated --> マーカー確認
 - 状態の損失がない
 - 知見が蓄積・整理される
 - ダッシュボードで全体像が確認できる
+
+---
+
+## 11. MCP 疎通テスト（環境確認）
+
+**目的**: ccmux-peers MCP の 12 ツールすべてが呼び出せるかを確認。
+
+**手順**:
+1. `claude mcp list` で `ccmux-peers` が Connected を表示することを確認
+2. 以下の MCP ツールを順次呼び出し、エラーなく応答が返るか確認:
+
+| ツール | 呼び出し例 | 期待応答 |
+|---|---|---|
+| `list_panes` | 引数なし | 現在のペイン一覧テキスト |
+| `list_peers` | 引数なし | 同タブ内 peer 一覧 or `(no peers — …)` |
+| `set_summary` | `summary="test"` | `Summary accepted (v1 stub: …)` |
+| `check_messages` | 引数なし | `No queued messages.` |
+| `send_message` | `to_id=<self>, message="ping"` | `Delivered to <self>.` or `(message dropped — …)` |
+| `poll_events` | `timeout_ms=0`（非ブロッキング drain） | `{next_since, events}` の JSON |
+| `inspect_pane` | `target="focused", lines=5, format="text"` | 画面末尾 5 行 |
+| `send_keys` | 疎通確認のため省略（副作用あり） | — |
+| `spawn_pane` / `close_pane` / `focus_pane` / `new_tab` | 疎通確認のため省略（副作用あり） | — |
+
+**期待結果**:
+- 9 ツール（副作用なし + 軽 side-effect）がすべてエラーなく応答
+- エラー時は `[<code>] <msg>` 形式のテキストが得られる（例: `list_panes` が ccmux 未起動なら `[shutting_down]` 等）
+
+**失敗パターンと対処**:
+- `claude mcp list` に `ccmux-peers` が出ない → `ccmux mcp install --force` 再実行
+- `list_panes` が error → `ccmux --version` で 0.14.0 以上か確認、古ければ `npm install -g ccmux-fork@0.14.0`
+- `poll_events` が JSON を返さない → `mcp_peer/mod.rs` の実装に不整合、ccmux バージョン確認
 
 ---
 


### PR DESCRIPTION
## Summary
親 Epic #20 子 [10] (#30) の **PR 3/3（最終）**。`docs/verification.md` を ccmux 0.14.0+ の MCP 単一経路に書き直し。PR #40（Skill / `.foreman` 実置換）+ PR #41（references クリーンアップ）に続く最終仕上げ。

## 主な変更
- **前提を明記**: ccmux 0.14.0+ / `ccmux mcp install --force` 済み
- **Test 1 (基本起動)**: MCP 有効性 chk (`list_panes`) を手順に追加、`spawn_pane` 経由での Foreman/Curator 起動を期待結果に
- **Test 2 (org-delegate)**: `ccmux split` → `spawn_pane`、`ccmux list` → `list_panes`、`ccmux events pane_started` → `poll_events(types=["pane_started"])`、claude-peers も `mcp__claude-peers__send_message` で明示
- **Test 2.1 (balanced split k=1-8)**: rect ベース Step 3-1b 判定が「候補空」を正しく返すかに観点を変更。`[split_refused]` 判定も MCP tool result text ベースに
- **Test 3 (org-suspend)**: `ccmux close` → `close_pane`、`ccmux events pane_exited` → `poll_events(types=["pane_exited"])`、Phase 2 スクレイプを `inspect_pane` ベースに（旧「API 未実装」注記を削除）
- **Test 4 (org-resume)**: 再開時ペイン起動 `spawn_pane`、`list_panes` で確認、`send_message` で役割指示
- **Test 5 (クラッシュリカバリ)**: `poll_events` cursor (`.state/foreman-event-cursor.txt`) 消失時の許容劣化を追記
- **Test 8 (Foreman/Curator)**: `send_message` 明示、`list_panes` で確認
- **Test 11 (MCP 疎通テスト) 新規追加**: ccmux-peers 12 ツールの呼び出し確認表。副作用なし系 + 軽 side-effect 系の 9 ツールの期待応答を明示、副作用大の 4 ツール（`send_keys` / `spawn_pane` / `close_pane` / `focus_pane` / `new_tab`）は疎通確認スキップ。環境 sanity チェックとして機能

## 実環境での MCP 疎通確認（本コミット時点、secretary セッション単独で実施）
| ツール | 呼び出し | 結果 |
|---|---|---|
| `claude mcp list` | - | `ccmux-peers: ... ✓ Connected` |
| `list_panes` | 引数なし | secretary ペイン (id=1, role=secretary) 返却 |
| `check_messages` | 引数なし | `"No queued messages. Channel push is the primary delivery path in v1."` |
| `poll_events` | `timeout_ms=0` | `{"events":[],"next_since":"0"}` |
| `inspect_pane` | `target="focused", lines=3, format="text"` | 画面末尾 3 行 + structuredContent |

## 完全 E2E 検証（PR 本スコープ外）
Test 1-10 の完全 E2E（Foreman/Curator 起動 + Worker 派遣 + balanced split k=1-8 + Suspend/Resume サイクル）は別セッションで `ccmux --layout ops` + `/org-start` フルフローで実施する想定。本 PR は verification.md の手順更新と MCP 疎通確認までをスコープに含める。

## Scope / 不変
- テスト 1〜10 の構造・目的・期待結果は変更なし
- 失敗パターンと対処も CLI → MCP の置換のみ、内容は保持
- テスト結果記録フォーマットは不変

## Test plan
- [ ] `docs/verification.md` の旧 CLI 参照（`ccmux split` / `ccmux close` / `ccmux list --format json` / `ccmux events` / `ccmux inspect`）がゼロ
- [ ] MCP 疎通テスト (Test 11) の 9 ツール確認手順が実環境で再現できる
- [ ] Test 1-10 の手順が `docs/overview-technical.md` / `README.md` の現記述と整合している

## Review
親 Epic #20 の共通ポリシーに従い merge 前に **Codex レビュー**（制約プロンプト）。CI 通過したら merge。

## Refs
- **Closes #30**
- **Parent Epic #20**
- 先行 PR: #40 (skills/.foreman 実置換), #41 (references クリーンアップ)
- Depends on: ccmux-fork@0.14.0 (published 2026-04-22T06:06Z)