### PR TITLE
feat(tools): add pr_watch helper for CI monitoring

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -562,6 +562,7 @@ mcp__renga-peers__send_message(
    2b-i. **PR 作成段階（即時実行）**:
    - 必要に応じて窓口がプッシュ・PR作成を行う（ワーカーには権限がないため）
    - `journal.jsonl` にイベント追記（push / PR open など）
+   - PR 番号が確定したら `tools/pr-watch.ps1 <PR>` (Windows) / `tools/pr-watch.sh <PR>` (POSIX) で CI を監視する。完了時に `ci_completed` が自動で journal に記録される
    - `org-state.md` の該当Work Item は **REVIEW のまま据え置く**（GitHub 側 PR レビュー指摘が来たら同ペインで対応するため。COMPLETED への遷移は 2b-ii で行う）
    - **ペインはまだ閉じない**: PR 作成直後に `CLOSE_PANE` を送らない。worktree 除去・Worker Directory Registry 更新も 2b-ii まで遅延する
    - PR レビューで指摘が来た場合は 2c のフローで同ワーカーに `send_message` 追指示を送り、同ペインで修正コミットを積ませる（新ワーカー再派遣は避ける — Issue / diff / 判断境界の再構築コストを払うことになる）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,9 @@
 - 依頼が曖昧なときは選択肢を提示して聞き返す
 - registry/projects.md を参照し、通称でプロジェクトを特定する
 
+## PR 後の CI 監視
+- PR 作成直後に `tools/pr-watch.ps1 <PR番号>` (Windows) または `tools/pr-watch.sh <PR番号>` (POSIX) を実行すると、`gh pr checks --watch` をブロッキングで起動し、完了時に `.state/journal.jsonl` へ `ci_completed` イベントを 1 行追記する。`--repo OWNER/REPO` 省略時はカレントリポジトリを自動解決する。
+
 ## 役割の境界
 - 窓口がやること: 人間との対話・判断、タスク分解と /org-delegate による委託、ワーカー報告の受信と伝達、.state/ や registry/ の管理、完了後の /org-retro
 - 実作業は全てワーカーに委譲する（コード編集、デバッグ、テスト、ビルド、git commit、環境構築等）

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -1,0 +1,6 @@
+#!/usr/bin/env pwsh
+# Thin PowerShell wrapper around tools/pr_watch.py.
+# Usage: tools/pr-watch.ps1 <PR> [--repo OWNER/REPO] [--interval SEC]
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+& py -3 (Join-Path $ScriptDir 'pr_watch.py') @args
+exit $LASTEXITCODE

--- a/tools/pr-watch.sh
+++ b/tools/pr-watch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Thin POSIX wrapper around tools/pr_watch.py.
+# Usage: tools/pr-watch.sh <PR> [--repo OWNER/REPO] [--interval SEC]
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/pr_watch.py" "$@"

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Watch GitHub PR CI checks and emit a journal event when finished.
+
+Cross-platform helper for the secretary role: after creating a PR,
+invoke this script to block on ``gh pr checks --watch`` and append a
+``ci_completed`` event to ``.state/journal.jsonl``.
+
+Usage::
+
+    py -3 tools/pr_watch.py <PR> [--repo OWNER/REPO] [--interval SEC]
+
+Behavior:
+
+* Resolves the repo via ``gh repo view --json nameWithOwner`` when
+  ``--repo`` is omitted.
+* Spawns ``gh pr checks <PR> --watch --interval <SEC>`` and forwards
+  its stdout/stderr.
+* Maps the gh exit code to ``passed`` / ``failed`` / ``canceled`` and
+  appends one JSON-Lines record to ``<repo_root>/.state/journal.jsonl``
+  (anchored to ``tools/..`` so cwd doesn't matter).
+* Prints the final status as a single line on stdout and exits with
+  the gh process' exit code.
+
+The journal payload shape is::
+
+    {"ts": "<ISO8601>", "event": "ci_completed",
+     "pr": <int>, "repo": "<owner/repo>",
+     "status": "passed|failed|canceled", "duration_sec": <int>}
+
+No new third-party dependencies; only the standard library plus the
+already-pinned ``core_harness.audit`` for the journal write.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from core_harness.audit import Journal
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+JOURNAL_PATH = REPO_ROOT / ".state" / "journal.jsonl"
+
+
+def _ensure_gh_installed() -> None:
+    if shutil.which("gh") is None:
+        sys.stderr.write(
+            "tools/pr_watch.py: error: GitHub CLI (gh) not found in PATH.\n"
+        )
+        sys.exit(127)
+
+
+def _resolve_repo() -> str:
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            "tools/pr_watch.py: error: failed to auto-detect repo via "
+            f"`gh repo view`: {exc.stderr.strip() or exc}\n"
+        )
+        sys.exit(2)
+    try:
+        data = json.loads(result.stdout)
+        repo = data["nameWithOwner"]
+    except (json.JSONDecodeError, KeyError) as exc:
+        sys.stderr.write(
+            "tools/pr_watch.py: error: unexpected `gh repo view` output: "
+            f"{exc}\n"
+        )
+        sys.exit(2)
+    if not isinstance(repo, str) or "/" not in repo:
+        sys.stderr.write(
+            f"tools/pr_watch.py: error: invalid repo {repo!r}\n"
+        )
+        sys.exit(2)
+    return repo
+
+
+def _classify(exit_code: int) -> str:
+    """Map a `gh pr checks --watch` exit code to a status string.
+
+    gh returns 0 on all-green, 8 when at least one check failed, and
+    other non-zero codes for transport / lookup errors. SIGINT from
+    the user surfaces as a negative code on POSIX or 0xC000013A on
+    Windows; both are treated as ``canceled``.
+    """
+    if exit_code == 0:
+        return "passed"
+    if exit_code == 8:
+        return "failed"
+    # SIGINT on POSIX: -signal.SIGINT (-2). Windows CTRL_C_EVENT: 0xC000013A.
+    if exit_code in (-signal.SIGINT, 0xC000013A, 130):
+        return "canceled"
+    return "failed"
+
+
+def _pr_exists(pr: int, repo: str) -> bool:
+    try:
+        subprocess.run(
+            ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "number"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return False
+    return True
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tools/pr_watch.py",
+        description="Watch a GitHub PR's CI checks and journal the result.",
+    )
+    parser.add_argument("pr", type=int, help="pull request number")
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="OWNER/REPO; auto-detected via `gh repo view` if omitted",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=30,
+        help="poll interval in seconds (default: 30)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.pr <= 0:
+        parser.error("PR number must be a positive integer")
+    if args.interval <= 0:
+        parser.error("--interval must be a positive integer")
+
+    _ensure_gh_installed()
+    repo = args.repo or _resolve_repo()
+
+    if not _pr_exists(args.pr, repo):
+        sys.stderr.write(
+            f"tools/pr_watch.py: error: PR #{args.pr} not found in {repo}\n"
+        )
+        return 2
+
+    cmd = [
+        "gh", "pr", "checks", str(args.pr),
+        "--repo", repo,
+        "--watch",
+        "--interval", str(args.interval),
+    ]
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(cmd)
+        exit_code = completed.returncode
+    except KeyboardInterrupt:
+        exit_code = -signal.SIGINT
+    duration = int(round(time.monotonic() - started))
+    status = _classify(exit_code)
+
+    Journal(JOURNAL_PATH).append(
+        "ci_completed",
+        pr=args.pr,
+        repo=repo,
+        status=status,
+        duration_sec=duration,
+    )
+
+    sys.stdout.write(f"pr_watch: PR #{args.pr} {status} ({duration}s)\n")
+    return 0 if status == "passed" else exit_code if exit_code else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
-import signal
 import subprocess
 import sys
 import time
@@ -91,18 +90,23 @@ def _resolve_repo() -> str:
 def _classify(exit_code: int) -> str:
     """Map a `gh pr checks --watch` exit code to a status string.
 
-    gh returns 0 on all-green, 8 when at least one check failed, and
-    other non-zero codes for transport / lookup errors. SIGINT from
-    the user surfaces as a negative code on POSIX or 0xC000013A on
-    Windows; both are treated as ``canceled``.
+    Reference: https://cli.github.com/manual/gh_help_exit-codes and
+    https://cli.github.com/manual/gh_pr_checks. With ``--watch`` gh
+    blocks until pending checks resolve and then returns 0 (all
+    checks passed) or 8 (at least one check failed). Exit code 2 is
+    gh's standard cancellation code (e.g. user interrupt). Other
+    non-zero values are treated as a generic failure so downstream
+    automation does not silently mistake an error for success.
+
+    SIGINT raised in the parent (Python ``KeyboardInterrupt``) is
+    normalized to 2 in :func:`main` before reaching this function.
     """
     if exit_code == 0:
         return "passed"
+    if exit_code == 2:
+        return "canceled"
     if exit_code == 8:
         return "failed"
-    # SIGINT on POSIX: -signal.SIGINT (-2). Windows CTRL_C_EVENT: 0xC000013A.
-    if exit_code in (-signal.SIGINT, 0xC000013A, 130):
-        return "canceled"
     return "failed"
 
 
@@ -163,7 +167,9 @@ def main(argv: "list[str] | None" = None) -> int:
         completed = subprocess.run(cmd)
         exit_code = completed.returncode
     except KeyboardInterrupt:
-        exit_code = -signal.SIGINT
+        # Normalize parent-side cancellation to gh's standard exit code 2
+        # so callers (and the journal status mapping) see a portable signal.
+        exit_code = 2
     duration = int(round(time.monotonic() - started))
     status = _classify(exit_code)
 
@@ -176,7 +182,7 @@ def main(argv: "list[str] | None" = None) -> int:
     )
 
     sys.stdout.write(f"pr_watch: PR #{args.pr} {status} ({duration}s)\n")
