### PR TITLE
docs(contracts): ratify Contract Set C (State Schema)

### DIFF
--- a/docs/contracts/state-schema-contract.md
+++ b/docs/contracts/state-schema-contract.md
@@ -1,6 +1,6 @@
-# Contract Set C — State Schema (Outline)
+# Contract Set C — State Schema
 
-> **Status**: Outline / skeleton — pending Lead Q&A (2026-05). Structural extraction of the on-disk state surface that the `claude-org` harness reads and writes, with placeholders left for design decisions the Lead must fill in before this contract is ratified.
+> **Status**: Ratified (2026-05-03). Lead-confirmed decisions for all 14 open questions. This contract defines the on-disk state surface that the `claude-org` harness reads and writes.
 >
 > **Scope**: Phase 1 Contract Set C only. Sets A (roles), B (delegation lifecycle), D (backend interface), and E (knowledge) are tracked in #121 / #122 / #123 / #125 and out of scope here.
 >
@@ -33,7 +33,7 @@ The harness's persistent state surface comprises the files listed below. Each en
 ### 1.1 `.state/org-state.md`
 
 - **Path**: `.state/org-state.md`
-- **Format**: Markdown with structured top-level fields (`Status:`, `Updated:`, `Current Objective:`, plus session-lifecycle metadata `Started:` / `Suspended:` / `Resumed:` written by `/org-start`, `/org-suspend`, `/org-resume`) followed by named H2 sections. The session-lifecycle metadata is not currently enumerated in `docs/org-state-schema.md`'s JSON projection — see the `[TBD by Lead]` in 1.2 on whether to fold it into the canonical schema.
+- **Format**: Markdown with structured top-level fields (`Status:`, `Updated:`, `Current Objective:`, plus session-lifecycle metadata `Started:` / `Suspended:` / `Resumed:` written by `/org-start`, `/org-suspend`, `/org-resume`) followed by named H2 sections. The session-lifecycle metadata is not currently enumerated in `docs/org-state-schema.md`'s JSON projection; since §1.2 ratifies the JSON projection as DERIVED (Markdown is canonical), folding session-lifecycle metadata into the JSON projection is a non-blocking documentation follow-up rather than a contract-level requirement.
 - **Schema**: `org-state.md` is the canonical state file (Markdown is normative; the JSON projection in 1.2 is derived per `docs/org-state-schema.md` § "Source of truth ルール"). Sections present in the markdown:
   - Header fields: `Status` ∈ `{ACTIVE, SUSPENDED, IDLE}`, `Updated` (ISO-8601), `Current Objective` (free text).
   - `## Active Work Items` — bullet list `- {task_id}: {title} [{STATUS}]` with `STATUS` ∈ the canonical Set B vocabulary `{IN_PROGRESS, REVIEW, COMPLETED, ABANDONED}` (per Set B §1 / §1 contract-state table). The wider enum currently documented in `docs/org-state-schema.md` (which additionally lists `PENDING` / `BLOCKED`) predates Set B's ratification; reconciling the schema doc to the Set B canonical set is tracked as a follow-up. Sub-bullets: `- ワーカー: {peerId}` and `- 結果: {progress note}`.
@@ -52,7 +52,7 @@ The harness's persistent state surface comprises the files listed below. Each en
 - **Owner**: derived — written ONLY by `dashboard/org_state_converter.py`. No role hand-edits this file.
 - **Readers**: `dashboard/server.py` (primary); other programmatic consumers in the future.
 - **Update cadence**: regenerated after every `org-state.md` write, per `docs/org-state-schema.md` § "更新ポイント" and `/org-suspend` Phase 3 step 3.
