### PR TITLE
chore(deps): revert claude-org-runtime to standard PyPI pin (>=0.1.1,<0.2)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@
 core-harness @ git+https://github.com/suisya-systems/core-harness@v0.3.1
 
 # Phase 4 (Layer 2): claude-org-runtime hosts the dispatcher runner and
-# worker settings generator that used to live under tools/. Installed
-# straight from the GitHub release tag (the package is not on PyPI yet)
-# — same pattern as the core-harness pin above. Bump the tag explicitly
-# when adopting a new runtime release.
-claude-org-runtime @ git+https://github.com/suisya-systems/claude-org-runtime@v0.1.0
+# worker settings generator that used to live under tools/. Published to
+# PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
+# breaking per the runtime's compatibility policy, so widen this pin
+# deliberately when adopting a new minor.
+claude-org-runtime>=0.1.1,<0.2


### PR DESCRIPTION
## Summary
Reverts the temporary \`git+https://github.com/suisya-systems/claude-org-runtime@v0.1.0\` pin (introduced in #209) to the standard PyPI pin \`claude-org-runtime>=0.1.1,<0.2\`. The Trusted Publisher is now registered (closes claude-org-runtime#5) and v0.1.1 is published to PyPI: https://pypi.org/project/claude-org-runtime/0.1.1/.

## Files (1)
- \`requirements.txt\` — pin form + accompanying comment

## Validation
- \`pip install -r requirements.txt\` → uninstalls 0.1.0 (the git+https artefact) and installs 0.1.1 from PyPI
- \`pip show claude-org-runtime\` → Version: 0.1.1
- \`claude-org-runtime --version\` → \`claude-org-runtime 0.1.1\`
- \`pytest tools/ tests/\` → 108 passed

## Test plan
- [ ] CI green
- [ ] Subsequent worker dispatch in a fresh session uses 0.1.1 from PyPI without git+https fetches

refs claude-org-runtime#5
refs #209