### PR TITLE
fix(tools): make pr-watch.ps1 robust on Windows

### DIFF
--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -1,6 +1,26 @@
 #!/usr/bin/env pwsh
 # Thin PowerShell wrapper around tools/pr_watch.py.
-# Usage: tools/pr-watch.ps1 <PR> [--repo OWNER/REPO] [--interval SEC]
+# Usage: tools/pr-watch.ps1 -PR <PR> [-Repo OWNER/REPO] [-Interval SEC]
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [int]$PR,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Repo,
+
+    [Parameter(Mandatory = $false)]
+    [int]$Interval = 30
+)
+
+$ErrorActionPreference = 'Stop'
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-& py -3 (Join-Path $ScriptDir 'pr_watch.py') @args
+$ScriptPath = Join-Path $ScriptDir 'pr_watch.py'
+
+$pyArgs = @($ScriptPath, '--pr', $PR, '--interval', $Interval)
+if ($PSBoundParameters.ContainsKey('Repo') -and $Repo) {
+    $pyArgs += @('--repo', $Repo)
+}
+
+& py -3 @pyArgs
 exit $LASTEXITCODE

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -17,10 +17,29 @@ $ErrorActionPreference = 'Stop'
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ScriptPath = Join-Path $ScriptDir 'pr_watch.py'
 
