### PR TITLE
docs(journal-events): add emitted-by and required-for-transition annotations

### DIFF
--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -71,15 +71,15 @@ addition to its writer / payload shape:
 | `worker_review`          | `worker`, `task`, `outcome`                                 | secretary    | secretary  | T4           | Review verdict on a worker's report. |
 | `worker_report_forwarded`| `worker`, `task`, `recipient`                               | secretary    | secretary  | —            | Forwarded to human / other. |
 | `worktree_removed`       | `path`, `task`                                              | dispatcher   | dispatcher | T5 (Pattern B) | Worktree cleanup. |
-| `retro_deferred`         | `worker`, `reason`                                          | dispatcher   | dispatcher | T5           | Retro Steps 1–2 could not be completed before `close_pane` (e.g., secretary unreachable within 5 minutes); pane close skipped. |
+| `retro_deferred`         | `worker`, `reason`                                          | dispatcher   | dispatcher | T7 (if retro skipped) | Retro Steps 1–2 could not be completed before `close_pane` (e.g., secretary unreachable within 5 minutes); pane close skipped. Listed alongside the `aborted` row in Set B §1 (visible journal events); not contract-mandated for normal T5 close. |
 
 ### Delegate flow
 
 | Event                | Typical fields                                              | Writer    | Emitted by | Required for |
 |----------------------|-------------------------------------------------------------|-----------|------------|--------------|
 | `delegate_sent`      | `task`, `worker`, `dir`                                     | secretary | secretary  | T1           |
-| `delegate_resume`    | `task`, `worker`                                            | secretary | secretary  | §4.4         |
-| `delegate_resume_r2` | `task`, `worker`, `round`                                   | secretary | secretary  | §4.4         |
+| `delegate_resume`    | `task`, `worker`                                            | secretary | secretary  | —            |
+| `delegate_resume_r2` | `task`, `worker`, `round`                                   | secretary | secretary  | —            |
 
 ### Plan / design
 
@@ -96,11 +96,11 @@ addition to its writer / payload shape:
 
 | Event           | Typical fields                          | Writer    | Emitted by | Required for |
 |-----------------|-----------------------------------------|-----------|------------|--------------|
-| `fix_pushed`    | `task`, `branch`, `commit`              | secretary | secretary  | T6           |
+| `fix_pushed`    | `task`, `branch`, `commit`              | secretary | secretary  | —            |
 | `pr_opened`     | `task`, `pr`, `url`                     | secretary | secretary  | —            |
 | `prs_opened`    | `count`, `prs[]`                        | secretary | secretary  | —            |
-| `pr_merged`     | `pr`, `task`                            | secretary | secretary  | §1.5         |
-| `prs_merged`    | `count`, `prs[]`                        | secretary | secretary  | §1.5         |
+| `pr_merged`     | `pr`, `task`                            | secretary | secretary  | —            |
+| `prs_merged`    | `count`, `prs[]`                        | secretary | secretary  | —            |
 | `prs_pushed`    | `count`, `branches[]`                   | secretary | secretary  | —            |
 
 ### History / phase markers
@@ -126,8 +126,8 @@ addition to its writer / payload shape:
 
 | Event              | Typical fields                          | Writer     | Emitted by | Required for |
 |--------------------|-----------------------------------------|------------|------------|--------------|
-| `anomaly_observed` | `worker`, `kind`, `confidence`, `note`  | dispatcher | dispatcher | E2, E3       |
-| `notify_sent`      | `recipient`, `kind`, `summary`          | dispatcher | dispatcher | E2, E3       |
+| `anomaly_observed` | `worker`, `kind`, `confidence`, `note`  | dispatcher | dispatcher | E2 (conditional) |
+| `notify_sent`      | `recipient`, `kind`, `summary`          | dispatcher | dispatcher | E2, E3 (de-dup ledger) |
 | `events_dropped`   | `count`, `since_ts`                     | dispatcher | dispatcher | —            |
 
 ### CI
@@ -151,9 +151,9 @@ itself errored — see the fallback rules in `tools/pr_watch.py`);
 
 | Event                          | Typical fields                          | Writer    | Emitted by | Required for |
 |--------------------------------|-----------------------------------------|-----------|------------|--------------|
