### PR TITLE
chore(deps): revert core-harness to standard PyPI pin (>=0.3.2,<0.4)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,14 @@
 # Step B: claude-org-ja depends on core-harness for permission/audit
 # primitives (tools/check_role_configs.py and the historical
 # tools/generate_worker_settings.py shim, which has since been
-# replaced by claude-org-runtime — see below). Pre-1.0 we pin to an
-# exact tag per design Q9/Q10 and §7.1: x-bumps imply breaking
-# changes that the ja side must verify before adopting.
+# replaced by claude-org-runtime — see below). Published to PyPI;
+# pre-1.0 we pin to a 0.x range per design Q9/Q10 and §7.1: x-bumps
+# imply breaking changes that the ja side must verify before adopting.
 #
 # Reproducibility note (1.0 migration): consider switching to a commit
-# SHA pin alongside the tag to guard against tag re-targeting, e.g.
-#   core-harness @ git+https://github.com/suisya-systems/core-harness@<sha>  # tag v0.3.1
-# Tracked for the 0.x to 1.0 cutover; tag pin is sufficient for 0.x.
-core-harness @ git+https://github.com/suisya-systems/core-harness@v0.3.1
+# SHA pin via git+https to guard against tag/release re-targeting.
+# Tracked for the 0.x to 1.0 cutover; PyPI range pin is sufficient for 0.x.
+core-harness>=0.3.2,<0.4
 
 # Phase 4 (Layer 2): claude-org-runtime hosts the dispatcher runner and
 # worker settings generator that used to live under tools/. Published to


### PR DESCRIPTION
## Summary
Reverts the temporary \`git+https://github.com/suisya-systems/core-harness@v0.3.1\` pin to the standard PyPI pin \`core-harness>=0.3.2,<0.4\`. core-harness has been live on PyPI since v0.3.2 (suisya-systems/core-harness#9, Trusted Publisher via core-harness#7); this PR catches \`requirements.txt\` up.

Same pattern as #210 (which reverted the analogous \`claude-org-runtime\` pin).

## Files (1)
- \`requirements.txt\` — pin form + accompanying comment

## Validation
- \`pip install -r requirements.txt\` → core-harness 0.3.1 → 0.3.2 upgrade succeeds
- \`pip show core-harness\` → Version: 0.3.2
- \`pytest tools/ tests/\` → 108 passed

## Test plan
- [ ] CI green
- [ ] Subsequent worker dispatch in a fresh session uses 0.3.2 from PyPI without git+https fetches

refs suisya-systems/core-harness#9
refs #210