-    return 0 if status == "passed" else exit_code if exit_code else 1
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -7,7 +7,6 @@ CLAUDE.local.md.
 from __future__ import annotations
 
 import json
-import signal
 import sys
 import unittest
 from pathlib import Path
@@ -25,14 +24,12 @@ class ClassifyTests(unittest.TestCase):
     def test_eight_is_failed(self) -> None:
         self.assertEqual(pr_watch._classify(8), "failed")
 
-    def test_sigint_negative_is_canceled(self) -> None:
-        self.assertEqual(pr_watch._classify(-signal.SIGINT), "canceled")
-
-    def test_windows_ctrl_c_is_canceled(self) -> None:
-        self.assertEqual(pr_watch._classify(0xC000013A), "canceled")
+    def test_two_is_canceled(self) -> None:
+        self.assertEqual(pr_watch._classify(2), "canceled")
 
     def test_other_nonzero_is_failed(self) -> None:
         self.assertEqual(pr_watch._classify(1), "failed")
+        self.assertEqual(pr_watch._classify(127), "failed")
 
 
 class JournalEmitTests(unittest.TestCase):

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -1,0 +1,89 @@
+"""Unit tests for tools/pr_watch.py (Issue #204).
+
+Mocks the gh CLI subprocess via monkey-patching so the suite stays
+hermetic. Verifies the journal payload shape matches the contract in
+CLAUDE.local.md.
+"""
+from __future__ import annotations
+
+import json
+import signal
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pr_watch  # noqa: E402
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_zero_is_passed(self) -> None:
+        self.assertEqual(pr_watch._classify(0), "passed")
+
+    def test_eight_is_failed(self) -> None:
+        self.assertEqual(pr_watch._classify(8), "failed")
+
+    def test_sigint_negative_is_canceled(self) -> None:
+        self.assertEqual(pr_watch._classify(-signal.SIGINT), "canceled")
+
+    def test_windows_ctrl_c_is_canceled(self) -> None:
+        self.assertEqual(pr_watch._classify(0xC000013A), "canceled")
+
+    def test_other_nonzero_is_failed(self) -> None:
+        self.assertEqual(pr_watch._classify(1), "failed")
+
+
+class JournalEmitTests(unittest.TestCase):
+    def _run(self, tmp_journal: Path, gh_exit: int) -> int:
+        completed = mock.Mock(returncode=gh_exit)
+
+        def fake_run(cmd, *args, **kwargs):
+            # _pr_exists() probe path
+            if "view" in cmd and "--json" in cmd and "number" in cmd:
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
+            # the watched run
+            return completed
+
+        with mock.patch.object(pr_watch, "JOURNAL_PATH", tmp_journal), \
+             mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+             mock.patch.object(pr_watch.time, "monotonic", side_effect=[100.0, 142.0]):
+            return pr_watch.main(["205", "--repo", "octo/repo", "--interval", "5"])
+
+    def test_passed_emits_ci_completed(self) -> None:
+        with self.subTest("passed"):
+            with TempDir() as tmp:
+                journal = tmp / ".state" / "journal.jsonl"
+                self._run(journal, gh_exit=0)
+                lines = journal.read_text(encoding="utf-8").splitlines()
+                self.assertEqual(len(lines), 1)
+                rec = json.loads(lines[0])
+                self.assertEqual(rec["event"], "ci_completed")
+                self.assertEqual(rec["pr"], 205)
+                self.assertEqual(rec["repo"], "octo/repo")
+                self.assertEqual(rec["status"], "passed")
+                self.assertEqual(rec["duration_sec"], 42)
+                self.assertIn("ts", rec)
+
+    def test_failed_status(self) -> None:
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "journal.jsonl"
+            self._run(journal, gh_exit=8)
+            rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(rec["status"], "failed")
+
+
+class TempDir:
+    def __enter__(self) -> Path:
+        import tempfile
+        self._dir = tempfile.TemporaryDirectory()
+        return Path(self._dir.name)
+
+    def __exit__(self, *exc) -> None:
+        self._dir.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements Option A (secretary helper) from the #204 design comparison: a small wrapper around \`gh pr checks --watch\` that emits a structured \`ci_completed\` event into \`.state/journal.jsonl\` when CI finishes.