-| `suspend`                      | `reason`, `active_workers[]`, `pending_items[]` | secretary | secretary  | §4           |
-| `resume`                       | `restored_workers[]`, `note`            | secretary | secretary  | §4.4         |
-| `task_completed`               | `task`                                  | secretary | secretary  | T5           |
+| `suspend`                      | `reason`, `active_workers[]`, `pending_items[]` | secretary | secretary  | —            |
+| `resume`                       | `restored_workers[]`, `note`            | secretary | secretary  | —            |
+| `task_completed`               | `task`                                  | secretary | secretary  | —            |
 | `secretary_identity_restored`  | `note`                                  | org-start | secretary  | —            |
 
 ## Adding a new event type

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -68,10 +68,10 @@ addition to its writer / payload shape:
 | `worker_completed`       | `worker`, `task`                                            | secretary    | worker     | T4           | Worker reported done. |
 | `worker_closed`          | `worker`, `pane_id`                                         | dispatcher   | dispatcher | T5, T7       | Pane closed, registry updated. |
 | `worker_reported`        | `worker`, `task`, `summary`                                 | secretary    | worker     | T3           | Mid-task report received. |
-| `worker_review`          | `worker`, `task`, `outcome`                                 | secretary    | secretary  | T4           | Review verdict on a worker's report. |
+| `worker_review`          | `worker`, `task`, `outcome`                                 | secretary    | secretary  | —            | Review verdict on a worker's report. Visible at §1 awaiting_review row but not on T4's mandatory-Journal line. |
 | `worker_report_forwarded`| `worker`, `task`, `recipient`                               | secretary    | secretary  | —            | Forwarded to human / other. |
 | `worktree_removed`       | `path`, `task`                                              | dispatcher   | dispatcher | T5 (Pattern B) | Worktree cleanup. |
-| `retro_deferred`         | `worker`, `reason`                                          | dispatcher   | dispatcher | T7 (if retro skipped) | Retro Steps 1–2 could not be completed before `close_pane` (e.g., secretary unreachable within 5 minutes); pane close skipped. Listed alongside the `aborted` row in Set B §1 (visible journal events); not contract-mandated for normal T5 close. |
+| `retro_deferred`         | `worker`, `reason`                                          | dispatcher   | dispatcher | —            | Retro Steps 1–2 could not be completed before `close_pane` (e.g., secretary unreachable within 5 minutes); pane close skipped. Listed at Set B §1 aborted row as a visible journal event, but no §2 transition's mandatory-Journal line cites it. |
 
 ### Delegate flow
 

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -52,11 +52,15 @@ addition to its writer / payload shape:
   message. Source: Set A Q3 ratification, role-contract §
   Authoritative journal events.
 - **Required for** — the lifecycle transition (Set B
-  `docs/contracts/delegation-lifecycle-contract.md` §2 T1–T8, error
-  classes E1–E5, or §1.5 close-condition / §4 SUSPEND) for which
-  emission of this event is contract-mandated. `—` indicates the
-  event is informational / observability and not bound to any
-  specific transition. Source: Set B Q2 ratification.
+  `docs/contracts/delegation-lifecycle-contract.md` §2 T1–T8 *Journal*
+  line, or §3 E1–E5 detection / de-dup ledger reference) for which
+  emission of this event is contract-mandated. The scope is
+  deliberately narrow: events that merely *appear* in §1's
+  per-state "visible journal events" column, or that are referenced
+  by §1.5 / §4 prose without a mandatory-emission requirement, are
+  marked `—`. `—` therefore covers both informational /
+  observability events and lifecycle-adjacent events whose emission
+  is not contract-mandated. Source: Set B Q2 ratification.
 
 ## Event types
 

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -37,83 +37,104 @@ the caller runs).
 Workers do **not** write the journal directly; they report via
 `send_message` and the dispatcher / secretary persists the event.
 