-- **`[TBD by Lead]`** — Whether `org-state.json` is a NORMATIVE state file (canonical schema lives in this contract) or a DOWNSTREAM ARTIFACT (canonical state is `org-state.md`; the JSON is reproducible from it and need not be contracted as state). Today `docs/org-state-schema.md` already declares "Markdown is canonical, JSON is derived"; the question is whether Set C inherits that ruling or asserts dual normativity.
+- **Normativity**: DERIVED. Set C inherits the `docs/org-state-schema.md` ruling that Markdown (`org-state.md`) is canonical and the JSON projection is derived. Set C does NOT separately normativize the JSON projection; the converter's `SCHEMA_VERSION = 1` is informational for downstream consumers (e.g., `dashboard/server.py`) only. Migration policy (§4) applies to the JSON shape solely insofar as it tracks the canonical Markdown.
 
 ### 1.3 `.state/journal.jsonl`
 
@@ -62,7 +62,7 @@ The harness's persistent state surface comprises the files listed below. Each en
 - **Owner**: secretary, dispatcher, and `org-start` identity recovery (per `docs/journal-events.md` § Writers). Workers do NOT write the journal directly.
 - **Readers**: retros (`/org-retro`, `org-curate`), ad-hoc `tail` / `jq`, `tools/pr_watch.py` consumers (read-after-append for CI signaling), future dashboard readers.
 - **Update cadence**: append-only, per event. Writes MUST go through `tools/journal_append.sh` or `tools/journal_append.py` (raw `>>` is forbidden by Set A constraints).
-- **`[TBD by Lead]`** — Whether the append-only obligation is contracted at the schema level (i.e., manual edits during retro are forbidden) or whether retros may rewrite past entries to correct errors. Today the helper does not enforce append-only at the file-system level (no chattr `+a`, no checksum chain); the contract today is convention-only. Versioning of the line envelope (whether to add a per-line `schema_version` beyond the existing `ts` / `event` keys) is folded into §4.1.
+- **Append-only obligation**: CONVENTION-ONLY. Appends MUST go through `tools/journal_append.{sh,py}`; raw `>>` is forbidden. Manual edits during `/org-retro` are permitted ONLY to correct factual errors, and the corrected line MUST add a reserved `_correction` field (JSON string) on the same line recording the rationale, so the line remains valid JSON consumable by `dashboard/server.py` and `jq` (no JSONL-illegal inline comments). The contract does NOT impose filesystem-level enforcement (no chattr `+a`, no checksum chain). Per-line schema versioning beyond the `ts` / `event` envelope is not introduced; see §4.1.
 
 ### 1.4 `.state/workers/worker-{task_id}.md`
 
@@ -72,7 +72,7 @@ The harness's persistent state surface comprises the files listed below. Each en
 - **Owner**: dispatcher (creation at T2, Status transitions, final update on T7 / CLOSE_PANE) and secretary (Progress Log appends on each report — per Set B T3, T4).
 - **Readers**: secretary (resume / progress review), dispatcher (close-pane retro), `/org-resume` and `/org-suspend` (state collection).
 - **Update cadence**: per delegation transition (Set B T2, T3, T4, T5, T7) and each progress / suspend / resume message.
-- **`[TBD by Lead]`** — Whether the per-worker file's authoritative format is normalized to a single shape (e.g., a Markdown-with-front-matter template rendered from a TOML brief by `tools/gen_worker_brief.py` — analogous to the `gen_worker_brief.py` precedent for `CLAUDE.md`) or remains free-form Markdown enforced only by helper convention. Versioning is folded into §4.1; format-language uniformity is folded into §2.
+- **Authoritative format**: FREE-FORM Markdown enforced by helper convention. The `delegate-plan` helper output template is the de facto shape; no separate generator analogous to `tools/gen_worker_brief.py` is required for the per-worker state file. Format-language uniformity is addressed in §2; versioning in §4.1.
 
 ### 1.5 `.state/dispatcher/inbox/{task_id}.json`
 
@@ -82,7 +82,7 @@ The harness's persistent state surface comprises the files listed below. Each en
 - **Owner**: secretary (writes per `/org-delegate` Step 1.5 / before sending `DELEGATE`).
 - **Readers**: dispatcher (consumed by `delegate-plan` helper at T2).
 - **Update cadence**: one-shot per delegation; written before T1, consumed at T2.
