### PR TITLE
docs(skills): lower secretary protection height threshold from 45 to 30

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -353,7 +353,7 @@ DELEGATE: 以下のワーカーを派遣してください。
 
 **定数**:
 - `MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5`: renga 側の分割下限（findings: renga-split-inv）
-- `SECRETARY_MIN_WIDTH = 125` / `SECRETARY_MIN_HEIGHT = 45`: secretary を分割候補にしてよい最小幅・最小高さ（保険条項、実運用ではほぼ不発動）
+- `SECRETARY_MIN_WIDTH = 125` / `SECRETARY_MIN_HEIGHT = 30`: secretary を分割候補にしてよい最小幅・最小高さ（保険条項、実運用ではほぼ不発動）
 
 **Step 1. curator を特定**: `role == "curator"` のペインを 1 つ選ぶ（複数あれば先頭）。以降 `$curator` と呼ぶ。存在しなければ `$curator = null`。
 

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -50,7 +50,7 @@ renga は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 
 2. **候補集合**: `role ∈ {worker, dispatcher, secretary}` のペイン (curator は常に除外)
 3. **候補の絞り込み**:
    - **dispatcher-curator 隣接維持**: dispatcher は curator と rect 隣接 (後述) しているときのみ候補に入れる。組織運営上 dispatcher と curator の隣接配置は前提。dispatcher を分割すると隣接が崩れ得るので、既に非隣接な dispatcher は候補から外す
-   - **secretary 保護**: secretary は分割後の新ペイン幅 `new_w >= 125` **かつ** 新ペイン高さ `new_h >= 45` を満たす場合のみ候補化 (保険条項、実運用では通常発動しない)。width だけ通っても height が足りなければ却下する
+   - **secretary 保護**: secretary は分割後の新ペイン幅 `new_w >= 125` **かつ** 新ペイン高さ `new_h >= 30` を満たす場合のみ候補化 (保険条項、実運用では通常発動しない)。width だけ通っても height が足りなければ却下する
 4. **direction 決定** (各候補の aspect ratio から):
    - `width > height * 2` → `vertical` (左右分割)
    - それ以外 → `horizontal` (上下分割)
@@ -72,7 +72,7 @@ renga の cell 座標は整数なので tolerance なし完全一致で判定す
 
 ### 初期状態と典型的な挙動
 
-ワーカー 0 人の時点では、候補は `dispatcher` のみ (secretary は `new_w >= 125` / `new_h >= 45` 条件または隣接条件で除外されるのが通常。curator は常に除外)。dispatcher は典型的に横長なので vertical 分割され、最初のワーカー zone が dispatcher の右側に作られる。
+ワーカー 0 人の時点では、候補は `dispatcher` のみ (secretary は `new_w >= 125` / `new_h >= 30` 条件または隣接条件で除外されるのが通常。curator は常に除外)。dispatcher は典型的に横長なので vertical 分割され、最初のワーカー zone が dispatcher の右側に作られる。
 
 以降は既存ペインの中で「分割後サイズが最大」のものが選ばれ、direction が rect に応じて自然に交替することで準 balanced な配置になる。固定的な 4 並列 / 8 並列の図は意味を持たないため割愛する (動的で決まるため)。
 


### PR DESCRIPTION
## Summary

- Lower the `SECRETARY_MIN_HEIGHT` threshold from 45 to 30 in `org-delegate` so the secretary-protection rule reflects the actual minimum readable height (input area + a few turns of recent context) instead of carrying headroom for very tall terminals.
- Doc-only edit. No code or behavior change beyond the constant value the dispatcher's balanced-split algorithm reads.

## Changes

- `.claude/skills/org-delegate/SKILL.md`: `SECRETARY_MIN_HEIGHT = 45` → `30` (the operational SOT the dispatcher applies).
- `.claude/skills/org-delegate/references/pane-layout.md`: two textual references to `new_h >= 45` updated to `new_h >= 30` so the rule definition and the worker-zero illustration stay in sync.

## Test plan

- [ ] CI green
- [ ] No other `45` references for the secretary rule remain (`grep -n SECRETARY_MIN_HEIGHT` only matches symbol references after this PR)

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)