### PR TITLE
docs(org-delegate): elevate gitignore precheck to Step 0.7

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -99,6 +99,49 @@ description: >
 - 複数マッチした場合は関連度順に全て含める
 - org- プレフィックスのスキル（org-retro, org-delegate 等）は組織運営スキルなので検索対象外
 
+## Step 0.7: ターゲットファイル gitignore 事前チェック（窓口が実行）
+
+> **この Step は Step 1 のディレクトリパターン判定に先行する最上位判定である**。Step 1 の A / B / C ヒューリスティックに入る前に、編集対象ファイルが `.gitignore` で除外されていないかを確認し、ignored なら **Pattern C 強制（gitignored サブモード）** に分岐させる。operator が見落とすと tracked 用の Pattern B / A 経路に落ちて対象ファイルに届かないワーカーを派遣することになるため、必ずここで判定する。
+
+**「対象ファイル」は窓口がタスク説明から抽出する**（依頼文・Issue 本文・ユーザー発話の中で明示されたパス。機械的判定はしない）。対象ファイルが特定できないタスク（純粋な調査、対象パス未定の新規作成など）はこのチェックをスキップし、Step 1 の通常判定に進む。
+
+### 適用条件
+
+このチェックは **ローカルに git repo が既に存在するプロジェクトでのみ実行する**。具体的には:
+
+- registry/projects.md の「パス」がローカル絶対パスで、かつ `.git/` を持つディレクトリ（または worktree）として解決できる場合のみ実行
+- パスが URL（未 clone）/ `-` / 解決不能なら **チェック自体をスキップ**して Step 1 の通常判定へ（初回 clone 後の状態は git の通常挙動に従うため、tracked 既存ファイルが gitignored になっているレアケースは別途レビューで拾う）
+
+### 判定コマンド
+
+ローカル repo root（=「パス」が指す絶対パス）で:
+
+```
+git -C {project_path} check-ignore -q -- <target>
+```
+
+- 終了コード 1（=ignored ではない）→ tracked または「単に未存在の新規ファイル」。**Step 1 の通常 A / B / C 判定に進む**
+- 終了コード 0（=ignored）→ **Pattern C 強制（gitignored サブモード）**。下記参照。Step 1 の通常判定はスキップする
+- 終了コード 128 等（コマンド失敗、repo 未初期化など）→ 適用条件外。スキップして Step 1 の通常判定へ
+
+> `git check-ignore` は「現在の `.gitignore` ルールにマッチするか」だけを判定し、ファイルが実在しなくても評価できる。`ls-files --error-unmatch` を使うと「単に未作成の新規ファイル」まで untracked 扱いで Pattern C に落としてしまうため、こちらを使わない。
+
+### Pattern C 強制（gitignored サブモード）
+
+通常の Pattern C は `{workers_dir}/{task_id}/` のエフェメラル空ディレクトリだが、gitignored 対象を編集する場合はそれでは対象ファイルに届かない。次の特例運用とする:
+
+- **WORKER_DIR**: 既存ローカル clone の **repo root を直接指定**する（registry の「パス」値そのもの）
+- **CLAUDE.md / settings.local.json の配置先**: その repo root 直下。既に他用途の CLAUDE.md がある場合は `CLAUDE.local.md` に書く（`references/claude-org-self-edit.md` の特例参照）
+- **Worker Directory Registry**: Pattern を `C` として登録、Directory に repo root の絶対パス、Status を `in_use`。完了時はエントリ削除（ディレクトリ自体は元プロジェクトなので保持）
+- **並行作業との競合**: repo root を直接掴むため、同 repo に対する Pattern A / B のワーカーと同時起動はしない（窓口側で順次化する）
+- **窓口メモ**: 「Pattern B 不可: 対象 `<target>` が gitignored。WORKER_DIR=既存 repo root 運用」と一文残す
+
+ここで Pattern C 強制が確定した場合、**Step 1 のディレクトリパターン判定基準テーブルおよび判定フローはスキップ**し、そのまま Step 1.5 のワーカーディレクトリ準備に進む（パターンは C 確定）。
+
+### claude-org 自己編集との関係
+
+通常のスキル / ドキュメント編集（`.claude/skills/...`, `references/...`）は tracked なので従来どおり Pattern B が選べる。`docs/internal/`, `notes/`, `tmp/` 等の gitignored 内部メモを編集する場合のみ本事前チェックで Pattern C 強制（gitignored サブモード）となる（`references/claude-org-self-edit.md` 参照）。
+
 ## Step 1: タスク分解（窓口が実行）
 
 人間の依頼を分析し、ワーカーに委譲するタスクを定義する:
