### PR TITLE
feat(tools): schema-driven worker settings generator (Issue #99 Phase 1)

### DIFF
--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -276,6 +276,123 @@ class CheckOnDiskTests(unittest.TestCase):
         self.assertTrue(any("unknown --role" in f.message for f in findings))
 
 
+class CheckWorkerSettingsTests(unittest.TestCase):
+    """Coverage for the --include-worker-settings drift path (Issue #99)."""
+
+    SCHEMA = {
+        "version": 1,
+        "global": {"forbidden_allow_exact": [], "forbidden_allow_regex": []},
+        "required_hook_scripts": [],
+        "roles": {},
+        "worker_roles": {
+            "$comment": "test fixture",
+            "default": {
+                "description": "test default",
+                "permissions": {"allow": ["Bash(sleep:*)"], "deny": []},
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "bash \"{claude_org_path}/.hooks/x.sh\"",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "env": {
+                    "WORKER_DIR": "{worker_dir}",
+                    "CLAUDE_ORG_PATH": "{claude_org_path}",
+                },
+            },
+        },
+    }
+
+    def _emit(self, worker_dir: str, claude_org_path: str) -> dict:
+        import sys as _sys
+        _sys.path.insert(0, str(REPO_ROOT / "tools"))
+        import generate_worker_settings as gws
+        return gws.render_role(
+            self.SCHEMA,
+            role="default",
+            worker_dir=worker_dir,
+            claude_org_path=claude_org_path,
+        )
+
+    def test_generated_file_passes(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            wd = base / "w1"
+            (wd / ".claude").mkdir(parents=True)
+            cfg = self._emit(str(wd.resolve()), "/abs/co")
+            (wd / ".claude" / "settings.local.json").write_text(
+                json.dumps(cfg), encoding="utf-8"
+            )
+            findings = crc.check_worker_settings(self.SCHEMA, base)
+            self.assertEqual(findings, [], [f.format() for f in findings])
+
+    def test_drift_detected(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            wd = base / "w1"
+            (wd / ".claude").mkdir(parents=True)
+            (wd / ".claude" / "settings.local.json").write_text(
+                json.dumps({"permissions": {"allow": ["Bash(rogue)"]}}),
+                encoding="utf-8",
+            )
+            findings = crc.check_worker_settings(self.SCHEMA, base)
+            self.assertTrue(
+                any("does not match" in f.message for f in findings),
+                [f.format() for f in findings],
+            )
+
+    def test_inconsistent_path_substitution_rejected(self):
+        # Two occurrences of {claude_org_path} resolved to different values
+        # — a copy/paste class of drift the wildcard-only matcher would miss.
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            wd = base / "w1"
+            (wd / ".claude").mkdir(parents=True)
+            cfg = self._emit(str(wd.resolve()), "/abs/co")
+            cfg["env"]["CLAUDE_ORG_PATH"] = "/different/co"
+            (wd / ".claude" / "settings.local.json").write_text(
+                json.dumps(cfg), encoding="utf-8"
+            )
+            findings = crc.check_worker_settings(self.SCHEMA, base)
+            self.assertTrue(
+                any("does not match" in f.message for f in findings),
+                [f.format() for f in findings],
+            )
+
+    def test_wrong_worker_dir_rejected(self):
+        # File is under <base>/w1 but its WORKER_DIR env points at /elsewhere.
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            wd = base / "w1"
+            (wd / ".claude").mkdir(parents=True)
+            cfg = self._emit("/elsewhere", "/abs/co")
+            (wd / ".claude" / "settings.local.json").write_text(
+                json.dumps(cfg), encoding="utf-8"
+            )
+            findings = crc.check_worker_settings(self.SCHEMA, base)
+            self.assertTrue(
+                any("does not match" in f.message for f in findings),
+                [f.format() for f in findings],
+            )
+
+    def test_missing_base_dir_errors(self):
+        findings = crc.check_worker_settings(
+            self.SCHEMA, Path("/no/such/dir/__nope__")
+        )
+        self.assertTrue(any("does not exist" in f.message for f in findings))
+
+
 class RealRepoSmokeTests(unittest.TestCase):
     """Sanity check: the real schema + real permissions.md must pass.
 

--- a/tests/test_generate_worker_settings.py
+++ b/tests/test_generate_worker_settings.py
@@ -125,6 +125,14 @@ class GenerateWorkerSettingsTest(unittest.TestCase):
                 any(forbidden in entry for entry in allow),
                 f"doc-audit allow must not include {forbidden!r}: {allow}",
             )
+        # Edit/Write must be explicitly denied to honour the read-only contract
+        # (omission alone does not block the tool).
+        deny = data["permissions"]["deny"]
+        for required_deny in ("Edit", "Write"):
+            self.assertIn(
+                required_deny, deny,
+                f"doc-audit deny must include {required_deny!r}: {deny}",
+            )
 
     def test_out_writes_file(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_generate_worker_settings.py
+++ b/tests/test_generate_worker_settings.py
@@ -1,0 +1,131 @@
+"""Unit tests for ``tools/generate_worker_settings.py``."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import generate_worker_settings as gws  # noqa: E402
+
+
+def _run(*argv) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = gws.main(list(argv))
+    return rc, out.getvalue(), err.getvalue()
+
+
+class GenerateWorkerSettingsTest(unittest.TestCase):
+    def test_role_default_emits_valid_json(self):
+        rc, stdout, _ = _run(
+            "--role", "default",
+            "--worker-dir", "/tmp/wd",
+            "--claude-org-path", "/tmp/co",
+        )
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        self.assertIn("permissions", data)
+        self.assertIn("hooks", data)
+        self.assertIn("env", data)
+        self.assertEqual(data["env"]["WORKER_DIR"], "/tmp/wd")
+        self.assertEqual(data["env"]["CLAUDE_ORG_PATH"], "/tmp/co")
+        # description is metadata, must not leak into emitted settings.
+        self.assertNotIn("description", data)
+
+    def test_role_resolves_paths_in_hook_commands(self):
+        rc, stdout, _ = _run(
+            "--role", "default",
+            "--worker-dir", "/abs/worker",
+            "--claude-org-path", "/abs/claude-org",
+        )
+        self.assertEqual(rc, 0)
+        text = stdout
+        self.assertNotIn("{worker_dir}", text)
+        self.assertNotIn("{claude_org_path}", text)
+        data = json.loads(text)
+        bash_hooks = next(
+            entry for entry in data["hooks"]["PreToolUse"]
+            if entry["matcher"] == "Bash"
+        )
+        commands = [h["command"] for h in bash_hooks["hooks"]]
+        self.assertTrue(
+            any("/abs/claude-org/.hooks/block-git-push.sh" in c for c in commands),
+            commands,
+        )
+
+    def test_unknown_role_exits_nonzero(self):
+        rc, _, stderr = _run(
+            "--role", "no-such-role",
+            "--worker-dir", "/tmp/wd",
+            "--claude-org-path", "/tmp/co",
+        )
+        self.assertNotEqual(rc, 0)
+        self.assertIn("unknown worker role", stderr)
+
+    def test_role_claude_org_self_edit_drops_block_org_structure(self):
+        rc, stdout, _ = _run(
+            "--role", "claude-org-self-edit",
+            "--worker-dir", "/tmp/wd",
+            "--claude-org-path", "/tmp/co",
+        )
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        all_commands = [
+            h["command"]
+            for entry in data["hooks"]["PreToolUse"]
+            for h in entry["hooks"]
+        ]
+        self.assertFalse(
+            any("block-org-structure.sh" in c for c in all_commands),
+            f"claude-org-self-edit must not include block-org-structure.sh: {all_commands}",
+        )
+        self.assertTrue(
+            any("check-worker-boundary.sh" in c for c in all_commands),
+            "boundary check must remain",
+        )
+        self.assertTrue(
+            any("block-git-push.sh" in c for c in all_commands),
+            "block-git-push must remain",
+        )
+
+    def test_role_doc_audit_has_no_write_allows(self):
+        rc, stdout, _ = _run(
+            "--role", "doc-audit",
+            "--worker-dir", "/tmp/wd",
+            "--claude-org-path", "/tmp/co",
+        )
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        allow = data["permissions"]["allow"]
+        # Read-only contract: no add / commit / write-side git verbs.
+        for forbidden in ("git add", "git commit", "git push", "git checkout"):
+            self.assertFalse(
+                any(forbidden in entry for entry in allow),
+                f"doc-audit allow must not include {forbidden!r}: {allow}",
+            )
+
+    def test_out_writes_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "nested" / "settings.local.json"
+            rc, _, _ = _run(
+                "--role", "default",
+                "--worker-dir", "/tmp/wd",
+                "--claude-org-path", "/tmp/co",
+                "--out", str(target),
+            )
+            self.assertEqual(rc, 0)
+            self.assertTrue(target.is_file())
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertIn("permissions", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generate_worker_settings.py
+++ b/tests/test_generate_worker_settings.py
@@ -70,6 +70,17 @@ class GenerateWorkerSettingsTest(unittest.TestCase):
         self.assertNotEqual(rc, 0)
         self.assertIn("unknown worker role", stderr)
 
+    def test_reserved_key_rejected_as_role(self):
+        # `$comment` lives under worker_roles as schema metadata; it must not
+        # be selectable as a role even though the key technically exists.
+        rc, _, stderr = _run(
+            "--role", "$comment",
+            "--worker-dir", "/tmp/wd",
+            "--claude-org-path", "/tmp/co",
+        )
+        self.assertNotEqual(rc, 0)
+        self.assertIn("unknown worker role", stderr)
+
     def test_role_claude_org_self_edit_drops_block_org_structure(self):
         rc, stdout, _ = _run(
             "--role", "claude-org-self-edit",
@@ -105,8 +116,11 @@ class GenerateWorkerSettingsTest(unittest.TestCase):
         self.assertEqual(rc, 0)
         data = json.loads(stdout)
         allow = data["permissions"]["allow"]
-        # Read-only contract: no add / commit / write-side git verbs.
-        for forbidden in ("git add", "git commit", "git push", "git checkout"):
+        # Read-only contract: no add / commit / branch / write-side git verbs.
+        for forbidden in (
+            "git add", "git commit", "git push", "git checkout",
+            "git branch", "git switch", "git worktree", "git stash",
+        ):
             self.assertFalse(
                 any(forbidden in entry for entry in allow),
                 f"doc-audit allow must not include {forbidden!r}: {allow}",

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -468,41 +468,73 @@ def _strip_meta(template: dict) -> dict:
     return {k: v for k, v in template.items() if k not in {"description", "$comment"}}
 
 
-def _matches_worker_template(config: dict, template: dict) -> bool:
-    """Return True when ``config`` matches ``template`` once placeholders in
-    the template are treated as wildcards.
+_PLACEHOLDERS = ("{worker_dir}", "{claude_org_path}")
 
-    A literal value matches itself; a string containing ``{worker_dir}`` or
-    ``{claude_org_path}`` matches any string that fits the surrounding
-    fixed segments. Comparison is structural (dict keys / list ordering must
-    match exactly) so drift in shape — added/removed allows, hook reorder —
-    is reported as a mismatch.
+
+def _matches_worker_template(
+    config: dict,
+    template: dict,
+    *,
+    expected_worker_dir: str | None = None,
+) -> bool:
+    """Return True when ``config`` matches ``template``.
+
+    Placeholders ``{worker_dir}`` / ``{claude_org_path}`` in the template act
+    as captures: every occurrence must resolve to the *same* string within
+    one match attempt. This catches drift where, e.g., one hook command
+    points at a different worker dir than the rest, or where a copy/paste
+    left a stale absolute path behind. When ``expected_worker_dir`` is given,
+    the captured ``{worker_dir}`` value must additionally equal it (modulo
+    path separator normalization), pinning the file to the worker directory
+    that hosts it.
     """
-    return _match(config, template)
+    bindings: dict[str, str] = {}
+    if not _match(config, template, bindings):
+        return False
+    if expected_worker_dir is not None and "{worker_dir}" in bindings:
+        return _norm_path(bindings["{worker_dir}"]) == _norm_path(expected_worker_dir)
+    return True
 
 
-def _match(value, template) -> bool:
+def _norm_path(s: str) -> str:
+    return s.replace("\\", "/").rstrip("/")
+
+
+def _match(value, template, bindings: dict[str, str]) -> bool:
     if isinstance(template, str):
         if not isinstance(value, str):
             return False
-        if "{worker_dir}" not in template and "{claude_org_path}" not in template:
+        if not any(p in template for p in _PLACEHOLDERS):
             return value == template
-        # Build a regex from the template's literal segments.
         import re as _re
         parts = _re.split(r"(\{worker_dir\}|\{claude_org_path\})", template)
         pattern = "".join(
-            ".*" if p in ("{worker_dir}", "{claude_org_path}") else _re.escape(p)
-            for p in parts
+            f"(?P<__ph{idx}>.*)" if p in _PLACEHOLDERS else _re.escape(p)
+            for idx, p in enumerate(parts)
         )
-        return _re.fullmatch(pattern, value) is not None
+        m = _re.fullmatch(pattern, value)
+        if m is None:
+            return False
+        # Map each placeholder occurrence to its captured value and enforce
+        # consistency with prior bindings.
+        ph_indices = [i for i, p in enumerate(parts) if p in _PLACEHOLDERS]
+        for idx in ph_indices:
+            ph = parts[idx]
+            captured = m.group(f"__ph{idx}")
+            existing = bindings.get(ph)
+            if existing is None:
+                bindings[ph] = captured
+            elif existing != captured:
+                return False
+        return True
     if isinstance(template, list):
         if not isinstance(value, list) or len(value) != len(template):
             return False
-        return all(_match(v, t) for v, t in zip(value, template))
+        return all(_match(v, t, bindings) for v, t in zip(value, template))
     if isinstance(template, dict):
         if not isinstance(value, dict) or set(value) != set(template):
             return False
-        return all(_match(value[k], template[k]) for k in template)
+        return all(_match(value[k], template[k], bindings) for k in template)
     return value == template
 
 
@@ -558,9 +590,12 @@ def check_worker_settings(schema: dict, base_dir: Path) -> list[Finding]:
                 )
             )
             continue
+        expected_wd = str(worker_dir.resolve())
         matched = [
             name for name, tmpl in templates.items()
-            if _matches_worker_template(config, tmpl)
+            if _matches_worker_template(
+                config, tmpl, expected_worker_dir=expected_wd,
+            )
         ]
         if not matched:
             findings.append(

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -464,6 +464,120 @@ def check_on_disk(
     return findings
 
 
+def _strip_meta(template: dict) -> dict:
+    return {k: v for k, v in template.items() if k not in {"description", "$comment"}}
+
+
+def _matches_worker_template(config: dict, template: dict) -> bool:
+    """Return True when ``config`` matches ``template`` once placeholders in
+    the template are treated as wildcards.
+
+    A literal value matches itself; a string containing ``{worker_dir}`` or
+    ``{claude_org_path}`` matches any string that fits the surrounding
+    fixed segments. Comparison is structural (dict keys / list ordering must
+    match exactly) so drift in shape — added/removed allows, hook reorder —
+    is reported as a mismatch.
+    """
+    return _match(config, template)
+
+
+def _match(value, template) -> bool:
+    if isinstance(template, str):
+        if not isinstance(value, str):
+            return False
+        if "{worker_dir}" not in template and "{claude_org_path}" not in template:
+            return value == template
+        # Build a regex from the template's literal segments.
+        import re as _re
+        parts = _re.split(r"(\{worker_dir\}|\{claude_org_path\})", template)
+        pattern = "".join(
+            ".*" if p in ("{worker_dir}", "{claude_org_path}") else _re.escape(p)
+            for p in parts
+        )
+        return _re.fullmatch(pattern, value) is not None
+    if isinstance(template, list):
+        if not isinstance(value, list) or len(value) != len(template):
+            return False
+        return all(_match(v, t) for v, t in zip(value, template))
+    if isinstance(template, dict):
+        if not isinstance(value, dict) or set(value) != set(template):
+            return False
+        return all(_match(value[k], template[k]) for k in template)
+    return value == template
+
+
+def check_worker_settings(schema: dict, base_dir: Path) -> list[Finding]:
+    """Walk ``<base_dir>/*/.claude/settings.local.json`` and report any file
+    that does not match one of the ``worker_roles`` templates from the schema.
+
+    Opt-in drift detection for Issue #99 -- existing call sites stay
+    unchanged when this flag is omitted.
+    """
+    findings: list[Finding] = []
+    if not base_dir.is_dir():
+        findings.append(
+            Finding(
+                str(base_dir),
+                "<worker-settings>",
+                "ERROR",
+                "base directory does not exist",
+            )
+        )
+        return findings
+
+    worker_roles_raw = schema.get("worker_roles") or {}
+    templates = {
+        name: _strip_meta(body)
+        for name, body in worker_roles_raw.items()
+        if not name.startswith("$") and isinstance(body, dict)
+    }
+    if not templates:
+        findings.append(
+            Finding(
+                "schema",
+                "<worker-settings>",
+                "ERROR",
+                "schema has no worker_roles templates",
+            )
+        )
+        return findings
+
+    for worker_dir in sorted(p for p in base_dir.iterdir() if p.is_dir()):
+        settings_path = worker_dir / ".claude" / "settings.local.json"
+        if not settings_path.is_file():
+            continue
+        try:
+            config = json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            findings.append(
+                Finding(
+                    str(settings_path),
+                    "<worker-settings>",
+                    "ERROR",
+                    f"JSON parse error: {exc}",
+                )
+            )
+            continue
+        matched = [
+            name for name, tmpl in templates.items()
+            if _matches_worker_template(config, tmpl)
+        ]
+        if not matched:
+            findings.append(
+                Finding(
+                    str(settings_path),
+                    "<worker-settings>",
+                    "ERROR",
+                    (
+                        "does not match any worker_roles template; "
+                        "regenerate via tools/generate_worker_settings.py "
+                        "or add a new role to the schema"
+                    ),
+                )
+            )
+    return findings
+
+
 def run(
     schema_path: Path = DEFAULT_SCHEMA,
     permissions_md: Path = DEFAULT_PERMISSIONS_MD,
@@ -471,6 +585,7 @@ def run(
     include_on_disk: bool = True,
     include_untracked: bool = False,
     role_override: str | None = None,
+    worker_settings_base: Path | None = None,
 ) -> list[Finding]:
     schema = load_schema(schema_path)
     findings: list[Finding] = []
@@ -485,6 +600,8 @@ def run(
                 role_override=role_override,
             )
         )
+    if worker_settings_base is not None:
+        findings.extend(check_worker_settings(schema, worker_settings_base))
     return findings
 
 
@@ -525,6 +642,17 @@ def main(argv: list[str] | None = None) -> int:
             "--include-local semantics."
         ),
     )
+    parser.add_argument(
+        "--include-worker-settings",
+        type=Path,
+        default=None,
+        metavar="BASE_DIR",
+        help=(
+            "Also enumerate <BASE_DIR>/*/.claude/settings.local.json and "
+            "report drift against the worker_roles templates in the schema. "
+            "Opt-in; existing invocations are unaffected."
+        ),
+    )
     args = parser.parse_args(argv)
 
     findings = run(
@@ -534,6 +662,7 @@ def main(argv: list[str] | None = None) -> int:
         include_on_disk=not args.docs_only,
         include_untracked=args.include_local or args.role is not None,
         role_override=args.role,
+        worker_settings_base=args.include_worker_settings,
     )
 
     if not findings:

--- a/tools/generate_worker_settings.py
+++ b/tools/generate_worker_settings.py
@@ -50,8 +50,15 @@ def render_role(
     claude_org_path: str,
 ) -> dict:
     roles = schema.get("worker_roles") or {}
-    if role not in roles:
-        available = sorted(k for k in roles if not k.startswith("$"))
+    available = sorted(
+        k for k, v in roles.items()
+        if not k.startswith("$") and isinstance(v, dict)
+    )
+    if (
+        role not in roles
+        or role.startswith("$")
+        or not isinstance(roles[role], dict)
+    ):
         raise KeyError(
             f"unknown worker role: {role!r}. available: {available}"
         )

--- a/tools/generate_worker_settings.py
+++ b/tools/generate_worker_settings.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Schema-driven worker ``.claude/settings.local.json`` generator.
+
+Reads ``tools/role_configs_schema.json`` -> ``worker_roles[<role>]``,
+substitutes ``{worker_dir}`` and ``{claude_org_path}`` placeholders, and
+prints the resulting JSON. Used by org-delegate Step 3 (Phase 2 migration)
+and by the drift checker's ``--include-worker-settings`` mode to derive
+the expected template for an on-disk worker config. See Issue #99.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SCHEMA = REPO_ROOT / "tools" / "role_configs_schema.json"
+
+# Keys under worker_roles[<role>] that are metadata, not part of the emitted
+# settings.local.json content.
+_META_KEYS = {"description", "$comment"}
+
+
+def load_schema(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _substitute(value: Any, mapping: dict[str, str]) -> Any:
+    if isinstance(value, str):
+        out = value
+        for placeholder, replacement in mapping.items():
+            out = out.replace("{" + placeholder + "}", replacement)
+        return out
+    if isinstance(value, list):
+        return [_substitute(v, mapping) for v in value]
+    if isinstance(value, dict):
+        return {k: _substitute(v, mapping) for k, v in value.items()}
+    return value
+
+
+def render_role(
+    schema: dict,
+    role: str,
+    worker_dir: str,
+    claude_org_path: str,
+) -> dict:
+    roles = schema.get("worker_roles") or {}
+    if role not in roles:
+        available = sorted(k for k in roles if not k.startswith("$"))
+        raise KeyError(
+            f"unknown worker role: {role!r}. available: {available}"
+        )
+    template = {
+        k: v for k, v in roles[role].items() if k not in _META_KEYS
+    }
+    return _substitute(
+        template,
+        {"worker_dir": worker_dir, "claude_org_path": claude_org_path},
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate <worker_dir>/.claude/settings.local.json from "
+            "role_configs_schema.json -> worker_roles[<role>]."
+        ),
+    )
+    parser.add_argument(
+        "--role",
+        required=True,
+        help="worker role name (e.g. default, claude-org-self-edit, doc-audit)",
+    )
+    parser.add_argument(
+        "--worker-dir",
+        required=True,
+        help="absolute path that {worker_dir} resolves to",
+    )
+    parser.add_argument(
+        "--claude-org-path",
+        required=True,
+        help="absolute path to the claude-org repo (for hook script paths)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="output file (default: stdout)",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA,
+        help=f"schema path (default: {DEFAULT_SCHEMA})",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        schema = load_schema(args.schema)
+    except FileNotFoundError as exc:
+        print(f"error: schema not found: {exc.filename}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"error: schema is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        rendered = render_role(
+            schema,
+            role=args.role,
+            worker_dir=args.worker_dir,
+            claude_org_path=args.claude_org_path,
+        )
+    except KeyError as exc:
+        print(f"error: {exc.args[0]}", file=sys.stderr)
+        return 2
+
+    text = json.dumps(rendered, indent=2, ensure_ascii=False) + "\n"
+    if args.out is None:
+        sys.stdout.write(text)
+    else:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/role_configs_schema.json
+++ b/tools/role_configs_schema.json
@@ -397,7 +397,11 @@
           "Bash(git checkout *)",
           "Bash(git switch *)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Edit",
+          "Write",
+          "MultiEdit",
+          "NotebookEdit"
         ]
       },
       "hooks": {

--- a/tools/role_configs_schema.json
+++ b/tools/role_configs_schema.json
@@ -215,7 +215,7 @@
       ]
     },
     "worker": {
-      "description": "Worker (dynamic template) — <worker_dir>/.claude/settings.local.json.",
+      "description": "Worker (dynamic template, audit constraints) — <worker_dir>/.claude/settings.local.json. See also top-level worker_roles section for the concrete templates that generate_worker_settings.py emits.",
       "docs_section": "ワーカー",
       "settings_paths": [],
       "closed_world": true,
@@ -266,6 +266,171 @@
         "^Bash$",
         "^Bash\\(git push.*\\)$"
       ]
+    }
+  },
+  "worker_roles": {
+    "$comment": "Concrete templates emitted by tools/generate_worker_settings.py. Each entry shapes a worker's <worker_dir>/.claude/settings.local.json. Placeholders {worker_dir} and {claude_org_path} are substituted at generation time. The audit constraints in roles.worker still apply — drift tooling validates emitted files against them.",
+    "default": {
+      "description": "Standard worker template — git read/write within the worktree, no push, no recursive delete. Mirrors the historical org-delegate Step 3 inline JSON.",
+      "permissions": {
+        "allow": [
+          "Bash(git add:*)",
+          "Bash(git commit:*)",
+          "Bash(git status:*)",
+          "Bash(git diff:*)",
+          "Bash(git log:*)",
+          "Bash(git branch:*)",
+          "Bash(git checkout:*)",
+          "Bash(git switch:*)",
+          "Bash(git worktree:*)",
+          "Bash(git stash:*)",
+          "Bash(sleep:*)"
+        ],
+        "deny": [
+          "Bash(git push *)",
+          "Bash(git push)",
+          "Bash(rm -rf *)",
+          "Bash(rm -r *)"
+        ]
+      },
+      "hooks": {
+        "PreToolUse": [
+          {
+            "matcher": "Edit|Write",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/check-worker-boundary.sh\""
+              },
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-org-structure.sh\""
+              }
+            ]
+          },
+          {
+            "matcher": "Bash",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-git-push.sh\""
+              },
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-org-structure.sh\""
+              }
+            ]
+          }
+        ]
+      },
+      "env": {
+        "WORKER_DIR": "{worker_dir}",
+        "CLAUDE_ORG_PATH": "{claude_org_path}"
+      }
+    },
+    "claude-org-self-edit": {
+      "description": "Worker that edits the claude-org repo itself (e.g. tools/, .claude/skills/). Drops block-org-structure.sh hooks because by definition this role must touch org structure paths. check-worker-boundary.sh remains the boundary check.",
+      "permissions": {
+        "allow": [
+          "Bash(git add:*)",
+          "Bash(git commit:*)",
+          "Bash(git status:*)",
+          "Bash(git diff:*)",
+          "Bash(git log:*)",
+          "Bash(git branch:*)",
+          "Bash(git checkout:*)",
+          "Bash(git switch:*)",
+          "Bash(git worktree:*)",
+          "Bash(git stash:*)",
+          "Bash(sleep:*)"
+        ],
+        "deny": [
+          "Bash(git push *)",
+          "Bash(git push)",
+          "Bash(rm -rf *)",
+          "Bash(rm -r *)"
+        ]
+      },
+      "hooks": {
+        "PreToolUse": [
+          {
+            "matcher": "Edit|Write",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/check-worker-boundary.sh\""
+              }
+            ]
+          },
+          {
+            "matcher": "Bash",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-git-push.sh\""
+              }
+            ]
+          }
+        ]
+      },
+      "env": {
+        "WORKER_DIR": "{worker_dir}",
+        "CLAUDE_ORG_PATH": "{claude_org_path}"
+      }
+    },
+    "doc-audit": {
+      "description": "Read-only investigation worker — no Write/Edit allow, no commit/branch mutation. Suitable for survey / audit / reporting tasks where the worker should not modify the worktree.",
+      "permissions": {
+        "allow": [
+          "Bash(git status:*)",
+          "Bash(git diff:*)",
+          "Bash(git log:*)",
+          "Bash(git branch:*)",
+          "Bash(sleep:*)"
+        ],
+        "deny": [
+          "Bash(git push *)",
+          "Bash(git push)",
+          "Bash(git commit *)",
+          "Bash(git commit)",
+          "Bash(rm -rf *)",
+          "Bash(rm -r *)"
+        ]
+      },
+      "hooks": {
+        "PreToolUse": [
+          {
+            "matcher": "Edit|Write",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/check-worker-boundary.sh\""
+              },
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-org-structure.sh\""
+              }
+            ]
+          },
+          {
+            "matcher": "Bash",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-git-push.sh\""
+              },
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-org-structure.sh\""
+              }
+            ]
+          }
+        ]
+      },
+      "env": {
+        "WORKER_DIR": "{worker_dir}",
+        "CLAUDE_ORG_PATH": "{claude_org_path}"
+      }
     }
   }
 }

