### PR TITLE
docs(consistency): clean up ccmux 0.18.0 migration leftovers (closes #72)

### DIFF
--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -44,7 +44,7 @@ renga は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 
 
 ### アルゴリズム
 
-新規ワーカーを起動するディスパッチャーは、`spawn_pane` を呼ぶ前に以下を実行する。判定ステップの詳細は `SKILL.md` Step 3-1 を参照（Claude が `list_panes` の結果テキストを解釈してロジックを実行する）。
+新規ワーカーを起動するディスパッチャーは、`spawn_claude_pane` を呼ぶ前に以下を実行する。判定ステップの詳細は `SKILL.md` Step 3-1 を参照（Claude が `list_panes` の結果テキストを解釈してロジックを実行する）。
 
 1. `mcp__renga-peers__list_panes` で全ペインと属性 (id / name / role / focused / x / y / width / height) を取得する
 2. **候補集合**: `role ∈ {worker, dispatcher, secretary}` のペイン (curator は常に除外)
@@ -59,7 +59,7 @@ renga は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 
    - vertical 分割: `(new_w, new_h) = (floor(width / 2), height)`
    - horizontal 分割: `(new_w, new_h) = (width, floor(height / 2))`
 6. **target 選出**: 残った候補から **「分割軸方向の新サイズ」** (vertical なら `new_w`、horizontal なら `new_h`) が最大のペインを target にする。tie-break はその時点の pane id 昇順 (スナップショット内で再現可能。セッション跨ぎの安定性までは保証しない)
-7. **候補が空なら escalate**: `SKILL.md` Step 3-1c の `SPLIT_CAPACITY_EXCEEDED` 経路で窓口に escalate (`spawn_pane` は発行せず、該当ワーカー 1 件だけ派遣中止、ディスパッチャー本体は継続)
+7. **候補が空なら escalate**: `SKILL.md` Step 3-1c の `SPLIT_CAPACITY_EXCEEDED` 経路で窓口に escalate (`spawn_claude_pane` は発行せず、該当ワーカー 1 件だけ派遣中止、ディスパッチャー本体は継続)
 
 ### rect 隣接判定の定義
 
@@ -79,8 +79,8 @@ renga の cell 座標は整数なので tolerance なし完全一致で判定す
 ### Edge cases / 運用時の注意
 
 - **ワーカーが途中で閉じた後の再派遣**: 旧 k-table 方式で問題になった「閉じた slot を詰めるとテーブル前提と乖離」は rect ベースでは発生しない。常に実レイアウトから target を選ぶため、renga のレイアウト tree と判断が一致する
-- **`spawn_pane` エラー**: `[split_refused]` / `[pane_not_found]` が MCP 結果テキストで返る。`references/renga-error-codes.md` の手順でキュレーター → 窓口にエスカレーション (方針は旧設計と同じ)
-- **レース**: `list_panes` 実行から `spawn_pane` 実行までに他ワーカーが増減した場合、target 不整合は `[pane_not_found]` として顕在化する。既存のエラーハンドリング経路で吸収する
+- **`spawn_claude_pane` エラー**: `[split_refused]` / `[pane_not_found]` が MCP 結果テキストで返る。`references/renga-error-codes.md` の手順でキュレーター → 窓口にエスカレーション (方針は旧設計と同じ)
+- **レース**: `list_panes` 実行から `spawn_claude_pane` 実行までに他ワーカーが増減した場合、target 不整合は `[pane_not_found]` として顕在化する。既存のエラーハンドリング経路で吸収する
 - **target 選出の責務**: 計算はディスパッチャーが `list_panes` の rect ベースで行う。窓口は DELEGATE メッセージに task_id だけを渡せばよく、target は指定しない
 
 ## 運用メモ
@@ -101,16 +101,13 @@ renga の cell 座標は整数なので tolerance なし完全一致で判定す
      `[pane_not_found]` / `[pane_vanished]` は「既に閉じた扱い」として skip する)
 - **org-suspend 時の停止順**: ワーカー → ディスパッチャー → キュレーター (いずれも `mcp__renga-peers__close_pane` で破棄。最後の 1 ペインを閉じるときだけ `[last_pane]` が返るので、そのペインは自分自身で `exit` させる)
 
-## spawn_pane の direction 慣習
+## split direction 慣習
 
