### PR TITLE
feat(githooks): add pre-commit secret scanner (#69)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh text eol=lf
+.githooks/pre-commit text eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# pre-commit secret scanner (aainc-ops / Issue #69)
+# Scans newly-added lines in staged changes for common API key, token,
+# and PEM private key patterns and aborts the commit when one matches.
+#
+# Bypass (use sparingly): SKIP_SECRET_SCAN=1 git commit ...
+# Per-line allowlist: append the literal string "allow-secret" to the line
+# (for Markdown use an HTML comment, e.g. <!-- allow-secret -->).
+set -uo pipefail
+
+if [[ "${SKIP_SECRET_SCAN:-0}" == "1" ]]; then
+  echo "pre-commit: SKIP_SECRET_SCAN=1 set; secret scan skipped." >&2
+  exit 0
+fi
+
+# Directories whose files are excluded from scanning.
+# Ordered prefixes, matched with bash pattern matching below.
+EXCLUDED_PREFIXES=(
+  ".githooks/"
+  ".hooks/"
+  "tests/"
+  "knowledge/raw/"
+  "knowledge/curated/"
+)
+
+# name|ERE pattern. Names are shown in the violation report; patterns are
+# passed to `grep -E`. Keep patterns anchored enough to avoid common false
+# positives (short substrings of natural prose).
+PATTERNS=(
+  "OpenAI API key|sk-[A-Za-z0-9]{20,}"
+  "OpenAI project key|sk-proj-[A-Za-z0-9_-]{20,}"
+  "Anthropic API key|sk-ant-[A-Za-z0-9_-]{20,}"
+  "Google API key|AIza[0-9A-Za-z_-]{35}"
+  "GitHub PAT|ghp_[A-Za-z0-9]{36}"
+  "GitHub OAuth token|gho_[A-Za-z0-9]{36}"
+  "GitHub user-to-server token|ghu_[A-Za-z0-9]{36}"
+  "GitHub server-to-server token|ghs_[A-Za-z0-9]{36}"
+  "GitHub refresh token|ghr_[A-Za-z0-9]{36}"
+  "GitLab PAT|glpat-[A-Za-z0-9_-]{20,}"
+  "AWS access key ID|AKIA[0-9A-Z]{16}"
+  "Slack token|xox[abpr]-[A-Za-z0-9-]{10,}"
+  "PEM private key header|-----BEGIN (RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----"
+  "Generic secret assignment|(API_KEY|SECRET_KEY|PASSWORD|TOKEN)[[:space:]]*=[[:space:]]*[\"'][^\"']{12,}[\"']"
+)
+
+is_excluded() {
+  local file="$1" prefix
+  for prefix in "${EXCLUDED_PREFIXES[@]}"; do
+    if [[ "$file" == "$prefix"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Return 0 if $1 is a binary file according to git. git marks binary files
+# with '-' for both added and removed counts in --numstat.
+is_binary() {
+  local file="$1" numstat
+  numstat=$(git diff --cached --numstat -- "$file" 2>/dev/null | head -n 1)
+  [[ "$numstat" == "-"$'\t'"-"$'\t'* ]]
+}
+
+violations=()
+
+# Only scan Added/Copied/Modified/Renamed files (skip deletions).
+mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR -z \
+  | tr '\0' '\n' | sed '/^$/d')
+
+for file in "${files[@]}"; do
+  if is_excluded "$file"; then
+    continue
+  fi
+  if is_binary "$file"; then
+    continue
+  fi
+
+  # Walk added lines (those prefixed with '+' but not '+++') with line
+  # numbers derived from the hunk headers. -U0 keeps context out of the way.
+  diff_output=$(git diff --cached -U0 --no-color -- "$file" 2>/dev/null) || continue
+  [[ -z "$diff_output" ]] && continue
+
+  current_line=0
+  while IFS= read -r raw; do
+    if [[ "$raw" == @@* ]]; then
+      # @@ -a,b +c,d @@  -> c is the starting new-file line number
+      after=${raw#*+}
+      after=${after%% *}
+      start=${after%%,*}
+      current_line=$((start - 1))
+      continue
+    fi
+    if [[ "$raw" == +++* || "$raw" == ---* ]]; then
+      continue
+    fi
+    if [[ "$raw" == +* ]]; then
+      current_line=$((current_line + 1))
+      line_content=${raw:1}
+
+      # Per-line allowlist
+      if [[ "$line_content" == *"allow-secret"* ]]; then
+        continue
+      fi
+
+      for entry in "${PATTERNS[@]}"; do
+        name=${entry%%|*}
+        regex=${entry#*|}
+        if printf '%s\n' "$line_content" | grep -Eq -- "$regex"; then
+          # Truncate the leaked snippet so we don't re-echo the raw secret.
+          snippet=$(printf '%s' "$line_content" | cut -c1-20)
+          violations+=("$file:$current_line  [$name]  ${snippet}***")
+          break
+        fi
+      done
+    elif [[ "$raw" == " "* || "$raw" == "-"* ]]; then
+      # Context or removed lines are not counted against the new file.
+      :
+    fi
+  done <<< "$diff_output"
+done
+
+if (( ${#violations[@]} > 0 )); then
+  {
+    echo ""
+    echo "pre-commit: potential secret(s) detected in staged changes:"
+    for v in "${violations[@]}"; do
+      echo "  - $v"
+    done
+    echo ""
+    echo "If this is a legitimate example (e.g. README snippet), append the"
+    echo "marker 'allow-secret' to the line (HTML comment in Markdown) and"
+    echo "restage. To bypass temporarily: SKIP_SECRET_SCAN=1 git commit ..."
+    echo "or as a last resort: git commit --no-verify"
+  } >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,14 +13,15 @@ if [[ "${SKIP_SECRET_SCAN:-0}" == "1" ]]; then
   exit 0
 fi
 
-# Directories whose files are excluded from scanning.
-# Ordered prefixes, matched with bash pattern matching below.
+# Directories whose files are excluded from scanning. Only code directories
+# whose sole purpose is to host hook implementations or secret-shaped test
+# fixtures belong here. Content areas such as knowledge/ are intentionally
+# NOT excluded — that is where accidental pastes of real secrets are most
+# likely to land.
 EXCLUDED_PREFIXES=(
   ".githooks/"
   ".hooks/"
   "tests/"
-  "knowledge/raw/"
-  "knowledge/curated/"
 )
 
 # name|ERE pattern. Names are shown in the violation report; patterns are
@@ -32,6 +33,7 @@ PATTERNS=(
   "Anthropic API key|sk-ant-[A-Za-z0-9_-]{20,}"
   "Google API key|AIza[0-9A-Za-z_-]{35}"
   "GitHub PAT|ghp_[A-Za-z0-9]{36}"
+  "GitHub fine-grained PAT|github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}"
   "GitHub OAuth token|gho_[A-Za-z0-9]{36}"
   "GitHub user-to-server token|ghu_[A-Za-z0-9]{36}"
   "GitHub server-to-server token|ghs_[A-Za-z0-9]{36}"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ bash scripts/install-hooks.sh
 
 `core.hooksPath` が `.githooks/` に設定され、以降 `git commit` 直前に `.githooks/pre-commit` が走ります。AWS / GitHub（classic / fine-grained PAT 両対応）/ OpenAI / Anthropic / Google / GitLab / Slack 等の API キー、PEM 秘密鍵、典型的な `API_KEY=...` 代入がステージ差分に含まれると commit は拒否されます（詳細パターンは `.githooks/pre-commit` を参照）。
 
-- **既存の `core.hooksPath` がある環境**: 別パスが設定済みの場合、`scripts/install-hooks.sh` は黙って上書きせずエラー終了します。置き換えて良い場合は `--force` を付けて再実行してください。
+- **既存の repo-local `core.hooksPath` がある環境**: この repo の local 設定に別パスが入っている場合、`scripts/install-hooks.sh` は黙って上書きせずエラー終了します。置き換えて良い場合は `--force` を付けて再実行してください（global / system スコープの `core.hooksPath` は触らず、この repo の local 値のみを書き換えます）。
 - **誤検出の回避**: 該当行に `allow-secret` の文字列を含めて再 stage すると、その行は無視されます（Markdown なら HTML コメント `<!-- allow-secret -->` が読みやすい）。文字列は行頭・行中・行末のどこにあっても有効です。
 - **緊急バイパス**: `SKIP_SECRET_SCAN=1 git commit ...`（stderr に警告が出ます）。最後の手段として `git commit --no-verify` も有効ですが通常は使わないでください。
 - **ワーカー向け注記**: ワーカー Claude が commit しようとした際、secret を含むと hook がブロックします。対処は人間と同じく `allow-secret` マーカー or `SKIP_SECRET_SCAN=1` です。

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ claude mcp list                 # 一覧に ccmux-peers が含まれる
 
 互換性プリフライト（ccmux バージョンと 14 種 MCP ツール surface の一括チェック）は `tools/check_ccmux_compat.py` を参照。
 
+## Git Hooks（secret 漏洩防止）
+
+新しくクローンしたら、1 度だけ以下を実行してください:
+
+```bash
+bash scripts/install-hooks.sh
+```
+
+`core.hooksPath` が `.githooks/` に設定され、以降 `git commit` 直前に `.githooks/pre-commit` が走ります。AWS / GitHub / OpenAI / Anthropic / Google / GitLab / Slack 等の API キー、PEM 秘密鍵、典型的な `API_KEY=...` 代入がステージ差分に含まれると commit は拒否されます（詳細パターンは `.githooks/pre-commit` を参照）。
+
+- **誤検出の回避**: 該当行の末尾に `allow-secret` マーカーを付けて再 stage すると、その行は無視されます。Markdown なら HTML コメント `<!-- allow-secret -->` を使ってください。
+- **緊急バイパス**: `SKIP_SECRET_SCAN=1 git commit ...`（stderr に警告が出ます）。最後の手段として `git commit --no-verify` も有効ですが通常は使わないでください。
+- **ワーカー向け注記**: ワーカー Claude が commit しようとした際、secret を含むと hook がブロックします。対処は人間と同じく `allow-secret` マーカー or `SKIP_SECRET_SCAN=1` です。
+
 ## 仕組み
 
 ```

--- a/README.md
+++ b/README.md
@@ -98,11 +98,13 @@ claude mcp list                 # 一覧に ccmux-peers が含まれる
 bash scripts/install-hooks.sh
 ```
 
-`core.hooksPath` が `.githooks/` に設定され、以降 `git commit` 直前に `.githooks/pre-commit` が走ります。AWS / GitHub / OpenAI / Anthropic / Google / GitLab / Slack 等の API キー、PEM 秘密鍵、典型的な `API_KEY=...` 代入がステージ差分に含まれると commit は拒否されます（詳細パターンは `.githooks/pre-commit` を参照）。
+`core.hooksPath` が `.githooks/` に設定され、以降 `git commit` 直前に `.githooks/pre-commit` が走ります。AWS / GitHub（classic / fine-grained PAT 両対応）/ OpenAI / Anthropic / Google / GitLab / Slack 等の API キー、PEM 秘密鍵、典型的な `API_KEY=...` 代入がステージ差分に含まれると commit は拒否されます（詳細パターンは `.githooks/pre-commit` を参照）。
 
-- **誤検出の回避**: 該当行の末尾に `allow-secret` マーカーを付けて再 stage すると、その行は無視されます。Markdown なら HTML コメント `<!-- allow-secret -->` を使ってください。
+- **既存の `core.hooksPath` がある環境**: 別パスが設定済みの場合、`scripts/install-hooks.sh` は黙って上書きせずエラー終了します。置き換えて良い場合は `--force` を付けて再実行してください。
+- **誤検出の回避**: 該当行に `allow-secret` の文字列を含めて再 stage すると、その行は無視されます（Markdown なら HTML コメント `<!-- allow-secret -->` が読みやすい）。文字列は行頭・行中・行末のどこにあっても有効です。
 - **緊急バイパス**: `SKIP_SECRET_SCAN=1 git commit ...`（stderr に警告が出ます）。最後の手段として `git commit --no-verify` も有効ですが通常は使わないでください。
 - **ワーカー向け注記**: ワーカー Claude が commit しようとした際、secret を含むと hook がブロックします。対処は人間と同じく `allow-secret` マーカー or `SKIP_SECRET_SCAN=1` です。
+- **`.hooks/` との責任境界**: この `.githooks/pre-commit` は **git が `git commit` 直前に起動する** レイヤ。`.hooks/*.sh`（`block-git-push.sh` 等）は **Claude Code が Edit/Write/Bash ツールを呼ぶ前に起動する PreToolUse レイヤ**。対象タイミングが異なるため両者は直交し、併用を前提としています。
 
 ## 仕組み
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,8 +1,27 @@
 #!/usr/bin/env bash
 # Install git hooks for this repository (aainc-ops / Issue #69).
 # Points git at .githooks/ so contributors share the same pre-commit
-# secret scanner. Idempotent: safe to run any number of times.
+# secret scanner. Safe to run repeatedly when no conflicting hook path
+# is configured; use --force to replace an existing non-.githooks path.
 set -euo pipefail
+
+force=0
+for arg in "$@"; do
+  case "$arg" in
+    -f|--force) force=1 ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: scripts/install-hooks.sh [--force]
+
+Sets core.hooksPath to .githooks so git invokes the shared pre-commit
+secret scanner. Refuses to overwrite an existing value that points
+somewhere other than .githooks unless --force is given.
+USAGE
+      exit 0
+      ;;
+    *) echo "install-hooks: unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
 
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
 if [[ -z "$repo_root" ]]; then
@@ -18,6 +37,16 @@ hook_file="$hook_dir/pre-commit"
 if [[ ! -f "$hook_file" ]]; then
   echo "install-hooks: $hook_file not found under $repo_root." >&2
   exit 1
+fi
+
+current=$(git config --get core.hooksPath || true)
+if [[ -n "$current" && "$current" != "$hook_dir" ]]; then
+  if [[ "$force" != "1" ]]; then
+    echo "install-hooks: core.hooksPath is already set to '$current'." >&2
+    echo "install-hooks: refusing to overwrite; pass --force to replace it." >&2
+    exit 1
+  fi
+  echo "install-hooks: --force set; replacing core.hooksPath '$current' -> '$hook_dir'." >&2
 fi
 
 # chmod +x is a no-op on Windows filesystems but harmless; git-for-windows

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -39,22 +39,27 @@ if [[ ! -f "$hook_file" ]]; then
   exit 1
 fi
 
-current=$(git config --get core.hooksPath || true)
-if [[ -n "$current" && "$current" != "$hook_dir" ]]; then
+# Only inspect the repo-local value. `git config --get` without a scope
+# flag also reports global/system values, which would cause this script
+# to complain about (and, with --force, silently override) an
+# organization-wide core.hooksPath. We only want to guard against a
+# conflicting repo-local value here.
+current_local=$(git config --local --get core.hooksPath 2>/dev/null || true)
+if [[ -n "$current_local" && "$current_local" != "$hook_dir" ]]; then
   if [[ "$force" != "1" ]]; then
-    echo "install-hooks: core.hooksPath is already set to '$current'." >&2
+    echo "install-hooks: repo-local core.hooksPath is already '$current_local'." >&2
     echo "install-hooks: refusing to overwrite; pass --force to replace it." >&2
     exit 1
   fi
-  echo "install-hooks: --force set; replacing core.hooksPath '$current' -> '$hook_dir'." >&2
+  echo "install-hooks: --force set; replacing repo-local core.hooksPath '$current_local' -> '$hook_dir'." >&2
 fi
 
 # chmod +x is a no-op on Windows filesystems but harmless; git-for-windows
 # tracks the executable bit via the index.
 chmod +x "$hook_file" 2>/dev/null || true
 
-git config core.hooksPath "$hook_dir"
+git config --local core.hooksPath "$hook_dir"
 
-configured=$(git config --get core.hooksPath || true)
-echo "install-hooks: core.hooksPath = ${configured:-<unset>}"
+configured=$(git config --local --get core.hooksPath 2>/dev/null || true)
+echo "install-hooks: core.hooksPath (repo-local) = ${configured:-<unset>}"
 echo "install-hooks: pre-commit secret scanner enabled."

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Install git hooks for this repository (aainc-ops / Issue #69).
+# Points git at .githooks/ so contributors share the same pre-commit
+# secret scanner. Idempotent: safe to run any number of times.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$repo_root" ]]; then
+  echo "install-hooks: not inside a git repository." >&2
+  exit 1
+fi
+
+cd "$repo_root"
+
+hook_dir=".githooks"
+hook_file="$hook_dir/pre-commit"
+
+if [[ ! -f "$hook_file" ]]; then
+  echo "install-hooks: $hook_file not found under $repo_root." >&2
+  exit 1
+fi
+
+# chmod +x is a no-op on Windows filesystems but harmless; git-for-windows
+# tracks the executable bit via the index.
+chmod +x "$hook_file" 2>/dev/null || true
+
+git config core.hooksPath "$hook_dir"
+
+configured=$(git config --get core.hooksPath || true)
+echo "install-hooks: core.hooksPath = ${configured:-<unset>}"
+echo "install-hooks: pre-commit secret scanner enabled."

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Tests for scripts/install-hooks.sh (Issue #69).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SRC="$REPO_ROOT/scripts/install-hooks.sh"
+HOOK_SRC="$REPO_ROOT/.githooks/pre-commit"
+
+PASS=0; FAIL=0; TEST_NUM=0
+TMPDIRS=()
+cleanup() {
+  local d
+  for d in "${TMPDIRS[@]}"; do
+    [[ -d "$d" ]] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+assert_exit() {
+  local expected="$1" actual="$2" desc="$3"
+  ((TEST_NUM++))
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "ok $TEST_NUM - $desc"
+    ((PASS++))
+  else
+    echo "not ok $TEST_NUM - $desc (expected exit $expected, got $actual)"
+    ((FAIL++))
+  fi
+}
+
+assert_config_eq() {
+  local expected="$1" actual="$2" desc="$3"
+  ((TEST_NUM++))
+  if [[ "$actual" == "$expected" ]]; then
+    echo "ok $TEST_NUM - $desc"
+    ((PASS++))
+  else
+    echo "not ok $TEST_NUM - $desc (expected '$expected', got '$actual')"
+    ((FAIL++))
+  fi
+}
+
+make_repo() {
+  local d
+  d=$(mktemp -d)
+  TMPDIRS+=("$d")
+  git -C "$d" init -q
+  mkdir -p "$d/.githooks" "$d/scripts"
+  cp "$HOOK_SRC" "$d/.githooks/pre-commit"
+  cp "$INSTALL_SRC" "$d/scripts/install-hooks.sh"
+  chmod +x "$d/.githooks/pre-commit" "$d/scripts/install-hooks.sh"
+  echo "$d"
+}
+
+# 1. Fresh repo: installs cleanly, sets config.
+repo=$(make_repo)
+ec=0
+( cd "$repo" && bash scripts/install-hooks.sh >/dev/null 2>&1 ) || ec=$?
+assert_exit 0 "$ec" "install on fresh repo succeeds"
+cfg=$(git -C "$repo" config --get core.hooksPath || true)
+assert_config_eq ".githooks" "$cfg" "core.hooksPath is set to .githooks"
+
+# 2. Re-run is idempotent when value already matches.
+ec=0
+( cd "$repo" && bash scripts/install-hooks.sh >/dev/null 2>&1 ) || ec=$?
+assert_exit 0 "$ec" "re-install with matching config succeeds"
+
+# 3. Pre-existing different value: refuses without --force.
+repo=$(make_repo)
+git -C "$repo" config core.hooksPath custom-hooks
+ec=0
+( cd "$repo" && bash scripts/install-hooks.sh >/dev/null 2>&1 ) || ec=$?
+assert_exit 1 "$ec" "install refuses to overwrite existing non-.githooks path"
+cfg=$(git -C "$repo" config --get core.hooksPath || true)
+assert_config_eq "custom-hooks" "$cfg" "core.hooksPath was preserved"
+
+# 4. --force overwrites.
+ec=0
+( cd "$repo" && bash scripts/install-hooks.sh --force >/dev/null 2>&1 ) || ec=$?
+assert_exit 0 "$ec" "install --force overwrites existing value"
+cfg=$(git -C "$repo" config --get core.hooksPath || true)
+assert_config_eq ".githooks" "$cfg" "core.hooksPath updated to .githooks after --force"
+
+# 5. Outside a git repo: exits non-zero.
+d=$(mktemp -d); TMPDIRS+=("$d")
+cp "$INSTALL_SRC" "$d/install-hooks.sh"
+ec=0
+( cd "$d" && bash install-hooks.sh >/dev/null 2>&1 ) || ec=$?
+assert_exit 1 "$ec" "running outside a git repo fails"
+
+# 6. Unknown argument is rejected.
+repo=$(make_repo)
+ec=0
+( cd "$repo" && bash scripts/install-hooks.sh --bogus >/dev/null 2>&1 ) || ec=$?
+assert_exit 2 "$ec" "unknown argument exits with code 2"
+
+echo ""
+echo "# $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/tests/test-precommit-secret-scanner.sh
+++ b/tests/test-precommit-secret-scanner.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Tests for .githooks/pre-commit (Issue #69 secret scanner).
+# Creates throwaway git repositories in $TMPDIR, stages concrete inputs, and
+# invokes the hook exactly how git would during `git commit`.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK_SRC="$REPO_ROOT/.githooks/pre-commit"
+
+PASS=0; FAIL=0; TEST_NUM=0
+TMPDIRS=()
+cleanup() {
+  local d
+  for d in "${TMPDIRS[@]}"; do
+    [[ -d "$d" ]] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+assert_exit() {
+  local expected="$1" actual="$2" desc="$3"
+  ((TEST_NUM++))
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "ok $TEST_NUM - $desc"
+    ((PASS++))
+  else
+    echo "not ok $TEST_NUM - $desc (expected exit $expected, got $actual)"
+    ((FAIL++))
+  fi
+}
+
+assert_stderr_contains() {
+  local pattern="$1" file="$2" desc="$3"
+  ((TEST_NUM++))
+  if grep -qF "$pattern" "$file" 2>/dev/null; then
+    echo "ok $TEST_NUM - $desc"
+    ((PASS++))
+  else
+    echo "not ok $TEST_NUM - $desc (stderr did not contain '$pattern')"
+    ((FAIL++))
+  fi
+}
+
+# Build a fresh git repo, wire the hook in, and echo its path.
+make_repo() {
+  local d
+  d=$(mktemp -d)
+  TMPDIRS+=("$d")
+  git -C "$d" init -q
+  git -C "$d" config user.email "test@example.com"
+  git -C "$d" config user.name "tester"
+  git -C "$d" config commit.gpgsign false
+  mkdir -p "$d/.githooks"
+  cp "$HOOK_SRC" "$d/.githooks/pre-commit"
+  chmod +x "$d/.githooks/pre-commit"
+  git -C "$d" config core.hooksPath .githooks
+  echo "$d"
+}
+
+# Stage $2 as $3 inside repo $1 and attempt a commit.  Writes stderr to $4
+# and returns the exit code via stdout.
+run_commit() {
+  local repo="$1" content="$2" path="$3" stderr_file="$4"
+  local file="$repo/$path"
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$content" > "$file"
+  git -C "$repo" add -- "$path"
+  local ec=0
+  git -C "$repo" commit -m "test" >/dev/null 2>"$stderr_file" || ec=$?
+  echo "$ec"
+}
+
+# ---- Block cases ----
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'aws_key = "AKIAABCDEFGHIJKLMNOP"' "src/aws.txt" "$stderr")
+assert_exit 1 "$ec" "AWS access key id is blocked"
+assert_stderr_contains "AWS access key ID" "$stderr" "AWS stderr names the pattern"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123' "src/gh.txt" "$stderr")
+assert_exit 1 "$ec" "GitHub PAT is blocked"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'ANTHROPIC=sk-ant-abcdefghijklmnopqrstuvwxyz01234567' "src/an.txt" "$stderr")
+assert_exit 1 "$ec" "Anthropic API key is blocked"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'OPENAI=sk-abcdefghijklmnopqrstuvwxyz012345' "src/oa.txt" "$stderr")
+assert_exit 1 "$ec" "OpenAI API key is blocked"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" '-----BEGIN RSA PRIVATE KEY-----' "src/key.pem" "$stderr")
+assert_exit 1 "$ec" "PEM private key header is blocked"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'API_KEY = "supersecretvalue1234"' "src/assign.py" "$stderr")
+assert_exit 1 "$ec" "Generic API_KEY assignment is blocked"
+
+# ---- Allow cases ----
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'print("hello world")' "src/app.py" "$stderr")
+assert_exit 0 "$ec" "Plain code passes"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'Example: AKIAIOSFODNN7EXAMPLE  <!-- allow-secret -->' "docs/readme.md" "$stderr")
+assert_exit 0 "$ec" "allow-secret marker lets docs through"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123' "tests/fixtures/secret.txt" "$stderr")
+assert_exit 0 "$ec" "Files under tests/ are excluded"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'AKIAABCDEFGHIJKLMNOP' ".hooks/sample.sh" "$stderr")
+assert_exit 0 "$ec" "Files under .hooks/ are excluded"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'API_KEY = "short"' "src/short.py" "$stderr")
+assert_exit 0 "$ec" "Short generic assignment below length threshold passes"
+
+# ---- Bypass env var ----
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+file="$repo/src/bypass.txt"
+mkdir -p "$(dirname "$file")"
+printf '%s\n' 'AKIAABCDEFGHIJKLMNOP' > "$file"
+git -C "$repo" add -- "src/bypass.txt"
+ec=0
+SKIP_SECRET_SCAN=1 git -C "$repo" commit -m "bypass" >/dev/null 2>"$stderr" || ec=$?
+assert_exit 0 "$ec" "SKIP_SECRET_SCAN=1 bypasses the scan"
+assert_stderr_contains "SKIP_SECRET_SCAN=1" "$stderr" "Bypass logs a warning to stderr"
+
+echo ""
+echo "# $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/tests/test-precommit-secret-scanner.sh
+++ b/tests/test-precommit-secret-scanner.sh
@@ -80,7 +80,11 @@ assert_stderr_contains "AWS access key ID" "$stderr" "AWS stderr names the patte
 
 repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
 ec=$(run_commit "$repo" 'token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123' "src/gh.txt" "$stderr")
-assert_exit 1 "$ec" "GitHub PAT is blocked"
+assert_exit 1 "$ec" "GitHub classic PAT is blocked"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'token: github_pat_11ABCDEFG0abcdefghijkl_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345678' "src/gh2.txt" "$stderr")
+assert_exit 1 "$ec" "GitHub fine-grained PAT is blocked"
 
 repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
 ec=$(run_commit "$repo" 'ANTHROPIC=sk-ant-abcdefghijklmnopqrstuvwxyz01234567' "src/an.txt" "$stderr")
@@ -119,6 +123,16 @@ assert_exit 0 "$ec" "Files under .hooks/ are excluded"
 repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
 ec=$(run_commit "$repo" 'API_KEY = "short"' "src/short.py" "$stderr")
 assert_exit 0 "$ec" "Short generic assignment below length threshold passes"
+
+# ---- knowledge/ is now scanned (no longer excluded) ----
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'aws_key = "AKIAABCDEFGHIJKLMNOP"' "knowledge/raw/note.md" "$stderr")
+assert_exit 1 "$ec" "Secrets inside knowledge/raw/ are still blocked"
+
+repo=$(make_repo); stderr=$(mktemp); TMPDIRS+=("$stderr")
+ec=$(run_commit "$repo" 'aws_key = "AKIAABCDEFGHIJKLMNOP"' "knowledge/curated/note.md" "$stderr")
+assert_exit 1 "$ec" "Secrets inside knowledge/curated/ are still blocked"
 
 # ---- Bypass env var ----
 


### PR DESCRIPTION
Closes #69

## 概要
public リポでの鍵/トークン混入を防ぐための **pre-commit secret スキャナ** を導入。`sugiyama34/cc_harness` から取り込んだ `.githooks/pre-commit` + `scripts/install-hooks.sh` を当リポのファイル命名・シェル記法規約に合わせて再構成、Windows + Git Bash 環境も動作確認済。

## 新規
- `.githooks/pre-commit` — bash、ステージ diff の**新規追加行のみ**スキャン。AWS / GitHub (classic + fine-grained PAT) / OpenAI / Anthropic / Google / GitLab / Slack の API キー、PEM 秘密鍵、汎用 `API_KEY` 代入パターンを検出
- `scripts/install-hooks.sh` — `git config core.hooksPath .githooks` を冪等に設定、`--force` で既存 repo-local 値を上書き
- `tests/test-precommit-secret-scanner.sh` — 17 ケース
- `tests/test-install-hooks.sh` — 9 ケース
- `knowledge/raw/2026-04-24-precommit-secret-scanner.md` — Git Bash 固有の実装知見（is_binary 判定の差し替え、`git config --get` スコープ問題など）

## 変更
- `.gitattributes` — `.githooks/pre-commit text eol=lf` を 1 行追加（Windows での CRLF 化防止）
- `README.md` — 「Git Hooks（secret 漏洩防止）」セクションを新設

## False positive 対策
- **新規追加行のみ**スキャン（既存例示は再検査しない）
- `.githooks/` / `.hooks/` / `tests/` は自動スキップ
- 行内 `allow-secret` マーカーでスキップ
- `SKIP_SECRET_SCAN=1` で緊急バイパス（stderr に警告）

## Windows + Git Bash
- `.gitattributes` で LF 強制、shebang `#!/usr/bin/env bash`
- `is_binary` 判定を `git diff --numstat` に差し替え（Git Bash の `$'\x00'` 引数問題を回避）
- end-to-end の手動 block/bypass 確認済

## 整合性チェック（実装前）
- `.githooks/` / `scripts/` / `core.hooksPath`: いずれも未設定で衝突なし
- 既存 `.hooks/`（PreToolUse 層）とは直交。README で責任境界を明記
- GitHub Actions に secret scan 系なし

## 受け入れ条件
- [x] 新クローンで `bash scripts/install-hooks.sh` 一発で hook が有効化
- [x] AWS / GitHub (classic & fine-grained) / OpenAI / Anthropic / Google / GitLab / Slack API キー、PEM 秘密鍵、汎用 `API_KEY` 代入を検出
- [x] false positive で通常 commit が止まらない（allow-secret マーカー、バイパス、除外ディレクトリ）
- [x] Windows + Git Bash 動作

## Codex セルフレビュー
- 1 周目: Blocker 1（knowledge/ をスキャン除外にしていた）/ Major 2（fine-grained PAT 未対応、install-hooks 上書き挙動）/ Minor 2 → `3c0591c` で修正
- 2 周目: Major 1（`git config --get` のスコープ問題）→ `deb2770` で repo-local 限定に修正
- 3 周目: Blocker / Major ゼロ、Clean

## commits
- `2a9a35d` feat(githooks): add pre-commit secret scanner (#69)
- `3c0591c` fix(githooks): address Codex review (knowledge scan, fine-grained PAT, --force)
- `deb2770` fix(install-hooks): scope core.hooksPath checks to repo-local

## Test plan
- `tests/test-precommit-secret-scanner.sh`: 17/17 pass
- `tests/test-install-hooks.sh`: 9/9 pass
- `tests/run-all.sh` 全体: 106/108（失敗 2 件は `test-check-worker-boundary.sh` の既存問題で本 PR 無関係）

## 関連（Issue #70 への引き継ぎ）
Issue #70（PreToolUse フック + `permissions.deny` / sandbox 段階導入）が本 PR を前提としているため、merge 後に #70 ワーカーを派遣予定。本 PR は **commit 直前** の secret 混入防止層、#70 は **ツール呼び出し時** の dangerous action ブロック層として役割分担。