### PR TITLE
docs(internal): record Phase 5 design Q&A questions and decisions

### DIFF
--- a/docs/internal/phase5-decisions-2026-05-03.md
+++ b/docs/internal/phase5-decisions-2026-05-03.md
@@ -1,0 +1,176 @@
+# Phase 5 (Layer 3 = orchestration glue) — Lead 回答記録
+
+- 日付: 2026-05-03
+- 関連 Issue: ja#（Layer 3 抽出可否、未起票）
+- 入力 doc:
+  - `docs/internal/phase5-questions-2026-05-03.md`（12 問の Q&A 草案）
+  - `docs/internal/phase4-decisions-2026-05-02.md`（Layer 2 決定との整合確認）
+- セッション: Lead live Q&A（2026-05-03）にて 12 問の回答を確定。
+- 性質: Lead 判断の **永続化レコード**。Phase 4 と同様に、本 doc 1 枚を後続 worker / Lead が参照すれば Phase 5 の進路（kill / defer / extract）が確定する状態を目的とする。
+
+---
+
+## Phase 5 status: **deferred (kill gate 未評価)**
+
+- Q1=b により、Layer 3 抽出は **現時点で kill にも extract にも進めず保留**。
+- **Next action**: 2026-08-03 頃（= 本決定から 1 quarter 後）に、Q2=a で挙げた measurement (i) consumer 候補 inventory + (ii) skill churn を取得し、Q1 の kill 判定を再評価する。
+  - (i) 実施主体: Lead 手作業（gh search + Slack 観察、想定 30 min）。
+  - (ii) 実施主体: worker 派遣（`git log --since=...` 集計、想定 半日）。
+  - 自動 routine（cron / scheduled agent）は不要と判断。
+- 再評価で proceed が出た場合は本 doc Q3〜Q12 の回答（narrow scope = `org-delegate` + `org-start` の 2 skill、`claude-org-skills` を MIT で GitHub Release のみ publish 等）が **そのまま設計入力** となる。kill が出た場合は本 doc が結論として残り、Layer 3 は claude-org-ja に永続的に残置する。
+
+---
+
+## English summary (one paragraph)
+
+Phase 5 (Layer 3 = orchestration glue) extraction is **deferred**. The Lead chose Q1=b: defer the kill / extract decision by one quarter and revisit on or around 2026-08-03 after taking the two measurements that matter most — (i) inventory of real third-party consumers of `.claude/skills/org-*`, and (ii) churn of `.claude/skills/` over the past six months — under Q2=a. If the kill gate clears, Layer 3 will be extracted with a **narrow scope** (Q3=a): only `org-delegate` and `org-start` as the minimal "worker dispatch reference". The same Layer-2-style breaking policy applies (Q4=a, "0.x breaking allowed"); prompts stay in Layer 2 with claude-org-ja keeping its Japanese-rich `.dispatcher/` / `.curator/` files as consumer-side overrides (Q5=a); org-shaped hooks (Q6=b) and the dashboard (Q7=a, upholds Phase 4 Q9=c) stay in claude-org-ja; the Layer 2 enum catalog remains the single source of truth for events / states (Q8=a); the new Layer 3 repo becomes the SoT with ja/en as consumers (Q9=a, mirrors Phase 4 Q8=a); claude-org-ja remains as a "thin shim + 内部試験場" (Q10=b) — the Phase 5 DoD = `claude-org-skills` v0.1 release **plus** one merged ja PR that rewrites `.claude/skills/org-delegate` and `org-start` as override / consumer wrappers. Distribution is **public OSS via GitHub Release only** (no PyPI publish), consumed via git submodule / subtree / `pip install git+...` (Q11=b), under the name `claude-org-skills`, MIT license, governance shared with Layer 1 / Layer 2 / claude-org-ja under a single Lead-as-maintainer model (Q12=a).
+
+---
+
+## 各 Q への回答
+
+### Q1. 抽出根拠の測定 — kill ゲート
+
+- **回答**: **(b)** defer。1 quarter 後（= 2026-08-03 頃）に measurement (i) + (ii) を取得して kill / proceed を再判定。現時点ではどちらの結論にも進めない。
+- **根拠**:
+  - Layer 1 (core-harness) と Layer 2 (claude-org-runtime) には「framework primitives」「runtime SoT」という明確な抽出動機があったが、Layer 3 = orchestration glue は **積極理由が現時点で曖昧**。consumer 候補も churn 実績も未測定の状態で kill (a) に倒すと「測らずに諦めた」記録になり、proceed (c) に倒すと「需要なき extract」になる。
+  - Layer 2 v0.1 release が glue 層需要に与える影響（dispatcher_runner が PyPI 化された後、第三者が skill 層も欲しがるか）が読めない時期なので、measurement の前に判断を切る合理性が乏しい。
+  - 1 quarter は Layer 2 v0.1 が世に出て consumer の反応が見え始めるのに必要十分な期間として設定。
+- **トレードオフ**: 3 ヶ月間 Layer 3 の進路が宙吊りになる。ただし claude-org-ja の運用は現状維持で問題なく、機会損失は限定的。
+- **DoD 接続**: Phase 5 そのものの DoD は Q10 で確定（後述）。本 Q では「2026-08-03 頃の再評価セッション開催」が次の milestone。
+
+### Q2. measurement-first の具体プラン
+
+- **回答**: **(a)** (i) consumer 候補 inventory + (ii) skill churn を最優先で取り、Q1 kill 判定を下す。kill されなかった場合のみ (iii)〜(viii) を extract 着手後に追加で取る（Phase 4 Q12=b 流派）。
+- **根拠**:
+  - Q1=b の判定材料として必要なのは「需要 (i)」と「不安定度 (ii)」の 2 軸のみ。残り 6 指標（dependency graph / prompt diff / hooks 改訂 / dashboard 利用 / ja↔en drift / 残余 LOC 予測）は **設計判断には効くが kill 判定には効かない**。kill 判定前にすべて取るのは worker 負荷の無駄。
+  - (b) 全測定は Layer 3 の不確実性に対しては richer information を提供するが、kill が出た場合 (iii)〜(viii) は完全に sunk cost になる。
+  - (c) (i) のみで proceed まで決め切るのは churn 情報なしに「stable / unstable」が判断できないため拙速。
+- **実施主体**:
+  - (i) consumer 候補 inventory: **Lead 手作業**（gh search + Slack 観察、想定 30 min）。worker 派遣するほどの作業量ではなく、判断基準（「実際に読んでいる」の閾値）が Lead 内にしかないため。
+  - (ii) skill churn: **worker 派遣**（`git log --since=2026-02-03 -- .claude/skills/` 集計 + 追加/削除/変更行数の skill 別分類、想定 半日）。機械的集計のため worker 適性が高い。
+  - 自動 routine（cron / scheduled agent）は **不要**。1 quarter 後の単発測定であり、定常 monitoring の対象ではない。
+- **DoD 接続**: 2026-08-03 頃の再評価セッションまでに (i) Lead 手作業 + (ii) worker 報告 doc が揃っていること。
+
+### Q3. 抽出する場合のスコープ境界
+
+- **回答**: **(a)** narrow。`org-delegate` + `org-start` の 2 skill のみを起点とする。最小可動部 = 「ワーカー派遣の reference」。
+- **根拠**:
+  - Q1=b で defer している前提だが、proceed した場合の起点は narrow に倒す。理由は Layer 2 (Q1=c wide) と思想を分けるべきだから: Layer 2 の最小可動部は「役割が立ち上がる reference 一式」だが、Layer 3 の最小可動部は「**1 ユースケースが手で動く** reference」で十分。
+  - wide (b) で 10 skill + dispatcher/curator prompts + dashboard + hooks をまとめて extract すると、kill 判定が defer された段階の不確実性に対して投資が大きすぎる。
+  - split (c) で 3 リポに割るのは consumer がまだ 0 の段階で release cycle を 3 つ管理するコストが正当化できない。narrow が後から拡張する余地を残し、wide / split に進むのは v0.1 release 後の measurement 次第とする。
+- **トレードオフ**: `org-curate` / `org-suspend` / `org-resume` 等を使いたい第三者は claude-org-ja を直接参照するか、独自 port を維持することになる。narrow scope の段階では許容。
+- **DoD 接続**: Phase 5 v0.1 = この 2 skill が外部 consumer の `.claude/skills/` に置かれて Claude Code に直読される状態。
+
+### Q4. API 安定性ゲート
+
+- **回答**: **(a)** Layer 2 と同じ「0.x 期間 breaking 許容」流派。
+- **根拠**:
+  - Q3=a で skill 数が 2 に縮小されるため、per-skill semver (c) はナンセンス（2 skill で個別 release cycle を持つ over-engineering）。
+  - Layer 2 を exact pin する (b) は Layer 2 自身が 0.x breaking 許容（Phase 4 Q2=b）のため、Layer 3 だけ厳格にしても整合しない。Layer 2 を bump するたび Layer 3 を手で追従するコストが per-skill semver と同質の負荷を生む。
+  - Layer 2 と Layer 3 の breaking が同一リズムで動くことで、consumer 側（claude-org-ja / 第三者）の追従コストも 1 軸に集約される。
+- **トレードオフ**: Layer 2 の breaking が即 Layer 3 に波及するため、Layer 3 単体での「安定保証」は提供できない。0.x の段階では許容。
+- **DoD 接続**: v0.1 release 時に CHANGELOG に "0.x: breaking changes allowed (mirrors claude-org-runtime policy)" を明記。
+
+### Q5. Phase 4 で bundle 済みの prompt template との関係整理
+
+- **回答**: **(a)** prompt は Layer 2 にすべて寄せる。Layer 3 は narrow (Q3=a) のため prompt template を持たない。claude-org-ja の `.dispatcher/CLAUDE.md` / `.curator/CLAUDE.md`（日本語 rich）は Layer 2 英語 reference の **consumer-side override** として残る。
+- **根拠**:
+  - Q3=a で `org-delegate` + `org-start` の 2 skill だけ extract する以上、dispatcher / curator の prompt template は Layer 3 のスコープ外。Phase 4 Q5=b（Python runner + 英語版 prompt template を Layer 2 にバンドル）が SoT として既に確立しているので、Layer 3 で再度 prompt を持つ二重所属を避ける。
+  - (b) Layer 2 minimal + Layer 3 rich は Layer 2 を「reference として弱い」状態に格下げすることになり、Phase 4 Q1=c（wide MVP）と矛盾する。
+  - (c) Phase 4 Q5 の見直しは Phase 4 決定を遡って書き換えるコストが高く、現時点で正当化する measurement もない。
+- **トレードオフ**: Layer 2 の英語 reference prompt を「最小起動可能」と「ja の rich 版」の両方の役割で使い回す形になるが、Phase 4 Q1=c の wide scope 解釈と整合する。
+- **DoD 接続**: Phase 5 では prompt template を一切扱わない。Layer 2 v0.1 リリース後の prompt 改訂は Phase 4 ライン側の責務。
+
+### Q6. org-shaped hooks の去就
+
+- **回答**: **(b)** claude-org-ja 残置。`block-workers-delete.sh` / `block-dispatcher-out-of-scope.sh` / `block-org-structure.sh` / `block-git-push.sh` の 4 ファイルは Layer 3 に持ち込まない。
+- **根拠**:
+  - これら hooks は `registry/org-config.md` / `.dispatcher/` / `.state/` 等の **物理 path に強く結び付いて** いる。Layer 3 で抽出するには path 抽象化レイヤ（Layer 2 が org-shaped hooks の生成 / 検証 API を提供する Q6 選択肢 (c)）が前提となるが、Q3=a の narrow scope と整合せず over-engineering。
+  - (a) Layer 3 に skill と一緒に含めると、Layer 3 が claude-org-ja の物理構造を前提にする状態になり「reference として一般化された skill」と矛盾する。
+  - (c) Layer 2 に hooks 抽象 API を入れる案は Layer 2 v0.1 のスコープを膨らませるため、現段階では棄却。将来 hooks の OSS 化需要が顕在化した時点で再検討する余地はある。
+- **トレードオフ**: 第三者 consumer が org-shaped hooks 相当の安全策を欲しがった場合、claude-org-ja を参考に各自実装する必要がある。narrow scope の段階では許容。
+- **DoD 接続**: Phase 5 では hooks を Layer 3 リポに含めない。claude-org-ja の `.hooks/` 配下構造は変更しない。
+
+### Q7. dashboard の去就 — Phase 4 Q9=c との接続
+
+- **回答**: **(a)** Phase 4 Q9=c を維持。dashboard は claude-org-ja に残し、Layer 3 は dashboard を持たない。
+- **根拠**:
+  - Phase 4 Q9=c で「dashboard SPA は claude-org-ja、Layer 2 は schema (`org-state.json`) のみ」が確定済。Phase 5 で書き換える積極理由はない（Q3=a narrow との整合、en port 側の独自 dashboard との二重所属回避）。
+  - (b) dashboard を Layer 3 に統合すると、Phase 4 決定の書き換え + Layer 3 release cycle が SPA build に律速される + en port との重複を Layer 3 が抱える、の 3 重コスト。
+  - (c) Layer 3.5 = `claude-org-dashboard` リポを別出しする split 案は Q3=c と同じ理由で棄却（consumer 0 段階で release cycle を増やさない）。
+- **トレードオフ**: dashboard 改修と skill 改修が別 PR / 別リポに分かれることで、両方を触る変更（schema 拡張等）の coordination コストが発生。Layer 2 schema 経由で疎結合化されているので致命傷ではない。
+- **DoD 接続**: Phase 5 では dashboard 関連ファイル（`dashboard/` 配下）を Layer 3 リポに含めない。
+
+### Q8. State / event catalog の正規化 — どこを SoT にするか
+
+- **回答**: **(a)** Layer 2 enum がすべての SoT。Layer 3 narrow 2 skill が必要とする event は既に Layer 2 catalog (Phase 4 Q7=a の `Enum` + JSON schema、35 種カタログ) に揃っている。
+- **根拠**:
+  - Phase 4 Q7=a で「workflow_status / journal event / anomaly kind を Python `Enum` + JSON schema で固定」が確定済。Layer 3 の `org-delegate` + `org-start` が呼ぶ event（worker_dispatched, worker_started 等）は Layer 2 の 35 種カタログに包含されている前提（measurement 上は (iii) skill 間 dependency graph で要確認だが、kill 判定後の確認で十分）。
+  - (b) plugin event 機構は Layer 2 に `register_event(name, schema)` API を追加する必要があり、Q3=a の narrow との不整合 + Layer 2 の API surface 拡張で v0.1 がさらに膨らむ。
+  - (c) Layer 3 内 string 緩い運用は Phase 4 Q7=a の Enum 化決定を Layer 3 内で部分的に巻き戻す形になり、SoT 矛盾を生む。
+- **トレードオフ**: Layer 3 で新 event が必要になった場合、Layer 2 PR を経由する 2 step 追加コストが発生。narrow scope の段階では新 event 需要は低い見込み。
+- **DoD 接続**: Phase 5 で新 event を導入しない。proceed 時に Layer 2 catalog の不足が判明したら Layer 2 v0.x bump で吸収。
+
+### Q9. ja↔en 同期戦略との接続 — Layer 3 の SoT
+
+- **回答**: **(a)** Layer 3 リポを新 SoT、ja / en は consumer。skill は英語 SoT、ja は日本語訳 consumer（Phase 4 Q8=a と同流派）。
+- **根拠**:
+  - Phase 4 Q8=a で「`claude-org-runtime` を新 SoT、ja / en は consumer に降格」が確定済。Layer 3 でも同じ路線を採らないと、Layer 2 と Layer 3 で SoT 階層の解釈が分裂する。
+  - (b) claude-org-ja を Layer 3 SoT として残す案は Phase 4 Q8=a で却下した case を Layer 3 で復活させることになり整合しない。
+  - (c) bilingual SoT は ja / en を両方 SoT 扱いする fork-and-sync 方式で、translate コストが mirror 方式の 2 倍に膨らむ。Phase 4 で却下した発想を Layer 3 で採用する積極理由がない。
+  - claude-org-ja の `.dispatcher/CLAUDE.md` / `.curator/CLAUDE.md`（日本語 rich）は Q5=a により consumer-side override として残るので、ja の日本語性は維持される。
+- **トレードオフ**: skill の SoT が英語に動くため、ja に直接日本語で書き加える運用は禁止になる（必ず Layer 3 英語 SoT 経由）。#171 auto-mirror の射程を Layer 3 まで広げる必要があるかは別途検討（Phase 4 未決事項 §3 と同じ未決）。
+- **DoD 接続**: Layer 3 リポの skill ファイルは英語 Markdown。ja consumer は override / 翻訳 layer を `.claude/skills/org-delegate` 等に配置。
+
+### Q10. Phase 5 抽出後に claude-org-ja に残るもの (DoD)
+
+- **回答**: **(b)** thin shim。抽出後 claude-org-ja は narrow 抽出 (Q3=a) のため大半が残る（残置: 8 skill (`org-curate` / `org-dashboard` / `org-resume` / `org-retro` / `org-setup` / `org-suspend` / `skill-audit` / `skill-eligibility-check`) + dashboard + hooks + 日本語 rich prompt）。
+- **Phase 5 DoD**: 以下 2 つが揃った時点で Phase 5 完了。
+  1. `claude-org-skills` v0.1 release（`org-delegate` + `org-start` の英語 SoT 版が GitHub Release として配布される、Q11/Q12 参照）。
+  2. claude-org-ja の `.claude/skills/org-delegate` + `.claude/skills/org-start` が **override / consumer 構造に書き換わった PR が 1 件 merge** される。
+- **根拠**:
+  - Q3=a narrow を採った時点で claude-org-ja は「ほぼそのまま残る」状態になるため、(a) "live demo + 知識ベース"（runtime も skill も持たない）は narrow scope と矛盾する。10 skill のうち 8 が残るので "thin shim" 表現が実態に近い。
+  - (c) claude-org-ja archive 化は narrow scope の段階で打つには過激。後継 `claude-org-reference` を立ち上げるコストも正当化できない。
+  - DoD として「v0.1 release + ja 1 PR merge」を取るのは Phase 4 Q11=b（in-tree 置換まで）と対称的に、「extract したけど誰も使っていない」状態を防ぐため。
+- **トレードオフ**: claude-org-ja の `.claude/skills/` は extract 済みの 2 skill と未 extract の 8 skill が混在する状態になり、構造の一貫性が一時的に崩れる。narrow scope の進化過程として許容。
+- **DoD 接続**: 上記 2 条件が達成された時点で Phase 5 close。
+
+### Q11. 公開 OSS 化判断 (1/2) — 公開形態
+
+- **回答**: **(b)** public OSS、GitHub Release のみ（PyPI publish しない）。consumer は git submodule / git subtree / `pip install git+...` で取り込む。
+- **根拠**:
+  - skill / prompt は **Markdown ファイルが filesystem に置かれて Claude Code に直読される** consumption pattern。PyPI wheel に同梱して `importlib.resources` 経由で取り出す (a) は「ファイルが置かれる」consumption と整合せず、PyPI 経由の意味が薄い。
+  - (c) private GitHub repo は en port が既に public OSS の前提では実効性が低い（en port から実装は推測可能）し、Layer 1/2 の public OSS 路線とも分裂する。
+  - GitHub Release のみで `pip install git+https://github.com/suisya-systems/claude-org-skills@v0.1.0` のような取り込み口を出せば、submodule / subtree 派にも対応できる。Phase 3 Q10=A の流派と整合。
+- **トレードオフ**: PyPI search からの discoverability が落ちる。narrow scope の段階で discoverability 投資の優先度は低い。将来需要があれば PyPI publish に切り替える余地はある（Markdown wrapping wheel の追加で対応可能）。
+- **DoD 接続**: GitHub Release v0.1.0 の存在 = Q10 DoD 条件 1 の判定基準。
+
+### Q12. 公開 OSS 化判断 (2/2) — namespace / license / governance
+
+- **回答**: **(a)** 命名 `claude-org-skills`（narrow 2 skill を字義通り表現）、license **MIT**（Layer 1 / Layer 2 / claude-org-ja と統一）、governance は claude-org-ja / Layer 1 / Layer 2 と同じ maintainer 体制（**CODEOWNERS 共有、Lead 単一 maintainer**）。
+- **根拠**:
+  - 命名: `claude-org-glue` / `claude-org-orchestration` / `claude-org-doctrine` は Q3=a narrow scope (2 skill) に対して名前が広すぎる。`claude-org-skills` が「Claude Code skill 形式で配布される claude-org の component」という実態を最も素直に表現する。GitHub repo 名衝突は v0.1 release 直前に再点検（Phase 4 Q10 と同じ運用）。
+  - License: MIT は Layer 1 (core-harness) / Layer 2 (claude-org-runtime, Phase 4 Q10) / claude-org-ja と統一されており、consumer 側の license compatibility 判定を簡素化する。Apache-2.0 (Q12 選択肢 (c) 部分) の特許条項を Layer 3 だけ追加する積極理由がない。
+  - Governance: Lead 単一 maintainer + CODEOWNERS 共有は Layer 1/2 で機能している体制。Layer 3 だけ別 maintainer にする (c) は consumer 0 段階で community governance を構築する over-engineering。
+  - (b) 複数リポ分割は Q3=a narrow と矛盾（2 skill を 3 リポに割る合理性がない）。
+- **トレードオフ**: 単一 maintainer のため Lead 不在時の release / review がブロックする。Layer 1/2/4 でも同じ運用なので Phase 5 単独問題ではない。
+- **DoD 接続**: v0.1 release 時に repo metadata（LICENSE, CODEOWNERS, README）がこの命名 / license / governance を反映していること。
+
+---
+
+## 後続アクション
+
+1. **2026-08-03 頃の再評価セッション開催** — Q1=b に従い、measurement (i) Lead 手作業 + (ii) worker 派遣の結果を持ち寄って kill / proceed を判定。
+2. **measurement (ii) の worker 派遣準備** — 2026-07-下旬に `git log --since=2026-02-03 -- .claude/skills/` 集計タスクを worker 起票（CLAUDE.md / 入力指示はこの時点で起こす）。
+3. **proceed 判定が出た場合の Step B 相当タスク** — `claude-org-skills` リポ初期化（README / LICENSE / CODEOWNERS）+ `org-delegate` / `org-start` の英語 SoT 版作成 + claude-org-ja 側 override 構造への書き換え PR、の 2 トラックを並行起票。
+4. **kill 判定が出た場合** — 本 doc を「Phase 5 結論」として確定し、`docs/internal/phase5-conclusion-killed-2026-08-XX.md` 等で永続化。Layer 3 抽出は close。
+
+---
+
+## 未決事項
+
+1. **再評価セッションの正確な日時** — 「2026-08-03 頃」は目安であり、Layer 2 v0.1 release の進捗（Phase 4 完了タイミング）次第で前後する。Layer 2 v0.1 が出ていない状態で再評価しても consumer 反応が読めないため、**Layer 2 v0.1 release から最低 4 週間後** を実質下限とする。
+2. **#171 auto-mirror 射程の Layer 3 拡張** — Q9=a で Layer 3 を新 SoT にする以上、auto-mirror runtime (#171) の射程を Layer 3 まで広げるか、Layer 3 リポ内で独自に翻訳保守するかが未決。Phase 4 Q8=a の未決事項 (§3 prompt template の英訳保守) と同質の問題で、まとめて #171 側で議論する。
+3. **proceed 後の `claude-org-skills` PyPI publish 切替判断基準** — Q11=b で当面 GitHub Release のみだが、PyPI publish に切り替える発火条件（consumer 数 / discoverability 要望件数 等）を v0.1 release 時に CHANGELOG ないし README で明示するかは未決。
+4. **claude-org-ja `.claude/skills/` の混在期間の運用ルール** — Q10=b DoD 達成後、`org-delegate` + `org-start` のみ override 構造、残り 8 skill は in-tree のままという混在状態が長期化する。混在期間中の skill 改修ルール（override layer に書く / in-tree に書く / 両方）は Phase 5 close 後の Phase 6 等で改めて決める必要がある。

