### PR TITLE
docs(org-delegate): add tracked-file precheck to pattern selection (#132)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -115,23 +115,45 @@ description: >
   - **参考 work-skill**（Step 0.5 でマッチしたもの）
 - 注意: タスク説明にファイルパスを含める場合、それがワーカー作業ディレクトリからの相対パスであることを明記する。registry/projects.md の「パス」列の値をそのまま成果物パスとして指示しない（ワーカーが別の場所にパスを作成する原因になる）
 
-### 事前チェック: 対象ファイルが git tracked か
+### 事前チェック: 対象ファイルが gitignored か
 
-判定フローに入る前に、編集対象ファイルが git で追跡されているか確認する。
-**「対象ファイル」は窓口がタスク説明から抽出する**（依頼文・Issue 本文・ユーザー発話の中で明示されたパス。機械的判定はしない）。対象ファイルが特定できないタスク（純粋な調査・新規作成など）はこのチェックをスキップして通常判定に進む。
+判定フローに入る前に、編集対象ファイルが `.gitignore` で除外されていないか確認する。
+**「対象ファイル」は窓口がタスク説明から抽出する**（依頼文・Issue 本文・ユーザー発話の中で明示されたパス。機械的判定はしない）。対象ファイルが特定できないタスク（純粋な調査、対象パス未定の新規作成など）はこのチェックをスキップして通常判定に進む。
 
-対象ファイルが特定できた場合、project_path（registry/projects.md のパス）で:
+#### 適用条件
+
+このチェックは **ローカルに git repo が既に存在するプロジェクトでのみ実行する**。具体的には:
+
+- registry/projects.md の「パス」がローカル絶対パスで、かつ `.git/` を持つディレクトリ（または worktree）として解決できる場合のみ実行
+- パスが URL（未 clone）/ `-` / 解決不能なら **チェック自体をスキップ**して通常判定へ（初回 clone 後の状態は git の通常挙動に従うため、tracked 既存ファイルが gitignored になっているレアケースは別途レビューで拾う）
+
+#### 判定コマンド
+
+ローカル repo root（=「パス」が指す絶対パス）で:
 
 ```
-git -C {project_path} ls-files --error-unmatch <target>
+git -C {project_path} check-ignore -q -- <target>
 ```
 
-- 終了コード 0 → tracked。**通常の A / B / C 判定に進む**
-- 非 0（untracked / gitignored、または存在しない） → **Pattern C 強制**
-  - 理由: `git worktree add` は untracked / gitignored ファイルを新 worktree に複製しないため、Pattern B では対象ファイルが見えない / commit できない
-  - WORKER_DIR は対象ファイルにアクセス可能な親ディレクトリ（多くは元リポジトリ root を指す `{workers_dir}/{task_id}/` のエフェメラル運用ではなく、既存リポジトリ root を WORKER_DIR にする構成）に設定する。窓口メモに「Pattern B 不可: 対象 `<target>` が gitignored」と一文残すこと
+- 終了コード 1（=ignored ではない）→ tracked または「単に未存在の新規ファイル」。**通常の A / B / C 判定に進む**
+- 終了コード 0（=ignored）→ **Pattern C 強制（gitignored サブモード）**。下記参照
+- 終了コード 128 等（コマンド失敗、repo 未初期化など）→ 適用条件外。スキップして通常判定へ
 
-**claude-org 自己編集との関係**: 通常のスキル / ドキュメント編集（`.claude/skills/...`, `references/...`）は tracked なので従来どおり Pattern B が選べる。`docs/internal/`, `notes/`, `tmp/` 等の gitignored 内部メモを編集する場合のみ本事前チェックで Pattern C 強制となる（`references/claude-org-self-edit.md` 参照）。
+> `git check-ignore` は「現在の `.gitignore` ルールにマッチするか」だけを判定し、ファイルが実在しなくても評価できる。`ls-files --error-unmatch` を使うと「単に未作成の新規ファイル」まで untracked 扱いで Pattern C に落としてしまうため、こちらを使わない。
+
+#### Pattern C 強制（gitignored サブモード）
+
+通常の Pattern C は `{workers_dir}/{task_id}/` のエフェメラル空ディレクトリだが、gitignored 対象を編集する場合はそれでは対象ファイルに届かない。次の特例運用とする:
+
+- **WORKER_DIR**: 既存ローカル clone の **repo root を直接指定**する（registry の「パス」値そのもの）
+- **CLAUDE.md / settings.local.json の配置先**: その repo root 直下。既に他用途の CLAUDE.md がある場合は `CLAUDE.local.md` に書く（`references/claude-org-self-edit.md` の特例参照）
+- **Worker Directory Registry**: Pattern を `C` として登録、Directory に repo root の絶対パス、Status を `in_use`。完了時はエントリ削除（ディレクトリ自体は元プロジェクトなので保持）
+- **並行作業との競合**: repo root を直接掴むため、同 repo に対する Pattern A / B のワーカーと同時起動はしない（窓口側で順次化する）
+- **窓口メモ**: 「Pattern B 不可: 対象 `<target>` が gitignored。WORKER_DIR=既存 repo root 運用」と一文残す
+
+#### claude-org 自己編集との関係
+
+通常のスキル / ドキュメント編集（`.claude/skills/...`, `references/...`）は tracked なので従来どおり Pattern B が選べる。`docs/internal/`, `notes/`, `tmp/` 等の gitignored 内部メモを編集する場合のみ本事前チェックで Pattern C 強制（gitignored サブモード）となる（`references/claude-org-self-edit.md` 参照）。
 
 ### ディレクトリパターン判定基準
 
@@ -143,7 +165,7 @@ git -C {project_path} ls-files --error-unmatch <target>
 
 **判定フロー:**
 
-0. **事前チェック（対象ファイルが特定できる場合のみ）**: 上記「事前チェック: 対象ファイルが git tracked か」を実行する。tracked なら下記 1 へ。untracked / gitignored なら **パターン C 強制**で確定し、以降の判定はスキップする
+0. **事前チェック（対象ファイルが特定でき、かつローカル repo が存在する場合のみ）**: 上記「事前チェック: 対象ファイルが gitignored か」を実行する。ignored でないなら下記 1 へ。ignored なら **パターン C 強制（gitignored サブモード）** で確定し、以降の判定はスキップする。適用条件外（URL のみ・対象未特定など）はチェックを skip して下記 1 から通常判定
 1. プロジェクトの clone が必要な場合（registry/projects.md にパスが登録されているプロジェクト）:
    a. Worker Directory Registry で同プロジェクトに `in_use` のエントリがある場合 → **パターン B**（worktree で並行作業）
    b. 同プロジェクトに `available` のエントリがある場合 → **パターン A**（既存ディレクトリを再利用）

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -115,6 +115,24 @@ description: >
   - **参考 work-skill**（Step 0.5 でマッチしたもの）
 - 注意: タスク説明にファイルパスを含める場合、それがワーカー作業ディレクトリからの相対パスであることを明記する。registry/projects.md の「パス」列の値をそのまま成果物パスとして指示しない（ワーカーが別の場所にパスを作成する原因になる）
 
+### 事前チェック: 対象ファイルが git tracked か
+
+判定フローに入る前に、編集対象ファイルが git で追跡されているか確認する。
+**「対象ファイル」は窓口がタスク説明から抽出する**（依頼文・Issue 本文・ユーザー発話の中で明示されたパス。機械的判定はしない）。対象ファイルが特定できないタスク（純粋な調査・新規作成など）はこのチェックをスキップして通常判定に進む。
+
+対象ファイルが特定できた場合、project_path（registry/projects.md のパス）で:
+
+```
+git -C {project_path} ls-files --error-unmatch <target>
+```
+
+- 終了コード 0 → tracked。**通常の A / B / C 判定に進む**
+- 非 0（untracked / gitignored、または存在しない） → **Pattern C 強制**
+  - 理由: `git worktree add` は untracked / gitignored ファイルを新 worktree に複製しないため、Pattern B では対象ファイルが見えない / commit できない
+  - WORKER_DIR は対象ファイルにアクセス可能な親ディレクトリ（多くは元リポジトリ root を指す `{workers_dir}/{task_id}/` のエフェメラル運用ではなく、既存リポジトリ root を WORKER_DIR にする構成）に設定する。窓口メモに「Pattern B 不可: 対象 `<target>` が gitignored」と一文残すこと
+
+**claude-org 自己編集との関係**: 通常のスキル / ドキュメント編集（`.claude/skills/...`, `references/...`）は tracked なので従来どおり Pattern B が選べる。`docs/internal/`, `notes/`, `tmp/` 等の gitignored 内部メモを編集する場合のみ本事前チェックで Pattern C 強制となる（`references/claude-org-self-edit.md` 参照）。
+
 ### ディレクトリパターン判定基準
 
 | パターン | 名称 | 条件 | ディレクトリ |
@@ -125,6 +143,7 @@ description: >
 
 **判定フロー:**
 
+0. **事前チェック（対象ファイルが特定できる場合のみ）**: 上記「事前チェック: 対象ファイルが git tracked か」を実行する。tracked なら下記 1 へ。untracked / gitignored なら **パターン C 強制**で確定し、以降の判定はスキップする
 1. プロジェクトの clone が必要な場合（registry/projects.md にパスが登録されているプロジェクト）:
    a. Worker Directory Registry で同プロジェクトに `in_use` のエントリがある場合 → **パターン B**（worktree で並行作業）
    b. 同プロジェクトに `available` のエントリがある場合 → **パターン A**（既存ディレクトリを再利用）

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -1,5 +1,7 @@
 # claude-org 自身を編集するタスクの特例
 
+> **前提（Pattern 判定）**: 対象ファイルが gitignored（例: `docs/internal/`, `notes/`, `tmp/` 配下の内部メモ）の場合は、SKILL.md Step 1 の「事前チェック: 対象ファイルが git tracked か」により **Pattern C 強制**となる。本ドキュメントの特例（hook 除外・`CLAUDE.local.md`）は Pattern B / C いずれでも適用するが、Pattern C の場合 worktree は作らないため WORKER_DIR は対象ファイルにアクセスできる既存リポジトリ root を指定する。以下は Pattern B（tracked ファイル編集）を主に想定した手順。
+
 claude-org リポジトリのスキル / ドキュメント / 設定を編集するワーカーを派遣するとき、通常の worktree 準備のままでは以下の事故が発生する:
 
 - `block-org-structure.sh` hook が `.claude/skills/` などへの Edit / Write を拒否する（`bypassPermissions` モードでも exit code 2 により確認プロンプトが出る）


### PR DESCRIPTION
## Summary
- org-delegate Step 1 のディレクトリパターン判定フローに「対象ファイルが git tracked か」の事前チェックを追加
- gitignored ファイル編集タスクが Pattern B (worktree) で派遣される事故を防止（Issue #131 の派遣で実害発生したのを受けて）
- claude-org-self-edit.md に「gitignored 内部メモは Pattern C 強制」の前提注記を追加

## Background
Issue #131 関連タスクで `docs/internal/*.md` を編集する worker を Pattern B worktree で派遣したところ、対象ファイルが gitignored で worktree に存在せずブロック。Pattern C ephemeral + WORKER_DIR=親リポ root に再構成して完遂した。詳細: knowledge/raw/2026-04-26-delegation-gitignored-target-files.md

## Closes
- #132

## Test plan
- [ ] SKILL.md の判定フローが流れとして読めるか目視
- [ ] CI green (role config 非対象、影響なし想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)