+## Per-event annotations (Set A Q3 / Set B Q2)
+
+Each event row below carries two contract-required annotations in
+addition to its writer / payload shape:
+
+- **Emitted by** — the role(s) whose action *originates* the event
+  (one of `secretary`, `dispatcher`, `worker`, `curator`, or a
+  comma-separated combination). This may differ from the **Writer**
+  column: workers do not write the journal directly, so events
+  originating from a worker action (e.g. `worker_completed`,
+  `worker_reported`, `plan_delivered`) are emitted-by `worker` but
+  written by the secretary on receipt of the corresponding peer
+  message. Source: Set A Q3 ratification, role-contract §
+  Authoritative journal events.
+- **Required for** — the lifecycle transition (Set B
+  `docs/contracts/delegation-lifecycle-contract.md` §2 T1–T8, error
+  classes E1–E5, or §1.5 close-condition / §4 SUSPEND) for which
+  emission of this event is contract-mandated. `—` indicates the
+  event is informational / observability and not bound to any
+  specific transition. Source: Set B Q2 ratification.
+
 ## Event types
 
 ### Worker lifecycle
 
-| Event                    | Typical fields                                              | Writer       | Notes |
-|--------------------------|-------------------------------------------------------------|--------------|-------|
-| `worker_spawned`         | `worker`, `dir`, `task`                                     | dispatcher   | After MCP `spawn_pane`. |
-| `worker_completed`       | `worker`, `task`                                            | secretary    | Worker reported done. |
-| `worker_closed`          | `worker`, `pane_id`                                         | dispatcher   | Pane closed, registry updated. |
-| `worker_reported`        | `worker`, `task`, `summary`                                 | secretary    | Mid-task report received. |
-| `worker_review`          | `worker`, `task`, `outcome`                                 | secretary    | Review verdict on a worker's report. |
-| `worker_report_forwarded`| `worker`, `task`, `recipient`                               | secretary    | Forwarded to human / other. |
-| `worktree_removed`       | `path`, `task`                                              | dispatcher   | Worktree cleanup. |
-| `retro_deferred`         | `worker`, `reason`                                          | dispatcher   | Retro Steps 1–2 could not be completed before `close_pane` (e.g., secretary unreachable within 5 minutes); pane close skipped. |
+| Event                    | Typical fields                                              | Writer       | Emitted by | Required for | Notes |
+|--------------------------|-------------------------------------------------------------|--------------|------------|--------------|-------|
+| `worker_spawned`         | `worker`, `dir`, `task`                                     | dispatcher   | dispatcher | T2           | After MCP `spawn_pane`. |
+| `worker_completed`       | `worker`, `task`                                            | secretary    | worker     | T4           | Worker reported done. |
+| `worker_closed`          | `worker`, `pane_id`                                         | dispatcher   | dispatcher | T5, T7       | Pane closed, registry updated. |
+| `worker_reported`        | `worker`, `task`, `summary`                                 | secretary    | worker     | T3           | Mid-task report received. |
+| `worker_review`          | `worker`, `task`, `outcome`                                 | secretary    | secretary  | T4           | Review verdict on a worker's report. |
+| `worker_report_forwarded`| `worker`, `task`, `recipient`                               | secretary    | secretary  | —            | Forwarded to human / other. |
+| `worktree_removed`       | `path`, `task`                                              | dispatcher   | dispatcher | T5 (Pattern B) | Worktree cleanup. |
+| `retro_deferred`         | `worker`, `reason`                                          | dispatcher   | dispatcher | T5           | Retro Steps 1–2 could not be completed before `close_pane` (e.g., secretary unreachable within 5 minutes); pane close skipped. |
 
 ### Delegate flow
 
-| Event                | Typical fields                                              | Writer    |
-|----------------------|-------------------------------------------------------------|-----------|
-| `delegate_sent`      | `task`, `worker`, `dir`                                     | secretary |
-| `delegate_resume`    | `task`, `worker`                                            | secretary |
-| `delegate_resume_r2` | `task`, `worker`, `round`                                   | secretary |
+| Event                | Typical fields                                              | Writer    | Emitted by | Required for |
+|----------------------|-------------------------------------------------------------|-----------|------------|--------------|
+| `delegate_sent`      | `task`, `worker`, `dir`                                     | secretary | secretary  | T1           |
+| `delegate_resume`    | `task`, `worker`                                            | secretary | secretary  | §4.4         |
+| `delegate_resume_r2` | `task`, `worker`, `round`                                   | secretary | secretary  | §4.4         |
 
 ### Plan / design
 
