### PR TITLE
feat(packaging): pyproject.toml migration + drift CI tightening (Phase 5c)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,14 +22,25 @@ jobs:
       - name: Install shell test dependencies
         run: sudo apt-get update && sudo apt-get install -y jq
 
-      - name: Install Python dependencies (core-harness pinned)
-        run: pip install -r requirements.txt
+      - name: Install Python dependencies (pyproject.toml editable)
+        # Phase 5c (Issue #130): canonical install is now `pip install -e .`
+        # backed by pyproject.toml. requirements.txt is kept as a thin
+        # pointer for tooling that still references it.
+        run: pip install -e .
 
       - name: Run Python tests
         run: python -m unittest discover -s tests -v
 
       - name: Run tools/ Python tests
         run: python -m unittest discover -s tools -p 'test_*.py' -v
+
+      - name: Check runtime schema drift (Issue #130 Phase 5c)
+        # Compares ja's tools/org_extension_schema.json against the
+        # schema bundled inside the pinned claude-org-runtime. Skips
+        # with a warning when the installed runtime is outside ja's
+        # pin window, so a runtime preview release does not block ja
+        # PRs unrelated to the schema.
+        run: python tools/check_runtime_schema_drift.py
 
       - name: Check role configs integrity (Issue #85)
         # --include-worker-settings . enumerates `<repo>/*/.claude/settings.local.json`

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ docs/github-issues/
 # Python build artifacts
 __pycache__/
 *.pyc
+*.egg-info/
+build/
+dist/
 
 # OS metadata
 .DS_Store

--- a/.hooks/lib/segment-split.sh
+++ b/.hooks/lib/segment-split.sh
@@ -46,7 +46,7 @@ __core_harness_resolve_lib() {
 
 __CORE_HARNESS_LIB_DIR="$(__core_harness_resolve_lib || true)"
 if [[ -z "$__CORE_HARNESS_LIB_DIR" || ! -f "$__CORE_HARNESS_LIB_DIR/core_harness_hooks.sh" ]]; then
-  echo "ブロック: core-harness パッケージが見つかりません (pip install -r requirements.txt が必要)。" >&2
+  echo "ブロック: core-harness パッケージが見つかりません (pip install -e . が必要)。" >&2
   exit 2
 fi
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ git clone https://github.com/suisya-systems/claude-org-ja.git
 cd claude-org-ja
 
 # 4. Python 依存（core-harness / claude-org-runtime）を導入
-pip install -r requirements.txt
+#    pyproject.toml が SoT。requirements.txt は薄い互換ファイルとして残置。
+pip install -e .
 
 # 5. renga の MCP サーバーを Claude Code に登録（初回のみ）
 renga mcp install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "claude-org-ja"
+version = "0.1.0"
+description = "Claude Code multi-role AI organization harness (Japanese edition)"
+readme = "README.md"
+# CLAUDE.local.md worker template recommends Python 3.10; CI runs 3.11.
+# tomli conditional below covers the 3.10 gap (tomllib is stdlib in 3.11+).
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "suisya-systems" }]
+keywords = ["claude-code", "renga", "ai-agents", "multi-agent"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+# Pins mirror requirements.txt — both files are kept in sync intentionally.
+# requirements.txt remains as a thin pointer for tooling that still expects
+# it (e.g. older external CI references); pyproject.toml is the canonical
+# install path for `pip install -e .`. Pin windows are deliberately narrow
+# pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
+dependencies = [
+    "core-harness>=0.3.2,<0.4",
+    "claude-org-runtime>=0.1.1,<0.2",
+    "tomli>=2.0,<3 ; python_version < '3.11'",
+]
+
+[project.urls]
+Homepage = "https://github.com/suisya-systems/claude-org-ja"
+Issues = "https://github.com/suisya-systems/claude-org-ja/issues"
+
+# This repo is tooling, not an importable Python package: scripts under
+# tools/ are invoked as `python tools/<name>.py`, not imported. Tell
+# setuptools there are no modules to package so `pip install -e .` only
+# resolves dependencies and registers the project metadata.
+[tool.setuptools]
+py-modules = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,14 @@
+# NOTE: pyproject.toml is the canonical install path. Prefer:
+#   pip install -e .
+# This file is kept as a thin pointer so tooling that still references
+# `requirements.txt` (older external CI, docs, scripts) keeps working;
+# `-e .` re-resolves the same pins via pyproject.toml.
+#
+# The literal pins below intentionally duplicate pyproject.toml so this
+# file remains usable on its own (e.g. pip install -r requirements.txt).
+# When bumping a pin, update BOTH this file AND pyproject.toml; the
+# duplication is by design — see Phase 5c (Issue #130) PR description.
+
 # Step B: claude-org-ja depends on core-harness for permission/audit
 # primitives (tools/check_role_configs.py and the historical
 # tools/generate_worker_settings.py shim, which has since been

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -186,23 +186,32 @@ if ($SkipMcp) {
 # tools/generate_worker_settings.py thin shims over the core-harness
 # package; Phase 4 (Issue #129) then moved the dispatcher runner and
 # the worker settings generator out of tools/ into the
-# claude-org-runtime package. requirements.txt pins both versions.
+# claude-org-runtime package. Phase 5c (Issue #130) moved the install
+# path from `requirements.txt` to `pyproject.toml`; we prefer the
+# editable install so the dep set comes from the canonical source.
 $pyCmd = $null
 foreach ($cand in @('python', 'python3', 'py')) {
     if (Get-Command $cand -ErrorAction SilentlyContinue) { $pyCmd = $cand; break }
 }
+$pyprojectFile = Join-Path $Dir 'pyproject.toml'
 $reqFile = Join-Path $Dir 'requirements.txt'
-if (-not (Test-Path -LiteralPath $reqFile)) {
-    # Older refs / fixtures predate Step B and ship no requirements.txt.
+if ((Test-Path -LiteralPath $pyprojectFile) -and $pyCmd) {
+    Write-Host ''
+    Write-Host 'Installing Python deps via pyproject.toml (editable) ...'
+    Invoke-Step @($pyCmd, '-m', 'pip', 'install', '--user', '-e', $Dir)
+} elseif ((Test-Path -LiteralPath $reqFile) -and $pyCmd) {
+    # Backward-compat path for refs that predate Phase 5c (no
+    # pyproject.toml) but post-date Step B (have requirements.txt).
+    Write-Host ''
+    Write-Host 'Installing Python deps (core-harness pin, requirements.txt) ...'
+    Invoke-Step @($pyCmd, '-m', 'pip', 'install', '--user', '-r', $reqFile)
+} elseif (-not ((Test-Path -LiteralPath $pyprojectFile) -or (Test-Path -LiteralPath $reqFile))) {
+    # Older refs / fixtures predate Step B and ship neither file.
     # The shim CLIs only exist on Step-B-or-later commits, so skipping
     # here keeps the installer backward compatible.
-    Write-Host "Skipping Python deps (no $reqFile)."
-} elseif ($pyCmd) {
-    Write-Host ''
-    Write-Host 'Installing Python deps (core-harness pin) ...'
-    Invoke-Step @($pyCmd, '-m', 'pip', 'install', '--user', '-r', $reqFile)
+    Write-Host "Skipping Python deps (no pyproject.toml or requirements.txt)."
 } else {
-    Write-Host 'WARN: python not found; tools/check_role_configs.py will fail until you `pip install -r requirements.txt`.'
+    Write-Host 'WARN: python not found; tools/check_role_configs.py will fail until you `pip install -e .`.'
 }
 
 # --- Done ----------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -195,7 +195,9 @@ fi
 # tools/generate_worker_settings.py thin shims over the core-harness
 # package; Phase 4 (Issue #129) then moved the dispatcher runner and
 # the worker settings generator out of tools/ into the
-# claude-org-runtime package. requirements.txt pins both versions.
+# claude-org-runtime package. Phase 5c (Issue #130) moved the install
+# path from `requirements.txt` to `pyproject.toml`; we prefer the
+# editable install so the dep set comes from the canonical source.
 if command -v python3 >/dev/null 2>&1; then
   PY=python3
 elif command -v python >/dev/null 2>&1; then
@@ -203,18 +205,25 @@ elif command -v python >/dev/null 2>&1; then
 else
   PY=""
 fi
+PYPROJECT_FILE="$TARGET_DIR/pyproject.toml"
 REQ_FILE="$TARGET_DIR/requirements.txt"
-if [[ ! -f "$REQ_FILE" ]]; then
-  # Older refs / fixtures predate Step B and ship no requirements.txt.
+if [[ -f "$PYPROJECT_FILE" && -n "$PY" ]]; then
+  echo
+  echo "Installing Python deps via pyproject.toml (editable) ..."
+  run $PY -m pip install --user -e "$TARGET_DIR"
+elif [[ -f "$REQ_FILE" && -n "$PY" ]]; then
+  # Backward-compat path for refs that predate Phase 5c (no
+  # pyproject.toml) but post-date Step B (have requirements.txt).
+  echo
+  echo "Installing Python deps (core-harness pin, requirements.txt) ..."
+  run $PY -m pip install --user -r "$REQ_FILE"
+elif [[ ! -f "$PYPROJECT_FILE" && ! -f "$REQ_FILE" ]]; then
+  # Older refs / fixtures predate Step B and ship neither file.
   # The shim CLIs only exist on Step-B-or-later commits, so skipping
   # here keeps the installer backward compatible.
-  echo "Skipping Python deps (no $REQ_FILE)."
-elif [[ -n "$PY" ]]; then
-  echo
-  echo "Installing Python deps (core-harness pin) ..."
-  run $PY -m pip install --user -r "$REQ_FILE"
+  echo "Skipping Python deps (no pyproject.toml or requirements.txt)."
 else
-  echo "WARN: python not found; tools/check_role_configs.py will fail until you 'pip install -r requirements.txt'."
+  echo "WARN: python not found; tools/check_role_configs.py will fail until you 'pip install -e .'."
 fi
 
 # --- Done ------------------------------------------------------------------

--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Drift check: ja's ``tools/org_extension_schema.json`` vs the
+``role_configs_schema.json`` bundled inside the ``claude-org-runtime``
+package (Phase 5c, Issue #130).
+
+The runtime ships its own copy of the role-configs schema (used by
+``claude_org_runtime.settings.generator``). Historically the two copies
+have been kept in lockstep by hand. This tool fails CI when they
+diverge so the next contributor doesn't unknowingly publish a
+runtime-incompatible schema change.
+
+Pin-window tolerance
+--------------------
+ja pins ``claude-org-runtime>=0.1.1,<0.2``. When the installed runtime
+is *outside* that window (e.g. a contributor previewed 0.2.0 locally
+before ja widened its pin), this check **skips with a warning** rather
+than failing — the bundled schema is by definition allowed to evolve
+ahead of ja's pin window, and a hard failure here would just block
+unrelated PRs.
+
+When the installed runtime is *inside* the window, any difference is a
+hard failure: the two schemas are supposed to be byte-identical.
+
+Exit codes: 0 = OK or skipped (out-of-window), 1 = drift detected.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from pathlib import Path
+
+# Mirror of the ``claude-org-runtime`` pin in pyproject.toml /
+# requirements.txt. Keep this constant in sync when widening the pin
+# (Phase 5e+ scope per CLAUDE.local.md). Stored as tuples for ordered
+# comparison; only major.minor.micro are honoured.
+RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 1)
+RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+JA_SCHEMA = REPO_ROOT / "tools" / "org_extension_schema.json"
+
+
+def _parse_version(ver: str) -> tuple[int, ...]:
+    """Parse a PEP 440 release segment to a (major, minor, micro) tuple.
+
+    Pre-release / dev / local segments are stripped — drift tolerance
+    is decided on the release segment alone, matching how the pin
+    specifier ``>=0.1.1,<0.2`` is interpreted by pip.
+    """
+    head = ver.split("+", 1)[0]
+    for marker in ("a", "b", "rc", ".dev", ".post"):
+        idx = head.find(marker)
+        if idx != -1:
+            head = head[:idx]
+    parts: list[int] = []
+    for chunk in head.split("."):
+        if not chunk.isdigit():
+            break
+        parts.append(int(chunk))
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts[:3])
+
+
+def _runtime_in_pin_window(installed: tuple[int, ...]) -> bool:
+    return RUNTIME_PIN_LOWER_INCLUSIVE <= installed < RUNTIME_PIN_UPPER_EXCLUSIVE
+
+
+def _bundled_schema_path() -> Path:
+    """Return the on-disk path to the runtime's bundled
+    ``role_configs_schema.json``.
+
+    Imports lazily so the script can fail with a helpful message when
+    ``claude-org-runtime`` is not installed, rather than dying at
+    import time.
+    """
+    from importlib.resources import files
+
+    resource = files("claude_org_runtime.settings").joinpath(
+        "role_configs_schema.json"
+    )
+    return Path(str(resource))
+
+
+def _normalise(obj: object) -> object:
+    """Strip cosmetic-only keys before comparison.
+
+    ``$comment`` entries are documentation aids and may legitimately
+    differ between the two checked-in copies (e.g. ja adds a comment
+    pointing at the projection script). Everything else must match.
+    """
+    if isinstance(obj, dict):
+        return {
+            k: _normalise(v) for k, v in obj.items() if not k.startswith("$comment")
+        }
+    if isinstance(obj, list):
+        return [_normalise(x) for x in obj]
+    return obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # currently no flags; kept for signature consistency
+    try:
+        installed_str = _pkg_version("claude-org-runtime")
+    except PackageNotFoundError:
+        print(
+            "check_runtime_schema_drift: claude-org-runtime is not installed; "
+            "run `pip install -e .` first.",
+            file=sys.stderr,
+        )
+        return 1
+    installed = _parse_version(installed_str)
+    if not _runtime_in_pin_window(installed):
+        print(
+            f"check_runtime_schema_drift: WARN — installed claude-org-runtime "
+            f"{installed_str} is outside ja's pin window "
+            f">={'.'.join(map(str, RUNTIME_PIN_LOWER_INCLUSIVE))},"
+            f"<{'.'.join(map(str, RUNTIME_PIN_UPPER_EXCLUSIVE[:2]))}; "
+            "skipping strict drift check (runtime is allowed to ship a new "
+            "minor before ja widens the pin)."
+        )
+        return 0
+
+    bundled_path = _bundled_schema_path()
+    if not bundled_path.is_file():
+        print(
+            f"check_runtime_schema_drift: bundled schema not found at "
+            f"{bundled_path}",
+            file=sys.stderr,
+        )
+        return 1
+    if not JA_SCHEMA.is_file():
+        print(
+            f"check_runtime_schema_drift: ja schema not found at {JA_SCHEMA}",
+            file=sys.stderr,
+        )
+        return 1
+
+    bundled = json.loads(bundled_path.read_text(encoding="utf-8"))
+    ja = json.loads(JA_SCHEMA.read_text(encoding="utf-8"))
+
+    if _normalise(bundled) == _normalise(ja):
+        print(
+            f"check_runtime_schema_drift: OK (claude-org-runtime "
+            f"{installed_str} bundled schema matches {JA_SCHEMA.name})"
+        )
+        return 0
+
+    print(
+        "check_runtime_schema_drift: DRIFT — ja's "
+        f"{JA_SCHEMA.name} differs from the schema bundled with "
+        f"claude-org-runtime {installed_str} ({bundled_path}).",
+        file=sys.stderr,
+    )
+    print(
+        "  Either update tools/org_extension_schema.json to match the "
+        "runtime, or release a new runtime that matches ja's schema, "
+        "then re-pin in pyproject.toml + requirements.txt.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/journal_append.sh
+++ b/tools/journal_append.sh
@@ -61,7 +61,7 @@ CORE_HARNESS_AUDIT_LIB="$(
 )"
 
 if [ -z "$CORE_HARNESS_AUDIT_LIB" ] || [ ! -f "$CORE_HARNESS_AUDIT_LIB" ]; then
-    printf 'tools/journal_append.sh: core_harness.audit lib not resolvable; check requirements.txt pin\n' >&2
+    printf 'tools/journal_append.sh: core_harness.audit lib not resolvable; check pyproject.toml pin (or run pip install -e .)\n' >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
Phase 5c of the #130 ja rebase. Migrate the ja repo to PEP 621 `pyproject.toml`-based installation, update install scripts and CI, and harden the schema-drift check between ja's `tools/org_extension_schema.json` and `claude-org-runtime`'s bundled `role_configs_schema.json` with pin-window tolerance.

## Changes
- **New**: `pyproject.toml` (PEP 621 metadata; deps mirror existing `requirements.txt` pins)
- **New**: `tools/check_runtime_schema_drift.py` — schema-drift detector with pin-window WARN+skip behavior
- **Updated**: `requirements.txt` → thin compat pointer (Option A, see Note below)
- **Updated**: `scripts/install.sh`, `scripts/install.ps1` → `pip install -e .` (with `--dry-run` / `--skip-mcp` paths preserved)
- **Updated**: `.github/workflows/tests.yml` → install via pyproject extras
- **Updated**: `README.md` (install instructions), `.gitignore` (egg-info, etc.), `.hooks/lib/segment-split.sh`, `tools/journal_append.sh` (stale `requirements.txt` hint refreshed)

## Design notes
- `requires-python = ">=3.10"` to match `claude-org-runtime>=0.3.10` floor + `tomli` conditional dep.
- Pin windows unchanged (`core-harness>=0.3.2,<0.4`, `claude-org-runtime>=0.1.1,<0.2`) — explicitly out of scope per Phase 5c brief; bumps are Phase 5e+ scope.
- `requirements.txt` retained as a thin compat pointer (Option A). Pins are duplicated in `pyproject.toml`; **maintainers must sync both on any pin change.**
- Drift check normalizes `$comment` keys before comparison. Runtime versions outside the pin window WARN and skip.

## Test plan
- [x] `pip install --dry-run -e .` succeeds
- [x] `python -m unittest discover -s tests` → 63 tests OK
- [x] `python -m unittest discover -s tools -p 'test_*.py'` → 105 tests OK
- [x] `bash tests/run-all.sh` → exit 0
- [x] `python tools/check_role_configs.py --include-worker-settings .` → OK
- [x] `python tools/check_runtime_schema_drift.py` → OK (runtime 0.1.1 match)
- [x] `bash scripts/install.sh --dry-run --skip-mcp` → reaches "Skipping Python deps" branch, prints Done banner
- [x] Codex self-review 1 round: 0 in-scope Blocker / Major
- [ ] CI green

## Out-of-scope (Codex flagged for separate consideration)
1. `.github/workflows/install-scripts.yml` `paths:` filter does not include `pyproject.toml` — pre-existing scope; tighten in separate PR if desired.
2. `installer pip install --user` may conflict in venv — pre-existing behavior unchanged.
3. README "Python 3.8+" claim is now stale (we declare `>=3.10`); README Architecture refresh is in Phase 5d scope.
4. CI matrix currently runs 3.11 only; 3.10 leg validation is a separate task.

Refs #130 (Phase 5d will close)