### PR TITLE
docs(operations): clarify renga decoration vs. client_kind authority

### DIFF
--- a/docs/operations/renga-pane-conventions.md
+++ b/docs/operations/renga-pane-conventions.md
@@ -1,0 +1,34 @@
+# renga Pane Conventions
+
+## Decoration is cosmetic; `client_kind` is authoritative
+
+In renga, pane decoration — border color, pane label, and tab title markers —
+is **cosmetic only**. It is derived from a best-effort live signal (historically
+an OSC 0/2 window-title substring match for `"claude"` / `"codex"`) and can flip
+off at any moment, for example when Claude Code rewrites its window title to the
+current task name via `\x1b]0;✶ <task name>\x07`. A missing border or a tab
+label that has reverted to `shell` does **not** mean the Claude process has died
+or hung.
+
+The authoritative source of truth for "is this pane a Claude / Codex agent?" is
+the peer registry exposed by `mcp__renga-peers__list_peers`. Each registered
+pane carries a `client_kind` field (`claude`, `codex`, …) that is set when the
+agent registers over the MCP peer channel and is **not** affected by terminal
+title rewrites. Orchestration code, dashboards, and human operators should
+treat `client_kind` as ground truth and treat decoration purely as a UI hint.
+
+> Rule of thumb: if a pane is registered with `client_kind=claude` but has no
+> decoration, trust the kind and not the decoration.
+
+### Background
+
+This convention was hardened in response to renga issues
+[#208](https://github.com/suisya-systems/renga/issues/208) and
+[#209](https://github.com/suisya-systems/renga/issues/209), where the
+title-substring detection used for decoration was found to flip false during
+normal Claude Code operation (and to misclassify Claude panes whose task name
+contained the string `"codex"`). Both were fixed upstream by
+[renga PR #210](https://github.com/suisya-systems/renga/pull/210) on
+2026-05-02, but the underlying lesson remains: decoration is a derived,
+best-effort signal, while `client_kind` from the peer registry is the contract.
+New tooling and runbooks in this repo should follow that split.

--- a/docs/operations/renga-pane-conventions.md
+++ b/docs/operations/renga-pane-conventions.md
@@ -11,11 +11,17 @@ label that has reverted to `shell` does **not** mean the Claude process has died
 or hung.
 
 The authoritative source of truth for "is this pane a Claude / Codex agent?" is
-the peer registry exposed by `mcp__renga-peers__list_peers`. Each registered
-pane carries a `client_kind` field (`claude`, `codex`, …) that is set when the
-agent registers over the MCP peer channel and is **not** affected by terminal
-title rewrites. Orchestration code, dashboards, and human operators should
-treat `client_kind` as ground truth and treat decoration purely as a UI hint.
+the peer registry exposed by `mcp__renga-peers__list_peers`. When an agent
+registers over the MCP peer channel its entry carries a `client_kind` field
+(`claude`, `codex`, …) that is **not** affected by terminal title rewrites.
+Orchestration code, dashboards, and human operators should treat a present
+`client_kind` as ground truth and treat decoration purely as a UI hint.
+
+Note that `client_kind` is set "when known" — it can be absent or missing for
+panes that have not yet completed peer registration (e.g. a freshly spawned
+Claude pane during the brief window before its MCP channel is up). An absent
+`client_kind` means "unknown", not "not an agent"; resolve it by waiting for
+the peer to appear in `list_peers` rather than by falling back to decoration.
 
 > Rule of thumb: if a pane is registered with `client_kind=claude` but has no
 > decoration, trust the kind and not the decoration.


### PR DESCRIPTION
## Summary
- New `docs/operations/renga-pane-conventions.md` documenting that renga's pane decoration (border color, label, tab title) is cosmetic — the authoritative signal that a pane runs Claude is `mcp__renga-peers__list_peers` returning `client_kind=claude`.
- Notes the `client_kind` "when known" semantics (absent ≠ not an agent; wait for `list_peers` to converge).
- Cites renga#208/#209 (fixed by renga PR #210, 2026-05-02) as the originating incident.

Closes #217.

## Test plan
- [x] Markdown renders cleanly (verified locally).
- [x] Codex self-review: 0 Blocker, 1 Major (resolved by fixup b1674eb), 2 Minor (1 resolved by Major fix; 1 left as out-of-scope).
- [ ] CI green.