-- **`[TBD by Lead]`** — Lifecycle of the inbox file after consumption: deleted by the dispatcher post-spawn, retained as audit trail, or moved to a `processed/` subdirectory. Today behavior: per Set B §2 T8, the file MAY remain on disk for re-attempt after `SPLIT_CAPACITY_EXCEEDED`; otherwise lifecycle is implementation-defined in the runtime.
+- **Lifecycle**: RETAIN AS AUDIT TRAIL. Inbox JSON files are kept on disk after dispatcher consumption; deletion is not contracted. This makes the Set B §2 T8 `SPLIT_CAPACITY_EXCEEDED` retry behavior fall out naturally (the file is already on disk for re-attempt). Storage cost is negligible.
 
 ### 1.6 `.state/dispatcher/outbox/{task_id}-instruction.md`
 
@@ -101,7 +101,7 @@ The harness's persistent state surface comprises the files listed below. Each en
 - **Owner**: dispatcher (advances each watch-loop cycle).
 - **Readers**: dispatcher (resume after pane restart).
 - **Update cadence**: each `poll_events` round (per Set A "Journal append discipline" — written via the helper-or-direct-rewrite pattern, NOT via the journal helper).
-- **`[TBD by Lead]`** — In-scope-vs-runtime question for the cursor file and the dashboard runtime artifacts in §1.8 (treated as one cluster). Stances: (a) all runtime artifacts are out of contract scope (treated like PID files); (b) the event-cursor is normative state (since loss degrades dispatcher recovery, even if `list_panes` reconciliation absorbs the gap); (c) all listed runtime artifacts are normative. Decision affects whether §3.5 atomic-write rules and §4 migration apply to them.
+- **Scope**: HYBRID (in-scope). The dispatcher event cursor IS normative state — its loss measurably degrades dispatcher recovery, so the §3.5 atomic-write enumeration and §4 migration policy apply (see §3.5 for the specific atomicity ruling on this single-line transient cursor). The dashboard runtime artifacts in §1.8 are decided separately below as OUT of scope.
 
 ### 1.8 `.state/dashboard.pid` / `.state/dashboard.log`
 
@@ -109,7 +109,7 @@ The harness's persistent state surface comprises the files listed below. Each en
 - **Format**: PID file (single-line PID); log file (free-form text).
 - **Owner**: dashboard server process.
 - **Readers**: `/org-suspend` Phase 3.5 reads the PID file to send shutdown.
-- Coverage decision is folded into the §1.7 runtime-artifact cluster (the brief flagged these as "possibly out of contract scope"; whether they sit in or out is decided in one place).
+- **Scope**: OUT of contract scope. `dashboard.pid` and `dashboard.log` are treated like PID and log files — operational ephemera, not normative state. §3.5 atomic-write rules and §4 migration policy do NOT apply to them.
 
 ### 1.9 `registry/projects.md`
 
@@ -119,7 +119,7 @@ The harness's persistent state surface comprises the files listed below. Each en
 - **Owner**: secretary (registers new projects on user request).
 - **Readers**: secretary (resolves user-mentioned common names to projects per `CLAUDE.md` § Communication).
 - **Update cadence**: at project registration / update.
-- **`[TBD by Lead]`** — Whether `registry/` files (this file and `registry/org-config.md` — treated as one cluster) are in scope for Set C (state) or Set A (configuration / role-input). Today they sit under version control alongside state-shape artifacts but are functionally configuration. Decision affects whether migration policy (§4) applies to them.
+- **Scope**: IN SCOPE for Set C as "state-adjacent configuration". `registry/projects.md` and `registry/org-config.md` are version-controlled alongside state artifacts, and the §4 migration policy applies to them. They are NOT moved to Set A; Set A retains them only as Set A's "config inputs" reference. This dual-listing is intentional.
 
 ### 1.10 `registry/org-config.md`
 
