### PR TITLE
feat(tools): worker brief generator (CLAUDE.md / CLAUDE.local.md)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -280,15 +280,17 @@ git -C {project_path} check-ignore -q -- <target>
 
 ### 共通手順（全パターン・配置後）
 
-CLAUDE.md テンプレートの変数を実際の値で置換する（settings.local.json の置換は generator が自動で行うため対象外）:
-- `{project_name}` → registry の通称
-- `{project_description}` → registry の説明
-- `{task_id}` → タスクID（例: `data-analysis`）
-- `{task_description}` → タスクの目的と成果物
-- `{claude_org_path}` → claude-org リポジトリの絶対パス
-- `{worker_dir}` → ワーカーディレクトリの絶対パス（パターンにより異なる、上記参照）
+CLAUDE.md / CLAUDE.local.md は **`tools/gen_worker_brief.py` で自動生成する**（手書き禁止。settings.local.json の生成は generator が自動で行うため対象外）:
 
-生成した CLAUDE.md に「作業ディレクトリ（最重要制約）」セクションが含まれていることを確認する。含まれていない場合はテンプレート適用ミスのため再生成する
+```bash
+python tools/gen_worker_brief.py --config <task>.toml --out {worker_dir}/CLAUDE.md
+```
+
+self-edit task（Pattern B claude-org 自身編集）の場合は `--out` を `{worker_dir}/CLAUDE.local.md` にする（`worker.self_edit = true` を config に設定。テンプレートが自動的に「ルート CLAUDE.md は無視」注記を含める）。config TOML のフォーマットは `tools/templates/worker_brief.example.toml` を参照。
+
+config TOML が要求する主なキー: `task.{id, description, verification_depth, branch, commit_prefix, closes_issue|refs_issues}`、`worker.{dir, pattern, role, self_edit}`、`project.{name, description}`、`paths.claude_org`。任意セクション: `[implementation]` `[references]` `[parallel]` `[task].issue_url`。
+
+生成した CLAUDE.md / CLAUDE.local.md に「作業ディレクトリ」セクションが含まれていることを確認する。含まれていない場合は config 不備または generator バグのため再生成する。`tools/templates/worker_brief_normal.md` / `worker_brief_self_edit.md` が SOT であり、reference の `worker-claude-template.md` は互換性のため残置（Secretary 用 reference）。
 
 **参考 work-skill がある場合（Step 0.5 でマッチ）:**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,7 @@ core-harness>=0.3.2,<0.4
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
 claude-org-runtime>=0.1.1,<0.2
+
+# tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
+# but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).
+tomli>=2.0,<3 ; python_version < "3.11"

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -24,14 +24,12 @@ VALID_PATTERNS = {"A", "B", "C"}
 VALID_ROLES = {"default", "claude-org-self-edit", "doc-audit"}
 VALID_DEPTHS = {"full", "minimal"}
 
