### PR TITLE
fix(ccmux-layouts): add explicit channel flag to ops Secretary command

### DIFF
--- a/ccmux-layouts/ops.toml
+++ b/ccmux-layouts/ops.toml
@@ -11,20 +11,11 @@
 # Override the Secretary startup command by editing `command` below
 # or setting a shell alias pointing at your preferred `claude` invocation.
 #
-# A bare `claude` (or `claude <args>`) is auto-upgraded by ccmux
-# to the Alt+P form, so `server:ccmux-peers` channel notifications
-# are delivered to the Secretary without an explicit
-# `--dangerously-load-development-channels` flag — this Secretary
-# launch below qualifies because `command = "claude"` is bare.
-#
-# IMPORTANT: the auto-upgrade only fires when the first token is
-# `claude`. Foreman / Curator / Workers spawned from org-start /
-# org-delegate use `cd <subdir> && claude ...` to switch cwd, so
-# auto-upgrade does NOT fire for them. Those roles must carry
-# `--dangerously-load-development-channels server:ccmux-peers`
-# explicitly — without it, `send_message` channel push never
-# reaches them and the org becomes unable to route instructions.
-# (See the fix restoring the flag after the #46 regression.)
+# The Secretary must carry `--dangerously-load-development-channels
+# server:ccmux-peers` explicitly — without it, `send_message` channel
+# push never reaches it and the org becomes unable to route
+# instructions. Foreman / Curator / Workers spawned from org-start /
+# org-delegate do the same for consistency.
 
 version = 1
 name = "ops"
@@ -33,4 +24,4 @@ name = "ops"
 type = "pane"
 id = "secretary"
 role = "secretary"
-command = "claude"
+command = "claude --dangerously-load-development-channels server:ccmux-peers"


### PR DESCRIPTION
## Summary
- `ccmux --layout ops` で起動した Secretary に `server:ccmux-peers` チャンネルが通っていなかった問題を修正
- bare `claude` の auto-upgrade に依存せず、Foreman/Curator/Worker と同じく `--dangerously-load-development-channels server:ccmux-peers` を明示的に付与
- 旧仕様（auto-upgrade 前提）の説明コメントを実態に合わせて更新

## Test plan
- [ ] `ccmux --layout ops` で起動し、Secretary に peer からの `send_message` 通知が届くことを確認
- [ ] `/org-start` 経由で Foreman/Curator を spawn し、既存挙動が維持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)