@@ -111,49 +154,9 @@ description: >
   - 作業ディレクトリ（どのプロジェクトで作業するか）
   - 制約（ブランチ名、コーディング規約、依存関係等）
   - **検証深度（`full` / `minimal`）** — 派遣指示には必ずどちらか 1 値を明示する。既定は `full`（コード・挙動の変更を伴うタスクはすべてこちら）。`full` では **codex の有無に関わらず** リポジトリ通常検証（テスト / lint / type-check 等）を green まで実行し通常の完了報告フォーマットで報告するのが必須ゲート。**追加ゲート（任意）** として、codex CLI が available なら commit 完了後に Codex セルフレビュー・同一指摘 3 ラウンド上限のルールが走る（未導入環境では skip）。trivial fix（CI 出力整形 / typo / コメント修正 / 既存テスト形式合わせ等）のみ `minimal` を選択し、ワーカーは `git add` → `git commit` → `done` 報告のみで終わる。詳細は `references/instruction-template.md` の「検証深度」節と `references/worker-claude-template.md` の「Codex セルフレビュー手順」節参照。値の決定は窓口の責任で、ワーカーには判断させない
-  - **ディレクトリパターン（A / B / C）** — 以下の判定基準で決定する
+  - **ディレクトリパターン（A / B / C）** — 以下の判定基準で決定する（**Step 0.7 の事前チェックで Pattern C 強制が確定している場合はこの判定をスキップ**）
   - **参考 work-skill**（Step 0.5 でマッチしたもの）
 - 注意: タスク説明にファイルパスを含める場合、それがワーカー作業ディレクトリからの相対パスであることを明記する。registry/projects.md の「パス」列の値をそのまま成果物パスとして指示しない（ワーカーが別の場所にパスを作成する原因になる）
-
-### 事前チェック: 対象ファイルが gitignored か
-
-判定フローに入る前に、編集対象ファイルが `.gitignore` で除外されていないか確認する。
-**「対象ファイル」は窓口がタスク説明から抽出する**（依頼文・Issue 本文・ユーザー発話の中で明示されたパス。機械的判定はしない）。対象ファイルが特定できないタスク（純粋な調査、対象パス未定の新規作成など）はこのチェックをスキップして通常判定に進む。
-
-#### 適用条件
-
-このチェックは **ローカルに git repo が既に存在するプロジェクトでのみ実行する**。具体的には:
-
-- registry/projects.md の「パス」がローカル絶対パスで、かつ `.git/` を持つディレクトリ（または worktree）として解決できる場合のみ実行
-- パスが URL（未 clone）/ `-` / 解決不能なら **チェック自体をスキップ**して通常判定へ（初回 clone 後の状態は git の通常挙動に従うため、tracked 既存ファイルが gitignored になっているレアケースは別途レビューで拾う）
-
-#### 判定コマンド
-
-ローカル repo root（=「パス」が指す絶対パス）で:
-
-```
-git -C {project_path} check-ignore -q -- <target>
-```
-
-- 終了コード 1（=ignored ではない）→ tracked または「単に未存在の新規ファイル」。**通常の A / B / C 判定に進む**
-- 終了コード 0（=ignored）→ **Pattern C 強制（gitignored サブモード）**。下記参照
-- 終了コード 128 等（コマンド失敗、repo 未初期化など）→ 適用条件外。スキップして通常判定へ
-
-> `git check-ignore` は「現在の `.gitignore` ルールにマッチするか」だけを判定し、ファイルが実在しなくても評価できる。`ls-files --error-unmatch` を使うと「単に未作成の新規ファイル」まで untracked 扱いで Pattern C に落としてしまうため、こちらを使わない。
-
-#### Pattern C 強制（gitignored サブモード）
-
-通常の Pattern C は `{workers_dir}/{task_id}/` のエフェメラル空ディレクトリだが、gitignored 対象を編集する場合はそれでは対象ファイルに届かない。次の特例運用とする:
-
-- **WORKER_DIR**: 既存ローカル clone の **repo root を直接指定**する（registry の「パス」値そのもの）
-- **CLAUDE.md / settings.local.json の配置先**: その repo root 直下。既に他用途の CLAUDE.md がある場合は `CLAUDE.local.md` に書く（`references/claude-org-self-edit.md` の特例参照）
-- **Worker Directory Registry**: Pattern を `C` として登録、Directory に repo root の絶対パス、Status を `in_use`。完了時はエントリ削除（ディレクトリ自体は元プロジェクトなので保持）
-- **並行作業との競合**: repo root を直接掴むため、同 repo に対する Pattern A / B のワーカーと同時起動はしない（窓口側で順次化する）
-- **窓口メモ**: 「Pattern B 不可: 対象 `<target>` が gitignored。WORKER_DIR=既存 repo root 運用」と一文残す
-
-#### claude-org 自己編集との関係
-
-通常のスキル / ドキュメント編集（`.claude/skills/...`, `references/...`）は tracked なので従来どおり Pattern B が選べる。`docs/internal/`, `notes/`, `tmp/` 等の gitignored 内部メモを編集する場合のみ本事前チェックで Pattern C 強制（gitignored サブモード）となる（`references/claude-org-self-edit.md` 参照）。
 
 ### ディレクトリパターン判定基準
 
