### PR TITLE
docs: address README/docs drift findings (audit 2026-05-03)

### DIFF
--- a/.claude/skills/org-setup/SKILL.md
+++ b/.claude/skills/org-setup/SKILL.md
@@ -122,7 +122,7 @@ prune ツールが読むだけで、書き換えはしない）:
 closed-world 検証から除外する（`_load_override_allow`）。よって override に追加した
 個人 allow は CI / `--include-local` で `unknown allow entry` にならない。
 ただし `forbidden_allow_exact`（`Bash(git *)` 等の wide allow）と
-`disallow_allow_regex`（旧 `mcp__claude-peers__*` 等）は override 側にあっても
+`disallow_allow_regex`（旧 `mcp__claude-peers__*`、現 `renga-peers` 等）は override 側にあっても
 従来通り ERROR となる。安全契約は override で迂回できない。
 
 #### dispatcher の `{claude_org_path}` 解決

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -160,7 +160,7 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 
 **書いてはいけないもの**:
 - wide allow (`Bash(git *)`, `Bash(git push *)`, `Bash(git fetch *)`, `Bash(git branch *)`, `Bash(git pull *)`, `Bash(gh:*)`, `Bash(gh *)`)
-- 旧 `mcp__claude-peers__*`（2025 年に renga-peers へ移行済み）
+- 旧 `mcp__claude-peers__*`（2026 年に renga-peers へ移行済み）
 - 旧 `renga list/split/send/events/close/inspect *` の Bash allow（renga 0.14.0+ で MCP 化）
 - 過去の一発コマンド（特定 PR 番号・branch 名・PID を含むコマンド、`gh pr create --repo ... --head feat/xxx ...` 等）
 - user-specific absolute path（`Read(//c/Users/<you>/Documents/work/**)` のような）

--- a/docs/design/core-harness-extraction.md
+++ b/docs/design/core-harness-extraction.md
@@ -95,7 +95,7 @@ inventory §5.1-6 が指摘した「framework rule と org doctrine が同じ sc
 |---|---|---|
 | 役割名カタログ | `secretary`, `dispatcher`, `curator`, `worker`, `repo_shared`, `user_common` | claude-org doctrine の中核。他 org は別の役割分担を取る |
 | `secretary.required_allow` 38 entry | `Bash(gh issue:*)`, `Bash(codex exec:*)`, `mcp__renga-peers__*` 群, etc. | 「窓口」という claude-org 固有の概念に紐付く |
-| `^mcp__claude-peers__` ban list | `forbidden_allow_regex` 1 件 | claude-peers は renga の前身。claude-org が組織方針として禁止しているもので、framework default ではない |
+| `^mcp__claude-peers__` ban list | `forbidden_allow_regex` 1 件 | claude-peers (現 renga-peers) は renga の前身 MCP server。claude-org が組織方針として禁止しているもので、framework default ではない |
 | Org-structure 名 list | `.dispatcher/`, `.curator/`, `.state/`, `registry/`, `dashboard/`, `knowledge/` の 6 名 | inventory §5.1-3。`block-org-structure.sh` の `ALWAYS_BLOCKED` + `ROOT_ONLY_BLOCKED` 配列の中身 |
 | Workers dir 概念 | `registry/org-config.md` の `workers_dir:` 行 | `block-workers-delete.sh` が依存。「workers をまとめて消すな」は claude-org 固有のルール |
 | Dispatcher 許可パス | `.dispatcher/`, `.state/`, `knowledge/raw/<YYYY-MM-DD>-<kebab>.md` | `block-dispatcher-out-of-scope.sh` の policy。「dispatcher は限定 path のみ書ける」は claude-org 固有 |
@@ -349,7 +349,7 @@ strategy:
 
 ### 8.3 12 問が解いていない領域
 
