### PR TITLE
docs: clarify peerId vs paneId are independent identifiers

### DIFF
--- a/docs/org-state-schema.md
+++ b/docs/org-state-schema.md
@@ -31,7 +31,7 @@ python3 dashboard/org_state_converter.py     # Mac/Linux
 | ステータス変更 | org-delegate Step 5 | Work Item のステータス（REVIEW/COMPLETED/IN_PROGRESS） |
 | 組織中断 | org-suspend Phase 3 | Status=SUSPENDED, Updated, Work Items, Resume Instructions |
 | 組織再開 | org-resume Phase 4 | Status=ACTIVE |
-| 起動（Dispatcher/Curator 記録） | org-start Steps 2-3 | Dispatcher/Curator のピア ID とペイン名 |
+| 起動（Dispatcher/Curator 記録） | org-start Steps 2-3 | Dispatcher/Curator の peerId / paneId |
 
 ---
 
@@ -62,12 +62,12 @@ python3 dashboard/org_state_converter.py     # Mac/Linux
     }
   ],
   "dispatcher": {
-    "peerId": "<peer ID>",
-    "paneId": "<renga pane name>"
+    "peerId": "<renga-peers peer ID>",
+    "paneId": "<renga pane ID>"
   },
   "curator": {
-    "peerId": "<peer ID>",
-    "paneId": "<renga pane name>"
+    "peerId": "<renga-peers peer ID>",
+    "paneId": "<renga pane ID>"
   },
   "resumeInstructions": "<free text | null>"
 }
@@ -126,8 +126,8 @@ python3 dashboard/org_state_converter.py     # Mac/Linux
 
 | フィールド | 型 | 説明 |
 |---|---|---|
-| `peerId` | `string` | renga-peers のペイン名（`worker-{task_id}` / `dispatcher` / `curator` 形式）。`mcp__renga-peers__send_message` の `to_id` に渡す値 |
-| `paneId` | `string` | renga のペイン名 (`--id` で命名したもの、例: `dispatcher`, `curator`)。旧 WezTerm 時代は数値の pane-id を格納していたが、renga への移行に伴い安定名ベースに変更。現行仕様では `peerId` と同値になることが多い |
+| `peerId` | `string` | renga-peers が割り当てた安定 peer 識別子（`assigned` のとき設定）。`mcp__renga-peers__send_message` の `to_id` に渡す値。例: `peer-dispatcher-001` |
+| `paneId` | `string` | renga のペイン id。`peerId` とは独立した識別子で、ペインのライフサイクルに紐付く。例: `pane-42` |
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrite the peerId / paneId description in `docs/org-state-schema.md` (~L129) so it matches actual converter behavior demonstrated by `tests/test_org_state_converter.py` fixtures (`peer-dispatcher-001` / `pane-42`). The two fields are independent identifiers; remove the implication that they collapse to the same value.

Also normalize the same-file references that contradicted this (`<renga pane name>` → `<renga pane ID>` in JSON examples; the L34 update-points list now uses `peerId / paneId` consistently).

## Changes
- `docs/org-state-schema.md` — paragraph rewrite (L129-130), JSON example label fix (L66, L70), update-points naming (L34).

## Test plan
- [x] `git diff` scoped to `docs/org-state-schema.md` only
- [x] Codex self-review: 0 Blocker / 0 Major (Minor items addressed in same commit)
- [ ] CI green on push
- [ ] Manual: doc renders with consistent peerId/paneId terminology end-to-end

Closes #231

## Follow-up
The en-mirror (suisya-systems/claude-org) carries the same divergence and will be addressed in a separate PR.