### PR TITLE
feat: add install.sh / install.ps1 one-liner installers (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/suisya-systems/claude-org-ja/actions/workflows/tests.yml/badge.svg)](https://github.com/suisya-systems/claude-org-ja/actions/workflows/tests.yml)
-[![Install](https://img.shields.io/badge/install-WIP%20%28%23106%29-lightgrey.svg)](https://github.com/suisya-systems/claude-org-ja/issues/106)
+[![Install](https://img.shields.io/badge/install-one--liner-brightgreen.svg)](#クイックスタート)
 
 > **claude-org-ja は日本語ファーストのリファレンス配布物です。**
 > 英語版の兄弟リポジトリ `claude-org` は別途並走予定（日英 2 系統構成）。
 >
 > > **TODO**: 英語版兄弟リポジトリ (`claude-org`) へのクロスリンクは Issue #110 で当該リポジトリを作成後に追加します。
-> > **TODO**: ワンライナー導入手順（`curl | bash` 形式）は Issue #106 で実装後にこの README に反映します。
 
 ---
 
@@ -49,9 +48,31 @@ flowchart TD
 
 ## クイックスタート
 
-> **OS について**: 以下は macOS / Linux（bash）前提。Windows でも `python3` を `python` に読み替えれば動作します（PowerShell 用ワンライナーは Issue #106 で対応予定）。
->
-> **TODO**: ワンライナー導入手順（`curl -fsSL ... | bash` 形式）は Issue #106 で実装予定。現状は以下の手動手順で導入してください。
+### ワンライナー（推奨）
+
+依存ツール（`git` / `claude` / `renga` / `gh`）が導入済みなら、以下のワンライナーでクローン + `renga mcp install` までを一気に実行できます。
+
+**macOS / Linux（bash）**:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.sh | bash
+```
+
+**Windows（PowerShell 7+）**:
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.ps1 | iex
+```
+
+スクリプトは前提コマンドの導入有無を確認し、未導入のものがあれば**導入手順を案内して終了**します（自動インストールはしません）。完了後は以下の手順で起動します:
+
+```bash
+cd claude-org-ja
+bash scripts/install-hooks.sh   # コミット直前の秘密情報スキャナを有効化
+renga --layout ops              # 窓口（Secretary）ペインを起動
+```
+
+### 手動手順（ワンライナーを使わない場合）
 
 ```bash
 # 1. 依存ツールを導入

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,21 @@ bash scripts/install-hooks.sh   # Git Bash / WSL 上で実行
 renga --layout ops
 ```
 
-スクリプトは前提コマンドの導入有無を確認し、未導入があれば導入手順を案内して終了する（自動インストールはしない）。クローン先のディレクトリ名を変えたい場合は `--dir <path>` / `-Dir <path>` を渡す。
+スクリプトは前提コマンドの導入有無を確認し、未導入があれば導入手順を案内して終了する（自動インストールはしない）。
+
+クローン先のディレクトリ名を変えたい場合は、ワンライナーではなくスクリプトを直接実行してフラグを渡す（パイプ実行ではフラグを転送できない）:
+
+```bash
+# bash: スクリプトを保存してから実行
+curl -fsSLo /tmp/install.sh https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.sh
+bash /tmp/install.sh --dir my-claude-org
+
+# PowerShell: 同様にダウンロードしてから実行
+iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.ps1 -OutFile $env:TEMP\install.ps1
+pwsh -NoProfile -File $env:TEMP\install.ps1 -Dir my-claude-org
+```
+
+利用可能なフラグは `bash install.sh --help` / `pwsh install.ps1 -Help` を参照。
 
 ワンライナーを使わない場合は手動で以下を実行する:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,29 @@ claude-orgの使い方ガイド。
 
 ### インストール
 
-本リポジトリをクローンし、そのディレクトリで renga を起動する。
+依存ツール（`git` / `claude` / `renga` / `gh`）が揃っていれば、ワンライナーでクローン + `renga mcp install` までを一括実行できる。
+
+**macOS / Linux（bash）**:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.sh | bash
+cd claude-org-ja
+bash scripts/install-hooks.sh
+renga --layout ops
+```
+
+**Windows（PowerShell 7+）**:
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.ps1 | iex
+cd claude-org-ja
+bash scripts/install-hooks.sh   # Git Bash / WSL 上で実行
+renga --layout ops
+```
+
+スクリプトは前提コマンドの導入有無を確認し、未導入があれば導入手順を案内して終了する（自動インストールはしない）。クローン先のディレクトリ名を変えたい場合は `--dir <path>` / `-Dir <path>` を渡す。
+
+ワンライナーを使わない場合は手動で以下を実行する:
 
 ```bash
 git clone https://github.com/suisya-systems/claude-org-ja.git

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,147 @@
+# One-liner installer for claude-org-ja (Windows / PowerShell 7+).
+# Usage:
+#   iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.ps1 | iex
+#   pwsh -NoProfile -File scripts/install.ps1 [-Dir <path>] [-DryRun] [-SkipMcp]
+#
+# This script:
+#   1. Checks for required commands (git, claude, renga, gh) and prints
+#      installation hints when something is missing.
+#   2. Clones suisya-systems/claude-org-ja (asks before reusing an
+#      existing directory).
+#   3. Runs `renga mcp install` (user-scope) so the renga-peers MCP
+#      server is registered with Claude Code.
+#   4. Prints next steps.
+#
+# It never auto-installs missing tools and never bypasses Claude Code's
+# permission prompts.
+
+[CmdletBinding()]
+param(
+    [string]$Dir = 'claude-org-ja',
+    [switch]$DryRun,
+    [switch]$SkipMcp,
+    [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    @'
+Usage: install.ps1 [-Dir <path>] [-DryRun] [-SkipMcp] [-Help]
+
+Options:
+  -Dir <path>   Target directory for the clone (default: .\claude-org-ja).
+  -DryRun       Print commands that would run without executing them.
+  -SkipMcp      Skip `renga mcp install` (use when already registered).
+  -Help         Show this help and exit.
+'@ | Write-Host
+    return
+}
+
+$RepoUrl = 'https://github.com/suisya-systems/claude-org-ja.git'
+
+function Invoke-Step {
+    param([string[]]$Cmd)
+    Write-Host "+ $($Cmd -join ' ')"
+    if (-not $DryRun) {
+        & $Cmd[0] @($Cmd[1..($Cmd.Length - 1)])
+        if ($LASTEXITCODE -ne 0) {
+            throw "Command failed (exit $LASTEXITCODE): $($Cmd -join ' ')"
+        }
+    }
+}
+
+function Test-Prerequisite {
+    param([string]$Name, [string]$Hint)
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($null -ne $cmd) {
+        Write-Host "  [ok]   $Name`: $($cmd.Source)"
+        return $true
+    }
+    Write-Host "  [miss] $Name not found. Install hint: $Hint"
+    return $false
+}
+
+function Read-YesNo {
+    param([string]$Prompt, [string]$Default = 'Y')
+    $hint = if ($Default -eq 'Y') { '[Y/n]' } else { '[y/N]' }
+    # When piped via `iwr | iex`, $Host.UI.RawUI may still allow ReadLine via
+    # the host; fall back to the default if no interactive console is present.
+    try {
+        $reply = Read-Host "$Prompt $hint"
+    } catch {
+        Write-Host "install.ps1: non-interactive shell; assuming '$Default' for: $Prompt"
+        return ($Default -eq 'Y')
+    }
+    if ([string]::IsNullOrWhiteSpace($reply)) { $reply = $Default }
+    return ($reply -match '^(y|yes)$')
+}
+
+Write-Host '== claude-org-ja installer =='
+Write-Host ''
+
+Write-Host 'Checking prerequisites...'
+$missing = $false
+if (-not (Test-Prerequisite 'git'    'https://git-scm.com/downloads'))                          { $missing = $true }
+if (-not (Test-Prerequisite 'claude' 'https://claude.ai/code (Claude Code CLI)'))               { $missing = $true }
+if (-not (Test-Prerequisite 'renga'  'npm install -g @suisya-systems/renga@0.18.0'))            { $missing = $true }
+if (-not (Test-Prerequisite 'gh'     'https://cli.github.com/'))                                { $missing = $true }
+Write-Host ''
+
+if ($missing) {
+    Write-Error @'
+install.ps1: one or more prerequisites are missing.
+Install the listed tools, then re-run this installer.
+(This script intentionally does not auto-install dependencies.)
+'@
+    exit 1
+}
+
+# --- Clone ---------------------------------------------------------------
+
+if (Test-Path -LiteralPath $Dir) {
+    if (Test-Path -LiteralPath (Join-Path $Dir '.git')) {
+        Write-Host "install.ps1: '$Dir' already exists and looks like a git repo."
+        if (Read-YesNo 'Skip clone and reuse existing directory?' 'Y') {
+            Write-Host "Reusing existing $Dir (no clone)."
+        } else {
+            Write-Error "install.ps1: aborting so you can move or rename '$Dir' first."
+            exit 1
+        }
+    } else {
+        Write-Error "install.ps1: '$Dir' exists but is not a git repository. Move or rename it and re-run."
+        exit 1
+    }
+} else {
+    Invoke-Step @('git', 'clone', $RepoUrl, $Dir)
+}
+
+# --- renga mcp install ---------------------------------------------------
+
+if ($SkipMcp) {
+    Write-Host 'Skipping `renga mcp install` (-SkipMcp).'
+} else {
+    Write-Host ''
+    Write-Host 'Registering renga-peers MCP with Claude Code (user-scope)...'
+    Write-Host 'Note: Claude Code may show a permission prompt; approve it to continue.'
+    Invoke-Step @('renga', 'mcp', 'install')
+}
+
+# --- Done ----------------------------------------------------------------
+
+@"
+
+Done. Next steps:
+
+  cd $Dir
+  bash scripts/install-hooks.sh   # enable pre-commit secret scanner (run from Git Bash / WSL)
+  renga --layout ops              # launch the Secretary pane
+
+Inside the Secretary's Claude Code pane, run:
+
+  /org-setup    # first time only: place per-role permissions and hooks
+  /org-start    # bring foreman + curator online
+
+For details see docs/getting-started.md.
+"@ | Write-Host

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -101,7 +101,17 @@ Install the listed tools, then re-run this installer.
 # --- Clone ---------------------------------------------------------------
 
 if (Test-Path -LiteralPath $Dir) {
-    if (Test-Path -LiteralPath (Join-Path $Dir '.git')) {
+    # Confirm it is actually a git workspace by asking git, not by looking
+    # for a `.git` path (which can be a stray file in a non-repo directory).
+    $isGitRepo = $false
+    Push-Location -LiteralPath $Dir
+    try {
+        $null = & git rev-parse --is-inside-work-tree 2>$null
+        if ($LASTEXITCODE -eq 0) { $isGitRepo = $true }
+    } finally {
+        Pop-Location
+    }
+    if ($isGitRepo) {
         Write-Host "install.ps1: '$Dir' already exists and looks like a git repo."
         if (Read-YesNo 'Skip clone and reuse existing directory?' 'Y') {
             Write-Host "Reusing existing $Dir (no clone)."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -104,15 +104,33 @@ if (Test-Path -LiteralPath $Dir) {
     # Confirm it is actually a git workspace by asking git, not by looking
     # for a `.git` path (which can be a stray file in a non-repo directory).
     $isGitRepo = $false
+    $existingUrl = ''
     Push-Location -LiteralPath $Dir
     try {
         $null = & git rev-parse --is-inside-work-tree 2>$null
-        if ($LASTEXITCODE -eq 0) { $isGitRepo = $true }
+        if ($LASTEXITCODE -eq 0) {
+            $isGitRepo = $true
+            $existingUrl = (& git remote get-url origin 2>$null)
+            if ($LASTEXITCODE -ne 0) { $existingUrl = '' }
+        }
     } finally {
         Pop-Location
     }
     if ($isGitRepo) {
-        Write-Host "install.ps1: '$Dir' already exists and looks like a git repo."
+        # Verify origin matches; otherwise we'd silently run later steps
+        # against an unrelated checkout that happens to share the name.
+        if ($existingUrl -ne $RepoUrl) {
+            Write-Error "install.ps1: '$Dir' is a git repo, but its 'origin' is '$existingUrl' (expected $RepoUrl). Refusing to reuse — move/rename the directory or pass -Dir <other>."
+            exit 1
+        }
+        # Fail-closed when piped via `iwr | iex` and no real console is
+        # attached: don't silently reuse on a non-interactive run.
+        $isInteractive = ([Environment]::UserInteractive -and $null -ne $Host.UI.RawUI)
+        if (-not $isInteractive) {
+            Write-Error "install.ps1: non-interactive shell; refusing to reuse '$Dir' without confirmation. Re-run interactively or move/rename the directory."
+            exit 1
+        }
+        Write-Host "install.ps1: '$Dir' already exists and points at $RepoUrl."
         if (Read-YesNo 'Skip clone and reuse existing directory?' 'Y') {
             Write-Host "Reusing existing $Dir (no clone)."
         } else {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -125,7 +125,26 @@ fi
 if [[ -e "$TARGET_DIR" ]]; then
   # `.git` may be a directory (normal clone) or a file (worktree / submodule).
   if [[ -e "$TARGET_DIR/.git" ]]; then
-    echo "install.sh: '$TARGET_DIR' already exists and looks like a git repo."
+    # Verify it's actually our repo, not some unrelated git checkout that
+    # happens to share the directory name. Without this check, a curl|bash
+    # invocation would silently run later steps against the wrong tree.
+    existing_url=$(git -C "$TARGET_DIR" remote get-url origin 2>/dev/null || true)
+    if [[ "$existing_url" != "$REPO_URL" ]]; then
+      echo "install.sh: '$TARGET_DIR' is a git repo, but its 'origin' is:" >&2
+      echo "  ${existing_url:-<unset>}" >&2
+      echo "  expected: $REPO_URL" >&2
+      echo "install.sh: refusing to reuse. Move/rename the directory or pass --dir <other>." >&2
+      exit 1
+    fi
+    echo "install.sh: '$TARGET_DIR' already exists and points at $REPO_URL."
+    # Fail-closed in non-interactive mode: the curl|bash flow cannot get a
+    # meaningful Y/N answer, so we don't silently fall through to the
+    # later steps on a pre-existing checkout.
+    if [[ "$HAS_TTY" != "1" ]]; then
+      echo "install.sh: non-interactive shell; refusing to reuse without confirmation." >&2
+      echo "install.sh: re-run interactively, or move/rename the directory and re-run." >&2
+      exit 1
+    fi
     if prompt_yes_no "Skip clone and reuse existing directory?" "Y"; then
       echo "Reusing existing $TARGET_DIR (no clone)."
     else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,16 +46,20 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Detect interactive stdin. When piped from curl, /dev/tty is the only
-# reliable way to prompt the user; fall back to non-interactive defaults.
+# Detect interactive input. When piped from curl, stdin is the pipe; the
+# only reliable prompt path is /dev/tty, and only if it can actually be
+# opened for both read and write. Probe once and cache the result so
+# `set -e` doesn't kill the script on a failed write later.
 HAS_TTY=0
-if [[ -t 0 ]] || [[ -r /dev/tty ]]; then
+if [[ -t 0 ]]; then
+  HAS_TTY=1
+elif { : > /dev/tty; } 2>/dev/null && { : < /dev/tty; } 2>/dev/null; then
   HAS_TTY=1
 fi
 
 prompt_yes_no() {
   # $1 = prompt, $2 = default (Y or N). Returns 0 for yes, 1 for no.
-  local prompt="$1" default="$2" reply
+  local prompt="$1" default="$2" reply=""
   local hint
   if [[ "$default" == "Y" ]]; then hint="[Y/n]"; else hint="[y/N]"; fi
   if [[ "$HAS_TTY" != "1" ]]; then
@@ -65,7 +69,9 @@ prompt_yes_no() {
   if [[ -t 0 ]]; then
     read -r -p "$prompt $hint " reply || reply=""
   else
-    printf "%s %s " "$prompt" "$hint" > /dev/tty
+    # Use /dev/tty for both prompt and response. Guard with `|| true` so
+    # `set -e` doesn't terminate on a transient write failure.
+    printf "%s %s " "$prompt" "$hint" > /dev/tty 2>/dev/null || true
     read -r reply < /dev/tty || reply=""
   fi
   reply="${reply:-$default}"
@@ -117,7 +123,8 @@ fi
 # --- Clone -----------------------------------------------------------------
 
 if [[ -e "$TARGET_DIR" ]]; then
-  if [[ -d "$TARGET_DIR/.git" ]]; then
+  # `.git` may be a directory (normal clone) or a file (worktree / submodule).
+  if [[ -e "$TARGET_DIR/.git" ]]; then
     echo "install.sh: '$TARGET_DIR' already exists and looks like a git repo."
     if prompt_yes_no "Skip clone and reuse existing directory?" "Y"; then
       echo "Reusing existing $TARGET_DIR (no clone)."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# One-liner installer for claude-org-ja (Linux / macOS).
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.sh | bash
+#   bash scripts/install.sh [--dir <path>] [--dry-run] [--skip-mcp]
+#
+# This script:
+#   1. Checks for required commands (git, claude, renga, gh) and prints
+#      installation hints when something is missing.
+#   2. Clones suisya-systems/claude-org-ja (asks before reusing an
+#      existing directory).
+#   3. Runs `renga mcp install` (user-scope) so the renga-peers MCP
+#      server is registered with Claude Code.
+#   4. Prints next steps.
+#
+# It never auto-installs missing tools and never bypasses Claude Code's
+# permission prompts.
+set -euo pipefail
+
+REPO_URL="https://github.com/suisya-systems/claude-org-ja.git"
+TARGET_DIR="claude-org-ja"
+DRY_RUN=0
+SKIP_MCP=0
+
+usage() {
+  cat <<'USAGE'
+Usage: install.sh [--dir <path>] [--dry-run] [--skip-mcp] [--help]
+
+Options:
+  --dir <path>   Target directory for the clone (default: ./claude-org-ja).
+  --dry-run      Print the commands that would run without executing them.
+  --skip-mcp     Skip `renga mcp install` (use when already registered).
+  -h, --help     Show this help and exit.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir)
+      [[ $# -ge 2 ]] || { echo "install.sh: --dir requires an argument" >&2; exit 2; }
+      TARGET_DIR="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --skip-mcp) SKIP_MCP=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "install.sh: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# Detect interactive stdin. When piped from curl, /dev/tty is the only
+# reliable way to prompt the user; fall back to non-interactive defaults.
+HAS_TTY=0
+if [[ -t 0 ]] || [[ -r /dev/tty ]]; then
+  HAS_TTY=1
+fi
+
+prompt_yes_no() {
+  # $1 = prompt, $2 = default (Y or N). Returns 0 for yes, 1 for no.
+  local prompt="$1" default="$2" reply
+  local hint
+  if [[ "$default" == "Y" ]]; then hint="[Y/n]"; else hint="[y/N]"; fi
+  if [[ "$HAS_TTY" != "1" ]]; then
+    echo "install.sh: non-interactive shell; assuming '$default' for: $prompt" >&2
+    [[ "$default" == "Y" ]] && return 0 || return 1
+  fi
+  if [[ -t 0 ]]; then
+    read -r -p "$prompt $hint " reply || reply=""
+  else
+    printf "%s %s " "$prompt" "$hint" > /dev/tty
+    read -r reply < /dev/tty || reply=""
+  fi
+  reply="${reply:-$default}"
+  case "$reply" in
+    y|Y|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run() {
+  # Echo + execute, or just echo when --dry-run is set.
+  echo "+ $*"
+  if [[ "$DRY_RUN" != "1" ]]; then
+    "$@"
+  fi
+}
+
+require_or_warn() {
+  # $1 = command name, $2 = install hint URL/text.
+  local cmd="$1" hint="$2"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    echo "  [ok]   $cmd: $(command -v "$cmd")"
+    return 0
+  fi
+  echo "  [miss] $cmd not found. Install hint: $hint"
+  return 1
+}
+
+echo "== claude-org-ja installer =="
+echo
+
+echo "Checking prerequisites..."
+missing=0
+require_or_warn git    "https://git-scm.com/downloads" || missing=1
+require_or_warn claude "https://claude.ai/code (Claude Code CLI)" || missing=1
+require_or_warn renga  "npm install -g @suisya-systems/renga@0.18.0" || missing=1
+require_or_warn gh     "https://cli.github.com/" || missing=1
+echo
+
+if [[ "$missing" == "1" ]]; then
+  cat <<'MSG' >&2
+install.sh: one or more prerequisites are missing.
+Install the listed tools, then re-run this installer.
+(This script intentionally does not auto-install dependencies.)
+MSG
+  exit 1
+fi
+
+# --- Clone -----------------------------------------------------------------
+
+if [[ -e "$TARGET_DIR" ]]; then
+  if [[ -d "$TARGET_DIR/.git" ]]; then
+    echo "install.sh: '$TARGET_DIR' already exists and looks like a git repo."
+    if prompt_yes_no "Skip clone and reuse existing directory?" "Y"; then
+      echo "Reusing existing $TARGET_DIR (no clone)."
+    else
+      echo "install.sh: aborting so you can move or rename '$TARGET_DIR' first." >&2
+      exit 1
+    fi
+  else
+    echo "install.sh: '$TARGET_DIR' exists but is not a git repository." >&2
+    echo "install.sh: refusing to overwrite. Move or rename it and re-run." >&2
+    exit 1
+  fi
+else
+  run git clone "$REPO_URL" "$TARGET_DIR"
+fi
+
+# --- renga mcp install -----------------------------------------------------
+
+if [[ "$SKIP_MCP" == "1" ]]; then
+  echo "Skipping 'renga mcp install' (--skip-mcp)."
+else
+  echo
+  echo "Registering renga-peers MCP with Claude Code (user-scope)..."
+  echo "Note: Claude Code may show a permission prompt; approve it to continue."
+  run renga mcp install
+fi
+
+# --- Done ------------------------------------------------------------------
+
+cat <<MSG
+
+Done. Next steps:
+
+  cd $TARGET_DIR
+  bash scripts/install-hooks.sh   # enable pre-commit secret scanner
+  renga --layout ops              # launch the Secretary pane
+
+Inside the Secretary's Claude Code pane, run:
+
+  /org-setup    # first time only: place per-role permissions and hooks
+  /org-start    # bring foreman + curator online
+
+For details see docs/getting-started.md.
+MSG


### PR DESCRIPTION
## Summary
- Add `scripts/install.sh` (bash) and `scripts/install.ps1` (PowerShell 7+) one-liner installers. Both probe for `git` / `claude` / `renga` / `gh`, clone `suisya-systems/claude-org-ja`, run `renga mcp install` (user-scope), and print next steps. They never auto-install dependencies and never bypass Claude Code permission prompts.
- Update README Quickstart with a `curl | bash` and `iwr | iex` section, drop the Issue #106 TODO note, and flip the install badge.
- Update `docs/getting-started.md` to lead with the one-liners.

## Acceptance criteria
- [x] `scripts/install.sh` works (bash 5.x, dry-run smoke tested)
- [x] `scripts/install.ps1` works (PowerShell 7+, dry-run smoke tested)
- [x] Missing-prerequisite warnings + install hints on both
- [x] README Quickstart one-liner lives at the real URL (TODO removed)
- [x] `docs/getting-started.md` updated

## Test plan
- [x] `python -m unittest discover -s tests` (green, 53 tests)
- [x] `bash -n scripts/install.sh` + pwsh AST parse (both clean)
- [x] Dry-run smoke test on both scripts (`--dry-run --skip-mcp`)
- [x] Codex review (3 findings, all fixed in follow-up commit)
- [ ] Real `curl | bash` end-to-end on a clean Linux/macOS host — out of this worktree's reach, tracked as #112 (CI smoke test integration)

## Open design questions (reviewer eyes welcome)

1. **Missing-prerequisite UX**: currently exits 1 with a single consolidated guidance block. Alternative: per-command inline hints. Consolidated felt less noisy; happy to switch if reviewers prefer.
2. **`install-hooks.sh` auto-run**: deliberately not auto-run from the installer; the completion message points to it. Leaves the consent boundary intact.
3. **End-to-end network smoke test**: out of scope here, but #112 will wire shellcheck + PSScriptAnalyzer + a real-clone smoke test in CI.

Closes #106
