### PR TITLE
fix(tools): harden pr-watch (gh exit semantics + python import probe)

### DIFF
--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -108,6 +108,20 @@ Workers do **not** write the journal directly; they report via
 | `notify_sent`      | `recipient`, `kind`, `summary`          | dispatcher |
 | `events_dropped`   | `count`, `since_ts`                     | dispatcher |
 
+### CI
+
+| Event          | Typical fields                                            | Writer    |
+|----------------|-----------------------------------------------------------|-----------|
+| `ci_completed` | `pr`, `repo`, `status`, `duration_sec`                    | secretary |
+
+`status` ∈ `{passed, failed, incomplete, canceled}`. As of Issue #224
+the value is derived from `gh pr checks <pr> --json` (per-check
+`conclusion` / `state`) rather than the gh process' exit code, so a
+transient watch-loop error is no longer conflated with a real CI
+failure. `incomplete` is emitted when at least one check is still
+pending or has an unrecognized conclusion when the watch returns;
+`canceled` is emitted only when the parent receives SIGINT.
+
 ### Session lifecycle
 
 | Event                          | Typical fields                          | Writer    |

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -115,11 +115,14 @@ Workers do **not** write the journal directly; they report via
 | `ci_completed` | `pr`, `repo`, `status`, `duration_sec`                    | secretary |
 
 `status` ∈ `{passed, failed, incomplete, canceled}`. As of Issue #224
-the value is derived from `gh pr checks <pr> --json` (per-check
-`conclusion` / `state`) rather than the gh process' exit code, so a
-transient watch-loop error is no longer conflated with a real CI
-failure. `incomplete` is emitted when at least one check is still
-pending or has an unrecognized conclusion when the watch returns;
+the value is derived from `gh pr checks <pr> --json bucket,state,name`
+(per-check `bucket`, whose documented values are
+`{pass, fail, pending, skipping, cancel}`) rather than the gh process'
+exit code, so a transient watch-loop error is no longer conflated
+with a real CI failure. `failed` requires at least one `fail` or
+`cancel` bucket; `incomplete` is emitted when at least one check is
+still `pending` (or has an unrecognized bucket, or the JSON probe
+itself errored — see the fallback rules in `tools/pr_watch.py`);
 `canceled` is emitted only when the parent receives SIGINT.
 
 ### Session lifecycle

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -22,11 +22,19 @@ $ScriptPath = Join-Path $ScriptDir 'pr_watch.py'
 # target points at a moved python.exe — Get-Command says "yes, py is there"
 # but invoking it fails with "Unable to create process". Verifying with a
 # real exec lets us fall through to plain `python` / `python3` in that case.
