### PR TITLE
chore: audit Phase 3/4 shims for minimality (Phase 5b)

### DIFF
--- a/.hooks/lib/segment-split.sh
+++ b/.hooks/lib/segment-split.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Phase 5 shim audit: confirmed minimal as of 2026-05-04 (#130)
 # Compatibility shim — Step C / ja#128.
 #
 # The 325-line implementation that previously lived here moved up to

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Phase 5 shim audit: confirmed minimal as of 2026-05-04 (#130)
 """Role-based settings.local.json integrity checker (Step B shim).
 
 The validation engine now lives in ``core_harness.validator``. This

--- a/tools/journal_append.py
+++ b/tools/journal_append.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Phase 5 shim audit: confirmed minimal as of 2026-05-04 (#130)
 """claude-org-ja journal append wrapper (Step D shim).
 
 Thin CLI around :class:`core_harness.audit.Journal` with the org-specific

--- a/tools/journal_append.sh
+++ b/tools/journal_append.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Phase 5 shim audit: confirmed minimal as of 2026-05-04 (#130)
 # claude-org-ja journal append wrapper (Step D shim, refs ja#128 /
 # core-harness 0.3.0).
 #


### PR DESCRIPTION
## Summary
Phase 5b of the #130 ja rebase. Audit confirms all four Phase 3/4 shims wrap core-harness minimally and the remaining ja-specific surface is justified. No behavior change — adds a single audit-trail comment line to each file.

## Audit findings
- **`tools/check_role_configs.py`** — core_harness.validator/schema does the validation; shim retains ja-specific docs projection (`check_docs`), disk walk (`check_on_disk`), CLI, exit-code contract. Minimal.
- **`tools/journal_append.py`** — wraps `core_harness.audit.Journal`. ja-specific guard rails (canonical path baking, `--path` / `$JOURNAL_PATH` rejection) justified for multi-repo safety.
- **`tools/journal_append.sh`** — pip-resolves companion lib + forwards. Same guard rails. Minimal.
- **`.hooks/lib/segment-split.sh`** — injects `CORE_HARNESS_BLOCK_PREFIX="ブロック: "` (ja locale) and forwards. Minimal.

## Changes
4 files +1 line each — single audit-trail comment `# Phase 5 shim audit: confirmed minimal as of 2026-05-04 (#130)`.

## Test plan
- [x] `python -m unittest tests.test_check_role_configs -v` → 33 tests OK
- [x] `bash tests/test-unwrap-eval-bashc.sh` → 14 passed
- [x] Codex self-review: 0 in-scope Blocker / Major
- [ ] CI green

## Out-of-scope (Codex flagged for separate follow-up)
- `scripts/install.{sh,ps1}` Python-dependency hard-fail behavior — actual user impact possible; consider filing a separate Issue.
- `_is_git_tracked` fail-closed portability — already documented as intentional; no change needed.

Refs #130 (Phase 5d will close)