### PR TITLE
docs(org-delegate): fix stale paths and dual-schema sync in claude-org-self-edit reference

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -210,7 +210,7 @@ git -C {project_path} check-ignore -q -- <target>
 | `claude-org-self-edit` | **claude-org リポジトリ自身を編集するタスク（self-edit task）**。`worker_dir` が claude-org repo or its worktree（`tools/`, `.claude/skills/`, `docs/` 等の編集を含む）。`block-org-structure.sh` を外す代わりに `check-worker-boundary.sh` で境界を担保。詳細は `references/claude-org-self-edit.md` |
 | `doc-audit` | 読み取り中心の調査・監査・レポート（Edit/Write/MultiEdit/NotebookEdit を deny。commit / branch も禁止） |
 
-各 role の具体的な allow/deny/hooks は **本 ja リポジトリの `tools/org_extension_schema.json`** の `worker_roles[<role>]` を参照（drift validator `tools/check_role_configs.py` がこのファイルを正典として読む）。新しいパターンが必要な場合は schema に role を追加する PR を起こすこと（窓口の手書き拡張は不可）。framework 側の schema 形（`worker_roles` の許容形状定義）を変える必要がある場合のみ `claude-org-runtime` リポジトリへの PR となる。
+各 role の具体的な allow/deny/hooks は **本 ja リポジトリの `tools/org_extension_schema.json`** の `worker_roles[<role>]` を参照（drift validator `tools/check_role_configs.py` がこのファイルを正典として読む）。新しいパターンが必要な場合は **ja の `tools/org_extension_schema.json` と `claude-org-runtime` の bundled `role_configs_schema.json` の両方に role を追加する PR が必要**（窓口の手書き拡張は不可）: ja 側だけ追加しても `claude-org-runtime settings generate` が新 role を知らず生成失敗、runtime 側だけ追加しても drift CI が fail する。framework 側の schema 形（`worker_roles` の許容形状定義）のみ変える場合は `claude-org-runtime` 側のみで完結。詳細は `references/claude-org-self-edit.md` および `docs/internal/phase4-completion-2026-05-02.md:71-77` 参照。
 
 ### パターン A: プロジェクトディレクトリ
 

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -133,7 +133,7 @@ git -C {project_path} check-ignore -q -- <target>
 - **WORKER_DIR**: 既存ローカル clone の **repo root を直接指定**する（registry の「パス」値そのもの）
 - **CLAUDE.md / settings.local.json の配置先**: その repo root 直下。既に他用途の CLAUDE.md がある場合は `CLAUDE.local.md` に書く（`references/claude-org-self-edit.md` の特例参照）
 - **Worker Directory Registry**: Pattern を `C` として登録、Directory に repo root の絶対パス、Status を `in_use`。完了時はエントリ削除（ディレクトリ自体は元プロジェクトなので保持）
-- **並行作業との競合**: repo root を直接掴むため、同 repo に対する Pattern A / B のワーカーと同時起動はしない（窓口側で順次化する）
+- **並行作業との競合**: repo root を直接掴むため、同 repo に対する Pattern A / B のワーカーと同時起動はしない（窓口側で順次化する）。**さらに Pattern C 強制ワーカー同士も同 repo で 2 本以上同時起動しない**（`CLAUDE.local.md` / `.claude/settings.local.json` はファイル名固定なので相互上書きが起きる）
 - **窓口メモ**: 「Pattern B 不可: 対象 `<target>` が gitignored。WORKER_DIR=既存 repo root 運用」と一文残す
 
 ここで Pattern C 強制が確定した場合、**Step 1 のディレクトリパターン判定基準テーブルおよび判定フローはスキップ**し、そのまま Step 1.5 のワーカーディレクトリ準備に進む（パターンは C 確定）。
@@ -210,7 +210,7 @@ git -C {project_path} check-ignore -q -- <target>
 | `claude-org-self-edit` | **claude-org リポジトリ自身を編集するタスク（self-edit task）**。`worker_dir` が claude-org repo or its worktree（`tools/`, `.claude/skills/`, `docs/` 等の編集を含む）。`block-org-structure.sh` を外す代わりに `check-worker-boundary.sh` で境界を担保。詳細は `references/claude-org-self-edit.md` |
 | `doc-audit` | 読み取り中心の調査・監査・レポート（Edit/Write/MultiEdit/NotebookEdit を deny。commit / branch も禁止） |
 
