### PR TITLE
docs(readme): add attack-vector × covering-layer matrix for guardrails (closes #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,19 +238,24 @@ claude-org-ja は **4 層防御**（`permissions.deny` / PreToolUse フック / 
 
 ### 攻撃ベクトル × 防御層マトリクス
 
-`auto` モードロール（窓口・ワーカー・キュレーター）における主要な攻撃ベクトルと、各層がそれをどこまで止めるかの対応表（✅ ブロック / ⚠️ 部分・条件付き / — 対象外）:
+本リポジトリ自身の `.claude/settings.json`（窓口・キュレーター用、`auto` モード）と `.githooks/pre-commit` を基準にした、主要な攻撃ベクトルと各層の対応表です（✅ ブロック / ⚠️ 部分・条件付き / — 対象外 / ➖ 未配備）。**ワーカーロール用テンプレート（`.claude/skills/org-setup/references/permissions.md`）は `permissions.deny` が `git push *` / `rm -rf *` のみで、PreToolUse フックも `block-git-push.sh` / `block-org-structure.sh` のみが配備されます**。`--no-verify` / `git reset --hard` 系の遮断は本リポジトリ側の窓口・キュレーターのみが該当する点に注意してください（フォアマンは `.dispatcher/` 用の独立した hook 群、ワーカーは別テンプレートで管理されます）。
 
 | 攻撃ベクトル | `permissions.deny` | PreToolUse フック | sandbox | pre-commit |
 |---|---|---|---|---|
-| `git commit --no-verify` 直書き | ✅ | ✅ | — | — |
-| `eval "git commit --no-verify"` / `bash -c "..."` | — | ✅ (Phase 2a, [#79](https://github.com/suisya-systems/claude-org-ja/issues/79): `unwrap_eval_and_bashc`) | — | — |
-| `VAR=$(printf -- '--no-verify'); git commit $VAR` | — | ✅ (assignment 収集 + flatten) | — | — |
-| `git push --force` / `--no-verify` / `git reset --hard` | ✅ | ✅ | — | — |
-| `cat .env` / 認証情報読み取り | ⚠️ Read tool 経路のみ (`Read(./.env)` 等) | — | ⚠️ macOS / Linux / WSL2 のみ。Windows native は未実装（[docs/verification.md §10.1](docs/verification.md)） | — |
-| ステージ差分への秘密情報混入 | — | — | — | ✅ ([scripts/precommit-secret-scanner.sh](scripts/precommit-secret-scanner.sh)) |
-| シェル関数経由の bypass（`f(){ git commit --no-verify; }; f`） | — | ⚠️ 関数定義の静的解析は非対応（Phase 2c は廃案）。sandbox の denyWrite による副作用抑制で部分カバー | ⚠️ (上記 OS 制約に同じ) | — |
+| `git commit --no-verify` 直書き（窓口・キュレーター） | ✅ | ✅ (`block-no-verify.sh`) | — | — |
+| `eval "git commit --no-verify"` / `bash -c "..."` | — | ✅ Phase 2a [#79](https://github.com/suisya-systems/claude-org-ja/issues/79): `unwrap_eval_and_bashc` で明示パース | — | — |
+| `VAR=$(printf -- '--no-verify'); git commit $VAR` | — | ✅ assignment 収集 + `flatten_substitutions` | — | — |
+| `git push --force` / `git reset --hard` / `git branch -D`（窓口・キュレーター） | ✅ | ✅ (`block-dangerous-git.sh`) | — | — |
+| `cat .env` / 認証情報読み取り（Bash 経由） | — | — | ⚠️ macOS (Seatbelt) / Linux / WSL2 (`bubblewrap`+`socat`) のみ。**Windows native は Claude Code 側未実装で素通り**（[docs/verification.md §10.1](docs/verification.md)） | — |
+| ステージ差分への秘密情報混入 | — | — | — | ✅ ([.githooks/pre-commit](.githooks/pre-commit)) |
+| シェル関数経由の bypass（`f(){ git commit --no-verify; }; f`） | — | ➖ 関数定義の静的解析は非対応 | — | — |
 
-**残存リスク (residual risk)**: シェル関数定義経由のルーティングは静的検出が困難で、PreToolUse フック層では検出しません（Phase 2c で検討した shell-layer 静的解析は誤検知率と保守コストの観点から廃案）。Windows native では sandbox による副作用抑制も働かないため、フォアマンを含む `bypass` モードロールではこのベクトルがロール契約による自主規律のみで担保される状態となります。詳細と段階導入の意思決定は [Issue #79](https://github.com/suisya-systems/claude-org-ja/issues/79) と [docs/verification.md §10](docs/verification.md) を参照。
+**残存リスク (residual risk)**:
+- **シェル関数定義経由のルーティング**: 関数本体内に隠された禁止コマンドは PreToolUse フックの静的解析では検出できません（Phase 2c で検討した shell-layer 静的解析は誤検知率と保守コストの観点から廃案）。sandbox の `denyWrite` も対象が `~/.claude/settings.json` / `~/.ssh/**` 等の限定リストで、`git commit` などのリポジトリ副作用は止めません。本ベクトルは現状ロール契約による自主規律のみで担保されます。
+- **Windows native の sandbox 不在**: 上記表のとおり `cat .env` 等は Windows native では素通りします。ワーカー実行環境としては macOS / Linux / WSL2 を推奨し、Windows native では別経路（OS 側のファイル権限・GitHub Secret Scanning 等）で補完してください。
+- **ワーカーロールの薄い deny**: ワーカー用テンプレートの `permissions.deny` は意図的に小さく保たれており、`--no-verify` / `--force` の直接遮断はフォアマン経由の起動契約と CI 側の保護に依存します。
+
+詳細と段階導入の意思決定は [Issue #79](https://github.com/suisya-systems/claude-org-ja/issues/79) と [docs/verification.md §10](docs/verification.md) を参照。
 
 新しくクローンしたら、1 度だけ以下を実行してください:
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ claude-org-ja は **4 層防御**（`permissions.deny` / PreToolUse フック / 
 
 各層の責任境界・既知の残存リスク（関数定義経由の回避手段など）・PreToolUse フックの検知範囲は [docs/overview-technical.md](docs/overview-technical.md) と `.hooks/` / `.githooks/` 配下を参照。
 
+### 攻撃ベクトル × 防御層マトリクス
+
+`auto` モードロール（窓口・ワーカー・キュレーター）における主要な攻撃ベクトルと、各層がそれをどこまで止めるかの対応表（✅ ブロック / ⚠️ 部分・条件付き / — 対象外）:
+
+| 攻撃ベクトル | `permissions.deny` | PreToolUse フック | sandbox | pre-commit |
+|---|---|---|---|---|
+| `git commit --no-verify` 直書き | ✅ | ✅ | — | — |
+| `eval "git commit --no-verify"` / `bash -c "..."` | — | ✅ (Phase 2a, [#79](https://github.com/suisya-systems/claude-org-ja/issues/79): `unwrap_eval_and_bashc`) | — | — |
+| `VAR=$(printf -- '--no-verify'); git commit $VAR` | — | ✅ (assignment 収集 + flatten) | — | — |
+| `git push --force` / `--no-verify` / `git reset --hard` | ✅ | ✅ | — | — |
+| `cat .env` / 認証情報読み取り | ⚠️ Read tool 経路のみ (`Read(./.env)` 等) | — | ⚠️ macOS / Linux / WSL2 のみ。Windows native は未実装（[docs/verification.md §10.1](docs/verification.md)） | — |
+| ステージ差分への秘密情報混入 | — | — | — | ✅ ([scripts/precommit-secret-scanner.sh](scripts/precommit-secret-scanner.sh)) |
+| シェル関数経由の bypass（`f(){ git commit --no-verify; }; f`） | — | ⚠️ 関数定義の静的解析は非対応（Phase 2c は廃案）。sandbox の denyWrite による副作用抑制で部分カバー | ⚠️ (上記 OS 制約に同じ) | — |
+
+**残存リスク (residual risk)**: シェル関数定義経由のルーティングは静的検出が困難で、PreToolUse フック層では検出しません（Phase 2c で検討した shell-layer 静的解析は誤検知率と保守コストの観点から廃案）。Windows native では sandbox による副作用抑制も働かないため、フォアマンを含む `bypass` モードロールではこのベクトルがロール契約による自主規律のみで担保される状態となります。詳細と段階導入の意思決定は [Issue #79](https://github.com/suisya-systems/claude-org-ja/issues/79) と [docs/verification.md §10](docs/verification.md) を参照。
+
 新しくクローンしたら、1 度だけ以下を実行してください:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ claude-org-ja は **4 層防御**（`permissions.deny` / PreToolUse フック / 
 
 ### 攻撃ベクトル × 防御層マトリクス
 
-本リポジトリ自身の `.claude/settings.json`（窓口・キュレーター用、`auto` モード）と `.githooks/pre-commit` を基準にした、主要な攻撃ベクトルと各層の対応表です（✅ ブロック / ⚠️ 部分・条件付き / — 対象外 / ➖ 未配備）。**ワーカーロール用テンプレート（`.claude/skills/org-setup/references/permissions.md`）は `permissions.deny` が `git push *` / `rm -rf *` のみで、PreToolUse フックも `block-git-push.sh` / `block-org-structure.sh` のみが配備されます**。`--no-verify` / `git reset --hard` 系の遮断は本リポジトリ側の窓口・キュレーターのみが該当する点に注意してください（フォアマンは `.dispatcher/` 用の独立した hook 群、ワーカーは別テンプレートで管理されます）。
+本リポジトリ自身の `.claude/settings.json`（窓口・キュレーター用、`auto` モード）と `.githooks/pre-commit` を基準にした、主要な攻撃ベクトルと各層の対応表です（✅ ブロック / ⚠️ 部分・条件付き / — 対象外 / ➖ 未配備）。**ワーカーロール用テンプレート（`.claude/skills/org-setup/references/permissions.md`）は `permissions.deny` が `git push` 系と `rm -r` / `rm -rf` のみで、PreToolUse フックは `check-worker-boundary.sh` / `block-org-structure.sh` / `block-git-push.sh` が配備されます**（`block-no-verify.sh` / `block-dangerous-git.sh` はワーカー側には未配備）。`--no-verify` / `git reset --hard` / `git branch -D` 系の直接遮断は本リポジトリ側の窓口・キュレーターのみが該当します。ワーカーは `git push` 自体を `block-git-push.sh` で全面遮断するため、`--force` を含む push 系は副次的に止まりますが、ローカルでの `git commit --no-verify` や `git reset --hard` はロール契約による自主規律で担保される設計です（フォアマンは `.dispatcher/` 用の独立した hook 群で別途管理）。
 
 | 攻撃ベクトル | `permissions.deny` | PreToolUse フック | sandbox | pre-commit |
 |---|---|---|---|---|
@@ -253,7 +253,7 @@ claude-org-ja は **4 層防御**（`permissions.deny` / PreToolUse フック / 
 **残存リスク (residual risk)**:
 - **シェル関数定義経由のルーティング**: 関数本体内に隠された禁止コマンドは PreToolUse フックの静的解析では検出できません（Phase 2c で検討した shell-layer 静的解析は誤検知率と保守コストの観点から廃案）。sandbox の `denyWrite` も対象が `~/.claude/settings.json` / `~/.ssh/**` 等の限定リストで、`git commit` などのリポジトリ副作用は止めません。本ベクトルは現状ロール契約による自主規律のみで担保されます。
 - **Windows native の sandbox 不在**: 上記表のとおり `cat .env` 等は Windows native では素通りします。ワーカー実行環境としては macOS / Linux / WSL2 を推奨し、Windows native では別経路（OS 側のファイル権限・GitHub Secret Scanning 等）で補完してください。
-- **ワーカーロールの薄い deny**: ワーカー用テンプレートの `permissions.deny` は意図的に小さく保たれており、`--no-verify` / `--force` の直接遮断はフォアマン経由の起動契約と CI 側の保護に依存します。
+- **ワーカーロールの薄い deny**: ワーカー用テンプレートの `permissions.deny` は意図的に小さく保たれており、ローカルでの `git commit --no-verify` / `git reset --hard` の直接遮断は配備されません（`git push` 自体は hook で全面遮断されるため `--force` は副次的に止まります）。残るリスクはロール契約と窓口側 CI の保護に依存します。
 
 詳細と段階導入の意思決定は [Issue #79](https://github.com/suisya-systems/claude-org-ja/issues/79) と [docs/verification.md §10](docs/verification.md) を参照。
 


### PR DESCRIPTION
## Summary
- Add an explicit attack-vector × covering-layer matrix to README.md, mapping common bypass attempts (`eval`/`bash -c`, command substitution in assignments, `cat .env`, function-routed bypass, secret leakage in staged diffs, etc.) against the four defense layers (`permissions.deny` / PreToolUse hook / sandbox / pre-commit).
- Document residual risks: shell-function-routed bypass (Phase 2c abandoned), Windows-native sandbox non-enforcement, and the intentionally thin worker-role deny set.
- Closes the remaining acceptance criterion in #79; the sandbox config, `unwrap_eval_and_bashc()` parsing, and Windows-native verification log (docs/verification.md §10.1) were already in `main`.

## Test plan
- [x] `bash tests/run-all.sh` — 229/229 passed (incl. `tests/test-unwrap-eval-bashc.sh`)
- [x] Integration: verify-bypass flag attempts via `eval` and `bash -c` are rejected by `block-no-verify.sh` via the explicit-parse path (exit 2)
- [x] Windows + Git Bash sandbox probe — `.env.sandbox-test` reachable as expected (Windows-native sandbox not yet implemented; documented in matrix and docs/verification.md §10.1)
- [x] Codex self-review (2 rounds) — Round 1 Blocker/Major/Nit and Round 2 Major resolved

## Out of scope (follow-up)
- `.claude/skills/org-setup/references/permissions.md:311` and `.claude/skills/org-delegate/SKILL.md` still claim `permissions.deny` is always effective even in bypass-permissions mode, which conflicts with this README and `docs/non-goals.md`. Pre-existing — should be a separate cross-doc consistency issue rather than expand #79's scope.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