--- a/docs/internal/phase5-questions-2026-05-03.md
+++ b/docs/internal/phase5-questions-2026-05-03.md
@@ -1,0 +1,192 @@
+# Phase 5 (Layer 3 = orchestration glue) 設計議論用 Q&A 草案
+
+- 作成日: 2026-05-03
+- 関連 Issue: ja#（Layer 3 抽出可否、未起票）
+- 入力: Phase 4 の `phase4-questions-2026-05-02.md` / `phase4-decisions-2026-05-02.md`
+- 性質: **質問のみ**。回答は窓口（Lead）判断。Phase 3 / Phase 4 と同じく measurement-first で進める。
+- 数: 12 問（Phase 4 と粒度・章立てを揃える）。
+- **重要**: 本 Q&A は **「抽出するための質問」ではなく**、「Layer 3 を抽出すべきか / すべきでないか / どう抽出するか」を決めるための measurement-first 質問。最初の 2 問は kill 判定（= 抽出しない）にも進行判定（= 抽出する）にも耐える設計の measurement Q。最後の 3 問は公開 OSS 化判断（抽出形態 / public vs private / namespace・license・governance）。
+- Layer 3 候補の中身: `.claude/skills/` (org-curate / org-dashboard / org-delegate / org-resume / org-retro / org-setup / org-start / org-suspend / skill-audit / skill-eligibility-check)、`.dispatcher/CLAUDE.md`、`.curator/CLAUDE.md`、`.hooks/` の **org-shaped 残置分** (block-workers-delete / block-dispatcher-out-of-scope / block-org-structure / block-git-push 等。Phase 4 で core-harness に移管された generic 分は除外)、`dashboard/` (SPA + server.py)。Phase 4 で `claude-org-runtime` に bundle 済みの dispatcher / curator prompt template の英語版とは **重複領域** がある（→ Q5, Q8 で扱う）。
+
+---
+
+## Q1. 抽出根拠の測定 — そもそも consumer / 痛点はあるか（kill ゲート）
+
+Layer 1 (core-harness) と Layer 2 (claude-org-runtime) は「framework primitives」「runtime SoT」という明確な抽出動機があった。Layer 3 = orchestration glue については、抽出する積極理由が現時点で曖昧で、まず measurement で kill 判定にかける必要がある。
+
+- **この時点で測定すべき事実**:
+  - claude-org-ja 以外で `.claude/skills/org-*` を **実際に読み込んでいる** Claude Code consumer の数（en port を含めて何件か。fork / star ではなく実体）
+  - 過去 6 ヶ月で Lead / worker から「skill / dispatcher prompt の OSS 化要望」が出た回数（Issue / Slack / セッションログ）
+  - 直近 3 ヶ月の `.claude/skills/` 内ファイルの churn（追加 / 改稿 / 削除回数）— 高 churn = まだ glue 層が安定していない sign
+  - `.curator/CLAUDE.md` / `.dispatcher/CLAUDE.md` の Phase 4 v0.1 prompt template との **diff 量** — 大差なら Layer 2 で十分、小差なら Layer 3 必要性低下
+- **選択肢**:
+  - (a) **抽出しない (kill)**: consumer < 2 かつ要望 0 件なら、Layer 3 は claude-org-ja に永続的に残す reference 配布物として確定し、Phase 5 を close する
+  - (b) **保留 (defer)**: measurement だけ取って 1 quarter 後に再評価。Layer 2 v0.1 release が glue 層需要に与える影響を見てから判断
+  - (c) **抽出前提で設計に入る**: consumer 候補が見えなくても、claude-org-ja 自身の整理目的（reference vs runtime の境界明確化）で抽出する
+
+## Q2. measurement-first の具体プラン — 何をいつ計るか
+
+Phase 4 Q12 と同じく、コード extract 前に取るべき数値の合意を取る。Layer 3 は Layer 2 と違って「kill 判定」が現実的選択肢なので measurement の重みが Phase 4 より大きく、本 Q を Q1 と一体で先に決める。
+
+- **この時点で測定すべき事実 (= measurement の候補一覧)**:
+  - (i) **consumer 候補 inventory**: claude-org-ja 以外で `.claude/skills/` を採用しうる org / repo の数（Q1 の中核）
+  - (ii) **skill churn**: 過去 6 ヶ月の `.claude/skills/` 内ファイル commit 数、変更行数、stable / unstable 分類
+  - (iii) **skill 間 dependency graph**: Q3 の境界判断材料
+  - (iv) **prompt diff (Phase 4 v0.1 vs claude-org-ja current)**: Q5 の重複判定材料
+  - (v) **org-shaped hooks 改訂頻度**: Q6 の判断材料
+  - (vi) **dashboard 利用度 (ja / en port)**: Q7 の判断材料
+  - (vii) **ja↔en drift in skill / prompt**: Q9 の SoT 判断材料
+  - (viii) **claude-org-ja 残余 LOC 予測**: Q10 の reference 配布物 positioning 材料
+- **選択肢**:
+  - (a) **(i) + (ii) を最優先で取り、kill 判定 (Q1) を先に下す**。kill されたらこの doc が結論として残る。kill されなかったら (iii)〜(viii) は extract 着手後に追加で取る（Phase 4 Q12=b 流派）
+  - (b) **(i)〜(viii) すべて取ってから設計に入る**。measurement worker の負荷は大きいが、Layer 3 は Phase 4 より不確実性が高いので妥当（Phase 4 Q12=a 流派）
+  - (c) **measurement 最低限 ((i) のみ)** で Q1 だけ判定し、proceed なら即 Step B 相当の skill schema 抽出 PR を試作（Phase 4 Q12=c 流派、measurement-first を緩める）
+
+実施主体（worker 派遣 / Lead 手作業 / 自動 routine）も Phase 4 と同様に併せて決める。
+
+## Q3. 抽出する場合のスコープ境界 — Option α / β / γ のどれを起点にするか
+
+Q1 で (b)/(c) を取った場合、Layer 3 の MVP 境界をどこに置くか。
+
+- **この時点で測定すべき事実**:
+  - 各 skill の inter-dependency（`org-delegate` が `org-suspend` を呼ぶ等）。independent / coupled の比率（Q2-(iii)）
+  - skill ごとの「core-harness primitives + claude-org-runtime API のみで動くか / claude-org-ja 固有の path に依存するか」の依存度ヒートマップ
+  - dashboard SPA の `org-state.json` schema 依存度（Phase 4 Q9=c で schema は Layer 2 に置く決定との整合）
+- **選択肢**:
+  - (a) **narrow**: `org-delegate` と `org-start` の 2 skill だけ extract（最小可動部 = "ワーカー派遣の reference"）
+  - (b) **wide**: 10 skill 全部 + dispatcher / curator prompts（Phase 4 v0.1 から重複分は移管）+ dashboard SPA + org-shaped hooks をまとめて 1 リポにする
+  - (c) **split**: skill-only / dashboard-only / prompt-template-only に **3 分割** して Layer 3a/3b/3c とする（個別 release cycle）
+
+## Q4. API 安定性ゲート — Layer 2 と同じ流派を取るか
+
+Phase 4 Q2=b で Layer 2 は「0.x 期間 breaking 許容」が決定済。Layer 3 は **Layer 2 の上に立つ** 構造であり、Layer 2 の breaking がそのまま Layer 3 に波及する。
+
+- **この時点で測定すべき事実**:
+  - skill が Layer 2 API（journal events / org-state schema / dispatcher_runner CLI）を **どの粒度で叩くか** の inventory
+  - Layer 2 v0.1 → v0.2 の breaking change 想定頻度（Phase 4 measurement worker 結果待ち）
+  - skill の semver を独立に管理する妥当性（skill 単位で stable / unstable が分かれる sign があるか）
+- **選択肢**:
+  - (a) **Layer 2 と同じ「0.x breaking 許容」**（単純で運用負荷低い）
+  - (b) **Layer 2 を exact pin、Layer 3 自体は安定気味に運用**（Phase 3 Step E と同じ流派）。Layer 2 を bump するたび Layer 3 を手で追従
+  - (c) **stable skill / unstable skill を skill 単位で旗振り**（`org-delegate` は stable、`skill-audit` は experimental 等）。skill ごとに semver を分ける over-engineering risk あり
+
+## Q5. Phase 4 で bundle 済みの prompt template との関係整理
+
+Phase 4 Q5=b で「Python runner + 英語版 prompt template をセットで Layer 2 に extract」が決定済。Phase 5 で `.dispatcher/CLAUDE.md` / `.curator/CLAUDE.md` を Layer 3 に置こうとすると **二重所属** になる。
+
+- **この時点で測定すべき事実**:
+  - Phase 4 v0.1 にバンドル予定の prompt template が「reference 用 minimal version」か「現行 ja の full 版」か（Phase 4 decisions §Q5 のスコープ確認）
+  - claude-org-ja 内 `.dispatcher/CLAUDE.md` / `.curator/CLAUDE.md` の最新 LOC と、それを読む secretary / worker の頻度
+  - Phase 4 v0.1 prompt と claude-org-ja current prompt の diff（Q2-(iv)）
+- **選択肢**:
+  - (a) **prompt は Layer 2 にすべて寄せる**: Layer 3 は skill + hooks + dashboard のみ。dispatcher / curator prompt は Layer 2 SoT に一本化し、claude-org-ja は consumer
+  - (b) **Layer 2 は minimal reference prompt、Layer 3 が rich prompt**: Layer 2 は最小限の "起動可能な" template、Layer 3 が claude-org doctrine を反映した full prompt を持つ
+  - (c) **prompt は Layer 2 / Layer 3 両方に置かず、claude-org-ja に残す**: Phase 4 Q5 決定を見直し、prompt は reference 配布物 (claude-org-ja) の専管に戻す
+
+## Q6. org-shaped hooks（`.hooks/` の Phase 4 残置分）の去就
+
+`.hooks/` のうち generic な分 (`block-no-verify.sh`, `block-dangerous-git.sh`, `check-worker-boundary.sh` 等) は Phase 3/4 で core-harness に移管済。残った org-shaped hooks (`block-workers-delete.sh`, `block-dispatcher-out-of-scope.sh`, `block-org-structure.sh`, `block-git-push.sh`) は **claude-org doctrine の実装** であり、Layer 3 = orchestration glue の構成要素として extract 候補となる。
+
+- **この時点で測定すべき事実**:
+  - org-shaped hooks の改訂頻度（過去 6 ヶ月の commit 数、Q2-(v)）
+  - en port が同じ org-shaped hooks を独自移植しているか / どれだけ drift しているか
+  - これらの hooks が読む org 名 (`registry/org-config.md`, `.dispatcher/`, `.state/` 等) の **抽象化可能性**
+- **選択肢**:
+  - (a) **Layer 3 に含める**: skill と一緒に `.hooks/` の org-shaped 分も extract。en port もここから取り込む
+  - (b) **claude-org-ja 残置**: hooks は `registry/` / `.dispatcher/` 等の **物理 path** に強く結び付くため、reference 配布物 (claude-org-ja) の中でしか動かない。Layer 3 では持たない
+  - (c) **Layer 2 (claude-org-runtime) に hooks 抽象を入れる**: Layer 2 が runtime SoT の立場で org-shaped hooks の生成 / 検証 API を提供し、Layer 3 は purely declarative（hook 設定 YAML 程度）にとどめる
+
+## Q7. dashboard の去就 — Phase 4 Q9=c との接続
+
+Phase 4 Q9=c で「dashboard SPA は claude-org-ja に残し、Layer 2 は schema (`org-state.json`) のみ提供」が決定済。Phase 5 で dashboard を Layer 3 に持っていくと Phase 4 決定を **書き換える** ことになる。
+
+- **この時点で測定すべき事実**:
+  - en port が独自に port した dashboard と claude-org-ja の dashboard の drift（Q2-(vi)）
+  - dashboard SPA の release cycle が skill / prompt と揃うか（同じ頻度で改訂されるか）
+  - 第三者 consumer が dashboard だけを使いたい / skill だけを使いたい のどちらの需要が強いか
+- **選択肢**:
+  - (a) **Phase 4 Q9=c を維持**: dashboard は claude-org-ja に残し、Layer 3 は dashboard を持たない（skill + prompt + hooks のみ）
+  - (b) **dashboard を Layer 3 に統合**: Phase 4 Q9=c を書き換え、Layer 3 が dashboard SPA も持つ（release cycle が一致するなら筋）
+  - (c) **dashboard を Layer 3 から独立分離**: Layer 3 = skill のみ、dashboard は別の Layer 3.5 = `claude-org-dashboard` リポ（Q3=c の split と整合）
+
+## Q8. State / event catalog の正規化 — どこを SoT にするか
+
+Phase 4 Q7=a で「workflow_status / journal event / anomaly kind を Python `Enum` + JSON schema として Layer 2 で固定」が決定済。Layer 3 の skill は **これらの enum を多用** する（journal append / 状態遷移判定）。Layer 3 で **追加の event / state** を導入したいケースの扱い。
+
+- **この時点で測定すべき事実**:
+  - skill が呼び出している journal event 種別の inventory（Layer 2 の 35 種カタログとの差分。Phase 4 Step D の follow-up と整合）
+  - skill 固有の中間状態（`worker_dispatched_pending_pr` 等）が Layer 2 enum に含まれるか / Layer 3 拡張が必要か
+- **選択肢**:
+  - (a) **Layer 2 enum がすべての SoT**: Layer 3 は新規 event を導入できない。新 event 追加要求は Layer 2 PR で吸収
+  - (b) **Layer 3 で plugin event 機構を持つ**: Layer 2 が `register_event(name, schema)` API を提供し、Layer 3 がそれを使って独自 event を足す
+  - (c) **Layer 3 内では string で扱う緩い運用**: enum 化は Layer 2 のみ、Layer 3 では Phase 3 以前の "string convention" に戻す（型安全性を犠牲にして開発速度を取る）
+
+## Q9. ja↔en 同期戦略との接続 — Layer 3 の SoT をどこに置くか
+
+Phase 4 Q8=a で「`claude-org-runtime` を新 SoT、ja / en は consumer に降格」が決定済。Layer 3 についても同じ路線を採るかが論点。
+
+- **この時点で測定すべき事実**:
+  - skill / prompt / hooks / dashboard の **言語混在度**（日本語コメント / 英訳済み箇所の比率、Q2-(vii)）
+  - 第三者 consumer が日本語 skill のまま使うか英訳版を要求するかの想定
+  - #171 auto-mirror runtime が Layer 3 までカバーする / カバーしないの再定義
+- **選択肢**:
+  - (a) **Layer 3 リポを新 SoT** にし、ja / en の Layer 4 は consumer。skill / prompt は英語 SoT、ja application 層が日本語訳 consumer
+  - (b) **claude-org-ja を引き続き SoT**、Layer 3 は ja からの自動抽出 downstream（Phase 4 Q8 で却下した case を Layer 3 で復活）
+  - (c) **bilingual SoT**: skill / prompt は **ja と en を同等の SoT** として Layer 3 リポ内に併存。translate は両方向（mirror ではなく fork-and-sync）
+
+## Q10. Phase 5 抽出後に claude-org-ja に残るもの (DoD 観点も含む)
+
+Layer 3 を抽出した後、claude-org-ja は何を持つ reference 配布物として残るか、その positioning と Phase 5 DoD を確定する。Phase 4 までで `dispatcher_runner.py` 等の runtime コードは消える前提。
+
+- **この時点で測定すべき事実**:
+  - 抽出後 claude-org-ja の LOC 内訳予測（残るもの: `registry/org-config.md`, `.state/` snapshot, knowledge/, docs/, sessions/ 等。Q2-(viii)）
+  - 「reference 配布物として人が clone する」典型ユースケース（教育目的 / 内部試験 / 第三者 org 立ち上げ手本）
+- **選択肢**:
+  - (a) **claude-org-ja = "live demo + 知識ベース"**: runtime も skill も持たない。`registry/`, `knowledge/`, `sessions/`, `docs/` のみが本体。setup 手順は「Layer 1+2+3 を install して registry を書く」。Phase 5 DoD = ja から `.claude/skills/` 等が消えるまで（Phase 4 Q11=b 流派）
+  - (b) **claude-org-ja = "thin shim + 内部試験場"**: skill / prompt の override / 拡張だけが残る。Layer 3 をそのまま使うのではなく ja 流派の改造 layer を持つ。Phase 5 DoD = Layer 3 v0.1 release + ja shim 1 件 merge（Phase 4 Q11=a 流派）
+  - (c) **claude-org-ja を archive 化**: 抽出後は claude-org-ja を deprecated にし、後継 reference として `claude-org-reference`（仮）を Layer 4 として再起動する。Phase 5 DoD = archive 宣言 + 後継リポの README 完成
+
+---
+
+## 公開 OSS 化判断（最後の 2 問）
+
+ここから先は、Q1〜Q10 の答えがすべて Layer 3 抽出方向に揃った場合に固める **公開 OSS 化の具体実装**。Q1 で kill / defer が出た場合は Q11/Q12 はスキップ可能。
+
+## Q11. 公開 OSS 化判断 (1/2) — そもそも公開するか / private に留めるか / 配布形態
+
+Layer 1 / Layer 2 は OSS 公開前提だった (PyPI publish)。Layer 3 = skill + prompt + hooks は claude-org doctrine の **実装そのもの** に近く、公開すると組織方針を外部に晒す。さらに「skill / prompt は Markdown 主体」という性質が PyPI 配布と相性が悪い可能性もある。
+
+- **この時点で測定すべき事実**:
+  - skill / prompt 中に含まれる組織内 fixture（人名 / 内部 URL / 過去セッションの narrative）の量
+  - en port が既に public OSS なので、Layer 3 を private にしても en port から実装は推測可能 → private にする実効性
+  - Anthropic 公式 / コミュニティが「claude-org doctrine の実装」を OSS reference として参照したいニーズ
+  - Claude Code の plugin / skill 機構が「外部リポからの読み込み」をどこまで標準サポートしているか（symlink / submodule / marketplace 等）
+- **選択肢**:
+  - (a) **public OSS、PyPI publish**（Layer 1/2 と完全に揃える。Markdown は `importlib.resources` 経由で取り出す）
+  - (b) **public OSS、GitHub Release のみ**（Phase 3 Q10=A の流派）。consumer は git submodule / git subtree / `pip install git+...` で取り込む。Markdown 主体に整合
+  - (c) **private GitHub repo**（suisya-systems org 内 private、招待制配布）。en port の public 状態とは矛盾を許容、または en port の Layer 3 相当も private に揃える
+
+## Q12. 公開 OSS 化判断 (2/2) — namespace / license / governance
+
+Q11 で public を取った場合の具体実装。Phase 4 Q10 で `claude-org-runtime` を仮 namespace としたのと対称。本 Q が **本 doc の最終問** であり、ここの答え次第で Phase 5 の release 計画が組める。
+
+- **この時点で測定すべき事実**:
+  - PyPI / GitHub repo 名衝突確認: `claude-org-skills`, `claude-org-glue`, `claude-org-orchestration`, `claude-org-doctrine` 等の候補名
+  - GitHub org `suisya-systems` の repo 命名規約との整合
+  - License: MIT 統一（claude-org-ja / core-harness と同じ）か Apache-2.0（特許条項あり）か。skill / prompt が「Anthropic Claude Code を前提とする」性質との相性
+  - Governance: maintainer list / CODEOWNERS / RFC プロセス。Layer 1/2 と同じ governance を流用するか、Layer 3 だけ別運用にするか
+- **選択肢**:
+  - (a) **`claude-org-glue` (or `-skills`) を MIT で publish、governance は claude-org-ja / Layer 1 / Layer 2 と同じ maintainer 体制**（最小投資。Q3=a or Q3=b と整合）
+  - (b) **複数リポに分割** (Q3=c の split に対応): `claude-org-skills` + `claude-org-prompts` + `claude-org-dashboard` を別 release cycle で publish。各リポ MIT、governance は共有
+  - (c) **license / governance を Layer 1/2 と分離**: Layer 3 のみ Apache-2.0、別 maintainer 体制（claude-org doctrine の community 化を狙う）。over-engineering risk あり
+
+---
+
+## 窓口判断のハイライト（特に重要そうな質問）
+
+12 問の中で、**他の質問の答えを縛る** / **kill 判定に直結する** 順に重要だと思われるのは以下:
+
+1. **Q1（抽出根拠の測定 / kill ゲート）+ Q2（measurement プラン）** — 一体で先に答える。kill が出たら Q3〜Q12 は worker 投入不要、本 doc がそのまま結論として残る。
+2. **Q3（スコープ境界 narrow/wide/split）** — Q4〜Q10 の前提を縛る。kill されなかった場合の **二番目の分岐点**。
+3. **Q5（Phase 4 prompt template との関係整理）+ Q7（dashboard 去就）** — どちらも Phase 4 決定の書き換え可能性を含むため、Phase 4 Lead 判断との整合確認が必要。
+4. **Q11（public / private / 配布形態）** — Q12 の namespace / license / governance 実装は Q11 の答えに完全従属。


