### PR TITLE
docs(internal): Phase 4 (org-runtime) inventory + design Q&A draft (refs #129)

### DIFF
--- a/docs/internal/phase4-inventory-2026-05-02.md
+++ b/docs/internal/phase4-inventory-2026-05-02.md
@@ -32,6 +32,31 @@
 |---|---|---|---|---|---|
 | `.state/journal.jsonl` | 189 行 (実環境スナップショット) | JSONL。`{"ts","event","worker?","task?","reason?","kind?","confidence?","source?","matched?","cursor?"}` | secretary / dispatcher（worker_spawned / worker_respawned / suspend / resume / anomaly_observed / notify_sent / events_dropped / secretary_identity_restored） | dashboard/server.py（`_parse_journal`）、人間 | **public** schema、**scrub-then-public** 実データ。`docs/journal-events.md` に既に半 schema 化されている。Layer 2 の中心 contract 候補 |
 | `.state/org-state.md` | 507 (実セッション 5 のもの) | 自由 Markdown + 規約セクション (`Status:`, `Updated:`, `## Worker Directory Registry`, `## Dispatcher`, `## Curator`, `## Resume Instructions`) | secretary（人間との合意で更新）、`org-state_converter.py` は read-only | secretary（次セッション resume）、`org_state_converter.py` | **scrub-then-public**。schema は `docs/org-state-schema.md` に既存。session narrative / Lead voice TODO の混入が多く、抽出時はテンプレ化が必要 |
+
+#### 2.2.1 Worker Directory Registry スキーマ（重要 contract）
+
+Layer 2 抽出時に固める必要のある中核 contract のひとつ。Markdown と JSON の **2 表現を持つ** ため両方の field を明示しておく。
+
+**JSON 表現**（`org-state.json` `workerDirectoryRegistry[]`、`schemaVersion=1`、source: `dashboard/org_state_converter.py`）:
+
+| field | 型 | 例 | 備考 |
+|---|---|---|---|
+| `taskId` | string | `"role-config-drift-fix"` | 一意、`[A-Za-z0-9_-]+` 規約（`dispatcher_runner.py` の `_NAME_PATTERN` と同じ） |
+| `pattern` | string | `"A"` / `"B"` / `"C"` | A=ホスト直編集、B=worktree、C=clone |
+| `directory` | string (絶対パス) | `"C:/Users/iwama/.../workers/<task>/"` | OS 依存パスがそのまま入る |
+| `project` | string | `"claude-org"` / `"ccmux"` 等 | `registry/projects.md` の通称 |
+| `status` | string (自由文) | `"completed"` / `"merged (PR #93)"` / `"review (PR #94)"` | enum 化されておらず PR 番号付き自由文を許容 |
+
+**Markdown 表現**（`org-state.md` `## Worker Directory Registry` セクション）:
+- パイプ区切りテーブル。converter `parse_org_state_md` が行 → JSON に展開する。列順は JSON field と 1:1。
+- 書き手: secretary（手動更新）/ 一部 dispatcher（worker spawn 時に追記）。
+- 読み手: dashboard front-end、`/org-resume` の Phase 1 ブリーフィング、人間。
+
+**抽出上の論点**:
+- `status` を enum 化するか、PR 番号入り自由文を許容したまま JSON にするか（Q7 と連動）。
+- `directory` の OS-absolute パスは publish 時に必ず scrub が必要（`scrub-then-public` 区分）。
+- `pattern` を `A/B/C` のままにするか、`host/worktree/clone` 等の意味的名前に正規化するか。
+- Markdown を「人間 SoT」、JSON を「派生」のままにするか、**JSON を SoT** に反転させるか（converter の方向反転）は Layer 2 設計の中心論点。
 | `.state/org-state.json` | 〜 same | 派生 JSON (`schemaVersion=1`) | `dashboard/org_state_converter.py` の atomic write | dashboard front-end | **public**。converter とセットで extract 候補 |
 | `.state/workers/worker-{peer_id_or_task_id}.md` | 64 ファイル × 〜10〜30 行 | `Task: / Directory: / Pane Name: / Status: / Pane ID:` ヘッダ + `## Assignment` + `## Progress Log` | dispatcher (`dispatcher_runner.py` seed) + worker self-update | dashboard/server.py、retro、resume | **scrub-then-public**。task 記述・パスに個人 path 含む。template 化して extract |
 | `.state/dispatcher/outbox/*-instruction.md` | 可変 | 自動生成（`dispatcher_runner.py delegate-plan` の出力） | dispatcher_runner.py | dispatcher Claude（`send_message` の本文として読む） | **public**（ロジック）/ **scrub** 個別ファイル |

--- a/docs/internal/phase4-inventory-2026-05-02.md
+++ b/docs/internal/phase4-inventory-2026-05-02.md
@@ -1,0 +1,142 @@
+# Phase 4 (Layer 2 = org-runtime) コード棚卸し
+
+- 作成日: 2026-05-02
+- 関連 Issue: ja#129 (Layer 2 = org-runtime 抽出)
+- 目的: measurement-first で抽出方針を議論するための入力 inventory。
+- 親リポ参照ベース: `C:/Users/iwama/Documents/work/claude-org/`（読み込みのみ。本 doc は worktree `phase4-inventory` 配下の編集に閉じる）。
+- 行数は `wc -l` 計測値（2026-05-02 時点）。
+
+## 1. 分類凡例
+
+| 区分 | 意味 |
+|---|---|
+| **public** | 既に OSS（claude-org-ja MIT または en port）として公開済 / 抽出後も追加マスキング不要 |
+| **scrub-then-public** | 構造は公開可能だが、現ファイル内容に session narrative / 個人的ロードマップ / Lead voice TODO が混入。schema / template だけ抽出する形なら公開可 |
+| **ja-specific** | claude-org-ja の運用前提（日本語 prose、Pattern A/B/C 命名、`renga --layout ops` 固定など）に強く依存。抽出時に英語化 + 抽象化が必要 |
+| **internal-only** | 抽出対象外。組織運営に固有で OSS にしても他者再利用価値が薄い |
+
+抽出可否の見立ては「Layer 2 = org-runtime」を **renga + Claude Code 上で複数エージェントを協調させる runtime 部品** と仮定したうえでの粗評価。最終的な scope は Q&A 草案 (`phase4-questions-2026-05-02.md`) で詰める。
+
+## 2. インベントリ（候補コード一覧）
+
+### 2.1 ロール prompt（Markdown CLAUDE.md）
+
+| パス | 行数 | 主な責務 | 依存 | 抽出可否 |
+|---|---|---|---|---|
+| `.dispatcher/CLAUDE.md` | 305 | DELEGATE 受信ループ / `poll_events` cursor 管理 / `inspect_pane` による APPROVAL_BLOCKED 検出 / journal de-dup / CLOSE_PANE retro | renga-peers MCP 14 種、`tools/dispatcher_runner.py`、`.state/dispatcher-event-cursor.txt`、`.claude/skills/org-delegate/**`（ref） | **ja-specific**（日本語、anchored-regex リスト、journal フォーマット）。anomaly 検出ロジック / cursor 管理 / de-dup 設計は普遍的なので抽出時に英語 prose + テンプレ化推奨 |
+| `.curator/CLAUDE.md` | 41 | `knowledge/raw → curated` 整理ループ（`/loop 30m /org-curate`） | parent repo の `knowledge/` ディレクトリ規約、Glob | **scrub-then-public**。役割分担 + 親リポ相対パス問題は他プロジェクトでも生じるので extract 価値あり |
+
+### 2.2 状態ファイル（書き手 = Claude / 読み手 = ダッシュボード・他 Claude）
+
+| パス | 行数 / 件数 | スキーマ | 書き手 | 読み手 | 抽出可否 |
+|---|---|---|---|---|---|
+| `.state/journal.jsonl` | 189 行 (実環境スナップショット) | JSONL。`{"ts","event","worker?","task?","reason?","kind?","confidence?","source?","matched?","cursor?"}` | secretary / dispatcher（worker_spawned / worker_respawned / suspend / resume / anomaly_observed / notify_sent / events_dropped / secretary_identity_restored） | dashboard/server.py（`_parse_journal`）、人間 | **public** schema、**scrub-then-public** 実データ。`docs/journal-events.md` に既に半 schema 化されている。Layer 2 の中心 contract 候補 |
+| `.state/org-state.md` | 507 (実セッション 5 のもの) | 自由 Markdown + 規約セクション (`Status:`, `Updated:`, `## Worker Directory Registry`, `## Dispatcher`, `## Curator`, `## Resume Instructions`) | secretary（人間との合意で更新）、`org-state_converter.py` は read-only | secretary（次セッション resume）、`org_state_converter.py` | **scrub-then-public**。schema は `docs/org-state-schema.md` に既存。session narrative / Lead voice TODO の混入が多く、抽出時はテンプレ化が必要 |
+| `.state/org-state.json` | 〜 same | 派生 JSON (`schemaVersion=1`) | `dashboard/org_state_converter.py` の atomic write | dashboard front-end | **public**。converter とセットで extract 候補 |
+| `.state/workers/worker-{peer_id_or_task_id}.md` | 64 ファイル × 〜10〜30 行 | `Task: / Directory: / Pane Name: / Status: / Pane ID:` ヘッダ + `## Assignment` + `## Progress Log` | dispatcher (`dispatcher_runner.py` seed) + worker self-update | dashboard/server.py、retro、resume | **scrub-then-public**。task 記述・パスに個人 path 含む。template 化して extract |
+| `.state/dispatcher/outbox/*-instruction.md` | 可変 | 自動生成（`dispatcher_runner.py delegate-plan` の出力） | dispatcher_runner.py | dispatcher Claude（`send_message` の本文として読む） | **public**（ロジック）/ **scrub** 個別ファイル |
+| `.state/dispatcher/inbox/*.json` | 可変 | secretary が DELEGATE 時に書く task JSON (`task_id, worker_dir, permission_mode, task_description, instruction, instruction_vars?, model?`) | secretary（org-delegate skill） | dispatcher_runner.py | **public** schema |
+| `.state/dispatcher-event-cursor.txt` | 1 行 | renga `poll_events` の `next_since` cursor | dispatcher | dispatcher | **public**。普遍的なシンプル contract |
+| `.state/dispatcher/panes-snapshot.json` | 可変 | `mcp__renga-peers__list_panes.structuredContent.panes` の cache | dispatcher | dispatcher_runner.py | **public** |
+| `.state/dashboard.{pid,log,err}` | 1〜数行 | dashboard プロセス管理 | dashboard/server.py | server.py（自分自身） | **internal-only**（OS specific 扱い、抽出対象外でよい） |
+
+### 2.3 Python ツール（`tools/`）
+
+| パス | 行数 | 役割 | 入出力 | 抽出可否 |
+|---|---|---|---|---|
+| `tools/dispatcher_runner.py` | 653 | `delegate-plan` サブコマンド。balanced split target/direction、worker name / pane name 検証、instruction template 展開、worker state seed、dispatcher action plan JSON 生成 | in: task JSON + panes JSON / out: action plan JSON、`worker-{task_id}.md`、`outbox/{task_id}-instruction.md` | **public**（既に「OSS 抽出を見越した design」コメントあり）。Layer 2 中核 |
+| `tools/test_dispatcher_runner.py` | 669 | 上記の unittest | — | **public** |
+| `tools/check_role_configs.py` | 718 | secretary / dispatcher / curator / worker の `settings.json` 期待値を validate（drift 検出） | settings.json 群 | **public**。role-config schema 抽象化が必要 |
+| `tools/role_configs_schema.json` | （JSON） | 上記 validator の expected schema | — | **public** |
+| `tools/check_renga_compat.py` | 414 | renga バージョン要件 / MCP ツール一覧の compat check | renga CLI | **public**（renga 連携層として extract 価値あり） |
+| `tools/test_check_renga_compat.py` | 156 | unittest | — | **public** |
+| `tools/generate_worker_settings.py` | 140 | worker `settings.local.json` を schema-driven 生成（Issue #99） | input: role / project parameters | **public** |
+| `tools/org_setup_prune.py` | 457 | `/org-setup` の deterministic part（古い hooks / settings 削除） | settings ファイル群 | **public**（Layer 2 候補だが Layer 0/1 に近い性質） |
+| `tools/test_org_setup_prune.py` | 360 | unittest | — | **public** |
+
+### 2.4 Dashboard（HTTP / SPA）
+
+| パス | 行数 | 役割 | 抽出可否 |
+|---|---|---|---|
+| `dashboard/server.py` | 455 | stdlib only HTTP server（port 8099/8100/8101）、SSE feed、`.state/` parser、journal aggregator | **public**。runtime ↔ 観測層の間に入る重要 layer。Layer 2 抽出時は `_parse_*` 関数群を runtime parser library に切り出す候補 |
+| `dashboard/org_state_converter.py` | 253 | `org-state.md → org-state.json` atomic write、parser、`SCHEMA_VERSION = 1` | **public**。schema 仕様の単一実装 |
+| `dashboard/{app.js, index.html, style.css}` | — | SPA (vanilla JS) | **public**。Layer 2 (runtime 抽出) の scope に入れるか議論余地あり（観測 UI は別 layer かも） |
+
+### 2.5 Skill prompt（`.claude/skills/`）
+
+| パス | 行数 | 役割 | 抽出可否 |
+|---|---|---|---|
+| `org-start/SKILL.md` | 191 | renga 疎通確認、secretary identity 自動修復、`registry/org-config.md` 読み、ディスパッチャー / キュレーターペイン spawn | **ja-specific** prose、ロジックは **public** 化可能 |
+| `org-suspend/SKILL.md` | 138 | 全ワーカー sweep → state save → ペイン停止 | 同上 |
+| `org-resume/SKILL.md` | 65 | suspended 状態からの復元 (Phase 1〜3) | 同上 |
+| `org-delegate/SKILL.md` | 617 | secretary が DELEGATE を組み立てる本体スキル。`dispatcher_runner.py` 呼び出しガイド、Pattern A/B/C 命名規約、verification depth 指針 | 同上、Layer 2 のスコープに最も近い |
+| `org-delegate/references/{instruction-template.md, pane-layout.md, renga-error-codes.md, worker-claude-template.md, claude-org-self-edit.md}` | 計 ~700 | テンプレ群 | **public** schema、prose は ja |
+| `org-retro/SKILL.md` (+ work-skill-template.md) | 125 + 77 | 委譲 retro と skill 候補抽出 | **scrub-then-public** |
+| `org-curate/SKILL.md` (+ knowledge-standards.md) | 116 + 59 | knowledge 整理 | **public**（kn 規約は普遍） |
+| `org-dashboard/SKILL.md` | 45 | ダッシュボード起動 | **public** |
+| `org-setup/SKILL.md` (+ permissions.md) | 154 + 323 | 全 role の permission / hooks 配備 | **public**、role モデル抽象化次第 |
+| `skill-audit/SKILL.md` (+ audit-checklist.md) | 115 + 105 | skill 棚卸し | **scrub-then-public**（claude-org-ja 流のキュー設計に依存） |
+| `skill-eligibility-check/SKILL.md` (+ signals.md) | 130 + 80 | skill 化判定 | 同上 |
+
+### 2.6 Pane lifecycle（renga-peers MCP 周りの skill 内ロジック）
+
+renga-peers の **MCP プロトコル定義は `renga` 側に既に OSS 化済み**（v1.0.0 freeze）。本リポに残るのは「**runtime としての使い方**」レイヤで、以下に分散している:
+
+- `.dispatcher/CLAUDE.md` — `poll_events`(`since`/`timeout_ms`/`types`)、`inspect_pane`(grid/lines/cursor)、`check_messages`、`list_panes`、`close_pane`、`set_pane_identity` の **ループ + de-dup + cursor 永続化** 設計（前述）
+- `org-start/SKILL.md` — secretary identity 自動修復 (`set_pane_identity`)、`spawn_claude_pane` で role=dispatcher/curator 起動
+- `org-delegate/references/pane-layout.md` — balanced split rules、min サイズ、セクレタリ最小幅
+- `org-delegate/references/renga-error-codes.md` — `[<code>] <msg>` ハンドリングテーブル
+
+**抽出単位の選択肢**:
+- 選択肢 1: Python library 化（`renga_orchestration` package）—ループ・cursor・de-dup 状態を Python 側に寄せる（codex 路線）
+- 選択肢 2: Markdown spec 集 → 言語非依存の "behavioral contract" として publish（現状の延長）
+- 選択肢 3: ハイブリッド（state machine の deterministic 部分は Python、prompt は Markdown、cursor は file）
+
+これは Q&A 5/6/7 で議論したい。
+
+### 2.7 State machine（IN_PROGRESS / REVIEW / COMPLETED 等）
+
+実装は **string convention** に近く、固定された型システムは未実装。実観測値:
+
+| ドメイン | 値（現リポで観測） | 書く場所 |
+|---|---|---|
+| Org status | `ACTIVE`, `SUSPENDED`, `IDLE` | `org-state.md` `Status:` |
+| Worker status (state file) | `planned`, `active`, `pane_closed`, `completed` | `.state/workers/worker-*.md` `Status:` |
+| Worker registry status (registry) | `completed`, `merged (PR #93)`, `review (PR #94)` 等の自由文 | `org-state.md` Worker Directory Registry / `org-state.json` `workerDirectoryRegistry[].status` |
+| Work item status (dashboard) | `IN_PROGRESS`, `REVIEW`, `COMPLETED` を想定（`server.py` は upper-case 化、自由値受け入れ） | `org-state.md` の `- task: title [STATUS]` |
+| Journal events | `worker_spawned`, `worker_respawned`, `worker_closed`, `suspend`, `resume`, `anomaly_observed`, `notify_sent`, `events_dropped`, `secretary_identity_restored` | `journal.jsonl` |
+| Anomaly kinds | `approval_blocked`, `error` | journal `kind` |
+| Anomaly source | `inspect`, `self_report` | journal `source` |
+| Confidence | `high`, `low`, `n/a` | journal `confidence` |
+| Worker pattern | `A` (host), `B` (worktree), `C` (clone) | `org-state.json` `workerDirectoryRegistry[].pattern` |
+| Verification depth | `full`, `minimal` | task instruction（dispatcher_runner で validate） |
+
+抽出時は **これらの enum を contract として正規化する**（`docs/org-state-schema.md` を拡張）か、**state machine 図として library 化する**かが論点。現状 Markdown / JSON の両方に分散している。
+
+### 2.8 install / hook（参考）
+
+| パス | 行数 | 抽出可否 |
+|---|---|---|
+| `scripts/install.sh` / `install.ps1` | 208 / 200 | **public**（既に公開）、Layer 2 に含める必要は低い |
+| `scripts/install-hooks.sh` | 65 | **public** |
+| `.hooks/` / `.githooks/` | 列挙のみ | **public**、Layer 0/1 寄り |
+
+## 3. 抽出方針サマリ（暫定）
+
+`docs/design/core-harness-extraction.md`（Layer 1 の前例）からの推定で、Layer 2 = org-runtime の **MVP scope** はおおよそ次のいずれかに収束しそう:
+
+- **Option α (narrow)**: `dispatcher_runner.py` + `dashboard/org_state_converter.py` + `.state/journal.jsonl` schema + worker state file template、の **deterministic 4 点セット** だけを Python package + JSON schema として publish。ロール prompt と skill prompt は claude-org-ja に残す
+- **Option β (wide)**: 上記に加え、ロール prompt（dispatcher / curator / secretary）と skill 群を **英語化 + テンプレ化**して、「Claude Code を使った組織型 multi-agent runtime」の reference implementation 一式として publish
+- **Option γ (renga 同等)**: renga / core-harness と同じく **API surface freeze + semver + consumer ≥ 2 ゲート**を最初から運用して、claude-org-ja 自身を最初の consumer にする
+
+選択肢の意思決定材料を Q&A 草案で問う。
+
+## 4. measurement の入力候補
+
+Phase 3 (Layer 1) の learnings から、measurement-first で先に取りたい数値:
+
+- `dispatcher_runner.py` の関数別 churn（git log で 3 ヶ月の line-touch カウント）→ API stable な部分とそうでない部分の見極め
+- `journal.jsonl` の event 種別分布（過去 30 日）→ schema にすべき event がどれか
+- `.state/workers/worker-*.md` の field 出現率 → template に固めるべきフィールド
+- `inspect_pane` regex の hit 率 / false positive 率 → APPROVAL_BLOCKED 検出ロジックを extract する価値の根拠
+- ja↔en 同期の drift 量（`/sync-policy` や `notify-en-changes` で蓄積）→ "中央 OSS layer" を作ったときに 2 言語維持するコスト

--- a/docs/internal/phase4-questions-2026-05-02.md
+++ b/docs/internal/phase4-questions-2026-05-02.md
@@ -1,0 +1,136 @@
+# Phase 4 (Layer 2 = org-runtime) 設計議論用 Q&A 草案
+
+- 作成日: 2026-05-02
+- 関連 Issue: ja#129
+- 入力: `phase4-inventory-2026-05-02.md`
+- 性質: **質問のみ**。回答は窓口（Lead）判断。Phase 3 (core-harness) と同じく measurement-first で進めるための論点整理。
+- 数: 12 問（Phase 3 design memo の Q&A 構成に倣う）。
+
+---
+
+## Q1. スコープ境界 — Option α / β / γ のどれを起点にするか
+
+inventory §3 で示した narrow / wide / renga 同等の 3 案のうち、measurement を取りに行く **MVP の境界** をどこに置くか。具体的には:
+
+- (a) `dispatcher_runner.py` の `delegate-plan` 一個だけを最初に extract（Layer 1 = core-harness と同じ「最小可動部」戦略）
+- (b) `delegate-plan` + `org_state_converter.py` + journal schema をセットで extract（state contract 中心）
+- (c) ロール prompt まで含めて extract し、外部の Claude Code consumer が secretary / dispatcher / curator を立てられる reference 構成にする
+
+(a)→(b)→(c) は段階追加可能なので「初期 release のスコープ」を聞いている。
+
+## Q2. API 安定性ゲート — consumer ≥ 2 を最初から課すか
+
+core-harness は "consumer ≥ 2 + 6 ヶ月 no-break" を 1.0 graduation gate にした（README 参照）。org-runtime は consumer 候補がより限定的（claude-org-ja 自身 + 翻訳版 en + 内部試験用 worker のみ）なので、
+
+- (a) core-harness 同等のゲートを課す
+- (b) 0.x の間は "API は壊しうる" として breaking change を許容（claude-org-ja のみが consumer の前提）
+- (c) ゲートを「consumer ≥ 2」ではなく「`journal.jsonl` の event 種別が 30 日以上不変」のような **measurement-driven gate** に置き換える
+
+どれを採るか。
+
+## Q3. 実装言語 — Python だけか、Rust 補助か
+
+`dispatcher_runner.py` は現状 Python (stdlib only)。renga は Rust。Layer 2 を:
+
+- (a) **Python のみ**（Claude Code consumer は既に Python を入れている前提でよい）
+- (b) **Python core + Rust optional**（hot path だけ Rust、ただし `dispatcher_runner.py` は単発 CLI なので速度要件は薄い）
+- (c) **Rust 中心 + Python thin wrapper**（renga と同じ runtime 言語に揃え、長期メンテを Rust に集約）
+
+の方針を 1 つ決めたい。
+
+## Q4. config schema の互換性 — `.state/` 形式を変えてよいか
+
+抽出に伴い `journal.jsonl` event スキーマや `org-state.md` セクション規約を整えるなら、claude-org-ja の既存ファイルとの互換が問題になる:
+
+- (a) **既存形式を完全に維持**（Layer 2 は現状 schema を凍結して publish）
+- (b) **schema_version を導入**して旧/新並走、`org_state_converter.py` に migration 関数を追加
+- (c) **breaking change 許容**（claude-org-ja を fork 直前 snapshot に戻して新 schema へ一括移行）
+
+`docs/org-state-schema.md` / `docs/journal-events.md` の既存記述をどこまで動かしてよいか。
+
+## Q5. Dispatcher 単独抽出 vs バンドル — runtime と prompt は分離すべきか
+
+inventory §2.6 にあるとおり、dispatcher は Python helper (`dispatcher_runner.py`) と Markdown prompt (`.dispatcher/CLAUDE.md`) の **2 層**で動いている。Layer 2 の抽出単位は:
+
+- (a) **deterministic Python だけ extract**（prompt は claude-org-ja に残し、コミュニティが各自書く）
+- (b) **Python + 英語版 prompt template** をセットで extract（"reference dispatcher prompt" として公開）
+- (c) **prompt を schema 化**（Pydantic / JSON schema に近い形）して prompt rendering library として publish
+
+prompt の OSS 公開は Phase 3 で `core-harness` が「AI agent framework ではない」と positioning を明示した経緯があるので、ここを跨ぐかどうかは戦略判断。
+
+## Q6. Renga 依存の扱い — renga MCP プロトコルを spec として再宣言するか
+
+`.dispatcher/CLAUDE.md` は renga-peers MCP の `poll_events` / `inspect_pane` / `check_messages` 等の使い方に強く依存する。Layer 2 を extract した consumer から見たとき:
+
+- (a) **renga 必須**として publish（renga は 1.0 で API freeze 済なので問題ない）
+- (b) **renga ≒ tmux/wezterm/etc も使える抽象化層**を Layer 2 内に追加（pane lifecycle interface）。実装は renga のみ
+- (c) **renga 必須だが MCP tool name を直接 import せず adapter 経由**にして、将来差し替え余地を残す
+
+## Q7. State machine の正規化 — enum を contract として固めるか
+
+inventory §2.7 で示した worker status / journal event / anomaly kind の値はすべて **string convention** で、コードレベルで強制されていない。Layer 2 で:
+
+- (a) **Python `Enum` + JSON schema** として固定（`workflow_status.py` 等を新設）
+- (b) **JSON schema のみ**（言語非依存にする）で、実装側は string のまま
+- (c) **現状維持**（命名は `docs/` の散文だけで規定し、コードでは strict 検証しない）
+
+Phase 3 の Step B (schema/validator/generator) と同じノリで (a) を採るのが筋に見えるが、claude-org-ja 側の既存コードに型を入れる工数が読めない。
+
+## Q8. ja↔en 同期戦略との接続 — ソースオブトゥルースをどこに置くか
+
+claude-org-ja → en の sync は #171 の Option A（ja=SoT、auto-mirror runtime）で運用中。Layer 2 を **第三の repo (`org-runtime`)** に切り出した場合:
+
+- (a) `org-runtime` を新たな SoT にし、claude-org-ja / en は consumer に降格
+- (b) claude-org-ja を引き続き SoT、`org-runtime` は claude-org-ja から自動抽出される downstream
+- (c) `org-runtime` は最初から **英語のみ**で書かれ、claude-org-ja / en は日本語 / 英語の prompt thin layer だけ持つ
+
+current "ja=SoT" 体制と矛盾しないかが論点。
+
+## Q9. dashboard / observability の去就 — Layer 2 か別 layer か
+
+`dashboard/server.py` + `org_state_converter.py` は **runtime の観測層**。Layer 2 のスコープに含めるか:
+
+- (a) **含める**（runtime と観測は不可分）
+- (b) **別 layer (Layer 2.5 = org-observability) に分離**（dashboard SPA は別 release cycle）
+- (c) **dashboard は claude-org-ja に残し、Layer 2 は schema (`org-state.json`) だけ提供**
+
+en repo (`suisya-systems/claude-org`) には既に dashboard が port されているので、抽出時の重複も論点。
+
+## Q10. release / packaging — PyPI に出すか
+
+core-harness は PyPI Trusted Publisher 経由で公開予定（v0.3.2 で発火）。Layer 2 = org-runtime も:
+
+- (a) **PyPI publish**（`pip install org-runtime` で外部利用可能）
+- (b) **GitHub release のみ**（OSS としては公開、配布は git clone 想定）
+- (c) **当面 private**（claude-org-ja repo 内 monorepo 化、別リポ抽出はしない）
+
+PyPI に出すなら namespace（`suisya-org-runtime` / `claude-org-runtime` / `renga-orchestration`）の議論も必要。
+
+## Q11. Phase 4 の DoD（Definition of Done）— "完了" の定義
+
+Phase 3 は「core-harness 1.0 → claude-org-ja shim adoption → ja#128 close」で完了とした。Phase 4 は:
+
+- (a) **Layer 2 リポ作成 + v0.1.0 release + ja shim 1 件 merge** までが MVP
+- (b) **Layer 2 が claude-org-ja 内の `tools/dispatcher_runner.py` 等を実質置換**するまで（in-tree から消える）
+- (c) **Layer 2 を使った第二の consumer（en port 以外）が誕生**するまで
+
+Phase 3 と同等の "shim adoption" まで踏むのか、それとも単なる "extract & publish" で止めるのか。
+
+## Q12. measurement-first の具体プラン — 何を計ってから設計に入るか
+
+ja#129 で "measurement-first" を選んだので、コード extract 前に取るべき数値の合意が要る:
+
+- (a) inventory §4 の 5 項目（`dispatcher_runner.py` churn、journal event 分布、worker file field 出現率、anomaly regex hit 率、ja↔en drift）すべて取る
+- (b) **(a) のうち「event 分布」と「churn」だけ**取れば設計に入れる（残りは extract 後に取る）
+- (c) measurement は最低限にして、まずは Step B 相当の **schema 抽出だけ先行 PR** を作る（Phase 3 と同じ進め方）
+
+どこまで先に測るか、また measurement を **誰が**（worker 派遣 / Lead 手作業 / 自動 routine）取るか、両方を決めたい。
+
+---
+
+## 窓口判断のハイライト（特に重要そうな質問）
+
+12 問の中で、**他の質問の答えを縛る**順に重要だと思われるのは以下:
+
+1. **Q1（スコープ境界）** — α/β/γ の選択で他の質問の前提が大きく変わる。これだけは最初に決めたい。
+2. **Q3（実装言語）** — Python のみか Rust 補助かで、PyPI release / consumer 想定 / renga との関係 (Q6, Q10) が連鎖して変わる。


### PR DESCRIPTION
## Summary
Measurement-first input for Phase 4 (Layer 2 = org-runtime extraction, refs #129). Two internal docs only — no code changes.

- `docs/internal/phase4-inventory-2026-05-02.md` — inventory of org-runtime candidate code (role prompts, `.state/` schemas, Python tools, dashboard, skills, pane lifecycle, state machine), each classified as public / scrub-then-public / ja-specific / internal-only
- `docs/internal/phase4-questions-2026-05-02.md` — 12 design questions (questions only; answers are Lead judgment)

`docs/internal/` is gitignored, so files were added with `git add -f` per worker instructions.

## Highlights for Lead judgment
- **Q1 (scope)**: α (narrow=`dispatcher_runner.py` only) / β (wide=role prompts included) / γ (renga-style API freeze + ≥2 consumer gate) — gates the rest
- **Q3 (language)**: Python-only / Python+Rust optional / Rust-core+Python wrapper — interacts with PyPI release, consumer assumptions (Q10), renga interop (Q6)

## Validation
- codex CLI self-review run; 1 Major (Worker Directory Registry schema undercoverage) fixed in 037ca5b. No blockers.
- Doc-only PR; no test/lint impact.

## Test plan
- [ ] CI green (no test impact expected)
- [ ] Lead reviews Q1 / Q3 first to gate downstream design

Refs #129