### PR TITLE
feat(settings): add ccmux-peers permissions to project settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,30 @@
 {
   "env": {
     "CLAUDE_CODE_NO_FLICKER": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(ccmux --version)",
+      "Bash(ccmux --help)",
+      "Bash(ccmux --layout:*)",
+      "Bash(ccmux mcp install:*)",
+      "Bash(ccmux mcp uninstall:*)",
+      "Bash(ccmux mcp status:*)",
+      "Bash(ccmux mcp --help)",
+      "mcp__ccmux-peers__set_summary",
+      "mcp__ccmux-peers__list_peers",
+      "mcp__ccmux-peers__send_message",
+      "mcp__ccmux-peers__check_messages",
+      "mcp__ccmux-peers__list_panes",
+      "mcp__ccmux-peers__spawn_pane",
+      "mcp__ccmux-peers__close_pane",
+      "mcp__ccmux-peers__focus_pane",
+      "mcp__ccmux-peers__new_tab",
+      "mcp__ccmux-peers__inspect_pane",
+      "mcp__ccmux-peers__poll_events",
+      "mcp__ccmux-peers__send_keys",
+      "mcp__ccmux-peers__spawn_claude_pane",
+      "mcp__ccmux-peers__set_pane_identity"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- プロジェクトスコープの `.claude/settings.json` に 14 種の `mcp__ccmux-peers__*` と ccmux 運用 Bash 7 種（`--version` / `--help` / `--layout:*` / `mcp install|uninstall|status|--help`）の allow list を追加し、Secretary ロールを `git clone` 直後にゼロコンフィグで動かせるようにする
- これまでは `/org-setup` 実行で user-scope `~/.claude/settings.json` に配置する運用だったため、初回 clone 〜 `/org-setup` 実行までの間に窓口 Claude が `ccmux-peers` MCP を呼ぶと auto モード分類器に拒否される問題があった
- `.claude/skills/org-setup/references/permissions.md` の「ユーザー共通設定は user-scope に置く」方針は維持。フォアマン / キュレーター / ワーカー用の設定は `/org-setup` 側の責務として引き続き user-scope 経由で適用される

## Test plan
- [x] `.claude/settings.json` が valid JSON である（PowerShell `ConvertFrom-Json` で検証済）
- [x] 新規 clone 環境で `ccmux --layout ops` 直後に窓口 Claude が `mcp__ccmux-peers__list_panes` / `list_peers` を許可プロンプトなしで呼び出せる
- [x] 既存環境で `/org-setup` 実行時、user-scope との重複で不具合が出ないこと（project-scope と user-scope は union として扱われる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)