-- **claude-peers ban の所属**: `^mcp__claude-peers__` regex は ja 残置と決めたが、「Anthropic Claude Code とは関係ない過去の MCP サーバー」全般を core-harness が default deny するという別の選択肢もある。今は ja 残置で確定するが、外部 org が同じ判断を再発明する可能性あり
+- **claude-peers (現 renga-peers) ban の所属**: `^mcp__claude-peers__` regex は ja 残置と決めたが、「Anthropic Claude Code とは関係ない過去の MCP サーバー」全般を core-harness が default deny するという別の選択肢もある。今は ja 残置で確定するが、外部 org が同じ判断を再発明する可能性あり
 - **`description` / `$comment` strip ロジック**: generator が schema から抜くキー名のホワイトリスト/ブラックリストの扱いが不明確。Step B サブ issue で固める
 - **bash hook の Windows 動作**: ja は Git Bash 前提。core-harness としてもこれを継承するが、明示的に CI matrix で確認する必要あり
 

--- a/docs/org-state-schema.md
+++ b/docs/org-state-schema.md
@@ -127,7 +127,7 @@ python3 dashboard/org_state_converter.py     # Mac/Linux
 | フィールド | 型 | 説明 |
 |---|---|---|
 | `peerId` | `string` | renga-peers のペイン名（`worker-{task_id}` / `dispatcher` / `curator` 形式）。`mcp__renga-peers__send_message` の `to_id` に渡す値 |
-| `paneId` | `string` | renga のペイン名 (`--id` で命名したもの、例: `dispatcher`, `curator`)。旧 WezTerm 時代は数値の pane-id を格納していたが、ccmux 移行に伴い安定名ベースに変更。現行仕様では `peerId` と同値になることが多い |
+| `paneId` | `string` | renga のペイン名 (`--id` で命名したもの、例: `dispatcher`, `curator`)。旧 WezTerm 時代は数値の pane-id を格納していたが、renga への移行に伴い安定名ベースに変更。現行仕様では `peerId` と同値になることが多い |
 
 ---
 

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -12,6 +12,7 @@
       "Bash(gh:*)",
       "Bash(gh *)"
     ],
+    "$comment_forbidden_allow_regex": "claude-peers is the legacy name of renga-peers (renamed 2026-04). Old-name ban is intentionally retained: any settings.local.json that still grants mcp__claude-peers__* indicates a stale config that bypassed the rename sweep and should be re-run through /org-setup. Do NOT widen to ^mcp__.*-peers__ — renga-peers is the current allowed channel.",
     "forbidden_allow_regex": [
       "^mcp__claude-peers__"
     ]


### PR DESCRIPTION
## Summary
- `docs/org-state-schema.md`: replace the stale "ccmux 移行" reference with "renga への移行" so it matches the surrounding text and current product naming.
- `docs/design/core-harness-extraction.md`: add "(現 renga-peers)" annotation on the first mention of the legacy `claude-peers` namespace so historical context stays clear.
- `.claude/skills/org-setup/SKILL.md`: same legacy/current naming pair on the `mcp__claude-peers__*` reference.
- `.claude/skills/org-setup/references/permissions.md`: correct the migration year from "2025" to **"2026"** — verified against git log (commits c9d51c7 / 65c9000, 2026-04-26).
- `tools/org_extension_schema.json`: keep the `^mcp__claude-peers__` forbidden-allow regex unchanged, but add a `$comment` documenting why the legacy ban is retained.
- `CONTRIBUTING.md:21` anchor `#インストール` was verified to exist at `docs/getting-started.md:18` — no change needed.

## Validation
- `python tools/check_role_configs.py` → role_configs OK (schema edit still passes drift check)
- Codex self-review: no blockers

## Out of audit scope (filed as follow-up candidates)
Codex flagged two unrelated drift items not covered by the 2026-05-03 audit; they are **not** addressed here:
- `docs/design/core-harness-extraction.md` references deleted in-tree paths `tools/role_configs_schema.json` / `tools/generate_worker_settings.py` (now in claude-org-runtime).
- `docs/org-state-schema.md:129` `peerId` / `paneId` description diverges from current implementation/tests.

Refs: README/Docs Drift Audit 2026-05-03 (audit-only task readme-drift-audit)