-各 role の具体的な allow/deny/hooks は `claude-org-runtime の settings/role_configs_schema.json` の `worker_roles[<role>]` を参照（schema が SOT）。新しいパターンが必要な場合は schema に role を追加する PR を起こすこと（窓口の手書き拡張は不可）。
+各 role の具体的な allow/deny/hooks は **本 ja リポジトリの `tools/org_extension_schema.json`** の `worker_roles[<role>]` を参照（drift validator `tools/check_role_configs.py` がこのファイルを正典として読む）。新しいパターンが必要な場合は schema に role を追加する PR を起こすこと（窓口の手書き拡張は不可）。framework 側の schema 形（`worker_roles` の許容形状定義）を変える必要がある場合のみ `claude-org-runtime` リポジトリへの PR となる。
 
 ### パターン A: プロジェクトディレクトリ
 
@@ -220,7 +220,7 @@ git -C {project_path} check-ignore -q -- <target>
 
 1. `git clone {project_path} {workers_dir}/{project_slug}/` を実行
 2. ディレクトリ直下に CLAUDE.md を生成する（テンプレートの変数を置換）
-3. ディレクトリ直下に `.claude/settings.local.json` を **generator で生成する**（schema が SOT。詳細は `claude-org-runtime の settings/role_configs_schema.json` の `worker_roles` を参照）:
+3. ディレクトリ直下に `.claude/settings.local.json` を **generator で生成する**（schema が SOT。詳細は ja `tools/org_extension_schema.json` の `worker_roles` を参照）:
    ```bash
    claude-org-runtime settings generate \
      --role <ROLE> \
@@ -250,7 +250,7 @@ git -C {project_path} check-ignore -q -- <target>
    - `{branch_name}` は Step 1 で決定したブランチ名（指定がなければ `{task_id}` をブランチ名に使う）
    - ワーカーディレクトリ: `{workers_dir}/{project_slug}/.worktrees/{task_id}/`
 3. worktree 直下に CLAUDE.md を生成する（テンプレートの変数を置換）
-4. worktree 直下に `.claude/settings.local.json` を **generator で生成する**（schema-driven。詳細は `claude-org-runtime の settings/role_configs_schema.json` の `worker_roles` 参照）:
+4. worktree 直下に `.claude/settings.local.json` を **generator で生成する**（schema-driven。詳細は ja `tools/org_extension_schema.json` の `worker_roles` 参照）:
    ```bash
    claude-org-runtime settings generate \
      --role <ROLE> \
@@ -267,7 +267,7 @@ git -C {project_path} check-ignore -q -- <target>
 
 1. `{workers_dir}/{task_id}/` ディレクトリを作成する（例: `../workers/data-analysis/`）
 2. テンプレートから `{workers_dir}/{task_id}/CLAUDE.md` を生成する
-3. `{workers_dir}/{task_id}/.claude/settings.local.json` を **generator で生成する**（schema-driven。詳細は `claude-org-runtime の settings/role_configs_schema.json` の `worker_roles` 参照）:
+3. `{workers_dir}/{task_id}/.claude/settings.local.json` を **generator で生成する**（schema-driven。詳細は ja `tools/org_extension_schema.json` の `worker_roles` 参照）:
    ```bash
    claude-org-runtime settings generate \
      --role <ROLE> \

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -28,7 +28,7 @@ claude-org-runtime settings generate \
 ルートの `CLAUDE.md` は Secretary 用の指示なので、ワーカー用 CLAUDE.md で上書きしてはならない（他ロールが壊れる）。
 ワーカーへの指示は `{worker_dir}` 直下の `CLAUDE.local.md` に書く（git 管理外）。Pattern B（tracked ファイル編集）なら `{worker_dir}` は worktree 直下、Pattern C 強制（gitignored サブモード）なら `{worker_dir}` は対象ファイルにアクセスできる既存リポジトリ root を指す。
 
-> **Pattern C 強制での同 repo 排他**: `CLAUDE.local.md` と `.claude/settings.local.json` はファイル名固定なので、同一 repo root に対する Pattern C 強制ワーカーは **2 本以上同時起動しない**（先行ワーカーの指示・権限を上書きするため）。窓口側で順次化すること。SKILL.md Step 1.5 の Pattern C 強制節は A/B との競合のみ言及しているが、C/C も同様に排他とする。
+> **Pattern C 強制での同 repo 排他**: `CLAUDE.local.md` と `.claude/settings.local.json` はファイル名固定なので、同一 repo root に対する Pattern C 強制ワーカーは **2 本以上同時起動しない**（先行ワーカーの指示・権限を上書きするため）。窓口側で順次化すること。SKILL.md Step 0.7「Pattern C 強制（gitignored サブモード）」節は A/B との競合のみ言及していたが、C/C も同様に排他とする（同節「並行作業との競合」項に併記済み）。
 
 Claude Code は同一ディレクトリの `CLAUDE.md` と `CLAUDE.local.md` の両方を読み込むため、ワーカーには両方が見える。
 

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -21,12 +21,12 @@ claude-org-runtime settings generate \
   --out {worker_dir}/.claude/settings.local.json
 ```
 