+#
+# Issue #224: `--version` passing is necessary but not sufficient — pr_watch.py
+# does `from core_harness.audit import Journal`, so a Python whose
+# site-packages lacks core_harness will exit 1 with a confusing ImportError
+# at runtime. Probe the import too so we fall through to a sibling
+# interpreter that *does* have core_harness installed.
 function Test-Interpreter {
     param([string]$Exe, [string[]]$Prefix)
     if (-not (Get-Command $Exe -ErrorAction SilentlyContinue)) { return $false }
     try {
         $null = & $Exe @Prefix '--version' 2>&1
+        if ($LASTEXITCODE -ne 0) { return $false }
+        $null = & $Exe @Prefix '-c' 'import core_harness.audit' 2>&1
         return ($LASTEXITCODE -eq 0)
     } catch {
         return $false
@@ -50,7 +58,7 @@ foreach ($cand in $candidates) {
 }
 
 if (-not $pyExec) {
-    [Console]::Error.WriteLine('tools/pr-watch.ps1: no working Python interpreter found (tried py -3, python, python3).')
+    [Console]::Error.WriteLine('tools/pr-watch.ps1: no working Python interpreter found with core_harness.audit installed (tried py -3, python, python3).')
     exit 127
 }
 

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -34,7 +34,11 @@ function Test-Interpreter {
     try {
         $null = & $Exe @Prefix '--version' 2>&1
         if ($LASTEXITCODE -ne 0) { return $false }
-        $null = & $Exe @Prefix '-c' 'import core_harness.audit' 2>&1
+        # Combined probe: require Python 3 AND core_harness.audit importable.
+        # Bare `python`/`python3` on some systems still aliases to Python 2,
+        # which would pass `--version` but die on pr_watch.py's f-strings.
+        $probe = 'import sys; assert sys.version_info[0] == 3; import core_harness.audit'
+        $null = & $Exe @Prefix '-c' $probe 2>&1
         return ($LASTEXITCODE -eq 0)
     } catch {
         return $false

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -15,9 +15,17 @@ Behavior:
   ``--repo`` is omitted.
 * Spawns ``gh pr checks <PR> --watch --interval <SEC>`` and forwards
   its stdout/stderr.
-* Maps the gh exit code to ``passed`` / ``failed`` / ``canceled`` and
-  appends one JSON-Lines record to ``<repo_root>/.state/journal.jsonl``
-  (anchored to ``tools/..`` so cwd doesn't matter).
+* After the watch loop returns, queries ``gh pr checks <PR> --json``
+  for per-check ``conclusion`` / ``status`` so the journal status
+  reflects what CI actually decided rather than just the gh process'
+  exit code (gh exits non-zero on a transient watch error too).
+  Classifies as ``passed`` (all SUCCESS/SKIPPED/NEUTRAL),
+  ``failed`` (≥1 FAILURE/TIMED_OUT/CANCELLED/STALE/ACTION_REQUIRED),
+  ``incomplete`` (still pending or empty), or ``canceled`` (parent
+  SIGINT). Falls back to exit-code-based classification only if the
+  JSON probe itself fails. Appends one JSON-Lines record to
+  ``<repo_root>/.state/journal.jsonl`` (anchored to ``tools/..`` so
+  cwd doesn't matter).
 * Prints the final status as a single line on stdout and exits with
   the gh process' exit code.
 
@@ -25,7 +33,8 @@ The journal payload shape is::
 
     {"ts": "<ISO8601>", "event": "ci_completed",
      "pr": <int>, "repo": "<owner/repo>",
-     "status": "passed|failed|canceled", "duration_sec": <int>}
+     "status": "passed|failed|incomplete|canceled",
+     "duration_sec": <int>}
 
 No new third-party dependencies; only the standard library plus the
 already-pinned ``core_harness.audit`` for the journal write.
@@ -87,8 +96,14 @@ def _resolve_repo() -> str:
     return repo
 
 
+_FAILED_CONCLUSIONS = frozenset(
+    {"FAILURE", "TIMED_OUT", "CANCELLED", "STALE", "ACTION_REQUIRED"}
+)
+_PASSED_CONCLUSIONS = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
+
+
 def _classify(exit_code: int) -> str:
-    """Map a `gh pr checks --watch` exit code to a status string.
+    """Fallback classifier used only when the JSON probe is unavailable.
 
     Reference: https://cli.github.com/manual/gh_help_exit-codes and
     https://cli.github.com/manual/gh_pr_checks. With ``--watch`` gh
@@ -100,6 +115,11 @@ def _classify(exit_code: int) -> str:
 
     SIGINT raised in the parent (Python ``KeyboardInterrupt``) is
     normalized to 2 in :func:`main` before reaching this function.
+
+    Note: as of Issue #224 the primary classifier is
+    :func:`_classify_from_checks`, which inspects per-check JSON so a
+    transient gh error (e.g. exit 1 from a network blip in the watch
+    loop) is no longer conflated with a real CI failure.
     """
     if exit_code == 0:
         return "passed"
@@ -108,6 +128,65 @@ def _classify(exit_code: int) -> str:
     if exit_code == 8:
         return "failed"
     return "failed"
+
+
+def _classify_from_checks(checks: "list[dict]") -> str:
+    """Classify CI status from `gh pr checks --json` output.
+
+    * Empty list → ``incomplete`` (no checks reported).
+    * Any conclusion in :data:`_FAILED_CONCLUSIONS` → ``failed``.
+    * Any check still running (no conclusion / pending state) →
+      ``incomplete``.
+    * All checks have a passing conclusion → ``passed``.
+    * Otherwise → ``incomplete`` (unknown conclusion strings are
+      treated conservatively rather than silently passed).
+    """
+    if not checks:
+        return "incomplete"
+    has_pending = False
+    for chk in checks:
+        conclusion = (chk.get("conclusion") or "").upper()
+        state = (chk.get("state") or chk.get("status") or "").upper()
+        if conclusion in _FAILED_CONCLUSIONS:
+            return "failed"
+        if not conclusion or state in {"IN_PROGRESS", "QUEUED", "PENDING"}:
+            has_pending = True
+            continue
+        if conclusion not in _PASSED_CONCLUSIONS:
+            # Unknown conclusion — be conservative.
+            has_pending = True
+    return "incomplete" if has_pending else "passed"
+
+
+def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
+    """Return parsed `gh pr checks <pr> --json` results, or ``None`` on error.
+
+    The JSON field set is intentionally narrow (``state``,
+    ``conclusion``, ``name``) — gh's schema for this command is
+    relatively stable but we only depend on the two we actually use
+    for classification. ``name`` is fetched purely to aid debugging
+    when something goes sideways.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "pr", "checks", str(pr),
+                "--repo", repo,
+                "--json", "name,state,conclusion",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    try:
+        data = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list):
+        return None
+    return [c for c in data if isinstance(c, dict)]
 
 
 def _pr_exists(pr: int, repo: str) -> bool:
@@ -186,6 +265,7 @@ def main(argv: "list[str] | None" = None) -> int:
         "--interval", str(args.interval),
     ]
     started = time.monotonic()
+    canceled = False
     try:
         completed = subprocess.run(cmd)
         exit_code = completed.returncode
@@ -193,8 +273,26 @@ def main(argv: "list[str] | None" = None) -> int:
         # Normalize parent-side cancellation to gh's standard exit code 2
         # so callers (and the journal status mapping) see a portable signal.
         exit_code = 2
+        canceled = True
     duration = int(round(time.monotonic() - started))
-    status = _classify(exit_code)
+
+    if canceled:
+        status = "canceled"
+    else:
+        # Issue #224: gh exit 1 from a transient watch-loop error must not
+        # be conflated with "CI failed". Re-derive the status from the
+        # per-check JSON; only fall back to the exit code if the probe
+        # itself fails.
+        checks = _fetch_checks(args.pr, repo)
+        if checks is None:
+            sys.stderr.write(
+                "tools/pr_watch.py: warning: could not query check results "
+                "via `gh pr checks --json`; falling back to exit-code "
+                "classification.\n"
+            )
+            status = _classify(exit_code)
+        else:
+            status = _classify_from_checks(checks)
 
     Journal(JOURNAL_PATH).append(
         "ci_completed",

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -173,9 +173,16 @@ def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
     Requests ``bucket,state,name``: ``bucket`` is the only field we
     classify on (see :func:`_classify_from_checks`); ``state`` and
     ``name`` are fetched purely to aid debugging when something goes
-    sideways. ``gh pr checks --json`` exits non-zero with code 8 when
-    checks are still pending, so we tolerate that as a successful
-    probe and let :func:`_classify_from_checks` see the data.
+    sideways.
+
+    ``gh pr checks`` exits non-zero on multiple non-error conditions:
+    ``8`` for "Checks pending" and ``1`` when at least one check has
+    failed (gh treats a red PR as a CLI error too). In both cases
+    gh still writes the requested JSON to stdout. So we trust the
+    JSON whenever it parses as a list, and only fall back when the
+    output is unparseable or the binary is missing entirely — that's
+    the only condition under which downgrading to the exit-code
+    classifier is appropriate.
     """
     try:
         result = subprocess.run(
@@ -190,11 +197,8 @@ def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
         )
     except FileNotFoundError:
         return None
-    # gh exits 8 when checks pending, but still emits the JSON we want.
-    if result.returncode not in (0, 8):
-        return None
     try:
-        data = json.loads(result.stdout or "[]")
+        data = json.loads(result.stdout or "")
     except json.JSONDecodeError:
         return None
     if not isinstance(data, list):

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -15,15 +15,18 @@ Behavior:
   ``--repo`` is omitted.
 * Spawns ``gh pr checks <PR> --watch --interval <SEC>`` and forwards
   its stdout/stderr.
-* After the watch loop returns, queries ``gh pr checks <PR> --json``
-  for per-check ``conclusion`` / ``status`` so the journal status
+* After the watch loop returns, queries
+  ``gh pr checks <PR> --json bucket,state,name`` for per-check
+  ``bucket`` (gh's documented bucket values are
+  ``{pass, fail, pending, skipping, cancel}``) so the journal status
   reflects what CI actually decided rather than just the gh process'
-  exit code (gh exits non-zero on a transient watch error too).
-  Classifies as ``passed`` (all SUCCESS/SKIPPED/NEUTRAL),
-  ``failed`` (≥1 FAILURE/TIMED_OUT/CANCELLED/STALE/ACTION_REQUIRED),
-  ``incomplete`` (still pending or empty), or ``canceled`` (parent
-  SIGINT). Falls back to exit-code-based classification only if the
-  JSON probe itself fails. Appends one JSON-Lines record to
+  exit code (gh exits non-zero on a transient watch error too, and
+  exit 8 specifically means "Checks pending", not "failed").
+  Classifies as ``passed`` (all pass/skipping), ``failed``
+  (≥1 fail/cancel), ``incomplete`` (any pending / unknown bucket /
+  empty list), or ``canceled`` (parent SIGINT). Falls back to
+  exit-code-based classification only if the JSON probe itself
+  fails. Appends one JSON-Lines record to
   ``<repo_root>/.state/journal.jsonl`` (anchored to ``tools/..`` so
   cwd doesn't matter).
 * Prints the final status as a single line on stdout and exits with
@@ -96,10 +99,13 @@ def _resolve_repo() -> str:
     return repo
 
 
-_FAILED_CONCLUSIONS = frozenset(
-    {"FAILURE", "TIMED_OUT", "CANCELLED", "STALE", "ACTION_REQUIRED"}
-)
-_PASSED_CONCLUSIONS = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
+# gh's `bucket` field (see `gh pr checks --help`) categorizes a check's
+# `state` into one of these buckets: "pass", "fail", "pending",
+# "skipping", "cancel". We treat fail+cancel as failure signals,
+# pass+skipping as success, and pending as still-running.
+_FAILED_BUCKETS = frozenset({"fail", "cancel"})
+_PASSED_BUCKETS = frozenset({"pass", "skipping"})
+_PENDING_BUCKETS = frozenset({"pending"})
 
 
 def _classify(exit_code: int) -> str:
@@ -108,77 +114,84 @@ def _classify(exit_code: int) -> str:
     Reference: https://cli.github.com/manual/gh_help_exit-codes and
     https://cli.github.com/manual/gh_pr_checks. With ``--watch`` gh
     blocks until pending checks resolve and then returns 0 (all
-    checks passed) or 8 (at least one check failed). Exit code 2 is
-    gh's standard cancellation code (e.g. user interrupt). Other
-    non-zero values are treated as a generic failure so downstream
-    automation does not silently mistake an error for success.
+    checks passed). Exit code 2 is gh's standard cancellation code
+    (e.g. user interrupt). Exit code 8 means "Checks pending" per
+    gh's docs (NOT failure). Other non-zero values most likely
+    indicate an internal gh error rather than a CI verdict, so they
+    map to the conservative ``incomplete`` status — refusing to
+    silently turn a transient error into "passed" while also not
+    libelling green CI as "failed".
 
     SIGINT raised in the parent (Python ``KeyboardInterrupt``) is
     normalized to 2 in :func:`main` before reaching this function.
 
     Note: as of Issue #224 the primary classifier is
-    :func:`_classify_from_checks`, which inspects per-check JSON so a
-    transient gh error (e.g. exit 1 from a network blip in the watch
-    loop) is no longer conflated with a real CI failure.
+    :func:`_classify_from_checks`, which inspects per-check JSON. This
+    fallback is only used when the JSON probe itself is unavailable.
     """
     if exit_code == 0:
         return "passed"
     if exit_code == 2:
         return "canceled"
     if exit_code == 8:
-        return "failed"
-    return "failed"
+        return "incomplete"
+    return "incomplete"
 
 
 def _classify_from_checks(checks: "list[dict]") -> str:
-    """Classify CI status from `gh pr checks --json` output.
+    """Classify CI status from `gh pr checks --json bucket,state,name` output.
+
+    gh's documented ``bucket`` values are
+    ``{pass, fail, pending, skipping, cancel}``.
 
     * Empty list → ``incomplete`` (no checks reported).
-    * Any conclusion in :data:`_FAILED_CONCLUSIONS` → ``failed``.
-    * Any check still running (no conclusion / pending state) →
-      ``incomplete``.
-    * All checks have a passing conclusion → ``passed``.
-    * Otherwise → ``incomplete`` (unknown conclusion strings are
-      treated conservatively rather than silently passed).
+    * Any bucket in :data:`_FAILED_BUCKETS` (``fail``/``cancel``) →
+      ``failed``.
+    * Any bucket in :data:`_PENDING_BUCKETS` → ``incomplete``.
+    * All buckets in :data:`_PASSED_BUCKETS` (``pass``/``skipping``)
+      → ``passed``.
+    * Anything else (unrecognized bucket) → ``incomplete``
+      (conservative).
     """
     if not checks:
         return "incomplete"
-    has_pending = False
+    has_pending_or_unknown = False
     for chk in checks:
-        conclusion = (chk.get("conclusion") or "").upper()
-        state = (chk.get("state") or chk.get("status") or "").upper()
-        if conclusion in _FAILED_CONCLUSIONS:
+        bucket = (chk.get("bucket") or "").lower()
+        if bucket in _FAILED_BUCKETS:
             return "failed"
-        if not conclusion or state in {"IN_PROGRESS", "QUEUED", "PENDING"}:
-            has_pending = True
+        if bucket in _PASSED_BUCKETS:
             continue
-        if conclusion not in _PASSED_CONCLUSIONS:
-            # Unknown conclusion — be conservative.
-            has_pending = True
-    return "incomplete" if has_pending else "passed"
+        # pending, empty, or any unrecognized bucket → conservative incomplete.
+        has_pending_or_unknown = True
+    return "incomplete" if has_pending_or_unknown else "passed"
 
 
 def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
     """Return parsed `gh pr checks <pr> --json` results, or ``None`` on error.
 
-    The JSON field set is intentionally narrow (``state``,
-    ``conclusion``, ``name``) — gh's schema for this command is
-    relatively stable but we only depend on the two we actually use
-    for classification. ``name`` is fetched purely to aid debugging
-    when something goes sideways.
+    Requests ``bucket,state,name``: ``bucket`` is the only field we
+    classify on (see :func:`_classify_from_checks`); ``state`` and
+    ``name`` are fetched purely to aid debugging when something goes
+    sideways. ``gh pr checks --json`` exits non-zero with code 8 when
+    checks are still pending, so we tolerate that as a successful
+    probe and let :func:`_classify_from_checks` see the data.
     """
     try:
         result = subprocess.run(
             [
                 "gh", "pr", "checks", str(pr),
                 "--repo", repo,
-                "--json", "name,state,conclusion",
+                "--json", "bucket,state,name",
             ],
             capture_output=True,
             text=True,
-            check=True,
+            check=False,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except FileNotFoundError:
+        return None
+    # gh exits 8 when checks pending, but still emits the JSON we want.
+    if result.returncode not in (0, 8):
         return None
     try:
         data = json.loads(result.stdout or "[]")

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -289,7 +289,10 @@ def main(argv: "list[str] | None" = None) -> int:
         canceled = True
     duration = int(round(time.monotonic() - started))
 
-    if canceled:
+    # gh's documented cancellation exit code is 2 (parent SIGINT or
+    # subprocess-side Ctrl-C). Honor it directly so we don't overwrite a
+    # genuine cancellation with whatever the JSON probe returns.
+    if canceled or exit_code == 2:
         status = "canceled"
     else:
         # Issue #224: gh exit 1 from a transient watch-loop error must not

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -199,6 +199,25 @@ class JournalEmitTests(unittest.TestCase):
             rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
             self.assertEqual(rec["status"], "incomplete")
 
+    def test_gh_exit_2_is_canceled(self) -> None:
+        """gh exit 2 = cancellation. Must NOT be overwritten by JSON probe.
+
+        Regression: an earlier draft only honored Python-side
+        KeyboardInterrupt, so a Ctrl-C delivered to gh itself (exit 2)
+        would have been re-classified as passed/failed/incomplete by
+        the JSON probe. The journal must reflect cancellation so the
+        secretary can distinguish "user aborted" from "CI verdict".
+        """
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "journal.jsonl"
+            self._run(
+                journal,
+                gh_exit=2,
+                checks_json=[{"name": "ci", "state": "COMPLETED", "bucket": "pass"}],
+            )
+            rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(rec["status"], "canceled")
+
     def test_json_probe_failure_falls_back_to_exit_code(self) -> None:
         """If `gh pr checks --json` itself fails, use exit-code mapping."""
         with TempDir() as tmp:
@@ -343,6 +362,31 @@ class PowerShellInterpreterProbeTests(unittest.TestCase):
         self.assertFalse(
             self._run_probe(shim_body),
             "Test-Interpreter should reject a Python that fails the import check",
+        )
+
+    def test_python_2_is_rejected(self) -> None:
+        """A `--version`-passing Python 2 must not be accepted.
+
+        The combined `-c` probe asserts sys.version_info[0]==3, so a
+        shim that simulates Py2 by exiting nonzero on the `-c` call
+        should be rejected even though `--version` succeeds.
+        """
+        if os.name == "nt":
+            shim_body = (
+                "@echo off\r\n"
+                "if \"%~1\"==\"--version\" ( echo Python 2.7.18 & exit /b 0 )\r\n"
+                "if \"%~1\"==\"-c\" ( exit /b 1 )\r\n"
+                "exit /b 2\r\n"
+            )
+        else:
+            shim_body = (
+                "if [ \"$1\" = \"--version\" ]; then echo 'Python 2.7.18'; exit 0; fi\n"
+                "if [ \"$1\" = \"-c\" ]; then exit 1; fi\n"
+                "exit 2\n"
+            )
+        self.assertFalse(
+            self._run_probe(shim_body),
+            "Test-Interpreter must reject Python 2 even if --version exits 0",
         )
 
     def test_version_ok_import_ok_is_accepted(self) -> None:

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -1,4 +1,4 @@
-"""Unit tests for tools/pr_watch.py (Issue #204).
+"""Unit tests for tools/pr_watch.py (Issue #204, Issue #224).
 
 Mocks the gh CLI subprocess via monkey-patching so the suite stays
 hermetic. Verifies the journal payload shape matches the contract in
@@ -7,6 +7,9 @@ CLAUDE.local.md.
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -32,16 +35,44 @@ class ClassifyTests(unittest.TestCase):
         self.assertEqual(pr_watch._classify(127), "failed")
 
 
+def _make_fake_run(
+    watch_exit: int = 0,
+    checks_json: "list[dict] | None" = None,
+    checks_raises: "Exception | None" = None,
+):
+    """Build a `subprocess.run` stub matching the call sites in pr_watch.
+
+    Recognized commands:
+
+    * ``gh pr view ... --json number`` → success (PR exists probe)
+    * ``gh pr checks <pr> --json ...`` → ``checks_json`` (or raise)
+    * ``gh pr checks <pr> --watch ...`` → returncode = ``watch_exit``
+    """
+    if checks_json is None:
+        checks_json = [{"name": "ci", "state": "COMPLETED", "conclusion": "SUCCESS"}]
+
+    def fake_run(cmd, *args, **kwargs):
+        if "view" in cmd and "--json" in cmd and "number" in cmd:
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+        if "checks" in cmd and "--json" in cmd:
+            if checks_raises is not None:
+                raise checks_raises
+            return mock.Mock(
+                returncode=0,
+                stdout=json.dumps(checks_json),
+                stderr="",
+            )
+        # The watched run.
+        return mock.Mock(returncode=watch_exit)
+
+    return fake_run
+
+
 class ArgFormTests(unittest.TestCase):
     """Both `--pr <n>` and the legacy positional form must parse identically."""
 
     def _run(self, argv: "list[str]") -> "tuple[int, dict]":
-        completed = mock.Mock(returncode=0)
-
-        def fake_run(cmd, *args, **kwargs):
-            if "view" in cmd and "--json" in cmd and "number" in cmd:
-                return mock.Mock(returncode=0, stdout="{}", stderr="")
-            return completed
+        fake_run = _make_fake_run(watch_exit=0)
 
         with TempDir() as tmp:
             journal = tmp / ".state" / "journal.jsonl"
@@ -69,16 +100,18 @@ class ArgFormTests(unittest.TestCase):
 
 
 class JournalEmitTests(unittest.TestCase):
-    def _run(self, tmp_journal: Path, gh_exit: int) -> int:
-        completed = mock.Mock(returncode=gh_exit)
-
-        def fake_run(cmd, *args, **kwargs):
-            # _pr_exists() probe path
-            if "view" in cmd and "--json" in cmd and "number" in cmd:
-                return mock.Mock(returncode=0, stdout="{}", stderr="")
-            # the watched run
-            return completed
-
+    def _run(
+        self,
+        tmp_journal: Path,
+        gh_exit: int,
+        checks_json: "list[dict] | None" = None,
+        checks_raises: "Exception | None" = None,
+    ) -> int:
+        fake_run = _make_fake_run(
+            watch_exit=gh_exit,
+            checks_json=checks_json,
+            checks_raises=checks_raises,
+        )
         with mock.patch.object(pr_watch, "JOURNAL_PATH", tmp_journal), \
              mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
              mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
@@ -86,26 +119,231 @@ class JournalEmitTests(unittest.TestCase):
             return pr_watch.main(["--pr", "205", "--repo", "octo/repo", "--interval", "5"])
 
     def test_passed_emits_ci_completed(self) -> None:
-        with self.subTest("passed"):
-            with TempDir() as tmp:
-                journal = tmp / ".state" / "journal.jsonl"
-                self._run(journal, gh_exit=0)
-                lines = journal.read_text(encoding="utf-8").splitlines()
-                self.assertEqual(len(lines), 1)
-                rec = json.loads(lines[0])
-                self.assertEqual(rec["event"], "ci_completed")
-                self.assertEqual(rec["pr"], 205)
-                self.assertEqual(rec["repo"], "octo/repo")
-                self.assertEqual(rec["status"], "passed")
-                self.assertEqual(rec["duration_sec"], 42)
-                self.assertIn("ts", rec)
-
-    def test_failed_status(self) -> None:
         with TempDir() as tmp:
             journal = tmp / ".state" / "journal.jsonl"
-            self._run(journal, gh_exit=8)
+            self._run(journal, gh_exit=0)
+            lines = journal.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            rec = json.loads(lines[0])
+            self.assertEqual(rec["event"], "ci_completed")
+            self.assertEqual(rec["pr"], 205)
+            self.assertEqual(rec["repo"], "octo/repo")
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(rec["duration_sec"], 42)
+            self.assertIn("ts", rec)
+
+    def test_failed_status_from_check_conclusion(self) -> None:
+        """A FAILURE conclusion in the JSON probe → status=failed."""
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "journal.jsonl"
+            self._run(
+                journal,
+                gh_exit=8,
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                    {"name": "test", "state": "COMPLETED", "conclusion": "FAILURE"},
+                ],
+            )
             rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
             self.assertEqual(rec["status"], "failed")
+
+    def test_transient_gh_error_is_not_failed(self) -> None:
+        """Issue #224: gh exit 1 with all checks SUCCESS must classify as passed.
+
+        Regression: the old code conflated any non-zero exit with CI
+        failure, so a transient error in `gh pr checks --watch` (e.g.
+        a brief network blip) would be journaled as ``status=failed``
+        even when CI itself was green.
+        """
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "journal.jsonl"
+            self._run(
+                journal,
+                gh_exit=1,
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                    {"name": "test", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                ],
+            )
+            rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(rec["status"], "passed")
+
+    def test_pending_check_is_incomplete(self) -> None:
+        """A still-running check → status=incomplete (new in #224)."""
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "journal.jsonl"
+            self._run(
+                journal,
+                gh_exit=0,
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                    {"name": "deploy", "state": "IN_PROGRESS", "conclusion": ""},
+                ],
+            )
+            rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(rec["status"], "incomplete")
+
+    def test_empty_checks_is_incomplete(self) -> None:
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "journal.jsonl"
+            self._run(journal, gh_exit=0, checks_json=[])
+            rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(rec["status"], "incomplete")
+
+    def test_json_probe_failure_falls_back_to_exit_code(self) -> None:
+        """If `gh pr checks --json` itself fails, use exit-code mapping."""
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "journal.jsonl"
+            self._run(
+                journal,
+                gh_exit=8,
+                checks_raises=subprocess.CalledProcessError(1, ["gh"]),
+            )
+            rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
+            # exit 8 → failed via _classify fallback.
+            self.assertEqual(rec["status"], "failed")
+
+
+class ClassifyFromChecksTests(unittest.TestCase):
+    def test_all_success(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"conclusion": "SUCCESS"}, {"conclusion": "SUCCESS"}]
+            ),
+            "passed",
+        )
+
+    def test_skipped_counts_as_passed(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"conclusion": "SUCCESS"}, {"conclusion": "SKIPPED"}]
+            ),
+            "passed",
+        )
+
+    def test_any_failure_is_failed(self) -> None:
+        for bad in ("FAILURE", "TIMED_OUT", "CANCELLED", "STALE", "ACTION_REQUIRED"):
+            with self.subTest(bad=bad):
+                self.assertEqual(
+                    pr_watch._classify_from_checks(
+                        [{"conclusion": "SUCCESS"}, {"conclusion": bad}]
+                    ),
+                    "failed",
+                )
+
+    def test_pending_is_incomplete(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"conclusion": "SUCCESS"}, {"state": "IN_PROGRESS", "conclusion": ""}]
+            ),
+            "incomplete",
+        )
+
+    def test_empty_is_incomplete(self) -> None:
+        self.assertEqual(pr_watch._classify_from_checks([]), "incomplete")
+
+    def test_unknown_conclusion_is_incomplete(self) -> None:
+        # Conservative: unrecognized conclusion → don't claim "passed".
+        self.assertEqual(
+            pr_watch._classify_from_checks([{"conclusion": "MYSTERY_BUCKET"}]),
+            "incomplete",
+        )
+
+
+class PowerShellInterpreterProbeTests(unittest.TestCase):
+    """Issue #224 (b): pr-watch.ps1 must reject Pythons that lack core_harness.
+
+    These tests exercise the actual PowerShell script via pwsh; they are
+    skipped on hosts where pwsh isn't available (e.g. minimal CI images).
+    The probe logic itself is small and self-contained, so we extract just
+    the Test-Interpreter function and call it with synthetic shim
+    interpreters.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if not cls.pwsh:
+            raise unittest.SkipTest("pwsh/powershell not available")
+        cls.script = (
+            Path(__file__).resolve().parent / "pr-watch.ps1"
+        )
+        if not cls.script.exists():
+            raise unittest.SkipTest("pr-watch.ps1 not found")
+
+    def _run_probe(self, shim_body: str) -> bool:
+        """Write a fake interpreter shim, source Test-Interpreter, return result."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            if os.name == "nt":
+                shim = tdp / "fakepy.cmd"
+                shim.write_text(shim_body, encoding="ascii")
+                exe_arg = str(shim)
+            else:
+                shim = tdp / "fakepy"
+                shim.write_text("#!/usr/bin/env bash\n" + shim_body, encoding="ascii")
+                shim.chmod(0o755)
+                exe_arg = str(shim)
+            ps_cmd = (
+                ". '" + str(self.script).replace("'", "''") + "' -PR 1 "
+                "-ErrorAction SilentlyContinue 2>$null; "
+            )
+            # The dot-source above runs the full script which we don't want.
+            # Instead, extract just the function block via regex inline:
+            extract = (
+                "$src = Get-Content -Raw '" + str(self.script).replace("'", "''") + "'; "
+                "if ($src -match '(?ms)function Test-Interpreter \\{.*?^\\}') "
+                "{ Invoke-Expression $Matches[0] } "
+                "else { Write-Error 'function not found'; exit 99 }; "
+                "if (Test-Interpreter -Exe '" + exe_arg.replace("'", "''") + "' -Prefix @()) "
+                "{ exit 0 } else { exit 1 }"
+            )
+            res = subprocess.run(
+                [self.pwsh, "-NoProfile", "-Command", extract],
+                capture_output=True,
+                text=True,
+            )
+            return res.returncode == 0
+
+    def test_version_ok_import_fail_is_rejected(self) -> None:
+        if os.name == "nt":
+            shim_body = (
+                "@echo off\r\n"
+                "if \"%~1\"==\"--version\" ( echo Python 3.10.0 & exit /b 0 )\r\n"
+                "if \"%~1\"==\"-c\" ( echo ImportError 1>&2 & exit /b 1 )\r\n"
+                "exit /b 2\r\n"
+            )
+        else:
+            shim_body = (
+                "if [ \"$1\" = \"--version\" ]; then echo 'Python 3.10.0'; exit 0; fi\n"
+                "if [ \"$1\" = \"-c\" ]; then echo 'ImportError' 1>&2; exit 1; fi\n"
+                "exit 2\n"
+            )
+        self.assertFalse(
+            self._run_probe(shim_body),
+            "Test-Interpreter should reject a Python that fails the import check",
+        )
+
+    def test_version_ok_import_ok_is_accepted(self) -> None:
+        if os.name == "nt":
+            shim_body = (
+                "@echo off\r\n"
+                "if \"%~1\"==\"--version\" ( echo Python 3.10.0 & exit /b 0 )\r\n"
+                "if \"%~1\"==\"-c\" ( exit /b 0 )\r\n"
+                "exit /b 2\r\n"
+            )
+        else:
+            shim_body = (
+                "if [ \"$1\" = \"--version\" ]; then echo 'Python 3.10.0'; exit 0; fi\n"
+                "if [ \"$1\" = \"-c\" ]; then exit 0; fi\n"
+                "exit 2\n"
+            )
+        self.assertTrue(
+            self._run_probe(shim_body),
+            "Test-Interpreter should accept a Python that passes both probes",
+        )
 
 
 class TempDir:

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -48,6 +48,7 @@ def _make_fake_run(
     watch_exit: int = 0,
     checks_json: "list[dict] | None" = None,
     checks_raises: "Exception | None" = None,
+    checks_json_exit: "int | None" = None,
 ):
     """Build a `subprocess.run` stub matching the call sites in pr_watch.
 
@@ -60,6 +61,21 @@ def _make_fake_run(
     if checks_json is None:
         checks_json = [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}]
 
+    # gh exits non-zero (1) when at least one check is failing, and 8
+    # when checks are still pending — but in both cases it still writes
+    # the requested JSON. Mirror that here so the tests exercise the
+    # real protocol, not an idealized one.
+    def _gh_exit_for_checks(payload):
+        if checks_json_exit is not None:
+            return checks_json_exit
+        for chk in payload:
+            b = (chk.get("bucket") or "").lower()
+            if b in ("fail", "cancel"):
+                return 1
+            if b == "pending":
+                return 8
+        return 0
+
     def fake_run(cmd, *args, **kwargs):
         if "view" in cmd and "--json" in cmd and "number" in cmd:
             return mock.Mock(returncode=0, stdout="{}", stderr="")
@@ -67,7 +83,7 @@ def _make_fake_run(
             if checks_raises is not None:
                 raise checks_raises
             return mock.Mock(
-                returncode=0,
+                returncode=_gh_exit_for_checks(checks_json),
                 stdout=json.dumps(checks_json),
                 stderr="",
             )
@@ -198,6 +214,29 @@ class JournalEmitTests(unittest.TestCase):
             self._run(journal, gh_exit=0, checks_json=[])
             rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
             self.assertEqual(rec["status"], "incomplete")
+
+    def test_failed_check_with_gh_json_exit_1(self) -> None:
+        """gh exits 1 when a check failed but still emits JSON.
+
+        Regression: the previous implementation only trusted the JSON
+        when gh exited 0 or 8, so a real CI failure (gh exit 1 + valid
+        JSON listing a `fail` bucket) would be discarded and fall
+        through to the exit-code classifier — defeating Issue #224(a).
+        """
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "journal.jsonl"
+            self._run(
+                journal,
+                gh_exit=1,  # watch loop saw the failure too
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "test", "state": "COMPLETED", "bucket": "fail"},
+                ],
+                # `_gh_exit_for_checks` will emit 1 for this payload
+                # (failure present), matching real gh behavior.
+            )
+            rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(rec["status"], "failed")
 
     def test_gh_exit_2_is_canceled(self) -> None:
         """gh exit 2 = cancellation. Must NOT be overwritten by JSON probe.

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -21,18 +21,27 @@ import pr_watch  # noqa: E402
 
 
 class ClassifyTests(unittest.TestCase):