-| Event                                  | Typical fields                          | Writer    |
-|----------------------------------------|-----------------------------------------|-----------|
-| `plan_delivered`                       | `task`, `worker`                        | secretary |
-| `plan_approved`                        | `task`                                  | secretary |
-| `plan_approved_and_prep_dispatched`    | `task`, `prep_worker`                   | secretary |
-| `prep_delivered`                       | `task`, `worker`                        | secretary |
-| `design_approved`                      | `task`, `pr`                            | secretary |
-| `drift_reaudit`                        | `task`, `reason`                        | secretary |
+| Event                                  | Typical fields                          | Writer    | Emitted by | Required for |
+|----------------------------------------|-----------------------------------------|-----------|------------|--------------|
+| `plan_delivered`                       | `task`, `worker`                        | secretary | worker     | —            |
+| `plan_approved`                        | `task`                                  | secretary | secretary  | —            |
+| `plan_approved_and_prep_dispatched`    | `task`, `prep_worker`                   | secretary | secretary  | —            |
+| `prep_delivered`                       | `task`, `worker`                        | secretary | worker     | —            |
+| `design_approved`                      | `task`, `pr`                            | secretary | secretary  | —            |
+| `drift_reaudit`                        | `task`, `reason`                        | secretary | secretary  | —            |
 
 ### PR / push
 
-| Event           | Typical fields                          | Writer    |
-|-----------------|-----------------------------------------|-----------|
-| `fix_pushed`    | `task`, `branch`, `commit`              | secretary |
-| `pr_opened`     | `task`, `pr`, `url`                     | secretary |
-| `prs_opened`    | `count`, `prs[]`                        | secretary |
-| `pr_merged`     | `pr`, `task`                            | secretary |
-| `prs_merged`    | `count`, `prs[]`                        | secretary |
-| `prs_pushed`    | `count`, `branches[]`                   | secretary |
+| Event           | Typical fields                          | Writer    | Emitted by | Required for |
+|-----------------|-----------------------------------------|-----------|------------|--------------|
+| `fix_pushed`    | `task`, `branch`, `commit`              | secretary | secretary  | T6           |
+| `pr_opened`     | `task`, `pr`, `url`                     | secretary | secretary  | —            |
+| `prs_opened`    | `count`, `prs[]`                        | secretary | secretary  | —            |
+| `pr_merged`     | `pr`, `task`                            | secretary | secretary  | §1.5         |
+| `prs_merged`    | `count`, `prs[]`                        | secretary | secretary  | §1.5         |
+| `prs_pushed`    | `count`, `branches[]`                   | secretary | secretary  | —            |
 
 ### History / phase markers
 
-| Event                          | Typical fields                          | Writer    |
-|--------------------------------|-----------------------------------------|-----------|
-| `pre_history_reset_snapshot`   | `path`                                  | secretary |
-| `phase_d_snapshot`             | `path`                                  | secretary |
-| `phase_d_complete`             | `task`                                  | secretary |
-| `phase_d_force_push`           | `branch`                                | secretary |
-| `pane_closed`                  | `pane_id`, `worker`                     | dispatcher|
+| Event                          | Typical fields                          | Writer    | Emitted by | Required for |
+|--------------------------------|-----------------------------------------|-----------|------------|--------------|
+| `pre_history_reset_snapshot`   | `path`                                  | secretary | secretary  | —            |
+| `phase_d_snapshot`             | `path`                                  | secretary | secretary  | —            |
+| `phase_d_complete`             | `task`                                  | secretary | secretary  | —            |
+| `phase_d_force_push`           | `branch`                                | secretary | secretary  | —            |
+| `pane_closed`                  | `pane_id`, `worker`                     | dispatcher| dispatcher | —            |
 
 ### Issues
 
-| Event             | Typical fields                          | Writer    |
-|-------------------|-----------------------------------------|-----------|
-| `issue_filed`     | `issue`, `title`                        | secretary |
-| `issues_filed`    | `count`, `issues[]`                     | secretary |
-| `issues_swept`    | `count`                                 | secretary |
-| `issue_closed`    | `issue`                                 | secretary |
+| Event             | Typical fields                          | Writer    | Emitted by | Required for |
+|-------------------|-----------------------------------------|-----------|------------|--------------|
+| `issue_filed`     | `issue`, `title`                        | secretary | secretary  | —            |
+| `issues_filed`    | `count`, `issues[]`                     | secretary | secretary  | —            |
+| `issues_swept`    | `count`                                 | secretary | secretary  | —            |
+| `issue_closed`    | `issue`                                 | secretary | secretary  | —            |
 
 ### Observability
 