-`claude-org-self-edit` ロールは schema 上で `block-org-structure.sh` hook が **既に除外**された状態で定義されている（`Edit|Write` / `Bash` matcher 双方）。`check-worker-boundary.sh` / `block-git-push.sh` などその他の hook は通常どおり残る。生成済み JSON を手で再編集してはならない（drift CI が fail する。新パターンが必要なら `tools/role_configs_schema.json` の `worker_roles` に role を追加する PR を起こす）。
+`claude-org-self-edit` ロールは schema 上で `block-org-structure.sh` hook が **既に除外**された状態で定義されている（`Edit|Write` / `Bash` matcher 双方）。`check-worker-boundary.sh` / `block-git-push.sh` などその他の hook は通常どおり残る。生成済み JSON を手で再編集してはならない（drift CI が fail する。新パターンが必要なら `claude-org-runtime` リポジトリの `settings/role_configs_schema.json` の `worker_roles` に role を追加する PR を起こす）。
 
 ## 2. ワーカー指示は `CLAUDE.md` ではなく `CLAUDE.local.md` に書く
 
 ルートの `CLAUDE.md` は Secretary 用の指示なので、ワーカー用 CLAUDE.md で上書きしてはならない（他ロールが壊れる）。
-ワーカーへの指示は worktree 直下の `CLAUDE.local.md` に書く（git 管理外）。
+ワーカーへの指示は `{worker_dir}` 直下の `CLAUDE.local.md` に書く（git 管理外）。Pattern B（tracked ファイル編集）なら `{worker_dir}` は worktree 直下、Pattern C 強制（gitignored サブモード）なら `{worker_dir}` は対象ファイルにアクセスできる既存リポジトリ root を指す。
 
 Claude Code は同一ディレクトリの `CLAUDE.md` と `CLAUDE.local.md` の両方を読み込むため、ワーカーには両方が見える。
 
@@ -45,7 +45,7 @@ claude-org 自己編集タスクでは、SKILL.md Step 1.5 および `worker-cla
 
 `CLAUDE.local.md` の最初に以下の趣旨を必ず書く:
 
-> このワーカーは claude-org リポジトリ自身の worktree で作業する。`./CLAUDE.md`（ルート CLAUDE.md）の Secretary 指示は無視せよ。あなたは窓口ではなくワーカーである。
+> このワーカーは claude-org リポジトリ自身の `{worker_dir}`（Pattern B なら worktree 直下、Pattern C 強制なら repo root 直下）で作業する。`./CLAUDE.md`（ルート CLAUDE.md）の Secretary 指示は無視せよ。あなたは窓口ではなくワーカーである。
 
 この明示がないと、ワーカーがルート CLAUDE.md を先に読んで Secretary として振る舞い始める（/org-start の実行を促す等）。
 

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -21,7 +21,7 @@ claude-org-runtime settings generate \
   --out {worker_dir}/.claude/settings.local.json
 ```
 