-$pyArgs = @($ScriptPath, '--pr', $PR, '--interval', $Interval)
-if ($PSBoundParameters.ContainsKey('Repo') -and $Repo) {
-    $pyArgs += @('--repo', $Repo)
+# Probe the available Python interpreter. Mirrors scripts/install.ps1: try
+# `py -3` (Python Launcher) first, then `python` and `python3`. The launcher
+# is preferred because PEP 397 makes its argv handling well-defined on
+# Windows, but it isn't always installed and on some systems its default
+# Python target is broken — fall back rather than fail outright.
+$pyExec = $null
+$pyArgsPrefix = @()
+if (Get-Command 'py' -ErrorAction SilentlyContinue) {
+    $pyExec = 'py'
+    $pyArgsPrefix = @('-3')
+} elseif (Get-Command 'python' -ErrorAction SilentlyContinue) {
+    $pyExec = 'python'
+} elseif (Get-Command 'python3' -ErrorAction SilentlyContinue) {
+    $pyExec = 'python3'
+} else {
+    Write-Error 'tools/pr-watch.ps1: no Python interpreter found (tried py, python, python3).'
+    exit 127
 }
 
-& py -3 @pyArgs
+$forwardArgs = $pyArgsPrefix + @($ScriptPath, '--pr', $PR, '--interval', $Interval)
+if ($PSBoundParameters.ContainsKey('Repo') -and $Repo) {
+    $forwardArgs += @('--repo', $Repo)
+}
+
+& $pyExec @forwardArgs
 exit $LASTEXITCODE

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -17,22 +17,40 @@ $ErrorActionPreference = 'Stop'
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ScriptPath = Join-Path $ScriptDir 'pr_watch.py'
 
-# Probe the available Python interpreter. Mirrors scripts/install.ps1: try
-# `py -3` (Python Launcher) first, then `python` and `python3`. The launcher
-# is preferred because PEP 397 makes its argv handling well-defined on
-# Windows, but it isn't always installed and on some systems its default
-# Python target is broken — fall back rather than fail outright.
+# Probe interpreters by actually running `--version`, not just by checking
+# Get-Command. Some Windows boxes have a stale `py.exe` whose default 3.x
+# target points at a moved python.exe — Get-Command says "yes, py is there"
+# but invoking it fails with "Unable to create process". Verifying with a
+# real exec lets us fall through to plain `python` / `python3` in that case.
+function Test-Interpreter {
+    param([string]$Exe, [string[]]$Prefix)
+    if (-not (Get-Command $Exe -ErrorAction SilentlyContinue)) { return $false }
+    try {
+        $null = & $Exe @Prefix '--version' 2>&1
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+$candidates = @(
+    @{ Exe = 'py';      Prefix = @('-3') },
+    @{ Exe = 'python';  Prefix = @() },
+    @{ Exe = 'python3'; Prefix = @() }
+)
+
 $pyExec = $null
 $pyArgsPrefix = @()
-if (Get-Command 'py' -ErrorAction SilentlyContinue) {
-    $pyExec = 'py'
-    $pyArgsPrefix = @('-3')
-} elseif (Get-Command 'python' -ErrorAction SilentlyContinue) {
-    $pyExec = 'python'
-} elseif (Get-Command 'python3' -ErrorAction SilentlyContinue) {
-    $pyExec = 'python3'
-} else {
-    Write-Error 'tools/pr-watch.ps1: no Python interpreter found (tried py, python, python3).'
+foreach ($cand in $candidates) {
+    if (Test-Interpreter -Exe $cand.Exe -Prefix $cand.Prefix) {
+        $pyExec = $cand.Exe
+        $pyArgsPrefix = $cand.Prefix
+        break
+    }
+}
+
+if (-not $pyExec) {
+    [Console]::Error.WriteLine('tools/pr-watch.ps1: no working Python interpreter found (tried py -3, python, python3).')
     exit 127
 }
 

--- a/tools/pr-watch.sh
+++ b/tools/pr-watch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Thin POSIX wrapper around tools/pr_watch.py.
-# Usage: tools/pr-watch.sh <PR> [--repo OWNER/REPO] [--interval SEC]
+# Usage: tools/pr-watch.sh --pr <PR> [--repo OWNER/REPO] [--interval SEC]
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec python3 "$SCRIPT_DIR/pr_watch.py" "$@"

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -128,11 +128,23 @@ def main(argv: "list[str] | None" = None) -> int:
         prog="tools/pr_watch.py",
         description="Watch a GitHub PR's CI checks and journal the result.",
     )
+    # Accept both `--pr <n>` (preferred, unambiguous on PowerShell) and the
+    # legacy positional form `<n>` so direct python/bash invocations keep
+    # working. Exactly one of the two must be supplied.
     parser.add_argument(
         "--pr",
+        dest="pr_flag",
         type=int,
-        required=True,
+        default=None,
         help="pull request number",
+    )
+    parser.add_argument(
+        "pr_positional",
+        nargs="?",
+        type=int,
+        default=None,
+        metavar="PR",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--repo",
@@ -147,10 +159,16 @@ def main(argv: "list[str] | None" = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if args.pr <= 0:
+    if args.pr_flag is not None and args.pr_positional is not None:
+        parser.error("specify the PR number once (either --pr or positional)")
+    pr_number = args.pr_flag if args.pr_flag is not None else args.pr_positional
+    if pr_number is None:
+        parser.error("missing PR number (use --pr <n>)")
+    if pr_number <= 0:
         parser.error("PR number must be a positive integer")
     if args.interval <= 0:
         parser.error("--interval must be a positive integer")
+    args.pr = pr_number
 
     _ensure_gh_installed()
     repo = args.repo or _resolve_repo()

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -7,7 +7,7 @@ invoke this script to block on ``gh pr checks --watch`` and append a
 
 Usage::
 
-    py -3 tools/pr_watch.py <PR> [--repo OWNER/REPO] [--interval SEC]
+    py -3 tools/pr_watch.py --pr <PR> [--repo OWNER/REPO] [--interval SEC]
 
 Behavior:
 
@@ -128,7 +128,12 @@ def main(argv: "list[str] | None" = None) -> int:
         prog="tools/pr_watch.py",
         description="Watch a GitHub PR's CI checks and journal the result.",
     )
-    parser.add_argument("pr", type=int, help="pull request number")
+    parser.add_argument(
+        "--pr",
+        type=int,
+        required=True,
+        help="pull request number",
+    )
     parser.add_argument(
         "--repo",
         default=None,

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -47,7 +47,7 @@ class JournalEmitTests(unittest.TestCase):
              mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
              mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
              mock.patch.object(pr_watch.time, "monotonic", side_effect=[100.0, 142.0]):
-            return pr_watch.main(["205", "--repo", "octo/repo", "--interval", "5"])
+            return pr_watch.main(["--pr", "205", "--repo", "octo/repo", "--interval", "5"])
 
     def test_passed_emits_ci_completed(self) -> None:
         with self.subTest("passed"):

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -35,7 +35,7 @@ class ClassifyTests(unittest.TestCase):
 class ArgFormTests(unittest.TestCase):
     """Both `--pr <n>` and the legacy positional form must parse identically."""
 
-    def _run(self, argv: "list[str]") -> int:
+    def _run(self, argv: "list[str]") -> "tuple[int, dict]":
         completed = mock.Mock(returncode=0)
 
         def fake_run(cmd, *args, **kwargs):

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -32,6 +32,42 @@ class ClassifyTests(unittest.TestCase):
         self.assertEqual(pr_watch._classify(127), "failed")
 
 
+class ArgFormTests(unittest.TestCase):
+    """Both `--pr <n>` and the legacy positional form must parse identically."""
+
+    def _run(self, argv: "list[str]") -> int:
+        completed = mock.Mock(returncode=0)
+
+        def fake_run(cmd, *args, **kwargs):
+            if "view" in cmd and "--json" in cmd and "number" in cmd:
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
+            return completed
+
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "journal.jsonl"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                rc = pr_watch.main(argv)
+            rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
+            return rc, rec
+
+    def test_long_form(self) -> None:
+        rc, rec = self._run(["--pr", "42", "--repo", "octo/repo"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(rec["pr"], 42)
+
+    def test_positional_form(self) -> None:
+        rc, rec = self._run(["42", "--repo", "octo/repo"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(rec["pr"], 42)
+
+    def test_both_forms_rejected(self) -> None:
+        with self.assertRaises(SystemExit):
+            pr_watch.main(["7", "--pr", "9", "--repo", "octo/repo"])
+
+
 class JournalEmitTests(unittest.TestCase):
     def _run(self, tmp_journal: Path, gh_exit: int) -> int:
         completed = mock.Mock(returncode=gh_exit)


### PR DESCRIPTION
## Summary
- Rewrites `tools/pr-watch.ps1` with `[CmdletBinding()] param(-PR/-Repo/-Interval)`, converts to `--pr` / `--repo` long form, and probes Python interpreters by **executing `--version`** (falls back `py -3` → `python` → `python3`) so a broken `py.exe` install no longer wedges the wrapper.
- Adds `--pr` flag to `tools/pr_watch.py` while preserving the positional `<PR>` arg for backward compat (`pr-watch.sh 123`, `python pr_watch.py 123` still work).
- Updates `tools/pr-watch.sh` usage and adds 3 new test cases (long-form / positional / collision) to `tools/test_pr_watch.py` (9/9 PASS).

Closes #213.

## Verification
- Reproduced "Unable to create process" on Windows 11 with broken Python 3.12 install.
- After fix, `pwsh tools/pr-watch.ps1 -PR 221 -Repo suisya-systems/claude-org-ja` skips broken `py`, falls through to `python` (3.10), watches CI, and writes `{"event":"ci_completed","pr":221,"status":"passed",...}` to `.state/journal.jsonl`.
- `py -3.10 -m unittest tools.test_pr_watch` → 9/9 OK.

## Codex self-review
- Round 1: 2 Major (positional compat, hard-coded `py -3`) — fixed (`543785c`).
- Round 2: 1 Major (`Get-Command` doesn't detect broken `py.exe`) + 1 Minor + 1 Nit — fixed (`3c71525`).
- Round 3: 2 new Major out of scope — to be filed as a follow-up issue:
  - `gh pr checks` exit code 1 currently treated as `failed` (existing behavior from PR #206; changing it alters journal semantics).
  - Python interpreter passes `--version` but `core_harness.audit` import is not verified.

## Test plan
- [x] Local unit tests pass.
- [x] Manual Windows E2E verified.
- [ ] CI green.