@@ -165,7 +168,8 @@ git -C {project_path} check-ignore -q -- <target>
 
 **判定フロー:**
 
-0. **事前チェック（対象ファイルが特定でき、かつローカル repo が存在する場合のみ）**: 上記「事前チェック: 対象ファイルが gitignored か」を実行する。ignored でないなら下記 1 へ。ignored なら **パターン C 強制（gitignored サブモード）** で確定し、以降の判定はスキップする。適用条件外（URL のみ・対象未特定など）はチェックを skip して下記 1 から通常判定
+> **前提**: Step 0.7 のターゲットファイル gitignore 事前チェックが先行する。Step 0.7 で Pattern C 強制（gitignored サブモード）が確定している場合は本判定フローには入らない。Step 0.7 が「ignored ではない」または「適用条件外（URL のみ・対象未特定など）」で抜けた場合のみ、以下の通常判定を行う。
+
 1. プロジェクトの clone が必要な場合（registry/projects.md にパスが登録されているプロジェクト）:
    a. Worker Directory Registry で同プロジェクトに `in_use` のエントリがある場合 → **パターン B**（worktree で並行作業）
    b. 同プロジェクトに `available` のエントリがある場合 → **パターン A**（既存ディレクトリを再利用）

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -1,6 +1,6 @@
 # claude-org 自身を編集するタスクの特例
 
-> **前提（Pattern 判定）**: 対象ファイルが gitignored（例: `docs/internal/`, `notes/`, `tmp/` 配下の内部メモ）の場合は、SKILL.md Step 1 の「事前チェック: 対象ファイルが git tracked か」により **Pattern C 強制**となる。本ドキュメントの特例（hook 除外・`CLAUDE.local.md`）は Pattern B / C いずれでも適用するが、Pattern C の場合 worktree は作らないため WORKER_DIR は対象ファイルにアクセスできる既存リポジトリ root を指定する。以下は Pattern B（tracked ファイル編集）を主に想定した手順。
+> **前提（Pattern 判定）**: 対象ファイルが gitignored（例: `docs/internal/`, `notes/`, `tmp/` 配下の内部メモ）の場合は、SKILL.md **Step 0.7「ターゲットファイル gitignore 事前チェック」**により **Pattern C 強制**となる（Step 1 のディレクトリパターン判定基準には到達しない）。本ドキュメントの特例（hook 除外・`CLAUDE.local.md`）は Pattern B / C いずれでも適用するが、Pattern C の場合 worktree は作らないため WORKER_DIR は対象ファイルにアクセスできる既存リポジトリ root を指定する。以下は Pattern B（tracked ファイル編集）を主に想定した手順。
 
 claude-org リポジトリのスキル / ドキュメント / 設定を編集するワーカーを派遣するとき、通常の worktree 準備のままでは以下の事故が発生する:
 


### PR DESCRIPTION
## Summary
- Promotes the "target file gitignored?" precheck out of the Step 1 nested subsection into an independent top-level **Step 0.7** in `.claude/skills/org-delegate/SKILL.md`.
- Decision logic unchanged — presentation-order refactor only, so the gate is impossible to overlook.
- Updates `references/claude-org-self-edit.md` cross-reference to point at Step 0.7.

Closes #214.

## Test plan
- [x] Codex self-review: 0 Blocker / 0 Major / 0 Minor / 0 Nit.
- [x] No stale references to the old heading (grep verified).
- [ ] CI green.