@@ -129,7 +129,7 @@ The harness's persistent state surface comprises the files listed below. Each en
 - **Owner**: secretary (and the human via direct edit).
 - **Readers**: secretary, dispatcher, curator (permission-mode resolution per Set A constraints).
 - **Update cadence**: at organization configuration changes.
-- Coverage decision folded into §1.9 (registry-files cluster).
+- **Scope**: IN SCOPE per the §1.9 registry-cluster decision (state-adjacent configuration; §4 migration policy applies).
 
 ### 1.11 Out-of-scope: worker-directory inputs
 
@@ -147,12 +147,7 @@ The contract picks ONE normative schema-language per file, or accepts heterogene
 - `inbox/{task_id}.json` — declared by the runtime package's helper, not by an in-repo schema doc.
 - `tools/role_configs_schema.json` — actual machine-readable JSON Schema (draft-07-style), but lives in `claude-org-runtime`, not this repo.
 
-- **`[TBD by Lead]`** — Authoritative format choice per file. Candidate stances:
-  1. Normalize all state schemas to **machine-checkable JSON Schema** (draft-07), accepting that Markdown files like `org-state.md` and `worker-*.md` need a structured-fields-extracted JSON projection to be checkable.
-  2. Accept the current heterogeneity as deliberate (Markdown for human-edited files; JSON Schema for runtime-helper-managed files; JSONL with descriptive event catalog for the journal).
-  3. Adopt **TypeScript interfaces** or **Pydantic models** as the lingua franca, generating both runtime validation and prose docs from a single source.
-  
-  The Lead's choice constrains the migration mechanics in §4 (machine-checkable schemas can be diffed automatically; prose schemas require manual review).
+- **Decision**: ACCEPT THE CURRENT HETEROGENEITY AS DELIBERATE. Markdown is the schema language for human-edited files (`org-state.md`, `worker-*.md`, `registry/*.md`); JSON Schema-shaped prose is the language for runtime-helper-managed files (`org-state.json`, `inbox/*.json`); descriptive prose in `docs/journal-events.md` governs the journal (deliberately loose so consumers tolerate unknown fields). The contract does NOT mandate a single normative schema language. Migration mechanics in §4 therefore rely on manual review for Markdown-edited files and on the per-file top-level `version` integer for JSON files (see §4.1).
 
 ---
 