### PR DESCRIPTION
## Summary
- Land Phase 5 (Layer 3 = orchestration glue) design Q&A in `docs/internal/`, mirroring Phase 4 layout (questions + decisions, dated 2026-05-03).
- **Phase 5 status: deferred.** Per Q1=b, the Lead defers the kill / extract decision by one quarter and will revisit on or around 2026-08-03 after taking measurement (i) consumer inventory + (ii) skill churn (Q2=a).
- If proceed, the doc records: narrow scope = `org-delegate` + `org-start` only (Q3=a); Layer-2-style 0.x breaking allowed (Q4=a); prompts stay in Layer 2 (Q5=a); org-shaped hooks and dashboard stay in claude-org-ja (Q6=b, Q7=a upholds Phase 4 Q9=c); Layer 2 enum as single SoT for events (Q8=a); Layer 3 repo as new SoT with ja/en as consumers (Q9=a, mirrors Phase 4 Q8=a); claude-org-ja as thin shim with **Phase 5 DoD = `claude-org-skills` v0.1 release + one merged ja override PR for `org-delegate` + `org-start`** (Q10=b); public OSS via GitHub Release only, no PyPI publish (Q11=b); naming `claude-org-skills`, MIT license, governance shared with Layer 1 / Layer 2 / claude-org-ja under single Lead-as-maintainer model (Q12=a).

## Test plan
- [x] Decisions doc references every Q1-Q12 from the questions doc (codex self-review verified).
- [x] Q1=b deferred next action explicitly states 2026-08-03 timing + (i) Lead manual + (ii) worker dispatch measurement plan.
- [x] Phase 5 DoD wording in Q10=b matches `claude-org-skills` v0.1 release + one merged ja override PR for `org-delegate` + `org-start`.
- [ ] Lead final review of decisions doc before merge.