-| Event              | Typical fields                          | Writer     |
-|--------------------|-----------------------------------------|------------|
-| `anomaly_observed` | `worker`, `kind`, `confidence`, `note`  | dispatcher |
-| `notify_sent`      | `recipient`, `kind`, `summary`          | dispatcher |
-| `events_dropped`   | `count`, `since_ts`                     | dispatcher |
+| Event              | Typical fields                          | Writer     | Emitted by | Required for |
+|--------------------|-----------------------------------------|------------|------------|--------------|
+| `anomaly_observed` | `worker`, `kind`, `confidence`, `note`  | dispatcher | dispatcher | E2, E3       |
+| `notify_sent`      | `recipient`, `kind`, `summary`          | dispatcher | dispatcher | E2, E3       |
+| `events_dropped`   | `count`, `since_ts`                     | dispatcher | dispatcher | —            |
 
 ### CI
 
-| Event          | Typical fields                                            | Writer    |
-|----------------|-----------------------------------------------------------|-----------|
-| `ci_completed` | `pr`, `repo`, `status`, `duration_sec`                    | secretary |
+| Event          | Typical fields                                            | Writer    | Emitted by | Required for |
+|----------------|-----------------------------------------------------------|-----------|------------|--------------|
+| `ci_completed` | `pr`, `repo`, `status`, `duration_sec`                    | secretary | secretary  | E4           |
 
 `status` ∈ `{passed, failed, incomplete, canceled}`. As of Issue #224
 the value is derived from `gh pr checks <pr> --json bucket,state,name`
@@ -128,12 +149,12 @@ itself errored — see the fallback rules in `tools/pr_watch.py`);
 
 ### Session lifecycle
 
-| Event                          | Typical fields                          | Writer    |
-|--------------------------------|-----------------------------------------|-----------|
-| `suspend`                      | `reason`, `active_workers[]`, `pending_items[]` | secretary |
-| `resume`                       | `restored_workers[]`, `note`            | secretary |
-| `task_completed`               | `task`                                  | secretary |
-| `secretary_identity_restored`  | `note`                                  | org-start |
+| Event                          | Typical fields                          | Writer    | Emitted by | Required for |
+|--------------------------------|-----------------------------------------|-----------|------------|--------------|
+| `suspend`                      | `reason`, `active_workers[]`, `pending_items[]` | secretary | secretary  | §4           |
+| `resume`                       | `restored_workers[]`, `note`            | secretary | secretary  | §4.4         |
+| `task_completed`               | `task`                                  | secretary | secretary  | T5           |
+| `secretary_identity_restored`  | `note`                                  | org-start | secretary  | —            |
 
 ## Adding a new event type
 
@@ -142,7 +163,9 @@ itself errored — see the fallback rules in `tools/pr_watch.py`);
 2. Decide on the payload fields. Prefer flat string/number/bool keys
    for ergonomic `jq` queries; nested objects are allowed but require
    the Python entry point (`tools/journal_append.py --json '...'`).
-3. Add a row to the relevant table above.
+3. Add a row to the relevant table above, including the **Emitted
+   by** and **Required for** annotations (see "Per-event annotations"
+   above for the value vocabulary).
 4. Use the helper to write:
    - bash: `bash tools/journal_append.sh <event> k=v k2=v2`
    - python: `py -3 tools/journal_append.py <event> k=v --json '{"nested": {...}}'`


### PR DESCRIPTION
## Summary
Annotate each entry in `docs/journal-events.md` with two new metadata fields per Set A Q3 (emitted-by) and Set B Q2 (required-for-transition) ratifications.

- **Emitted by**: tags each event with its originating role (secretary / dispatcher / worker). Distinguishes write-attribution from emission origin (e.g., `worker_reported` is written by secretary but emitted-by worker).
- **Required for**: only events explicitly named in Set B §2 (T1-T8) or §3 (E1-E5) as mandatory journal lines carry transition tags. Events that appear only in §1 visible-journal-events or in §1.5 / §4 prose are tagged `—`.

A "Per-event annotations" definition section is added at the top of the file.

## Test plan
- [x] Every event entry has both new annotations
- [x] Codex self-review 3 rounds: 0 Blocker / 0 Major after final round
- [ ] CI green

Closes #236