@@ -184,11 +179,14 @@ The harness uses three identifier kinds (per `docs/org-state-schema.md` § dispa
 
 ### 3.5 Atomic-write requirement
 
-- **`[TBD by Lead]`** — Which files MUST be written via tempfile + rename (atomic) to avoid mid-write reads. Today `dashboard/org_state_converter.py` writes `org-state.json` atomically (via `tempfile`); journal helpers append (not atomic-rename, but POSIX append semantics make line-granularity atomic on small lines). The Lead's call: enumerate the files that MUST be atomic-write (e.g., `org-state.md`, `org-state.json`, per-worker state file) vs. those for which append/in-place rewrite is acceptable.
+- **Decision**: enumerated as follows.
+  - MUST be tempfile + rename (atomic): `.state/org-state.md`, `.state/org-state.json` (already atomic via `tempfile` in the converter), `.state/workers/worker-{task_id}.md`.
+  - APPEND-only is acceptable (POSIX line-atomicity for short lines via the journal helpers): `.state/journal.jsonl`.
+  - In-place rewrite is acceptable: `.state/dispatcher-event-cursor.txt` (single-line transient cursor; partial-write risk is bounded by the small fixed-size payload, and the dispatcher reconciles via `list_panes` after restart).
 
 ### 3.6 Encoding and line endings
 
-- **`[TBD by Lead]`** — Whether the contract requires UTF-8 encoding universally (today's de-facto standard, per `tools/journal_append.py` and the `encoding="utf-8"` Windows note in `worker-claude-template.md`) and whether line-ending normalization (`\n`) is contracted. The converter today does `.replace("\r\n", "\n")` defensively on read, suggesting in-the-wild CRLF is tolerated; the question is whether write-side normalization is normative.
+- **Decision**: REQUIRED. UTF-8 encoding is universally mandated on writes for all in-scope state files. Line-ending normalization to LF (`\n`) is required on writes. Readers MUST tolerate CRLF in legacy inputs, matching the converter's defensive `.replace("\r\n", "\n")` on read. This makes Windows-authored legacy state files readable while preventing new CRLF-bearing writes from entering the tree.
 
 ---
 
@@ -198,49 +196,38 @@ Per Issue #124's acceptance criterion, the contract must declare how state schem
 
 ### 4.1 Versioning approach
 
-- **`[TBD by Lead]`** — Whether each state file MUST carry an explicit `schema_version` field, or the contract version is applied implicitly (one global "Set C version" that bumps when any file's schema changes). Candidate stances:
-  1. **Per-file `schema_version`** — every JSON file carries a top-level `schema_version`; every Markdown file carries an HTML-comment / front-matter `schema_version: N` line. Allows independent evolution.
-  2. **Global Set C version** — a single contract version is bumped on any schema change; the converter and helpers read the global version from a single config (e.g., `docs/contracts/state-schema-contract.md` itself). Forces lock-step evolution.
-  3. **Hybrid** — JSON files versioned individually (today's `org-state.json` precedent); Markdown files versioned implicitly via the contract.
+- **Decision**: HYBRID. JSON files are versioned individually with a top-level integer `version` field. Today's `org-state.json` carries `version: 1` (set by `dashboard/org_state_converter.py` via `SCHEMA_VERSION`); the contract preserves the existing `version` key for `org-state.json` and standardizes on `version` as the field name for all in-scope JSON state files (no separate `schema_version` key is introduced — the precedent wins). The `inbox/{task_id}.json` shape ratified here is implicitly `version: 1`; the field becomes mandatory on emit at the first breaking change to the inbox schema, at which point the writing helper (`claude-org-runtime delegate-plan`) MUST start writing `version` and readers apply §4.3 tolerant-reader rules to legacy entries (treat absent `version` as `1`). The same retroactive-emit rule applies to any future JSON state file the contract picks up. Markdown files are NOT versioned in-file; their contract version is implicitly the Set C version of the harness build that wrote them. This keeps human-edited files clean while preserving machine-tractable versioning where it matters.
 
 ### 4.2 Backward-compat (renames / removals)
 
-- **`[TBD by Lead]`** — Deprecation-window policy for renames and removals. Set D's error-code vocabulary contracts a deprecation window (old + new codes emitted in parallel). Set C must decide the analogous policy for state-file fields:
-  - **Rename**: writer emits both old and new keys for N minor versions, then drops the old key.
-  - **Removal**: writer emits the deprecated key with a sentinel value for N minor versions, then drops it.
-  - **N**: number of minor versions of overlap. Set D leaves this to the deprecation window; Set C must pick a concrete bound or defer to Set D's policy.
+- **Decision**: N = 2 minor versions of overlap.
+  - **Rename**: writer emits both the old and new keys for 2 minor versions, then drops the old key.
+  - **Removal**: writer emits the deprecated key with a sentinel value for 2 minor versions, then drops it.
+  - **Operator window**: operators may skip at most one upgrade within this window without losing readability; this aligns with §4.5's "N-1 and N" simultaneous-readable bound.
 
 ### 4.3 Forward-compat
 
-- **`[TBD by Lead]`** — How does an old harness read a state file written by a newer schema. Two candidates:
-  1. **Tolerant readers** — readers ignore unknown keys, fall back to documented defaults for missing keys (consistent with `docs/journal-events.md` § "consumers should tolerate unknown fields gracefully" and Set D § "callers MUST treat unknown types as non-fatal").
-  2. **Hard-fail readers** — readers refuse to process a file whose `schema_version` exceeds their compiled-in maximum, forcing the operator to upgrade the harness.
+- **Decision**: TOLERANT READERS. Readers ignore unknown keys and fall back to documented defaults for missing keys. This is consistent with `docs/journal-events.md` § "consumers should tolerate unknown fields gracefully" and Set D's ruling that callers MUST treat unknown types as non-fatal. Hard-fail readers are explicitly NOT contracted; an old harness reading a newer file degrades gracefully rather than refusing to load.
 
 ### 4.4 Migration hooks
 
-- **`[TBD by Lead]`** — Where migration code lives. Candidate stances:
-  1. A dedicated `tools/state_migrate.py` runs migrations on `/org-resume` (or on first read of an old-version file).
-  2. Each reader inlines its own version-aware parsing (today's converter approach: `SCHEMA_VERSION` is a constant in the converter, not a separate migration script).
-  3. Migrations are out-of-band — the operator runs a one-shot script provided in release notes.
+- **Decision**: A dedicated `tools/state_migrate.py` is the long-term home for migrations. It runs on `/org-resume` and on first read of an old-version file when the harness encounters one. Per-reader inline parsing (today's converter approach, where `SCHEMA_VERSION` is a constant in the converter) is permitted as a transitional shim until `tools/state_migrate.py` lands. A follow-up Issue ("feat(tools): introduce `tools/state_migrate.py` as central migration entry point") tracks the introduction of that script.
 
 ### 4.5 Migration breadth (how many versions readable simultaneously)
 
-- **`[TBD by Lead]`** — How many minor versions of each schema must a single harness build be able to read. A common stance is "N-1 and N" (read previous version, write current); a more conservative stance is "N-2 through N" (allow operators to skip one upgrade). The bound interacts with §4.2 deprecation-window length.
+- **Decision**: N-1 AND N. A single harness build MUST be able to read its current schema version (N) and the immediately previous one (N-1). Operators upgrading from N-2 must perform an intermediate upgrade. This bound interacts with §4.2's deprecation-window length: 2 minor versions of overlap suffices to cover the N-1 read requirement.
 
 ---
 
-## 5. Decisions to ratify (open questions consolidated)
+## 5. Decision rationale digest
 
-The Lead-fill-in markers above are the explicit fill-in points. They cluster as follows:
+Lead-confirmed decisions for the 14 questions raised in the outline (2026-05-03 Q&A session #11). The detail lives inline at each section above; this digest summarizes the rationale by cluster.
 
-1. **In-scope vs. out-of-scope artifacts** — `org-state.json` (normative or derived?), `dispatcher-event-cursor.txt` (state or runtime?), `dashboard.pid` / `dashboard.log` (state or ephemera?), `registry/projects.md` and `registry/org-config.md` (state or configuration?). Each carries a separate marker because the answers may diverge.
-2. **Schema-language uniformity** — Whether to normalize to one normative schema language (machine-checkable JSON Schema, TypeScript interfaces, Pydantic) or accept the current heterogeneity (prose for Markdown-edited files, JSON Schema for runtime-helper-managed files, descriptive prose for the journal).
-3. **Per-file `schema_version` field** — Required on every file vs. global Set C version vs. hybrid.
-4. **Append-only obligation for `journal.jsonl`** — Codified as contract (forbids retro rewrites) or convention-only.
-5. **Per-worker state file authoritative shape** — Free-form Markdown vs. helper-rendered template (gen_worker_brief precedent).
-6. **Inbox lifecycle post-consumption** — Deleted, retained, or moved to `processed/`.
-7. **Atomic-write requirements** — Which files MUST use tempfile + rename.
-8. **Encoding / line-ending normativity** — UTF-8 mandated; LF mandated on write?
-9. **Migration policy** — Deprecation window length, forward-compat read policy, migration hook location, simultaneous-version breadth (cluster of four markers in §4).
-
-These are the design decisions that must be settled before Contract Set C is ratified; the structural skeleton above (file inventory, cross-file invariants, migration-strategy headings) is fixed.
+1. **In-scope vs. out-of-scope artifacts** (§1.2, §1.7, §1.8, §1.9, §1.10) — `org-state.json` is DERIVED (Markdown is canonical, inheriting the `docs/org-state-schema.md` ruling). The dispatcher event cursor is IN scope (its loss measurably degrades recovery). `dashboard.pid` / `dashboard.log` are OUT of scope (operational ephemera). `registry/projects.md` and `registry/org-config.md` are IN scope as state-adjacent configuration, dual-listed in Set A as config inputs.
+2. **Schema-language uniformity** (§2) — Heterogeneity is accepted as deliberate. Markdown for human-edited files, JSON Schema-shaped prose for runtime-helper-managed files, descriptive prose for the journal. No single normative schema language.
+3. **Append-only obligation for `journal.jsonl`** (§1.3) — Convention-only. Helper-mediated appends are mandatory; retro corrections are permitted with an inline marker. No filesystem-level enforcement.
+4. **Per-worker state file shape** (§1.4) — Free-form Markdown enforced by the `delegate-plan` helper template; no separate generator required.
+5. **Inbox lifecycle** (§1.5) — Retained as audit trail; `SPLIT_CAPACITY_EXCEEDED` retry falls out naturally.
+6. **Atomic-write requirements** (§3.5) — Enumerated: tempfile + rename for `org-state.md`, `org-state.json`, `worker-{task_id}.md`; append for `journal.jsonl`; in-place rewrite acceptable for the dispatcher event cursor.
+7. **Encoding / line endings** (§3.6) — UTF-8 universally; LF on writes; readers tolerate CRLF in legacy inputs.
+8. **Migration policy** (§4) — Hybrid versioning (per-file top-level `version` integer for JSON, preserving the `org-state.json` precedent; implicit for Markdown). Deprecation window N = 2 minor versions. Tolerant readers (ignore unknown keys, default missing keys). Centralized `tools/state_migrate.py` as the long-term migration entry point (per-reader shims permitted transitionally; tracked as a follow-up Issue). Simultaneous-readable bound: N-1 and N.


### PR DESCRIPTION
## Summary

Ratify Contract Set C (State Schema) by filling all 14 `[TBD by Lead]` placeholders with the decisions reached during the 2026-05-03 Lead Q&A session.

## Decision matrix (Lead-confirmed)

### §1 Inventory
- §1.2 `org-state.json`: DERIVED (Markdown is canonical, JSON is reproducible).
- §1.3 journal append-only: convention-only via helper; manual retro corrections permitted via reserved `_correction` field.
- §1.4 worker file format: free-form Markdown; helper convention is sufficient.
- §1.5 inbox file lifecycle: retain as audit trail.
- §1.7+§1.8 runtime artifacts: hybrid — cursor file is normative state; dashboard.pid/log are out of scope.
- §1.9+§1.10 registry/: in scope as state-adjacent configuration.

### §2 Schema language
- Stance 2: accept current heterogeneity (Markdown / JSON Schema / descriptive prose) as deliberate.

### §3 Cross-file invariants
- §3.5 atomic-write list: `org-state.md` / `org-state.json` / `worker-{task_id}.md` MUST be tempfile+rename. `journal.jsonl` POSIX-line-append. cursor file in-place rewrite OK.
- §3.6 encoding: UTF-8 universally; LF on writes; readers tolerate CRLF.

### §4 Migration
- §4.1 schema_version: hybrid — JSON files versioned individually (`version` field, matching `org-state.json` precedent); Markdown files versioned implicitly via Set C contract version.
- §4.2 deprecation window: N=2 minor versions of overlap.
- §4.3 forward-compat: tolerant readers (consistent with journal-events.md and Set D).
- §4.4 migration code: dedicated `tools/state_migrate.py`, runs on `/org-resume` (per Q13 follow-up #245).
- §4.5 simultaneous-readable versions: N-1 and N.

## Test plan
- [x] `git grep "TBD by Lead" docs/contracts/state-schema-contract.md` returns 0 matches
- [x] Codex self-review 3 rounds: 0 valid Blocker / Major after final round
- [ ] CI green

## Follow-up
- #245 — feat(tools): introduce `tools/state_migrate.py` as central migration entry point

Closes #124