-REQUIRED_KEYS = {
+REQUIRED_STRING_KEYS = {
     "task": ("id", "description", "verification_depth", "branch", "commit_prefix"),
-    "worker": ("dir", "pattern", "role", "self_edit"),
+    "worker": ("dir", "pattern", "role"),
     "project": ("name", "description"),
     "paths": ("claude_org",),
 }
-
-OPTIONAL_BLOCKS = ("issue_url", "implementation", "parallel", "references")
 
 _BLOCK_RE = re.compile(
     r"<!--BEGIN:(?P<name>[a-z_]+)-->(?P<body>.*?)<!--END:(?P=name)-->\n?",
@@ -43,17 +41,27 @@ class ConfigError(ValueError):
     """Raised when the TOML config is invalid."""
 
 
-def _require(d: dict[str, Any], section: str, keys: tuple[str, ...]) -> None:
-    if section not in d:
-        raise ConfigError(f"missing required section [{section}]")
+def _require_string(d: dict[str, Any], section: str, keys: tuple[str, ...]) -> None:
+    if not isinstance(d.get(section), dict):
+        raise ConfigError(f"missing or non-table required section [{section}]")
     for k in keys:
         if k not in d[section]:
             raise ConfigError(f"missing required key {section}.{k}")
+        if not isinstance(d[section][k], str) or not d[section][k]:
+            raise ConfigError(f"{section}.{k} must be a non-empty string")
+
+
+def _require_string_list(value: Any, label: str) -> None:
+    if not isinstance(value, list) or not all(isinstance(x, str) for x in value):
+        raise ConfigError(f"{label} must be a list of strings")
 
 
 def validate(config: dict[str, Any]) -> None:
-    for section, keys in REQUIRED_KEYS.items():
-        _require(config, section, keys)
+    if not isinstance(config, dict):
+        raise ConfigError("config root must be a TOML table")
+
+    for section, keys in REQUIRED_STRING_KEYS.items():
+        _require_string(config, section, keys)
 
     depth = config["task"]["verification_depth"]
     if depth not in VALID_DEPTHS:
@@ -67,8 +75,44 @@ def validate(config: dict[str, Any]) -> None:
     if role not in VALID_ROLES:
         raise ConfigError(f"worker.role must be one of {sorted(VALID_ROLES)}, got {role!r}")
 
+    if "self_edit" not in config["worker"]:
+        raise ConfigError("missing required key worker.self_edit")
     if not isinstance(config["worker"]["self_edit"], bool):
         raise ConfigError("worker.self_edit must be a boolean")
+
+    task = config["task"]
+    if "issue_url" in task and not isinstance(task["issue_url"], str):
+        raise ConfigError("task.issue_url must be a string")
+    if "closes_issue" in task and not isinstance(task["closes_issue"], int):
+        raise ConfigError("task.closes_issue must be an integer")
+    if "refs_issues" in task:
+        if not isinstance(task["refs_issues"], list) or not all(
+            isinstance(n, int) for n in task["refs_issues"]
+        ):
+            raise ConfigError("task.refs_issues must be a list of integers")
+
+    impl = config.get("implementation")
+    if impl is not None:
+        if not isinstance(impl, dict):
+            raise ConfigError("[implementation] must be a TOML table")
+        if "target_files" in impl:
+            _require_string_list(impl["target_files"], "implementation.target_files")
+        if "guidance" in impl and not isinstance(impl["guidance"], str):
+            raise ConfigError("implementation.guidance must be a string")
+
+    refs = config.get("references")
+    if refs is not None:
+        if not isinstance(refs, dict):
+            raise ConfigError("[references] must be a TOML table")
+        if "knowledge" in refs:
+            _require_string_list(refs["knowledge"], "references.knowledge")
+
+    parallel = config.get("parallel")
+    if parallel is not None:
+        if not isinstance(parallel, dict):
+            raise ConfigError("[parallel] must be a TOML table")
+        if "notes" in parallel and not isinstance(parallel["notes"], str):
+            raise ConfigError("parallel.notes must be a string")
 
 
 def _closes_or_refs(task: dict[str, Any]) -> str:
@@ -206,7 +250,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         config = load_config(args.config)
         output = render(config)
-    except (ConfigError, FileNotFoundError) as e:
+    except (ConfigError, FileNotFoundError, tomllib.TOMLDecodeError) as e:
         print(f"error: {e}", file=sys.stderr)
         return 2
 

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -1,0 +1,220 @@
+"""Generate a worker CLAUDE.md / CLAUDE.local.md brief from a TOML config.
+
+Replaces hand-written per-task briefs with template + variable substitution.
+See ``tools/templates/worker_brief.example.toml`` for the input schema.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from string import Template
+from typing import Any
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+VALID_PATTERNS = {"A", "B", "C"}
+VALID_ROLES = {"default", "claude-org-self-edit", "doc-audit"}
+VALID_DEPTHS = {"full", "minimal"}
+
+REQUIRED_KEYS = {
+    "task": ("id", "description", "verification_depth", "branch", "commit_prefix"),
+    "worker": ("dir", "pattern", "role", "self_edit"),
+    "project": ("name", "description"),
+    "paths": ("claude_org",),
+}
+
+OPTIONAL_BLOCKS = ("issue_url", "implementation", "parallel", "references")
+
+_BLOCK_RE = re.compile(
+    r"<!--BEGIN:(?P<name>[a-z_]+)-->(?P<body>.*?)<!--END:(?P=name)-->\n?",
+    re.DOTALL,
+)
+
+
+class ConfigError(ValueError):
+    """Raised when the TOML config is invalid."""
+
+
+def _require(d: dict[str, Any], section: str, keys: tuple[str, ...]) -> None:
+    if section not in d:
+        raise ConfigError(f"missing required section [{section}]")
+    for k in keys:
+        if k not in d[section]:
+            raise ConfigError(f"missing required key {section}.{k}")
+
+
+def validate(config: dict[str, Any]) -> None:
+    for section, keys in REQUIRED_KEYS.items():
+        _require(config, section, keys)
+
+    depth = config["task"]["verification_depth"]
+    if depth not in VALID_DEPTHS:
+        raise ConfigError(f"task.verification_depth must be one of {sorted(VALID_DEPTHS)}, got {depth!r}")
+
+    pattern = config["worker"]["pattern"]
+    if pattern not in VALID_PATTERNS:
+        raise ConfigError(f"worker.pattern must be one of {sorted(VALID_PATTERNS)}, got {pattern!r}")
+
+    role = config["worker"]["role"]
+    if role not in VALID_ROLES:
+        raise ConfigError(f"worker.role must be one of {sorted(VALID_ROLES)}, got {role!r}")
+
+    if not isinstance(config["worker"]["self_edit"], bool):
+        raise ConfigError("worker.self_edit must be a boolean")
+
+
+def _closes_or_refs(task: dict[str, Any]) -> str:
+    closes = task.get("closes_issue")
+    refs = task.get("refs_issues")
+    if closes:
+        return f"Closes #{closes}"
+    if refs:
+        nums = " ".join(f"#{n}" for n in refs)
+        return f"Refs {nums}"
+    return "（なし）"
+
+
+def _impl_target_files_block(files: list[str]) -> str:
+    if not files:
+        return ""
+    lines = ["対象ファイル:"]
+    for f in files:
+        lines.append(f"- `{f}`")
+    return "\n".join(lines) + "\n\n"
+
+
+def _impl_guidance_block(guidance: str | None) -> str:
+    if not guidance:
+        return ""
+    return guidance.strip() + "\n"
+
+
+def _references_knowledge_block(items: list[str]) -> str:
+    if not items:
+        return ""
+    return "\n".join(f"- `{p}`" for p in items)
+
+
+def _select_blocks(config: dict[str, Any]) -> dict[str, bool]:
+    """Decide which optional <!--BEGIN:name--> blocks to keep."""
+    task = config["task"]
+    depth = task["verification_depth"]
+    blocks = {
+        "issue_url": bool(task.get("issue_url")),
+        "implementation": "implementation" in config
+        and (
+            config["implementation"].get("target_files")
+            or config["implementation"].get("guidance")
+        ),
+        "parallel": "parallel" in config and bool(config["parallel"].get("notes")),
+        "references": "references" in config
+        and bool(config["references"].get("knowledge")),
+        "codex_full": depth == "full",
+        "codex_minimal": depth == "minimal",
+    }
+    return blocks
+
+
+def _apply_blocks(text: str, keep: dict[str, bool]) -> str:
+    def repl(m: re.Match[str]) -> str:
+        name = m.group("name")
+        body = m.group("body")
+        if keep.get(name, False):
+            return body
+        return ""
+
+    return _BLOCK_RE.sub(repl, text)
+
+
+def _build_substitutions(config: dict[str, Any]) -> dict[str, str]:
+    task = config["task"]
+    worker = config["worker"]
+    project = config["project"]
+    paths = config["paths"]
+
+    impl = config.get("implementation", {})
+    refs = config.get("references", {})
+    parallel = config.get("parallel", {})
+
+    return {
+        "worker_dir": worker["dir"],
+        "worker_pattern": worker["pattern"],
+        "worker_role": worker["role"],
+        "claude_org_path": paths["claude_org"],
+        "project_name": project["name"],
+        "project_description": project["description"],
+        "task_id": task["id"],
+        "task_description": task["description"].strip(),
+        "task_branch": task["branch"],
+        "task_verification_depth": task["verification_depth"],
+        "task_commit_prefix": task["commit_prefix"],
+        "task_issue_url": task.get("issue_url", ""),
+        "closes_or_refs": _closes_or_refs(task),
+        "implementation_target_files_block": _impl_target_files_block(
+            impl.get("target_files", []) or []
+        ),
+        "implementation_guidance_block": _impl_guidance_block(impl.get("guidance")),
+        "references_knowledge_block": _references_knowledge_block(
+            refs.get("knowledge", []) or []
+        ),
+        "parallel_notes": (parallel.get("notes") or "").strip(),
+    }
+
+
+def render(config: dict[str, Any]) -> str:
+    validate(config)
+    self_edit = config["worker"]["self_edit"]
+    template_name = (
+        "worker_brief_self_edit.md" if self_edit else "worker_brief_normal.md"
+    )
+    raw = (TEMPLATES_DIR / template_name).read_text(encoding="utf-8")
+    keep = _select_blocks(config)
+    raw = _apply_blocks(raw, keep)
+    subs = _build_substitutions(config)
+    rendered = Template(raw).safe_substitute(subs)
+    # collapse 3+ blank lines to a single blank line
+    rendered = re.sub(r"\n{3,}", "\n\n", rendered)
+    return rendered
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Generate a worker CLAUDE.md / CLAUDE.local.md from a TOML config",
+    )
+    p.add_argument("--config", required=True, type=Path, help="path to TOML config")
+    p.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="output path (typically CLAUDE.md or CLAUDE.local.md)",
+    )
+    args = p.parse_args(argv)
+
+    try:
+        config = load_config(args.config)
+        output = render(config)
+    except (ConfigError, FileNotFoundError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(output, encoding="utf-8")
+    print(f"wrote {args.out} ({len(output)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -83,11 +83,14 @@ def validate(config: dict[str, Any]) -> None:
     task = config["task"]
     if "issue_url" in task and not isinstance(task["issue_url"], str):
         raise ConfigError("task.issue_url must be a string")
-    if "closes_issue" in task and not isinstance(task["closes_issue"], int):
-        raise ConfigError("task.closes_issue must be an integer")
+    if "closes_issue" in task:
+        v = task["closes_issue"]
+        if isinstance(v, bool) or not isinstance(v, int):
+            raise ConfigError("task.closes_issue must be an integer")
     if "refs_issues" in task:
-        if not isinstance(task["refs_issues"], list) or not all(
-            isinstance(n, int) for n in task["refs_issues"]
+        v = task["refs_issues"]
+        if not isinstance(v, list) or not all(
+            isinstance(n, int) and not isinstance(n, bool) for n in v
         ):
             raise ConfigError("task.refs_issues must be a list of integers")
 

--- a/tools/templates/worker_brief.example.toml
+++ b/tools/templates/worker_brief.example.toml
@@ -1,0 +1,47 @@
+# Example config for tools/gen_worker_brief.py
+#
+# Usage:
+#   python tools/gen_worker_brief.py --config worker_brief.toml --out path/to/CLAUDE.md
+#   (--out CLAUDE.local.md when worker.self_edit = true)
+
+[task]
+id = "issue-217-renga-decoration-doc"
+description = "Issue #217 の解決 PR。renga decoration は装飾、authoritative source は peer client_kind であることを documentation として明記"
+issue_url = "https://github.com/suisya-systems/claude-org-ja/issues/217"
+verification_depth = "full"     # "full" or "minimal"
+branch = "issue-217-renga-decoration-doc"
+commit_prefix = "docs(operations):"
+closes_issue = 217              # Closes #N (omit for Refs)
+# refs_issues = [121, 214]      # used as "Refs #121 #214" when closes_issue is unset
+
+[worker]
+dir = "C:/Users/iwama/Documents/work/workers/claude-org/.worktrees/issue-217-renga-decoration-doc"
+pattern = "B"                   # "A" / "B" / "C"
+role = "claude-org-self-edit"   # "default" / "claude-org-self-edit" / "doc-audit"
+self_edit = true                # true → CLAUDE.local.md + ignore-root note; false → CLAUDE.md
+
+[project]
+name = "claude-org-ja"
+description = "Claude Code 多役 AI 組織ハーネス（Secretary / Dispatcher / Curator / Worker）日本語版本体"
+
+[paths]
+claude_org = "C:/Users/iwama/Documents/work/claude-org"
+
+# --- optional sections (omit any to skip its block) ---
+
+[implementation]
+target_files = [
+  "docs/operations/renga-pane-conventions.md",
+]
+guidance = """
+1-2 段落で「decoration は装飾、authoritative source は peer client_kind」を明記。
+背景として renga#208/#209 (PR #210, 2026-05-02 fix) に言及。英文で書くこと。
+"""
+
+[references]
+knowledge = [
+  "C:/Users/iwama/Documents/work/claude-org/knowledge/curated/renga.md",
+]
+
+[parallel]
+notes = "本ワーカーと並列で issue-216-dispatcher-retro-gate が走っている。編集ファイル独立。"

--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -1,0 +1,94 @@
+# Worker
+
+あなたは claude-org のワーカーである。以下の指示に従って作業を遂行する。
+
+## 作業ディレクトリ（最重要制約）
+
+あなたの作業ディレクトリ: `${worker_dir}`
+
+起動直後に `pwd` を実行し、上記パスと一致することを確認せよ。
+一致しない場合は作業を開始せず、窓口にエラー報告せよ。
+
+### 禁止事項（permissions.deny + PreToolUse Hooks により技術的にブロックされる）
+1. `${worker_dir}` 内に claude-org の構造（.claude/, .dispatcher/, .curator/, .state/, registry/, dashboard/, knowledge/ 等）を再現してはならない
+2. claude-org リポジトリ（`${claude_org_path}`）を別途 clone してはならない（直接編集すること）
+3. `git push` は実行できない（完了報告で窓口に依頼すること）
+
+### Windows 環境の注意事項
+- Python 実行時は `python` ではなく `py -3` を使用すること（Windows では `python` がストアアプリにリダイレクトされる場合がある）
+- 日本語を含むファイルを扱う場合は `encoding="utf-8"` を明示すること
+
+## プロジェクト情報
+- プロジェクト名: ${project_name}
+- 説明: ${project_description}
+
+## 現在のタスク
+- タスクID: ${task_id}
+- ブランチ: `${task_branch}`
+- 検証深度: **${task_verification_depth}**
+- commit prefix: `${task_commit_prefix}`
+- 関連 Issue: ${closes_or_refs}
+- 目的: ${task_description}
+<!--BEGIN:issue_url-->- Issue URL: ${task_issue_url}
+<!--END:issue_url-->
+<!--BEGIN:implementation-->
+
+### 実装ガイダンス
+${implementation_target_files_block}${implementation_guidance_block}
+<!--END:implementation-->
+<!--BEGIN:parallel-->
+
+## 並列タスクとの干渉
+${parallel_notes}
+<!--END:parallel-->
+<!--BEGIN:references-->
+
+## ナレッジ参照
+${references_knowledge_block}
+<!--END:references-->
+
+## 権限
+- git commit: 可
+- PR 作成: 不可（窓口経由）
+- git push: 不可（`permissions.deny` + hook により技術的にブロック。窓口経由で依頼すること）
+- `rm -rf` / `rm -r`: 不可（`permissions.deny` により技術的にブロック）
+
+<!--BEGIN:codex_full-->
+## Codex セルフレビュー手順（検証深度 full）
+
+`full` の前提（codex の有無に関わらず必ず実施）: 既存テストスイート / lint / type-check 等、リポジトリで定義された通常検証を実行し、green を確認してから完了報告する。
+
+追加ゲート: commit 完了後・完了報告前に **`codex` CLI が available なら** `codex exec --skip-git-repo-check` 直打ちでセルフレビューを実行する。未導入環境では skip して通常の完了報告に進む。
+
+```bash
+codex exec --skip-git-repo-check "このブランチの main からの差分をレビュー。Blocker/Major/Minor/Nit で分類し、各指摘に対象ファイル:行番号と根拠を添えて日本語で簡潔に"
+```
+
+- Blocker / Major は修正コミットを積み再レビュー、同一指摘カテゴリで 3 ラウンド消せない場合は設計問題と判断し窓口に仕様縮小の判断を仰ぐ
+- Minor / Nit は原則残置し PR 本文に既知制限として明記
+- `codex:rescue` skill は使用しないこと（過去 18 分超ハングの実害あり、`codex exec` 直打ちのみ）
+
+<!--END:codex_full-->
+<!--BEGIN:codex_minimal-->
+## Codex セルフレビュー手順（検証深度 minimal）
+
+minimal タスクでは Codex セルフレビュー・追加テスト実行・拡張された動作確認は **一切禁止**。指示された fix を反映したら `git add` → `git commit` → 窓口に以下 1 行だけ送信する:
+
+```
+done: {commit SHA 短縮形} {変更ファイル名}
+```
+
+- SHA は `git rev-parse --short HEAD`
+- ファイルが複数なら空白区切り
+- 通常の完了報告フォーマット（成果物説明・残作業・PR 草案等）は minimal では適用されない
+- 振り返り記録（`knowledge/raw/`）も minimal では不要
+
+<!--END:codex_minimal-->
+## 作業完了時
+
+1. **完了報告**: `mcp__renga-peers__send_message(to_id="secretary", message="...")` で窓口に報告する。**ディスパッチャーではなく窓口に送ること**。`to_id="secretary"` が `[pane_not_found]` で返る場合は DELEGATE メッセージ本文の numeric pane id を使用する。
+2. **PR 作成後はペインを保持してレビュー指摘待機**: 「閉じてよい」「マージ済み」など窓口からの明示クローズ指示が来るまで待機状態を維持する。
+3. **振り返り記録**: 再利用可能な学びがあれば `${claude_org_path}/knowledge/raw/{YYYY-MM-DD}-{topic}.md` に記録する（topic は英語 kebab-case）。記録基準: 再現性がある / 非自明 / コードを読むだけではわからない。
+
+## SUSPEND 対応
+"SUSPEND:" で始まるメッセージを受け取ったら、作業を中断し即座に以下を報告: 完了したこと / 変更ファイル（コミット済み・未コミット）/ 次にやろうとしていたこと / ブロッカー。

--- a/tools/templates/worker_brief_self_edit.md
+++ b/tools/templates/worker_brief_self_edit.md
@@ -1,0 +1,72 @@
+# Worker
+
+> このワーカーは claude-org リポジトリ自身の `${worker_dir}` で作業する。`./CLAUDE.md`（ルート CLAUDE.md）の Secretary 指示は無視せよ。あなたは窓口ではなくワーカーである。
+
+## 作業ディレクトリ
+`${worker_dir}`
+
+起動直後 `pwd` で確認。
+
+### 禁止事項
+1. claude-org 構造を `${worker_dir}` 内に再現しない
+2. claude-org リポジトリ（`${claude_org_path}`）を別途 clone しない（直接編集）
+3. `git push` 不可
+
+### Windows
+- Python は `py -3` または `python` (3.10 推奨)
+- 日本語ファイル: `encoding="utf-8"` 明示
+
+## プロジェクト
+- ${project_name}: ${project_description}
+
+## タスク
+- ID: ${task_id}
+- ブランチ: `${task_branch}`
+- 検証深度: **${task_verification_depth}**
+- commit prefix: `${task_commit_prefix}`
+- 関連 Issue: ${closes_or_refs}
+- 目的: ${task_description}
+<!--BEGIN:issue_url-->- Issue URL: ${task_issue_url}
+<!--END:issue_url-->
+<!--BEGIN:implementation-->
+
+### 実装ガイダンス
+${implementation_target_files_block}${implementation_guidance_block}
+<!--END:implementation-->
+<!--BEGIN:parallel-->
+
+## 並列タスクとの干渉
+${parallel_notes}
+<!--END:parallel-->
+<!--BEGIN:references-->
+
+## ナレッジ参照
+${references_knowledge_block}
+<!--END:references-->
+
+## 権限
+- git commit 可、push 不可、PR 不可、`rm -rf` 不可
+
+<!--BEGIN:codex_full-->
+## Codex セルフレビュー
+検証深度 full。`codex` available なら commit 後:
+```bash
+codex exec --skip-git-repo-check "このブランチの main からの差分をレビュー。Blocker/Major/Minor/Nit で分類し、各指摘に対象ファイル:行番号と根拠を添えて日本語で簡潔に"
+```
+- Blocker/Major 修正、3 ラウンド上限
+- Minor/Nit 残置可
+- `codex:rescue` skill 禁止、`codex exec` 直打ちのみ
+
+<!--END:codex_full-->
+<!--BEGIN:codex_minimal-->
+## Codex セルフレビュー
+検証深度 minimal。minimal 用 1 行報告フォーマットを使用（`done: {SHA} {files}`）。Codex セルフレビュー・追加テスト・拡張された動作確認は一切禁止。
+
+<!--END:codex_minimal-->
+## 完了時
+1. `mcp__renga-peers__send_message(to_id="secretary", ...)` で完了内容・変更ファイル・commit SHA・動作確認結果・残作業を報告
+2. PR 作成後ペイン保持
+3. 振り返り記録: 任意（非自明な学びがあれば `${claude_org_path}/knowledge/raw/{YYYY-MM-DD}-{topic}.md`）
+
+## SUSPEND
+"SUSPEND:" → 即報告（完了したこと / 変更ファイル / 次の予定 / ブロッカー）

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -1,0 +1,240 @@
+"""Tests for tools/gen_worker_brief.py."""
+from __future__ import annotations
+
+import copy
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools import gen_worker_brief as gwb
+
+
+def _base_config(self_edit: bool = False) -> dict:
+    return {
+        "task": {
+            "id": "demo-task",
+            "description": "デモタスク。X を Y に変更する。",
+            "verification_depth": "full",
+            "branch": "demo-task",
+            "commit_prefix": "feat(tools):",
+            "refs_issues": [121, 214],
+        },
+        "worker": {
+            "dir": "/tmp/workers/demo-task",
+            "pattern": "B" if self_edit else "A",
+            "role": "claude-org-self-edit" if self_edit else "default",
+            "self_edit": self_edit,
+        },
+        "project": {
+            "name": "claude-org-ja",
+            "description": "テスト用説明",
+        },
+        "paths": {
+            "claude_org": "/home/user/work/claude-org",
+        },
+    }
+
+
+class RenderNormal(unittest.TestCase):
+    def test_normal_full_contains_boilerplate(self):
+        cfg = _base_config(self_edit=False)
+        out = gwb.render(cfg)
+        # boilerplate sections
+        self.assertIn("作業ディレクトリ（最重要制約）", out)
+        self.assertIn("禁止事項", out)
+        self.assertIn("Windows 環境の注意事項", out)
+        self.assertIn("プロジェクト情報", out)
+        self.assertIn("権限", out)
+        self.assertIn("Codex セルフレビュー", out)
+        self.assertIn("作業完了時", out)
+        self.assertIn("SUSPEND", out)
+        # variable substitution
+        self.assertIn("/tmp/workers/demo-task", out)
+        self.assertIn("/home/user/work/claude-org", out)
+        self.assertIn("claude-org-ja", out)
+        self.assertIn("feat(tools):", out)
+        self.assertIn("Refs #121 #214", out)
+        # not-self-edit must NOT contain ignore-root note
+        self.assertNotIn("ルート CLAUDE.md", out)
+        # codex full present, minimal absent
+        self.assertIn("検証深度 full", out)
+        self.assertNotIn("minimal 用 1 行報告フォーマット", out)
+        # no leftover marker comments
+        self.assertNotIn("<!--BEGIN:", out)
+        self.assertNotIn("<!--END:", out)
+        # no leftover ${...} placeholders
+        self.assertNotIn("${", out)
+
+
+class RenderSelfEdit(unittest.TestCase):
+    def test_self_edit_emits_ignore_root_note(self):
+        cfg = _base_config(self_edit=True)
+        out = gwb.render(cfg)
+        self.assertIn("ルート CLAUDE.md", out)
+        self.assertIn("Secretary 指示は無視せよ", out)
+        self.assertIn("あなたは窓口ではなくワーカーである", out)
+        self.assertNotIn("<!--BEGIN:", out)
+
+
+class OptionalSections(unittest.TestCase):
+    def test_optional_sections_omitted_when_absent(self):
+        cfg = _base_config(self_edit=False)
+        out = gwb.render(cfg)
+        self.assertNotIn("実装ガイダンス", out)
+        self.assertNotIn("並列タスクとの干渉", out)
+        self.assertNotIn("ナレッジ参照", out)
+        self.assertNotIn("Issue URL", out)
+
+    def test_optional_sections_included_when_present(self):
+        cfg = _base_config(self_edit=False)
+        cfg["task"]["issue_url"] = "https://example.com/issues/9"
+        cfg["implementation"] = {
+            "target_files": ["a.md", "b.py"],
+            "guidance": "  do the thing  ",
+        }
+        cfg["references"] = {"knowledge": ["/k/curated/x.md"]}
+        cfg["parallel"] = {"notes": "並列ワーカーは無し"}
+        out = gwb.render(cfg)
+        self.assertIn("実装ガイダンス", out)
+        self.assertIn("- `a.md`", out)
+        self.assertIn("- `b.py`", out)
+        self.assertIn("do the thing", out)
+        self.assertIn("ナレッジ参照", out)
+        self.assertIn("/k/curated/x.md", out)
+        self.assertIn("並列タスクとの干渉", out)
+        self.assertIn("並列ワーカーは無し", out)
+        self.assertIn("Issue URL", out)
+        self.assertIn("https://example.com/issues/9", out)
+
+    def test_implementation_with_only_guidance_keeps_block(self):
+        cfg = _base_config(self_edit=False)
+        cfg["implementation"] = {"guidance": "guidance only"}
+        out = gwb.render(cfg)
+        self.assertIn("実装ガイダンス", out)
+        self.assertIn("guidance only", out)
+
+
+class VerificationDepth(unittest.TestCase):
+    def test_minimal_replaces_codex_section(self):
+        cfg = _base_config(self_edit=False)
+        cfg["task"]["verification_depth"] = "minimal"
+        out = gwb.render(cfg)
+        self.assertIn("検証深度 minimal", out)
+        self.assertIn("done: {commit SHA", out)
+        # full-mode marker text must NOT be present
+        self.assertNotIn("3 ラウンド消せない場合は設計問題", out)
+
+    def test_minimal_self_edit_uses_one_liner(self):
+        cfg = _base_config(self_edit=True)
+        cfg["task"]["verification_depth"] = "minimal"
+        out = gwb.render(cfg)
+        self.assertIn("minimal 用 1 行報告フォーマット", out)
+
+
+class Validation(unittest.TestCase):
+    def test_invalid_pattern(self):
+        cfg = _base_config(False)
+        cfg["worker"]["pattern"] = "Z"
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_invalid_role(self):
+        cfg = _base_config(False)
+        cfg["worker"]["role"] = "bogus"
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_invalid_depth(self):
+        cfg = _base_config(False)
+        cfg["task"]["verification_depth"] = "deep"
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_missing_required_section(self):
+        cfg = _base_config(False)
+        del cfg["paths"]
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_missing_required_key(self):
+        cfg = _base_config(False)
+        del cfg["task"]["branch"]
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_self_edit_must_be_bool(self):
+        cfg = _base_config(False)
+        cfg["worker"]["self_edit"] = "yes"
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+
+class ClosesOrRefs(unittest.TestCase):
+    def test_closes_takes_priority(self):
+        cfg = _base_config(False)
+        cfg["task"]["closes_issue"] = 42
+        cfg["task"]["refs_issues"] = [1, 2]
+        out = gwb.render(cfg)
+        self.assertIn("Closes #42", out)
+        self.assertNotIn("Refs #1 #2", out)
+
+    def test_no_issue_refs(self):
+        cfg = _base_config(False)
+        cfg["task"].pop("refs_issues", None)
+        out = gwb.render(cfg)
+        self.assertIn("（なし）", out)
+
+
+class RoundTrip217(unittest.TestCase):
+    """Reproduce the session #9 #217 brief as a round-trip smoke test."""
+
+    def test_217_brief_renders(self):
+        example = (
+            Path(__file__).parent / "templates" / "worker_brief.example.toml"
+        )
+        cfg = gwb.load_config(example)
+        out = gwb.render(cfg)
+        # the example TOML is the #217 brief — check key substrings round-trip
+        self.assertIn("issue-217-renga-decoration-doc", out)
+        self.assertIn("Closes #217", out)
+        self.assertIn("docs(operations):", out)
+        self.assertIn("renga decoration", out)
+        self.assertIn(
+            "C:/Users/iwama/Documents/work/workers/claude-org/.worktrees/issue-217-renga-decoration-doc",
+            out,
+        )
+        # self_edit=true → ignore-root note present, output style is local
+        self.assertIn("Secretary 指示は無視せよ", out)
+        # optional sections all present
+        self.assertIn("docs/operations/renga-pane-conventions.md", out)
+        self.assertIn("knowledge/curated/renga.md", out)
+        self.assertIn("issue-216-dispatcher-retro-gate", out)
+
+
+class CLI(unittest.TestCase):
+    def test_cli_writes_file(self):
+        example = (
+            Path(__file__).parent / "templates" / "worker_brief.example.toml"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "CLAUDE.local.md"
+            rc = gwb.main(["--config", str(example), "--out", str(out)])
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.exists())
+            text = out.read_text(encoding="utf-8")
+            self.assertIn("issue-217-renga-decoration-doc", text)
+
+    def test_cli_invalid_returns_2(self):
+        with tempfile.TemporaryDirectory() as td:
+            bad = Path(td) / "bad.toml"
+            bad.write_text(
+                '[task]\nid="x"\n', encoding="utf-8"
+            )  # missing many keys
+            out = Path(td) / "out.md"
+            rc = gwb.main(["--config", str(bad), "--out", str(out)])
+            self.assertEqual(rc, 2)
+            self.assertFalse(out.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -1,7 +1,6 @@
 """Tests for tools/gen_worker_brief.py."""
 from __future__ import annotations
 
-import copy
 import tempfile
 import unittest
 from pathlib import Path
@@ -195,6 +194,18 @@ class Validation(unittest.TestCase):
     def test_closes_issue_must_be_int(self):
         cfg = _base_config(False)
         cfg["task"]["closes_issue"] = "217"
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_closes_issue_rejects_bool(self):
+        cfg = _base_config(False)
+        cfg["task"]["closes_issue"] = True
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_refs_issues_rejects_bool(self):
+        cfg = _base_config(False)
+        cfg["task"]["refs_issues"] = [True, 2]
         with self.assertRaises(gwb.ConfigError):
             gwb.render(cfg)
 

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -168,6 +168,36 @@ class Validation(unittest.TestCase):
         with self.assertRaises(gwb.ConfigError):
             gwb.render(cfg)
 
+    def test_non_string_description_rejected(self):
+        cfg = _base_config(False)
+        cfg["task"]["description"] = 1
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_empty_string_rejected(self):
+        cfg = _base_config(False)
+        cfg["task"]["branch"] = ""
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_implementation_guidance_must_be_string(self):
+        cfg = _base_config(False)
+        cfg["implementation"] = {"guidance": 42}
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_target_files_must_be_string_list(self):
+        cfg = _base_config(False)
+        cfg["implementation"] = {"target_files": ["a.md", 7]}
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+    def test_closes_issue_must_be_int(self):
+        cfg = _base_config(False)
+        cfg["task"]["closes_issue"] = "217"
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
 
 class ClosesOrRefs(unittest.TestCase):
     def test_closes_takes_priority(self):
@@ -232,6 +262,24 @@ class CLI(unittest.TestCase):
             )  # missing many keys
             out = Path(td) / "out.md"
             rc = gwb.main(["--config", str(bad), "--out", str(out)])
+            self.assertEqual(rc, 2)
+            self.assertFalse(out.exists())
+
+    def test_cli_malformed_toml_returns_2(self):
+        with tempfile.TemporaryDirectory() as td:
+            bad = Path(td) / "broken.toml"
+            bad.write_text("not = = valid", encoding="utf-8")
+            out = Path(td) / "out.md"
+            rc = gwb.main(["--config", str(bad), "--out", str(out)])
+            self.assertEqual(rc, 2)
+            self.assertFalse(out.exists())
+
+    def test_cli_missing_config_returns_2(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "out.md"
+            rc = gwb.main(
+                ["--config", str(Path(td) / "nope.toml"), "--out", str(out)]
+            )
             self.assertEqual(rc, 2)
             self.assertFalse(out.exists())
 


### PR DESCRIPTION
## Summary
- New `tools/gen_worker_brief.py` renders worker briefs from a TOML config into either `CLAUDE.md` (Pattern A/C) or `CLAUDE.local.md` (Pattern B claude-org self-edit).
- Two templates under `tools/templates/` carry the boilerplate (working dir / forbidden actions / Windows notes / permissions / Codex flow / completion / SUSPEND); the config supplies only the task-specific bits (id, description, target files, guidance, branch, commit prefix, optional knowledge refs / parallel notes).
- `tools/templates/worker_brief.example.toml` documents the schema with the session #9 issue-217 brief as a worked example (used in the round-trip test).
- `tools/test_gen_worker_brief.py` (27 tests, all PASS) covers normal vs self-edit output, optional sections skipped when absent, verification depth `full` vs `minimal`, role / pattern validation, TOMLDecodeError handling, type checks, and a round-trip against the issue-217 brief.
- `.claude/skills/org-delegate/SKILL.md` Step 1.5 common steps now point at the generator instead of telling the secretary to substitute variables manually. The legacy `references/worker-claude-template.md` stays for reference.
- `requirements.txt` adds `tomli ; python_version<"3.11"` so Python 3.10 hosts (this Lead's box, currently with broken `py -3.12`) can read the config.

## Motivation
Session #9 retro: secretary was spending 5-8 min per worker brief, ~40% of which was identical boilerplate. Across the 8 worker dispatches in this session that compounds to ~30 min of pure overhead. This generator targets that bottleneck while leaving the substantive "what to do" portion of the brief as the secretary's judgment call. Refs #121 #214 (no dedicated issue — session-internal improvement, Lead agreed in retro).

## Codex self-review
- Round 1: 2 Major (missing `tomli` dep / shallow input validation) + 1 Minor (false positive — declined). Fixed in `5916a7c`.
- Round 2: 0 Blocker / 0 Major. Minor (`bool` slipping through int validation) + Nit (unused import) fixed in `9610fc4`.

## Test plan
- [x] `python -m unittest tools.test_gen_worker_brief` → 27 / 27 PASS.
- [x] Round-trip the issue-217 brief from `worker_brief.example.toml`.
- [x] CI green.