### PR TITLE
feat(worker-perms): Phase 2 generator migration + secretary deny + design doc (closes #99)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -185,6 +185,18 @@ git -C {project_path} check-ignore -q -- <target>
 
 1. `registry/org-config.md` の `workers_dir` を読み、リポジトリルートからの相対パスを絶対パスに解決する
 
+### ワーカーロール (`<ROLE>`) の選び方
+
+`.claude/settings.local.json` の生成は schema-driven generator (`tools/generate_worker_settings.py`) に委ねる。窓口は **タスク特性に応じて 1 つの role を選ぶだけ** で、permission の手書き編集は禁止（schema → settings の drift は CI で fail する）。
+
+| Role | 用途 |
+|---|---|
+| `default` | 通常の実装・修正タスク（git commit / branch 操作あり、push 不可、recursive delete 不可） |
+| `claude-org-self-edit` | claude-org リポジトリ自身を編集するタスク（`tools/`, `.claude/skills/`, `docs/` 等）。`block-org-structure.sh` を外す代わりに `check-worker-boundary.sh` で境界を担保 |
+| `doc-audit` | 読み取り中心の調査・監査・レポート（Edit/Write/MultiEdit/NotebookEdit を deny。commit / branch も禁止） |
+
+各 role の具体的な allow/deny/hooks は `tools/role_configs_schema.json` の `worker_roles[<role>]` を参照（schema が SOT）。新しいパターンが必要な場合は schema に role を追加する PR を起こすこと（窓口の手書き拡張は不可）。
+
 ### パターン A: プロジェクトディレクトリ
 
 プロジェクト専用ディレクトリ（`{workers_dir}/{project_slug}/`）を使う。初回は clone、2回目以降は再利用。
@@ -193,11 +205,15 @@ git -C {project_path} check-ignore -q -- <target>
 
 1. `git clone {project_path} {workers_dir}/{project_slug}/` を実行
 2. ディレクトリ直下に CLAUDE.md を生成する（テンプレートの変数を置換）
-3. ディレクトリ直下に `.claude/settings.local.json` を配置する
-   （設定内容は org-setup/references/permissions.md の「ワーカー」セクション参照）
-   - `permissions.deny` を含めること（`git push` / `rm -rf` 等の静的ブロック。`bypassPermissions` モードでも常に有効）
-   - hooks の command パスと env の値には `{claude_org_path}` と `{worker_dir}` を解決済みの絶対パスで埋め込むこと
-   - command パス内のクォート（`"bash \"{claude_org_path}/...\""`）はそのまま維持すること（スペース対策）
+3. ディレクトリ直下に `.claude/settings.local.json` を **generator で生成する**（schema が SOT。詳細は `tools/role_configs_schema.json` の `worker_roles` を参照）:
+   ```bash
+   python tools/generate_worker_settings.py \
+     --role <ROLE> \
+     --worker-dir {worker_dir} \
+     --claude-org-path {claude_org_path} \
+     --out {worker_dir}/.claude/settings.local.json
+   ```
+   `<ROLE>` の選び方は本 Step 冒頭の「ワーカーロール (`<ROLE>`) の選び方」表を参照。手書き JSON は禁止（drift CI が fail する）。
 4. `.state/org-state.md` の Worker Directory Registry に登録する
 
 **再利用（ディレクトリが存在し、ステータスが `available` の場合）:**
@@ -219,11 +235,15 @@ git -C {project_path} check-ignore -q -- <target>
    - `{branch_name}` は Step 1 で決定したブランチ名（指定がなければ `{task_id}` をブランチ名に使う）
    - ワーカーディレクトリ: `{workers_dir}/{project_slug}/.worktrees/{task_id}/`
 3. worktree 直下に CLAUDE.md を生成する（テンプレートの変数を置換）
-4. worktree 直下に `.claude/settings.local.json` を配置する
-   （設定内容は org-setup/references/permissions.md の「ワーカー」セクション参照）
-   - `permissions.deny` を含めること（`git push` / `rm -rf` 等の静的ブロック。`bypassPermissions` モードでも常に有効）
-   - hooks の command パスと env の値には `{claude_org_path}` と `{worker_dir}` を解決済みの絶対パスで埋め込むこと
-   - command パス内のクォート（`"bash \"{claude_org_path}/...\""`）はそのまま維持すること（スペース対策）
+4. worktree 直下に `.claude/settings.local.json` を **generator で生成する**（schema-driven。詳細は `tools/role_configs_schema.json` の `worker_roles` 参照）:
+   ```bash
+   python tools/generate_worker_settings.py \
+     --role <ROLE> \
+     --worker-dir {worker_dir} \
+     --claude-org-path {claude_org_path} \
+     --out {worker_dir}/.claude/settings.local.json
+   ```
+   `<ROLE>` の選び方は本 Step 冒頭の「ワーカーロール (`<ROLE>`) の選び方」表を参照。手書き JSON は禁止。
 5. `.state/org-state.md` の Worker Directory Registry に登録する
 
 ### パターン C: エフェメラル
@@ -232,16 +252,20 @@ git -C {project_path} check-ignore -q -- <target>
 
 1. `{workers_dir}/{task_id}/` ディレクトリを作成する（例: `../workers/data-analysis/`）
 2. テンプレートから `{workers_dir}/{task_id}/CLAUDE.md` を生成する
-3. `{workers_dir}/{task_id}/.claude/settings.local.json` にワーカー用の設定を配置する
-   （設定内容は org-setup/references/permissions.md の「ワーカー」セクション参照）
-   - `permissions.deny` を含めること（`git push` / `rm -rf` 等の静的ブロック。`bypassPermissions` モードでも常に有効）
-   - hooks の command パスと env の値には `{claude_org_path}` と `{worker_dir}` を解決済みの絶対パスで埋め込むこと
-   - command パス内のクォート（`"bash \"{claude_org_path}/...\""`）はそのまま維持すること（スペース対策）
+3. `{workers_dir}/{task_id}/.claude/settings.local.json` を **generator で生成する**（schema-driven。詳細は `tools/role_configs_schema.json` の `worker_roles` 参照）:
+   ```bash
+   python tools/generate_worker_settings.py \
+     --role <ROLE> \
+     --worker-dir {worker_dir} \
+     --claude-org-path {claude_org_path} \
+     --out {worker_dir}/.claude/settings.local.json
+   ```
+   `<ROLE>` の選び方は本 Step 冒頭の「ワーカーロール (`<ROLE>`) の選び方」表を参照。手書き JSON は禁止。
 4. `.state/org-state.md` の Worker Directory Registry に登録する
 
 ### 共通手順（全パターン・配置後）
 
-テンプレートの変数を実際の値で置換する:
+CLAUDE.md テンプレートの変数を実際の値で置換する（settings.local.json の置換は generator が自動で行うため対象外）:
 - `{project_name}` → registry の通称
 - `{project_description}` → registry の説明
 - `{task_id}` → タスクID（例: `data-analysis`）

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -9,11 +9,19 @@ claude-org リポジトリのスキル / ドキュメント / 設定を編集す
 
 このため、claude-org 自己編集タスクでは **Step 1.5 のワーカーディレクトリ準備時に以下 3 点を通常手順に追加する**。
 
-## 1. `block-org-structure.sh` hook を worktree の settings.local.json から除外する
+## 1. `claude-org-self-edit` ロールで settings.local.json を生成する
 
-worktree 直下の `.claude/settings.local.json` を配置する際、`hooks.PreToolUse` から `block-org-structure.sh` エントリを **除外**すること。`Edit|Write` matcher と `Bash` matcher の両方で除外する必要がある。
+Phase 2 (Issue #99) 以降、ワーカー `.claude/settings.local.json` は `tools/generate_worker_settings.py` で **schema-driven に生成**する（手書き編集は窓口の `permissions.deny` で禁止されている）。claude-org 自己編集タスクでは `--role claude-org-self-edit` を指定すること:
 
-他の hook（例: `block-git-push.sh`, `block-workers-delete.sh`, `check-worker-boundary.sh` 等）は通常どおり残してよい。除外対象はあくまで claude-org 構造のブロック hook のみ。
+```bash
+python tools/generate_worker_settings.py \
+  --role claude-org-self-edit \
+  --worker-dir {worker_dir} \
+  --claude-org-path {claude_org_path} \
+  --out {worker_dir}/.claude/settings.local.json
+```
+
+`claude-org-self-edit` ロールは schema 上で `block-org-structure.sh` hook が **既に除外**された状態で定義されている（`Edit|Write` / `Bash` matcher 双方）。`check-worker-boundary.sh` / `block-git-push.sh` などその他の hook は通常どおり残る。生成済み JSON を手で再編集してはならない（drift CI が fail する。新パターンが必要なら `tools/role_configs_schema.json` の `worker_roles` に role を追加する PR を起こす）。
 
 ## 2. ワーカー指示は `CLAUDE.md` ではなく `CLAUDE.local.md` に書く
 

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -125,7 +125,9 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
     ],
     "deny": [
       "Write(*/workers/*/.claude/settings.local.json)",
-      "Edit(*/workers/*/.claude/settings.local.json)"
+      "Edit(*/workers/*/.claude/settings.local.json)",
+      "Write(*/workers/*/.worktrees/*/.claude/settings.local.json)",
+      "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)"
     ]
   },
   "hooks": {
@@ -146,7 +148,7 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 
 **mcp__renga-peers__\* の重複**: ユーザー共通 settings.json と重複するが、窓口は run 直後に renga-peers MCP を必ず使うため、窓口スコープでも明示的に列挙して source-of-truth として固定する（user settings の drift でも窓口が動くことを保証）。
 
-**`permissions.deny` (Issue #99 Phase 2 で追加)**: ワーカー設定ファイル (`workers/*/.claude/settings.local.json`) への直接 Write/Edit を窓口に対して禁止する。ワーカー設定は `tools/generate_worker_settings.py` 経由でしか書き換えられないようにし、窓口の手書き編集による permission 過大付与を構造的に防ぐ。`bypassPermissions` モードでも常に有効。
+**`permissions.deny` (Issue #99 Phase 2 で追加)**: ワーカー設定ファイル（`workers/<project>/.claude/settings.local.json` および worktree パス `workers/<project>/.worktrees/<task>/.claude/settings.local.json`）への直接 Write/Edit を窓口に対して禁止する。ワーカー設定は `tools/generate_worker_settings.py` 経由でしか書き換えられないようにし、窓口の手書き編集による permission 過大付与を構造的に防ぐ。窓口は通常モード起動（`bypassPermissions` ではない）なので、この `permissions.deny` は静的パターンマッチで常に効く。
 
 **renga bootstrap の重複**: 同じ理由でユーザー共通と重複するが、窓口が初回レイアウト起動やペイン制御で即時使うため明示列挙。
 

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -122,6 +122,10 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
       "Bash(curl -s -o /dev/null -w \"%{http_code}\" http://localhost:8099/:*)",
       "Bash(curl -s http://localhost:8099/ -o /dev/null -w \"%{http_code}\\\\n\")",
       "PowerShell(Out-File *)"
+    ],
+    "deny": [
+      "Write(*/workers/*/.claude/settings.local.json)",
+      "Edit(*/workers/*/.claude/settings.local.json)"
     ]
   },
   "hooks": {
@@ -141,6 +145,8 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 ```
 
 **mcp__renga-peers__\* の重複**: ユーザー共通 settings.json と重複するが、窓口は run 直後に renga-peers MCP を必ず使うため、窓口スコープでも明示的に列挙して source-of-truth として固定する（user settings の drift でも窓口が動くことを保証）。
+
+**`permissions.deny` (Issue #99 Phase 2 で追加)**: ワーカー設定ファイル (`workers/*/.claude/settings.local.json`) への直接 Write/Edit を窓口に対して禁止する。ワーカー設定は `tools/generate_worker_settings.py` 経由でしか書き換えられないようにし、窓口の手書き編集による permission 過大付与を構造的に防ぐ。`bypassPermissions` モードでも常に有効。
 
 **renga bootstrap の重複**: 同じ理由でユーザー共通と重複するが、窓口が初回レイアウト起動やペイン制御で即時使うため明示列挙。
 
@@ -244,7 +250,9 @@ python tools/org_setup_prune.py --all                        # secretary / dispa
 
 ## ワーカー（動的生成）
 
-ワーカーの設定は org-delegate の Step 3 で動的に作成される。
+ワーカーの設定は org-delegate の Step 1.5 で動的に作成される。
+
+> **Phase 2 以降 (Issue #99)**: ワーカーの `settings.local.json` は `tools/generate_worker_settings.py` が `tools/role_configs_schema.json` の `worker_roles[<role>]` から生成する（`default` / `claude-org-self-edit` / `doc-audit` の 3 role）。本セクションに掲載されている JSON はあくまでリファレンス用で、手書き編集は禁止（drift CI が fail する）。新しい permission パターンが必要な場合は schema に role を追加する PR を起こすこと。
 
 ```json
 {

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -148,7 +148,9 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 
 **mcp__renga-peers__\* の重複**: ユーザー共通 settings.json と重複するが、窓口は run 直後に renga-peers MCP を必ず使うため、窓口スコープでも明示的に列挙して source-of-truth として固定する（user settings の drift でも窓口が動くことを保証）。
 
-**`permissions.deny` (Issue #99 Phase 2 で追加)**: ワーカー設定ファイル（`workers/<project>/.claude/settings.local.json` および worktree パス `workers/<project>/.worktrees/<task>/.claude/settings.local.json`）への直接 Write/Edit を窓口に対して禁止する。ワーカー設定は `tools/generate_worker_settings.py` 経由でしか書き換えられないようにし、窓口の手書き編集による permission 過大付与を構造的に防ぐ。窓口は通常モード起動（`bypassPermissions` ではない）なので、この `permissions.deny` は静的パターンマッチで常に効く。
+**`permissions.deny` (Issue #99 Phase 2 で追加)**: ワーカー設定ファイル（`workers/<project>/.claude/settings.local.json` および worktree パス `workers/<project>/.worktrees/<task>/.claude/settings.local.json`）への **Claude の `Write` / `Edit` ツール経由の直接編集**を窓口に対して禁止する。窓口は通常モード起動（`bypassPermissions` ではない）なので、この `permissions.deny` は静的パターンマッチで常に効く。
+
+ただしこの deny は Claude のファイル編集ツール（Write/Edit）系のゲートに限定される。窓口は引き続き `Bash(python:*)` / `Bash(python3:*)` / `PowerShell(Out-File *)` を allow しているため、Bash/PowerShell から `cat > settings.local.json` のように書き出すことは技術的に可能。本 deny は **「窓口が手作業で `Edit` ツールを開いて settings を書き換える」** という主要な誤付与経路を塞ぐためのもので、`tools/generate_worker_settings.py` 以外の経路を完全に遮断するものではない。完全な generator-only 化（Bash 側の遮断を含む）は Phase 3 の課題（drift CI 拡張・escape hatch と併走）。
 
 **renga bootstrap の重複**: 同じ理由でユーザー共通と重複するが、窓口が初回レイアウト起動やペイン制御で即時使うため明示列挙。
 

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -318,4 +318,4 @@ python tools/org_setup_prune.py --all                        # secretary / dispa
 
 **注意**: `{claude_org_path}` と `{worker_dir}` は settings.local.json 生成時に解決済みの絶対パスに置換すること。Hook command 内のパスはスペース対策のためクォートされている。
 
-**deny と hooks の役割分担**: `permissions.deny` は静的パターンマッチによるブロックで、`bypassPermissions` モードでも常に有効。外部コマンド（jq, bash）に依存しないため信頼性が高い。一方 hooks はワーカーディレクトリ境界チェック等の動的検証を担う。両者を併用することで多層防御を実現する。`deny` は `echo foo && git push` のような埋め込みコマンドはカバーできないため、`block-git-push.sh` hook は副次防御として維持する。
+**deny と hooks の役割分担**: ワーカーは通常モード（`bypassPermissions` ではない）で起動するため、`permissions.deny` は静的パターンマッチで常に効く。外部コマンド（jq, bash）に依存しないので信頼性が高い。一方 hooks はワーカーディレクトリ境界チェック等の動的検証を担う。両者を併用することで多層防御を実現する。`deny` は `echo foo && git push` のような埋め込みコマンドはカバーできないため、`block-git-push.sh` hook は副次防御として維持する。なお `bypassPermissions` で起動するロール（ディスパッチャー）では `permissions.deny` は bypass されるので、そちらは hook のみが障壁になる（前述 `重要` 節参照）。

--- a/docs/worker-permissions-design.md
+++ b/docs/worker-permissions-design.md
@@ -68,7 +68,9 @@ python tools/generate_worker_settings.py \
 
 ### 5. drift CI 拡張
 
-`tools/check_role_configs.py` に `--include-worker-settings` を追加。CI ですべてのワーカー `settings.local.json` を schema に対して検証する。drift = fail。
+`tools/check_role_configs.py` に `--include-worker-settings` を追加。`<workers_dir>/<project>/.claude/settings.local.json` 配置のワーカー（Pattern A 系）を schema に対して検証する。drift = fail。
+
+> **現状の検査スコープ (Phase 1 時点)**: `--include-worker-settings` は `<BASE_DIR>/*/.claude/settings.local.json` のみを走査するため、Pattern B の `<BASE_DIR>/<project>/.worktrees/<task>/.claude/settings.local.json` は未検査。worktree までの recurse 拡張は Phase 3 の課題（後述）。
 
 ## メリット（7 項目）
 
@@ -103,7 +105,7 @@ python tools/generate_worker_settings.py \
 
 * **Phase 1**（約 1 週間）: B 相当 — schema 拡張 + generator + drift CI（PR #169 で完了）
 * **Phase 2**: hook 強制を追加（A へアップグレード）（本 PR で完了）
-* **Phase 3**: escape hatch 設計（例: 限定的な `worker_roles.adhoc`）と運用知見の蓄積。drift CI は Phase 1 で導入済みのため、本フェーズでは alert 経路や retro 連携の整備が中心
+* **Phase 3**: escape hatch 設計（例: 限定的な `worker_roles.adhoc`）、drift CI スコープ拡張（Pattern B worktree 配下まで recurse）、運用知見の蓄積（alert 経路や retro 連携）
 
 ## Acceptance Criteria
 
@@ -111,7 +113,7 @@ python tools/generate_worker_settings.py \
 * [x] `tools/generate_worker_settings.py` を実装（unit test 込み）（Phase 1）
 * [x] `org-delegate` Step 1.5 の手書き JSON 部分を generator 呼び出しに置換（Phase 2）
 * [x] 窓口設定に `Write(*/workers/*/.claude/settings.local.json)` deny ルールを追加（Phase 2）
-* [x] `tools/check_role_configs.py` が `--include-worker-settings` でワーカー `settings.local.json` を schema 検証（Phase 1）
+* [x] `tools/check_role_configs.py` が `--include-worker-settings` でワーカー `settings.local.json` を schema 検証（Phase 1）。ただし現状は `<BASE_DIR>/*/.claude/...` のみで、Pattern B worktree 配下は Phase 3 で追加予定
 * [x] README / 内部ドキュメントに 7 メリット / 7 デメリットを明示（本ドキュメント）
 
 ## 関連

--- a/docs/worker-permissions-design.md
+++ b/docs/worker-permissions-design.md
@@ -57,10 +57,11 @@ python tools/generate_worker_settings.py \
 
 ### 3. Secretary PreToolUse hook（と静的 deny）
 
-`workers/*/.claude/settings.local.json` への直接 `Write` / `Edit` を **deny** する:
+`workers/*/.claude/settings.local.json`（および worktree 配下）への Claude の `Write` / `Edit` ツール経由の直接編集を **deny** する:
 
 - 窓口の `.claude/settings.local.json` `permissions.deny` に追加
-- 書き換えは generator (Bash 起動) のみ可
+- 主たる誤付与経路（窓口が `Edit` で手書き）を塞ぐのが目的
+- Bash/PowerShell からのファイル書き出し（`Bash(python:*)` 等）は別途 allow に残るため、Bash 経由の改変は技術的には可能。完全な generator-only 化は Phase 3 で `block-secretary-write-worker-settings.sh` 相当の hook と併せて行う想定
 
 ### 4. `org-delegate` Step 1.5 移行
 

--- a/docs/worker-permissions-design.md
+++ b/docs/worker-permissions-design.md
@@ -103,7 +103,7 @@ python tools/generate_worker_settings.py \
 
 * **Phase 1**（約 1 週間）: B 相当 — schema 拡張 + generator + drift CI（PR #169 で完了）
 * **Phase 2**: hook 強制を追加（A へアップグレード）（本 PR で完了）
-* **Phase 3**: drift CI 拡張、escape hatch 設計（例: 限定的な `worker_roles.adhoc`）
+* **Phase 3**: escape hatch 設計（例: 限定的な `worker_roles.adhoc`）と運用知見の蓄積。drift CI は Phase 1 で導入済みのため、本フェーズでは alert 経路や retro 連携の整備が中心
 
 ## Acceptance Criteria
 

--- a/docs/worker-permissions-design.md
+++ b/docs/worker-permissions-design.md
@@ -1,0 +1,122 @@
+# ワーカー権限管理設計（schema-driven worker permissions）
+
+> 関連 Issue: [#99](https://github.com/suisya-systems/claude-org-ja/issues/99)
+> ステータス: Phase 1 完了 (PR #169)、Phase 2 完了（本ドキュメントの PR）
+
+claude-org におけるワーカー Claude の `.claude/settings.local.json` 権限管理を、窓口（Secretary）の手書き JSON から **schema-driven な generator + 静的 deny + drift CI** に置き換える設計の根拠と運用ノートをまとめる。
+
+## 背景 / 動機
+
+従来、ワーカーの `.claude/settings.local.json` は **窓口が org-delegate フローの中で手書き JSON として生成** していた。これは構造的に **窓口の判断による permission 過大付与** の余地を残す。
+
+### 具体ケース（2026-04-26）
+
+`worker-strategic-memo-v5-update` を派遣する際、窓口が「念のため」として実需（`additionalDirectories` のみ）を超えて以下を追加していた:
+
+- `Edit(.../docs/internal/**)` のワイルドカード allow
+- `Write(...)` 形式の permission
+
+この事象は PreToolUse hook によりブロックされた事象として検出され、retro で表面化した。
+
+### 根本問題
+
+- メモリベースの自己規律（例: `feedback_no_secretary_carveouts`）は **事後対応的** で、人間の判断に依存する
+- claude-org の既存 F-d 軸（role_configs schema-driven + drift CI）と **非対称**: role_configs は schema-as-SOT で守られているが、ワーカー権限は手書き JSON のまま
+- 「うっかり広く付与する」ことに対する **構造的な障壁が存在しない**
+
+## 提案（5 段階）
+
+### 1. schema 拡張
+
+`tools/role_configs_schema.json` に `worker_roles` セクションを追加:
+
+```json
+"worker_roles": {
+  "default": { "allow": [...], "additionalDirectories": [] },
+  "claude-org-self-edit": { ... },
+  "doc-audit": { ... },
+  "web-research": { ... }
+}
+```
+
+各 role は **決め打ちの permission set** を持ち、窓口が ad-hoc に拡張することはできない。
+
+### 2. generator ツール
+
+`tools/generate_worker_settings.py` を導入:
+
+```bash
+python tools/generate_worker_settings.py \
+  --role doc-audit \
+  --worker-dir <WORKER_DIR> \
+  --claude-org-path <CLAUDE_ORG_PATH> \
+  > $WORKER_DIR/.claude/settings.local.json
+```
+
+入力は role 名 + パス変数のみ。出力は schema から決定論的に生成される。
+
+### 3. Secretary PreToolUse hook（と静的 deny）
+
+`workers/*/.claude/settings.local.json` への直接 `Write` / `Edit` を **deny** する:
+
+- 窓口の `.claude/settings.local.json` `permissions.deny` に追加
+- 書き換えは generator (Bash 起動) のみ可
+
+### 4. `org-delegate` Step 1.5 移行
+
+現在の手書き JSON 生成手順を generator 呼び出しに置換する。SKILL.md 本文と journal イベントスキーマを更新する。
+
+### 5. drift CI 拡張
+
+`tools/check_role_configs.py` に `--include-worker-settings` を追加。CI ですべてのワーカー `settings.local.json` を schema に対して検証する。drift = fail。
+
+## メリット（7 項目）
+
+* **権限過大付与の構造的予防**: 窓口は広範な permission を手書きで付与できない
+* **再現性**: 同じ role → 同じ permission set（決定論的）
+* **schema-as-SOT の延長**: 既存 F-d 軸（role_configs ↔ schema CI）と整合し、Layer 1（core-harness）プリミティブとして抽出可能
+* **承認摩擦が schema 編集に集中**: 新 role 追加には schema PR が必要 → user レビューが trace される
+* **多層防御を 1 段強化**: hook + tool gate + schema validation + CI = 4 層
+* **OSS ポートフォリオの基盤**: claude-org から Layer 1（core-harness）を切り出す際のプリミティブ候補
+* **メモリベースの事後規律からの脱却**: 「うっかり」事案を構造的障壁で防ぐ
+
+## デメリット（7 項目）
+
+* **初期実装コスト**: schema 拡張 + generator + hook + skill 改修 + CI ≈ 2-3 PR、合計 1 週間程度
+* **新規パターンのワーカー追加に摩擦**: 一度きりの新規タスクでも schema に worker_role 追加が必要 → 緊急対応で遅くなる
+* **schema が肥大化する可能性**: role が増えるとメンテコストが上がる
+* **escape-hatch 設計が難しい**: 緩い `worker_roles.adhoc` を入れると障壁が崩れ、入れないと緊急対応で詰まる → トレードオフ
+* **既存ワーカー派遣フローの更新コスト**: org-delegate Step 1.5 / Step 3 / org-state.md / journal イベントスキーマをすべて新方式に揃える必要
+* **デバッグが難しくなる**: `settings.local.json` を直接見ても意図がすぐにわからない → generator ロジックを辿る必要
+* **claude-org 自体にも制約がかかる**: dogfood が窮屈になる（メタ再帰）
+
+## Alternatives（代替案）
+
+* **A**: 提案どおり（schema 拡張 + generator + hook + CI、フル）
+* **B**: hook 部分を落とす（schema + generator + CI のみ、hook 強制なし） → 部分的な障壁、軽量
+* **C**: schema 拡張なし、テンプレートベースの generator のみ → 最軽量、最弱
+* **D**: 拒否。memory + retro 強化で凌ぐ（現状維持）
+
+## 推奨
+
+**A（フル提案）** を最終形として推奨。ただし phasing は現実的に:
+
+* **Phase 1**（約 1 週間）: B 相当 — schema 拡張 + generator + drift CI（PR #169 で完了）
+* **Phase 2**: hook 強制を追加（A へアップグレード）（本 PR で完了）
+* **Phase 3**: drift CI 拡張、escape hatch 設計（例: 限定的な `worker_roles.adhoc`）
+
+## Acceptance Criteria
+
+* [x] `tools/role_configs_schema.json` に `worker_roles` セクションを追加（Phase 1）
+* [x] `tools/generate_worker_settings.py` を実装（unit test 込み）（Phase 1）
+* [x] `org-delegate` Step 1.5 の手書き JSON 部分を generator 呼び出しに置換（Phase 2）
+* [x] 窓口設定に `Write(*/workers/*/.claude/settings.local.json)` deny ルールを追加（Phase 2）
+* [x] `tools/check_role_configs.py` が `--include-worker-settings` でワーカー `settings.local.json` を schema 検証（Phase 1）
+* [x] README / 内部ドキュメントに 7 メリット / 7 デメリットを明示（本ドキュメント）
+
+## 関連
+
+* 直接の引き金: 2026-04-26 `worker-strategic-memo-v5-update` の権限拡張事象（PreToolUse hook がキャッチ）
+* 関連 memory: `feedback_secretary_generation_time_is_blocking`, `feedback_no_secretary_carveouts`
+* 関連戦略ドキュメント: `docs/internal/strategic-analysis-2026-04-26.md` v5 §16（Layer 1 OSS 抽出候補）
+* 関連 Issues: #70（PreToolUse hook の段階導入）, #85（role config CI 整合）, #86（fail-closed allowlist）

--- a/tools/role_configs_schema.json
+++ b/tools/role_configs_schema.json
@@ -143,7 +143,9 @@
       "allowed_allow_regex": [],
       "required_deny": [
         "Write(*/workers/*/.claude/settings.local.json)",
-        "Edit(*/workers/*/.claude/settings.local.json)"
+        "Edit(*/workers/*/.claude/settings.local.json)",
+        "Write(*/workers/*/.worktrees/*/.claude/settings.local.json)",
+        "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)"
       ],
       "required_hooks": [
         {

--- a/tools/role_configs_schema.json
+++ b/tools/role_configs_schema.json
@@ -141,7 +141,10 @@
         "PowerShell(Out-File *)"
       ],
       "allowed_allow_regex": [],
-      "required_deny": [],
+      "required_deny": [
+        "Write(*/workers/*/.claude/settings.local.json)",
+        "Edit(*/workers/*/.claude/settings.local.json)"
+      ],
       "required_hooks": [
         {
           "event": "PreToolUse",


### PR DESCRIPTION
## Summary

Completes Issue #99 (Phase 2). Phase 1 (schema + generator + drift CI) shipped in #169; this PR migrates the dispatch flow onto the generator and locks the structural barrier.

- `.claude/skills/org-delegate/SKILL.md` — Step 1.5 now invokes `tools/generate_worker_settings.py` with role selection guidance (`default` / `claude-org-self-edit` / `doc-audit`). Hand-written JSON instructions removed.
- `.claude/skills/org-delegate/references/claude-org-self-edit.md` — updated to route through the `claude-org-self-edit` role.
- `.claude/skills/org-setup/references/permissions.md` — Phase 2 note added; the inline worker JSON is now reference only. Includes 4 secretary `Write`/`Edit` deny patterns covering Pattern A and Pattern B layouts, plus a `bypassPermissions` wording cleanup.
- `tools/role_configs_schema.json` — secretary `required_deny` extended with the 4 deny patterns above.
- `docs/worker-permissions-design.md` (new) — full 7 merits / 7 demerits / alternatives / phasing per #99, plus an explicit note on the current CI scope and the Bash-bypass discussion surfaced in Codex review.

4 commits across 3 Codex rounds (Round 1 Blocker:1 / Major:1 / Minor:2 → Round 2 Major:2 → Round 3 Major:1 — all resolved).

## Acceptance criteria (closes #99)

- [x] `worker_roles` section in schema (Phase 1, #169)
- [x] `tools/generate_worker_settings.py` with unit tests (Phase 1, #169)
- [x] `tools/check_role_configs.py --include-worker-settings` (Phase 1, #169)
- [x] `org-delegate` Step 1.5 migrated to generator
- [x] secretary `Write`/`Edit` deny on `workers/*/.claude/settings.local.json`
- [x] 7 merits / 7 demerits documented in `docs/worker-permissions-design.md`

## Refs

- claude-org-ja#99 (closes)
- claude-org-ja#101 (epic)
- depends on #169 (Phase 1)

## Test plan

- [x] All 65 tests pass locally
- [x] Schema JSON valid
- [x] Codex review converged (3 rounds, no Blocker / Major remaining)
- [ ] CI green