### PR TITLE
chore: post-public hygiene (SECURITY.md, broken-link fix, issue/PR templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please fill in as much detail as possible.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Describe the unexpected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Claude Code version, renga version, gh version, Python / Node versions if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / output
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/suisya-systems/claude-org-ja/security/advisories/new
+    about: For security issues, please use private vulnerability reporting instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest a new capability or behavior
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- Brief description of what this PR does and why. -->
+
+## Related issues
+
+<!-- Link related issues, e.g. "Closes #123" or "Refs #456". Leave blank if none. -->
+
+## Checklist
+
+- [ ] Tests added or updated (if behavior changed)
+- [ ] Docs updated (README / CLAUDE.md / skill SKILL.md / docs/* as applicable)
+- [ ] Linked Issue (if this PR closes one)
+- [ ] CI green locally before pushing (where applicable)
+- [ ] No secrets, internal-only paths, or personal absolute paths added to tracked files
+
+## Notes for reviewer
+
+<!-- Anything specific the reviewer should focus on, or context that's not obvious from the diff. -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,9 @@ We take the security of claude-org-ja seriously. If you discover a security issu
 
 ### Preferred channel: GitHub Private Vulnerability Reporting
 
-Use [GitHub's private vulnerability reporting](https://github.com/suisya-systems/claude-org-ja/security/advisories/new) feature. This is the fastest channel and ensures the report is encrypted and only visible to maintainers.
+Use [GitHub's private vulnerability reporting](https://github.com/suisya-systems/claude-org-ja/security/advisories/new) feature. This is the only supported reporting channel and ensures the report is encrypted and only visible to maintainers. The same link is also surfaced in the issue chooser as the "Security report" contact link.
 
-### Alternative
-
-If you cannot use GitHub PVR, open a regular Issue **without** including reproduction details and we will reach out via a private channel.
+Please do **not** open a public Issue or Pull Request for security reports — the public issue templates require reproduction details and would expose sensitive information.
 
 ## Disclosure Policy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of claude-org-ja seriously. If you discover a security issue, please report it privately so we can address it before public disclosure.
+
+### Preferred channel: GitHub Private Vulnerability Reporting
+
+Use [GitHub's private vulnerability reporting](https://github.com/suisya-systems/claude-org-ja/security/advisories/new) feature. This is the fastest channel and ensures the report is encrypted and only visible to maintainers.
+
+### Alternative
+
+If you cannot use GitHub PVR, open a regular Issue **without** including reproduction details and we will reach out via a private channel.
+
+## Disclosure Policy
+
+- We aim to acknowledge reports within 72 hours.
+- We aim to provide an initial assessment and remediation plan within 14 days.
+- We will coordinate disclosure timing with the reporter; default is public disclosure once a fix is available.
+
+## Supported Versions
+
+Only the latest tagged release on `main` is actively supported. Earlier development history was squashed at the v0.1.0 public release; pre-v0.1.0 references are not in scope.
+
+## Scope
+
+Security reports for the following are in scope:
+- Permission / hook bypass in worker / dispatcher / curator settings
+- Path traversal or arbitrary write through Skill / hook execution
+- Secret leakage in default skills, workflows, or scripts
+- Privilege escalation via MCP tool misuse
+
+Out of scope: third-party tools (Claude Code CLI, renga, gh CLI itself); please report to those projects directly.

--- a/docs/worker-permissions-design.md
+++ b/docs/worker-permissions-design.md
@@ -121,5 +121,4 @@ python tools/generate_worker_settings.py \
 
 * 直接の引き金: 2026-04-26 `worker-strategic-memo-v5-update` の権限拡張事象（PreToolUse hook がキャッチ）
 * 関連 memory: `feedback_secretary_generation_time_is_blocking`, `feedback_no_secretary_carveouts`
-* 関連戦略ドキュメント: `docs/internal/strategic-analysis-2026-04-26.md` v5 §16（Layer 1 OSS 抽出候補）
 * 関連 Issues: #70（PreToolUse hook の段階導入）, #85（role config CI 整合）, #86（fail-closed allowlist）


### PR DESCRIPTION
## Summary

Post-public follow-up hygiene work bundled in one PR. Closes 4 of the 7 audit findings; the 5th (CODE_OF_CONDUCT.md) was excluded due to a content-filter block on the Contributor Covenant body and will be added separately.

- **SECURITY.md**: defines vulnerability reporting policy. After codex self-review, the file was tightened to make GitHub Private Vulnerability Reporting the sole supported channel and explicitly forbid public Issues for security reports (rationale: \`config.yml\` sets \`blank_issues_enabled: false\` and the only public bug template requires reproduction steps — a "fall back to a regular Issue" path would have pressured reporters into public oversharing).
- **Broken link fix**: removed dangling reference to \`docs/internal/strategic-analysis-2026-04-26.md\` (gitignored, 404 for external users) from \`docs/worker-permissions-design.md\`.
- **Issue templates**: \`bug_report.yml\`, \`feature_request.yml\`, \`config.yml\` (blank issues disabled, security contact link to PVR).
- **PR template**: checklist matching \`CONTRIBUTING.md\`.

## Related issues

- Closes #182
- Closes #183
- Closes #185
- Closes #186
- Refs #187 (CoC, deferred — content-filter block on Contributor Covenant text)

## Checklist

- [x] Tests added or updated — N/A (docs / config only)
- [x] Docs updated — this PR is the docs update
- [x] Linked Issue
- [x] CI green locally — N/A for these files
- [x] No secrets, internal-only paths, or personal absolute paths added

## Notes for reviewer

5 commits, with the last one being the codex-review fixup on SECURITY.md. Squash-merge recommended.