-renga の分割方向は以下の定義（旧 `renga split --direction` と同じ）:
+renga の分割方向は以下の定義（`spawn_pane` / `spawn_claude_pane` 共通）:
 - `direction="vertical"` = 左右分割 (既存ペイン=左、新ペイン=右)
 - `direction="horizontal"` = 上下分割 (既存ペイン=上、新ペイン=下)
 
 ## 将来機能 / upstream 追跡
 
-- **ペイン lifecycle 購読**: 現在は `renga events` CLI 併用（ディスパッチャー監視ループなど）。upstream suisya-systems/renga#117 / renga PR #120 で `mcp__renga-peers__poll_events` が追加されたら後続 Issue で MCP に切替
-- **画面スクレイプ**: `renga inspect` CLI 併用。upstream suisya-systems/renga#116 / renga PR #121 で `mcp__renga-peers__inspect_pane` が追加されたら後続 Issue で MCP に切替
-- **raw キー送信**: `renga send --text` CLI 併用（開発チャネル Enter / permission mode 切替 Shift+Tab 等）。upstream suisya-systems/renga#118 で `send_keys` MCP が設計中。追加されたら後続 Issue で MCP に切替
-- `spawn_pane --ratio 0.2` 等の比率指定 (現状は 50/50 固定)
-- `spawn_pane --target-largest` / `--direction auto` 等の renga 側自動 target 選出 (現状はディスパッチャー側で `list_panes` rect から算出。upstream に移譲できれば balanced split ロジックを MCP 側に畳める)
+- `spawn_pane` / `spawn_claude_pane` の `--ratio 0.2` 等の比率指定 (現状は 50/50 固定)
+- `--target-largest` / `--direction auto` 等の renga 側自動 target 選出 (現状はディスパッチャー側で `list_panes` rect から算出。upstream に移譲できれば balanced split ロジックを MCP 側に畳める)

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -66,7 +66,7 @@ py -3 tools/check_renga_compat.py --json     # 機械可読出力
 
 **期待結果**:
 - `.state/org-state.md` が存在しないので、初回起動と判断される
-- `mcp__renga-peers__spawn_pane` でディスパッチャーペインが窓口の下に開き、その右にキュレーターペインが開く
+- `mcp__renga-peers__spawn_claude_pane` でディスパッチャーペインが窓口の下に開き、その右にキュレーターペインが開く
 - Dispatcher / Curator 起動直後の「開発チャネル確認プロンプト」を `mcp__renga-peers__send_keys(target=<pane>, enter=true)` で Enter 注入して通過している（`org-start` SKILL Step 2 / Step 3 の手順）
 - キュレーターに `mcp__renga-peers__send_message` 経由で `/loop 30m /org-curate` の実行が指示される
 - 「初回起動です。何をしましょうか？」と報告される
@@ -94,7 +94,7 @@ py -3 tools/check_renga_compat.py --json     # 機械可読出力
 **期待結果**:
 - プロジェクトが `registry/projects.md` に自動登録される
 - 窓口がディスパッチャーに DELEGATE メッセージを送信し、すぐにユーザーとの対話に戻る
-- ディスパッチャーが `mcp__renga-peers__spawn_pane` で同一タブ内にワーカーペインを派生する（`name="worker-{task_id}"`、balanced split 戦略は `pane-layout.md` に従う）
+- ディスパッチャーが `mcp__renga-peers__spawn_claude_pane` で同一タブ内にワーカーペインを派生する（`name="worker-{task_id}"`、balanced split 戦略は `pane-layout.md` に従う）
 - ディスパッチャーが `mcp__renga-peers__poll_events(types=["pane_started"])` で起動完了を確認
 - ワーカー起動直後の「開発チャネル確認プロンプト」を `mcp__renga-peers__send_keys(target="worker-{task_id}", enter=true)` で Enter 注入して通過（`org-delegate` SKILL Step 3-2）
 - ディスパッチャーが `mcp__renga-peers__send_message` 経由でワーカーに作業指示を送信する
@@ -134,11 +134,11 @@ mcp__renga-peers__list_panes    # 現在のペイン一覧
 **手順**:
 1. `tput cols` を実行し W を記録。160 未満なら検証不能としてスキップ or ターミナルを広げる。
 2. 窓口に互いに独立な 8 タスク（ダミーで良い。例: `echo-1` 〜 `echo-8` のような軽量タスク）を順次依頼。k=1〜8 それぞれが以下を満たすことを確認:
-   - a. ディスパッチャーの `mcp__renga-peers__spawn_pane` 呼び出し結果テキストに `[split_refused]` が含まれない
+   - a. ディスパッチャーの `mcp__renga-peers__spawn_claude_pane` 呼び出し結果テキストに `[split_refused]` が含まれない
    - b. Step 3-1b のアルゴリズムが選出した `target` / `direction` が、`list_panes` の直前スナップショットから rect ベースで再現可能
    - c. 起動直後の `mcp__renga-peers__list_panes` を **別ログファイル (例: `.state/verification/balanced-split-{timestamp}.log`)** に保存するか、その場で `role == "worker"` の `name` / `id` を記録し、`.state/journal.jsonl` の `worker_spawned` イベントと事後照合する
 3. 各 k 到達時点でペイン配置を `list_panes` で取得し、Step 3-1b のアルゴリズム（curator 特定 → role filter → dispatcher-curator 隣接判定 → direction 判定 → `new_w / new_h` 計算 → MIN_PANE 制約 → SECRETARY 保険条項 → metric sort）をスナップショットに対して手計算で再現できることを確認する。`pane-layout.md` の「ワーカーの balanced split 戦略」で述べている通り、rect ベース動的配置なので 2×2 や 2×4 のような固定グリッド形状は成功基準にしない。
-4. 9 人目のダミータスクを試し、ディスパッチャーが `renga-peers` で窓口に `SPLIT_CAPACITY_EXCEEDED` を送信することを確認。**当該 9 人目のワーカーのみ派遣を中止し、ディスパッチャー本体の監視ループは継続稼働**すること（`spawn_pane` は発行されず、`exit` などでディスパッチャーが落ちない）。
+4. 9 人目のダミータスクを試し、ディスパッチャーが `renga-peers` で窓口に `SPLIT_CAPACITY_EXCEEDED` を送信することを確認。**当該 9 人目のワーカーのみ派遣を中止し、ディスパッチャー本体の監視ループは継続稼働**すること（`spawn_claude_pane` は発行されず、`exit` などでディスパッチャーが落ちない）。
 
 > **注**: `.state/verification/balanced-split-{timestamp}.log` 等の検証用ログは一時ファイルなのでコミット対象外。`.state/*` は既存の `.gitignore` で除外済み。
 
@@ -219,7 +219,7 @@ cat .state/journal.jsonl | tail -1  # suspend イベントを確認
 - 各作業ディレクトリのgit状態との照合結果が報告される
 - 再開計画が提案される
 - 人間の承認を待つ（勝手にワーカーを派遣しない）
-- ディスパッチャーとキュレーターペインが `mcp__renga-peers__spawn_pane` 経由で再起動される
+- ディスパッチャーとキュレーターペインが `mcp__renga-peers__spawn_claude_pane` 経由で再起動される
 
 **確認ポイント**:
 - ブリーフィング内容が `.state/org-state.md` と一致するか
@@ -229,7 +229,7 @@ cat .state/journal.jsonl | tail -1  # suspend イベントを確認
 **失敗パターンと対処**:
 - `/org-start` が状態を読まない → org-start スキルの Step 1 を見直し
 - 状態が不正確 → org-state.md のフォーマットまたはorg-suspendの書き込みを見直し
-- キュレーターが起動しない → org-start Step 3 の `send_message` / `spawn_pane` を確認
+- キュレーターが起動しない → org-start Step 3 の `send_message` / `spawn_claude_pane` を確認
 
 ---
 


### PR DESCRIPTION
## Summary
- Removes ccmux 0.18.0-era stale wording from 2 files
- Worker / dispatcher / curator spawn contexts: `spawn_pane` → `spawn_claude_pane`
- Drops already-implemented entries (`poll_events` / `inspect_pane` / `send_keys`) from the "future / upstream tracking" section in pane-layout.md

## Files
- `.claude/skills/org-delegate/references/pane-layout.md` (+6 / -9)
- `docs/verification.md` (+6 / -6)

## Preserved on purpose (history)
- pane-layout.md L15/L22/L33: regression-check grep pattern intentionally lists both `spawn_pane` and `spawn_claude_pane` (Issue #58 design)
- verification.md L463/L472/L488: 14-tool MCP surface listing where both names appear by design

## Test plan
- [ ] Docs-only change, no unit tests
- [ ] verification.md Test 0 regression-check grep patterns unchanged

Closes #72