This addresses the primary pain point identified in the worker analysis — *CI state has no place to live in the journal* — at minimum blast radius (no dispatcher loop changes, stdlib-only).

## Files
- \`tools/pr_watch.py\` (new) — CI monitor CLI (stdlib + \`core_harness.audit\`)
- \`tools/pr-watch.ps1\` (new) — Windows wrapper
- \`tools/pr-watch.sh\` (new) — POSIX wrapper
- \`tools/test_pr_watch.py\` (new) — 6 unit tests, gh subprocess mocked
- \`CLAUDE.md\` — adds a "post-PR CI monitoring" section
- \`.claude/skills/org-delegate/SKILL.md\` — Step 2b-i now references pr-watch

## Journal payload
\`\`\`json
{"ts":"<ISO8601>","event":"ci_completed","pr":<#>,"repo":"<owner/repo>","status":"passed|failed|canceled","duration_sec":<int>}
\`\`\`

## Validation
- \`python -m unittest tools.test_pr_watch -v\` → 6 tests pass
- \`python tools/pr_watch.py --help\` → argparse output OK
- Codex self-review 2 rounds: round 1 caught a Blocker (gh exit code 8 misinterpreted) and a Major (KeyboardInterrupt returning -SIGINT); both fixed in 4719207. Round 2: no Blocker/Major.

## Test plan
- [x] Unit tests pass
- [ ] CI green
- [ ] Manual smoke after merge: \`pr-watch <some open PR#>\` and confirm journal append

closes #204