### PR TITLE
chore(readme): reflect Phase 3 / Layer 1 (core-harness v0.3.1) shipping status

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ flowchart TD
 
     classDef shipped fill:#d4edda,stroke:#28a745,color:#000
     classDef planned fill:#fff3cd,stroke:#856404,color:#000
-    class L4,L3 shipped
-    class L2,L1 planned
+    class L4,L3,L1 shipped
+    class L2 planned
 ```
 
-緑のボックス（Layer 3 / Layer 4）は同時公開済み、黄色のボックス（Layer 1 / Layer 2）は今後 claude-org-ja 本体から段階的に抽出予定の層です。`renga` は単体で AI 開発以外の用途でも使える汎用ツールで、claude-org-ja はその上に組織運用規律を載せたリファレンス配布物として位置づけられます。各層の責務の詳細は [docs/overview-technical.md](docs/overview-technical.md) を参照。
+緑のボックス（Layer 1 / Layer 3 / Layer 4）は公開済み、黄色のボックス（Layer 2）は今後 claude-org-ja 本体から段階的に抽出予定の層です。`renga` は単体で AI 開発以外の用途でも使える汎用ツールで、claude-org-ja はその上に組織運用規律を載せたリファレンス配布物として位置づけられます。各層の責務の詳細は [docs/overview-technical.md](docs/overview-technical.md) を参照。
 
-> Layer 1 (`core-harness`) の抽出設計は [docs/design/core-harness-extraction.md](docs/design/core-harness-extraction.md)（Issue [#128](https://github.com/suisya-systems/claude-org-ja/issues/128)）にて進行中。
+> Layer 1 (`core-harness`) は v0.3.1 として独立 OSS リポ ([suisya-systems/core-harness](https://github.com/suisya-systems/core-harness)) で公開済み。claude-org-ja は Step B/C/D shim を経由してこの Layer 1 を consumer として利用しています。設計の詳細は [docs/design/core-harness-extraction.md](docs/design/core-harness-extraction.md)（Issue [#128](https://github.com/suisya-systems/claude-org-ja/issues/128) closed）。
 
 ---
 


### PR DESCRIPTION
Updates the README to match the actual state of the 4-layer architecture after Phase 3 (Layer 1 = core-harness) shipped.

## Summary
- Mermaid 4-layer diagram: Layer 1 (`core-harness`) recoloured **planned (yellow) → shipped (green)**.
- Extraction-status paragraph: now points to the published v0.3.1 release on `suisya-systems/core-harness` and the closed Issue #128.
- Layer 2 (`org-runtime`) remains **planned**, unchanged.

## Refs
- core-harness v0.3.1: https://github.com/suisya-systems/core-harness/releases/tag/v0.3.1
- Phase 3 Epic: #128 (closed)
- Design: #196