--- a/tools/role_configs_schema.json
+++ b/tools/role_configs_schema.json
@@ -385,7 +385,6 @@
           "Bash(git status:*)",
           "Bash(git diff:*)",
           "Bash(git log:*)",
-          "Bash(git branch:*)",
           "Bash(sleep:*)"
         ],
         "deny": [
@@ -393,6 +392,10 @@
           "Bash(git push)",
           "Bash(git commit *)",
           "Bash(git commit)",
+          "Bash(git branch *)",
+          "Bash(git branch)",
+          "Bash(git checkout *)",
+          "Bash(git switch *)",
           "Bash(rm -rf *)",
           "Bash(rm -r *)"
         ]


### PR DESCRIPTION
## Summary

Phase 1 of Issue #99 — moves worker `.claude/settings.local.json` away from hand-written JSON toward a schema-driven generator. Phase 2 (secretary-side `Write` deny on `workers/*/.claude/settings.local.json`, `org-delegate` Step 1.5 migration, escape-hatch design) is intentionally deferred to a follow-up PR.

- `tools/role_configs_schema.json` — new top-level `worker_roles` section with three roles: `default`, `claude-org-self-edit`, `doc-audit`. Existing `secretary` / `dispatcher` / `curator` / `worker` / `user_common` entries unchanged.
- `tools/generate_worker_settings.py` — CLI generator. Inputs: `--role`, `--worker-dir`, `--claude-org-path`. Output: deterministic `settings.local.json`. Stdlib only (json / argparse / pathlib).
- `tools/check_role_configs.py` — adds `--include-worker-settings <BASE_DIR>` flag. Existing call sites unchanged; flag is opt-in.
- `tests/test_generate_worker_settings.py` — new unit tests (role lookup, path substitution, error paths).
- `tests/test_check_role_configs.py` — extended for `--include-worker-settings` coverage.

3 commits across 3 Codex review rounds (Round 1 Blocker:1 / Major:3 / Minor:1 → Round 2 Major:1 → Round 3 clean).

## Acceptance criteria progress

- [x] `worker_roles` section in schema
- [x] `tools/generate_worker_settings.py` with unit tests
- [x] `tools/check_role_configs.py --include-worker-settings`
- [ ] `org-delegate` Step 1.5 migration (Phase 2)
- [ ] secretary `Write(workers/*/.claude/settings.local.json)` deny (Phase 2)
- [ ] README / internal docs listing 7 merits / 7 demerits (Phase 2 doc PR)

## Refs

- closes claude-org-ja#99 partially (Phase 1 of 2)
- claude-org-ja#101 (epic)

## Test plan

- [x] All 65 tests pass locally
- [x] Generator produces valid JSON for all three roles
- [x] Codex review converged (3 rounds, no Blocker/Major remaining)
- [ ] CI green