-`claude-org-self-edit` ロールは schema 上で `block-org-structure.sh` hook が **既に除外**された状態で定義されている（`Edit|Write` / `Bash` matcher 双方）。`check-worker-boundary.sh` / `block-git-push.sh` などその他の hook は通常どおり残る。生成済み JSON を手で再編集してはならない（drift CI が fail する。新パターンが必要なら **本 ja リポジトリの `tools/org_extension_schema.json`** の `worker_roles` セクションに role を追加する PR を起こす。`tools/check_role_configs.py` の drift validator はこのファイルを正典として読む。framework 側の schema 形（`worker_roles` の許容形状定義そのもの）を変える場合のみ `claude-org-runtime` リポジトリへの PR となる）。
+`claude-org-self-edit` ロールは schema 上で `block-org-structure.sh` hook が **既に除外**された状態で定義されている（`Edit|Write` / `Bash` matcher 双方）。`check-worker-boundary.sh` / `block-git-push.sh` などその他の hook は通常どおり残る。生成済み JSON を手で再編集してはならない（drift CI が fail する。新しい role を追加する場合、**ja の `tools/org_extension_schema.json`（drift validator `tools/check_role_configs.py` の正典）と `claude-org-runtime` の bundled `role_configs_schema.json`（generator `claude-org-runtime settings generate` の正典）の両方に追加する PR が必要**: ja 側だけ追加しても generator が新 role を知らず生成失敗、runtime 側だけ追加しても drift CI が fail する。framework 側の schema 形（`worker_roles` の許容形状定義そのもの）を変える場合は `claude-org-runtime` 側のみで完結する。両者の同期未整備状態は `docs/internal/phase4-completion-2026-05-02.md:71-77` に follow-up として記録）。
 
 ## 2. ワーカー指示は `CLAUDE.md` ではなく `CLAUDE.local.md` に書く
 

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -21,12 +21,14 @@ claude-org-runtime settings generate \
   --out {worker_dir}/.claude/settings.local.json
 ```
 
-`claude-org-self-edit` ロールは schema 上で `block-org-structure.sh` hook が **既に除外**された状態で定義されている（`Edit|Write` / `Bash` matcher 双方）。`check-worker-boundary.sh` / `block-git-push.sh` などその他の hook は通常どおり残る。生成済み JSON を手で再編集してはならない（drift CI が fail する。新パターンが必要なら `claude-org-runtime` リポジトリの `settings/role_configs_schema.json` の `worker_roles` に role を追加する PR を起こす）。
+`claude-org-self-edit` ロールは schema 上で `block-org-structure.sh` hook が **既に除外**された状態で定義されている（`Edit|Write` / `Bash` matcher 双方）。`check-worker-boundary.sh` / `block-git-push.sh` などその他の hook は通常どおり残る。生成済み JSON を手で再編集してはならない（drift CI が fail する。新パターンが必要なら **本 ja リポジトリの `tools/org_extension_schema.json`** の `worker_roles` セクションに role を追加する PR を起こす。`tools/check_role_configs.py` の drift validator はこのファイルを正典として読む。framework 側の schema 形（`worker_roles` の許容形状定義そのもの）を変える場合のみ `claude-org-runtime` リポジトリへの PR となる）。
 
 ## 2. ワーカー指示は `CLAUDE.md` ではなく `CLAUDE.local.md` に書く
 
 ルートの `CLAUDE.md` は Secretary 用の指示なので、ワーカー用 CLAUDE.md で上書きしてはならない（他ロールが壊れる）。
 ワーカーへの指示は `{worker_dir}` 直下の `CLAUDE.local.md` に書く（git 管理外）。Pattern B（tracked ファイル編集）なら `{worker_dir}` は worktree 直下、Pattern C 強制（gitignored サブモード）なら `{worker_dir}` は対象ファイルにアクセスできる既存リポジトリ root を指す。
+
+> **Pattern C 強制での同 repo 排他**: `CLAUDE.local.md` と `.claude/settings.local.json` はファイル名固定なので、同一 repo root に対する Pattern C 強制ワーカーは **2 本以上同時起動しない**（先行ワーカーの指示・権限を上書きするため）。窓口側で順次化すること。SKILL.md Step 1.5 の Pattern C 強制節は A/B との競合のみ言及しているが、C/C も同様に排他とする。
 
 Claude Code は同一ディレクトリの `CLAUDE.md` と `CLAUDE.local.md` の両方を読み込むため、ワーカーには両方が見える。
 


### PR DESCRIPTION
## Summary
- Fixes the Blocker (CLAUDE.local.md placement contradicting Pattern C forced mode) by switching to a `{worker_dir}`-neutral wording with explicit Pattern B / Pattern C examples.
- Fixes the Major (stale schema path). Primary evidence (`tools/check_role_configs.py:46`, `tools/org_extension_schema.json:336`, `docs/internal/phase4-completion-2026-05-02.md:71-77`) shows ja's `tools/org_extension_schema.json` is still a live SOT alongside `claude-org-runtime`'s bundled `settings/role_configs_schema.json`. The reference now spells out **both** repos and the dual-schema sync requirement for new roles.
- Sweeps the same stale references throughout `.claude/skills/org-delegate/SKILL.md` and adds a Pattern C / Pattern C exclusion note (concurrent C-forced workers on the same repo would clobber each other's `CLAUDE.local.md` / `.claude/settings.local.json`).

Closes #222.

## Codex self-review
- Round 1: 0 Blocker / 2 Major / 1 Minor — Major×2 fixed (`3d96578`).
- Round 2: 0 Blocker / 2 Major / 1 Minor / 1 Nit — Major×2 + Nit fixed (`678d967`).
- Round 3: 0 Blocker / 1 Major / 0 Minor — Major fixed (`af77b36`).
- 3-round cap reached. Residual Minor (broken link to `knowledge/curated/delegation.md`) is pre-existing and out of scope.

## Note on scope expansion vs. delegation brief
Worker correctly applied the "trust primary evidence over delegation instruction when they conflict" rule. The original brief said "replace the path with `claude-org-runtime`'s `settings/role_configs_schema.json`", but the codebase shows ja still has a live schema. Final wording covers both repos.

## Test plan
- [ ] CI green.