### PR TITLE
docs(secretary): document --permission-mode exemption rationale (closes #10)

### DIFF
--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -62,7 +62,7 @@ renga 0.18.0+ では `mcp__renga-peers__spawn_claude_pane` が役割別の構造
 - `permission_mode`: registry/org-config.md の default_permission_mode の値を使用（ディスパッチャー除く）
 - `cwd`: 各ロール専用ディレクトリへの相対パス（caller pane の cwd 基準で解決される）
 
-> **注**: Secretary は `renga --layout ops` で起動され、`--permission-mode` 未指定のまま動作する（人間判断窓口のため）。`registry/org-config.md` の Secretary exemption 節を参照。
+> **注**: Secretary は `renga --layout ops` で起動され、`--permission-mode` 未指定のまま動作する（人間判断窓口のため）。`registry/org-config.md` の「Role別の適用範囲」節を参照。
 
 ### ディスパッチャー
 

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -62,6 +62,8 @@ renga 0.18.0+ では `mcp__renga-peers__spawn_claude_pane` が役割別の構造
 - `permission_mode`: registry/org-config.md の default_permission_mode の値を使用（ディスパッチャー除く）
 - `cwd`: 各ロール専用ディレクトリへの相対パス（caller pane の cwd 基準で解決される）
 
+> **注**: Secretary は `renga --layout ops` で起動され、`--permission-mode` 未指定のまま動作する（人間判断窓口のため）。`registry/org-config.md` の Secretary exemption 節を参照。
+
 ### ディスパッチャー
 
 - `cwd=".dispatcher"`

--- a/registry/org-config.md
+++ b/registry/org-config.md
@@ -10,6 +10,10 @@ default_permission_mode: auto
 - acceptEdits: ファイル編集のみ自動許可
 - dontAsk: 明示許可のみ
 
+### Secretary exemption
+
+`default_permission_mode` は Foreman / Curator / Worker に適用される。Secretary は意図的に対象外で、`--permission-mode` 未指定の Claude Code デフォルト挙動（ツール実行前に確認プロンプトを表示）を維持する。Secretary は人間との接点であり、人間判断を要する操作の自動承認を避けるため。詳細は Issue #10 を参照。
+
 ## Workers Directory
 workers_dir: ../workers
 

--- a/registry/org-config.md
+++ b/registry/org-config.md
@@ -10,9 +10,12 @@ default_permission_mode: auto
 - acceptEdits: ファイル編集のみ自動許可
 - dontAsk: 明示許可のみ
 
-### Secretary exemption
+### Role別の適用範囲
 
-`default_permission_mode` は Foreman / Curator / Worker に適用される。Secretary は意図的に対象外で、`--permission-mode` 未指定の Claude Code デフォルト挙動（ツール実行前に確認プロンプトを表示）を維持する。Secretary は人間との接点であり、人間判断を要する操作の自動承認を避けるため。詳細は Issue #10 を参照。
+`default_permission_mode` は Curator / Worker に適用される。他のロールは以下のように扱う:
+
+- **Secretary**: 対象外。`--permission-mode` 未指定の Claude Code デフォルト挙動（ツール実行前に確認プロンプトを表示）を維持する。Secretary は人間との接点であり、人間判断を要する操作の自動承認を避けるため。詳細は Issue #10 を参照。
+- **Dispatcher**: `default_permission_mode` の値にかかわらず、固定で `bypassPermissions` を使用する。理由は `.claude/skills/org-start/SKILL.md` の「ディスパッチャー」節を参照。
 
 ## Workers Directory
 workers_dir: ../workers

--- a/renga-layouts/ops.toml
+++ b/renga-layouts/ops.toml
@@ -18,6 +18,10 @@
 version = 1
 name = "ops"
 
+# Secretary intentionally has no --permission-mode set: it uses Claude Code defaults
+# (confirmation prompts on tool execution). As the human-facing window requiring human
+# judgment, the org-wide bypass (default_permission_mode in registry/org-config.md) does
+# not apply here. See Issue #10 for the full rationale.
 [root]
 type = "pane"
 id = "secretary"

--- a/renga-layouts/ops.toml
+++ b/renga-layouts/ops.toml
@@ -20,8 +20,9 @@ name = "ops"
 
 # Secretary intentionally has no --permission-mode set: it uses Claude Code defaults
 # (confirmation prompts on tool execution). As the human-facing window requiring human
-# judgment, the org-wide bypass (default_permission_mode in registry/org-config.md) does
-# not apply here. See Issue #10 for the full rationale.
+# judgment, the org-wide default_permission_mode (registry/org-config.md, applied to
+# Curator and Workers) is intentionally not propagated here. See Issue #10 for the
+# full rationale.
 [root]
 type = "pane"
 id = "secretary"


### PR DESCRIPTION
## Summary
- Document why Secretary is started without `--permission-mode` (Issue #10): inline comment in `renga-layouts/ops.toml` and a "Role-wise applicability" section in `registry/org-config.md`
- Also document Dispatcher's fixed `bypassPermissions` exception alongside Secretary's exemption
- No behavior change. Docs / comments only

## Test plan
- [x] python tools/check_role_configs.py → OK
- [x] python -m pytest tests/ tools/ → 151 passed
- [x] renga-layouts/ops.toml TOML parse verified
- [x] Codex self-review applied (Major×2 fixed)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>