+    """Fallback classifier (used only when JSON probe is unavailable).
+
+    Per `gh help exit-codes`, exit 8 is "Checks pending" — NOT failure.
+    Issue #224 corrects the prior mapping.
+    """
+
     def test_zero_is_passed(self) -> None:
         self.assertEqual(pr_watch._classify(0), "passed")
 
-    def test_eight_is_failed(self) -> None:
-        self.assertEqual(pr_watch._classify(8), "failed")
+    def test_eight_is_incomplete(self) -> None:
+        # gh exit 8 = "Checks pending", per gh's help text.
+        self.assertEqual(pr_watch._classify(8), "incomplete")
 
     def test_two_is_canceled(self) -> None:
         self.assertEqual(pr_watch._classify(2), "canceled")
 
-    def test_other_nonzero_is_failed(self) -> None:
-        self.assertEqual(pr_watch._classify(1), "failed")
-        self.assertEqual(pr_watch._classify(127), "failed")
+    def test_other_nonzero_is_incomplete(self) -> None:
+        # Conservative: treat unknown gh errors as incomplete rather
+        # than libelling the PR as failed.
+        self.assertEqual(pr_watch._classify(1), "incomplete")
+        self.assertEqual(pr_watch._classify(127), "incomplete")
 
 
 def _make_fake_run(
@@ -49,7 +58,7 @@ def _make_fake_run(
     * ``gh pr checks <pr> --watch ...`` → returncode = ``watch_exit``
     """
     if checks_json is None:
-        checks_json = [{"name": "ci", "state": "COMPLETED", "conclusion": "SUCCESS"}]
+        checks_json = [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}]
 
     def fake_run(cmd, *args, **kwargs):
         if "view" in cmd and "--json" in cmd and "number" in cmd:
@@ -132,23 +141,23 @@ class JournalEmitTests(unittest.TestCase):
             self.assertEqual(rec["duration_sec"], 42)
             self.assertIn("ts", rec)
 
-    def test_failed_status_from_check_conclusion(self) -> None:
-        """A FAILURE conclusion in the JSON probe → status=failed."""
+    def test_failed_status_from_check_bucket(self) -> None:
+        """A `fail` bucket in the JSON probe → status=failed."""
         with TempDir() as tmp:
             journal = tmp / ".state" / "journal.jsonl"
             self._run(
                 journal,
                 gh_exit=8,
                 checks_json=[
-                    {"name": "lint", "state": "COMPLETED", "conclusion": "SUCCESS"},
-                    {"name": "test", "state": "COMPLETED", "conclusion": "FAILURE"},
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "test", "state": "COMPLETED", "bucket": "fail"},
                 ],
             )
             rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
             self.assertEqual(rec["status"], "failed")
 
     def test_transient_gh_error_is_not_failed(self) -> None:
-        """Issue #224: gh exit 1 with all checks SUCCESS must classify as passed.
+        """Issue #224: gh exit 1 with all checks `pass` must classify as passed.
 
         Regression: the old code conflated any non-zero exit with CI
         failure, so a transient error in `gh pr checks --watch` (e.g.
@@ -161,8 +170,8 @@ class JournalEmitTests(unittest.TestCase):
                 journal,
                 gh_exit=1,
                 checks_json=[
-                    {"name": "lint", "state": "COMPLETED", "conclusion": "SUCCESS"},
-                    {"name": "test", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "test", "state": "COMPLETED", "bucket": "pass"},
                 ],
             )
             rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
@@ -176,8 +185,8 @@ class JournalEmitTests(unittest.TestCase):
                 journal,
                 gh_exit=0,
                 checks_json=[
-                    {"name": "lint", "state": "COMPLETED", "conclusion": "SUCCESS"},
-                    {"name": "deploy", "state": "IN_PROGRESS", "conclusion": ""},
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"},
                 ],
             )
             rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
@@ -196,45 +205,51 @@ class JournalEmitTests(unittest.TestCase):
             journal = tmp / ".state" / "journal.jsonl"
             self._run(
                 journal,
-                gh_exit=8,
-                checks_raises=subprocess.CalledProcessError(1, ["gh"]),
+                gh_exit=0,
+                checks_raises=FileNotFoundError("gh missing"),
             )
             rec = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
-            # exit 8 → failed via _classify fallback.
-            self.assertEqual(rec["status"], "failed")
+            # exit 0 → passed via _classify fallback.
+            self.assertEqual(rec["status"], "passed")
 
 
 class ClassifyFromChecksTests(unittest.TestCase):
-    def test_all_success(self) -> None:
+    def test_all_pass(self) -> None:
         self.assertEqual(
             pr_watch._classify_from_checks(
-                [{"conclusion": "SUCCESS"}, {"conclusion": "SUCCESS"}]
+                [{"bucket": "pass"}, {"bucket": "pass"}]
             ),
             "passed",
         )
 
-    def test_skipped_counts_as_passed(self) -> None:
+    def test_skipping_counts_as_passed(self) -> None:
         self.assertEqual(
             pr_watch._classify_from_checks(
-                [{"conclusion": "SUCCESS"}, {"conclusion": "SKIPPED"}]
+                [{"bucket": "pass"}, {"bucket": "skipping"}]
             ),
             "passed",
         )
 
-    def test_any_failure_is_failed(self) -> None:
-        for bad in ("FAILURE", "TIMED_OUT", "CANCELLED", "STALE", "ACTION_REQUIRED"):
-            with self.subTest(bad=bad):
-                self.assertEqual(
-                    pr_watch._classify_from_checks(
-                        [{"conclusion": "SUCCESS"}, {"conclusion": bad}]
-                    ),
-                    "failed",
-                )
+    def test_fail_bucket_is_failed(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "fail"}]
+            ),
+            "failed",
+        )
+
+    def test_cancel_bucket_is_failed(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "cancel"}]
+            ),
+            "failed",
+        )
 
     def test_pending_is_incomplete(self) -> None:
         self.assertEqual(
             pr_watch._classify_from_checks(
-                [{"conclusion": "SUCCESS"}, {"state": "IN_PROGRESS", "conclusion": ""}]
+                [{"bucket": "pass"}, {"bucket": "pending"}]
             ),
             "incomplete",
         )
@@ -242,11 +257,18 @@ class ClassifyFromChecksTests(unittest.TestCase):
     def test_empty_is_incomplete(self) -> None:
         self.assertEqual(pr_watch._classify_from_checks([]), "incomplete")
 
-    def test_unknown_conclusion_is_incomplete(self) -> None:
-        # Conservative: unrecognized conclusion → don't claim "passed".
+    def test_unknown_bucket_is_incomplete(self) -> None:
+        # Conservative: unrecognized bucket → don't claim "passed".
         self.assertEqual(
-            pr_watch._classify_from_checks([{"conclusion": "MYSTERY_BUCKET"}]),
+            pr_watch._classify_from_checks([{"bucket": "mystery"}]),
             "incomplete",
+        )
+
+    def test_case_insensitive_bucket(self) -> None:
+        # gh emits lowercase, but be defensive.
+        self.assertEqual(
+            pr_watch._classify_from_checks([{"bucket": "PASS"}]),
+            "passed",
         )
 
 
@@ -286,12 +308,9 @@ class PowerShellInterpreterProbeTests(unittest.TestCase):
                 shim.write_text("#!/usr/bin/env bash\n" + shim_body, encoding="ascii")
                 shim.chmod(0o755)
                 exe_arg = str(shim)
-            ps_cmd = (
-                ". '" + str(self.script).replace("'", "''") + "' -PR 1 "
-                "-ErrorAction SilentlyContinue 2>$null; "
-            )
-            # The dot-source above runs the full script which we don't want.
-            # Instead, extract just the function block via regex inline:
+            # We can't dot-source pr-watch.ps1 directly (it has a mandatory
+            # -PR param that would error out), so extract just the
+            # Test-Interpreter function block via regex and Invoke-Expression.
             extract = (
                 "$src = Get-Content -Raw '" + str(self.script).replace("'", "''") + "'; "
                 "if ($src -match '(?ms)function Test-Interpreter \\{.*?^\\}') "


### PR DESCRIPTION
## Summary
- **gh exit semantics**: trust `gh pr checks --json` output regardless of exit code. gh exits 1 when at least one check fails but still emits valid JSON; the previous code threw the JSON away and downgraded to a fallback that lost the per-check breakdown. Now JSON-parseable output is the source of truth and the exit code is only consulted when the binary itself didn't run.
- **bucket-based classifier**: switched from the non-existent `conclusion` field to gh's documented `bucket,state,name`. Adds explicit handling for gh's exit-2 (cancellation) and exit-8 (pending) signals.
- **interpreter probe**: extends `tools/pr-watch.ps1`'s probe with `python -c "import sys; assert sys.version_info[0]==3; import core_harness.audit"`, so a Python 2 interpreter or one missing the runtime dep is rejected and the next candidate is tried.
- **tests**: 26 cases (existing + 18 new) covering bucket classifier, gh exit 1 with valid JSON, exit 2 cancellation, exit 8 pending, Python 2 / import-fail rejection, JSON-probe-failure fallback. All pass under `python -m unittest tools.test_pr_watch`.
- **docs**: new `ci_completed` section in `docs/journal-events.md` documenting the bucket-based statuses.

Closes #224.

## Codex self-review (3 rounds)
- Round 1: 1 Blocker (`--json conclusion` is invalid; correct field is `bucket`) + exit-8 = pending classification fixed (`991cb36`).
- Round 2: 2 Major (gh exit-2 cancellation lost; Python 2 could pass `--version`) — both fixed (`1558930`).
- Round 3: 1 Major (gh exits 1 when checks fail but still emits valid JSON; old logic dropped the JSON and missed Issue #224's main goal) — fixed (`3ad693b`).
- 3-round cap reached. No residual Blocker/Major.

## Test plan
- [x] `python -m unittest tools.test_pr_watch` → 26/26 PASS.
- [ ] CI green.
- [ ] Optional: live E2E against a known-failing PR (deferred — exercise covered by mocked tests).

## Notable lessons
- `gh pr checks --json` field is `bucket`, not `conclusion`. The `conclusion` field is from the raw GitHub Checks API and is not surfaced by gh.
- gh exit-code semantics: `0` all pass / `1` ≥1 fail / `2` cancel / `8` pending. The JSON payload is valid for exit 1 and 8, so JSON-parseability — not exit code — should be the success signal.
- A combined Windows interpreter probe (`-c "import sys; assert version_info[0]==3; import <runtime_dep>"`) catches Python 2 and missing deps in one shot, where `--version` alone catches neither.