### PR TITLE
fix(dashboard): exclude closed workers from live count (Issue #264)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -594,6 +594,8 @@ mcp__renga-peers__send_message(
    実施内容:
    - `org-state.md` の該当Work Itemを **COMPLETED** に更新
    - ワーカーの状態ファイルを最終更新
+   - **ワーカー状態ファイルをアーカイブへ移動**: `mv .state/workers/worker-{task_id}.md .state/workers/archive/`
+     （`archive/` ディレクトリが無ければ作成。dashboard はこのディレクトリ内のファイルを live ワーカーとして扱わない (Issue #264)。journal / retro が履歴参照する可能性に備えて削除はしない）
    - `journal.jsonl` にイベント追記
    - ディスパッチャーにペインクローズを依頼:
      `CLOSE_PANE: {pane_id} のペインを閉じてください。`

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -249,12 +249,9 @@ def build_state():
     projects_text = _read(BASE_DIR / "registry" / "projects.md")
     projects = _parse_projects(projects_text)
 
-    all_workers = _parse_workers(state_dir / "workers")
-
-    # Filter out workers whose task is completed/abandoned/review
-    done_statuses = {"COMPLETED", "ABANDONED", "REVIEW"}
-    done_tasks = {wi["id"] for wi in work_items if wi["status"] in done_statuses}
-    workers = [w for w in all_workers if w["task"] not in done_tasks]
+    # Source of truth for "live worker" is presence directly under .state/workers/;
+    # closing a worker moves its md file to .state/workers/archive/ (org-delegate Step 5).
+    workers = _parse_workers(state_dir / "workers")
 
     knowledge = _parse_knowledge(BASE_DIR / "knowledge" / "curated")
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -14,6 +14,7 @@ from dashboard.server import (
     _parse_projects,
     _parse_workers,
     _parse_knowledge,
+    build_state,
 )
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -115,6 +116,62 @@ class TestParseWorkers(unittest.TestCase):
     def test_nonexistent_dir(self):
         workers = _parse_workers(FIXTURES / "nonexistent")
         self.assertEqual(workers, [])
+
+    def test_archive_subdir_excluded(self):
+        """Issue #264: workers under .state/workers/archive/ must not appear as live."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            wdir = Path(td)
+            (wdir / "worker-live.md").write_text(
+                "Task: live-task\nPane ID: pane-1\nStarted: now\n",
+                encoding="utf-8",
+            )
+            (wdir / "archive").mkdir()
+            (wdir / "archive" / "worker-old.md").write_text(
+                "Task: old-task\nPane ID: pane-9\nStarted: long ago\n",
+                encoding="utf-8",
+            )
+            workers = _parse_workers(wdir)
+            self.assertEqual([w["task"] for w in workers], ["live-task"])
+
+
+class TestBuildStateLiveWorkers(unittest.TestCase):
+    """Issue #264 regression: live worker list = files in .state/workers/ root only.
+
+    Workers in REVIEW must remain visible (pane is still open, awaiting human approval).
+    Workers whose md file has been moved to archive/ must NOT appear as live, regardless
+    of whether their task id still appears in org-state.md Active Work Items.
+    """
+
+    def test_review_workers_stay_visible_and_archived_disappear(self):
+        import tempfile
+        from unittest.mock import patch
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            (base / ".state" / "workers" / "archive").mkdir(parents=True)
+            (base / ".state" / "workers" / "worker-active.md").write_text(
+                "Task: active-task\nPane ID: pane-1\nStarted: now\n", encoding="utf-8",
+            )
+            (base / ".state" / "workers" / "worker-review.md").write_text(
+                "Task: review-task\nPane ID: pane-2\nStarted: now\n", encoding="utf-8",
+            )
+            (base / ".state" / "workers" / "archive" / "worker-old.md").write_text(
+                "Task: old-task\nPane ID: pane-3\nStarted: ages ago\n", encoding="utf-8",
+            )
+            (base / ".state" / "org-state.md").write_text(
+                "## Active Work Items\n"
+                "- active-task: 作業中 [IN_PROGRESS]\n"
+                "- review-task: レビュー中 [REVIEW]\n",
+                encoding="utf-8",
+            )
+            (base / "registry").mkdir()
+            (base / "registry" / "projects.md").write_text("", encoding="utf-8")
+
+            with patch("dashboard.server.BASE_DIR", base):
+                state = build_state()
+
+            tasks = sorted(w["task"] for w in state["workers"])
+            self.assertEqual(tasks, ["active-task", "review-task"])
 
 
 class TestParseKnowledge(unittest.TestCase):

--- a/tools/sweep_stale_workers.py
+++ b/tools/sweep_stale_workers.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""One-shot sweep: move closed worker state files into .state/workers/archive/.
+
+Used to bulk-clean accumulated stale `.state/workers/worker-*.md` files (Issue #264).
+A worker is considered live iff its task id appears in `.state/org-state.md` Work Items
+with status NOT in {COMPLETED, ABANDONED, REVIEW}; everything else is archived.
+
+Usage:
+    py -3 tools/sweep_stale_workers.py [--dry-run] [--repo-root PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+DONE_STATUSES = {"COMPLETED", "ABANDONED", "REVIEW"}
+
+
+def parse_live_task_ids(org_state_md: Path) -> set[str]:
+    if not org_state_md.exists():
+        return set()
+    text = org_state_md.read_text(encoding="utf-8").replace("\r\n", "\n")
+    live: set[str] = set()
+    for line in text.splitlines():
+        m = re.match(r"^- ([\w-]+):\s*.+?\s*\[(\w+)\]", line)
+        if m and m.group(2).upper() not in DONE_STATUSES:
+            live.add(m.group(1))
+    return live
+
+
+def task_id_from_worker_md(text: str, fallback: str) -> str:
+    for line in text.splitlines():
+        m = re.match(r"^Task:\s*(\S+)", line)
+        if m:
+            return m.group(1).strip()
+    return fallback
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--repo-root", type=Path, default=Path(__file__).parent.parent)
+    args = p.parse_args()
+
+    workers_dir = args.repo_root / ".state" / "workers"
+    archive_dir = workers_dir / "archive"
+    org_state = args.repo_root / ".state" / "org-state.md"
+
+    if not workers_dir.exists():
+        print(f"no workers dir: {workers_dir}", file=sys.stderr)
+        return 1
+
+    live = parse_live_task_ids(org_state)
+    print(f"live task ids ({len(live)}): {sorted(live) if live else '(none)'}")
+
+    moved = kept = 0
+    for md in sorted(workers_dir.glob("worker-*.md")):
+        text = md.read_text(encoding="utf-8", errors="replace")
+        fallback = md.stem.replace("worker-", "")
+        task_id = task_id_from_worker_md(text, fallback)
+        if task_id in live:
+            kept += 1
+            continue
+        target = archive_dir / md.name
+        if args.dry_run:
+            print(f"[dry-run] archive: {md.name} (task={task_id})")
+        else:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            md.rename(target)
+            print(f"archived: {md.name} (task={task_id})")
+        moved += 1
+
+    print(f"\nsummary: moved={moved} kept_live={kept}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sweep_stale_workers.py
+++ b/tools/sweep_stale_workers.py
@@ -2,11 +2,22 @@
 """One-shot sweep: move closed worker state files into .state/workers/archive/.
 
 Used to bulk-clean accumulated stale `.state/workers/worker-*.md` files (Issue #264).
-A worker is considered live iff its task id appears in `.state/org-state.md` Work Items
-with status NOT in {COMPLETED, ABANDONED, REVIEW}; everything else is archived.
+
+Two modes:
+
+* **safe (default)** — archive only workers whose task id appears in
+  `.state/org-state.md` Active Work Items with status `COMPLETED` or `ABANDONED`.
+  `REVIEW` is treated as live (pane is still open, human approval pending).
+
+* **--include-orphans** — additionally archive workers whose task id does NOT
+  appear in org-state.md at all (assumed long-rotated-out, the typical Issue #264
+  cause). Orphans whose md was modified within `--orphan-min-age-days` (default 7)
+  are kept untouched as a safety guard against archiving still-live workers whose
+  org-state entry got out of sync.
 
 Usage:
-    py -3 tools/sweep_stale_workers.py [--dry-run] [--repo-root PATH]
+    py -3 tools/sweep_stale_workers.py [--dry-run] [--include-orphans]
+                                       [--orphan-min-age-days N] [--repo-root PATH]
 """
 
 from __future__ import annotations
@@ -14,22 +25,24 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+import time
 from pathlib import Path
 
 
-DONE_STATUSES = {"COMPLETED", "ABANDONED", "REVIEW"}
+TERMINAL_STATUSES = {"COMPLETED", "ABANDONED"}
 
 
-def parse_live_task_ids(org_state_md: Path) -> set[str]:
+def parse_work_item_statuses(org_state_md: Path) -> dict[str, str]:
+    """Return {task_id: STATUS} for every Active Work Item line. Empty if file missing."""
     if not org_state_md.exists():
-        return set()
+        return {}
     text = org_state_md.read_text(encoding="utf-8").replace("\r\n", "\n")
-    live: set[str] = set()
+    out: dict[str, str] = {}
     for line in text.splitlines():
         m = re.match(r"^- ([\w-]+):\s*.+?\s*\[(\w+)\]", line)
-        if m and m.group(2).upper() not in DONE_STATUSES:
-            live.add(m.group(1))
-    return live
+        if m:
+            out[m.group(1)] = m.group(2).upper()
+    return out
 
 
 def task_id_from_worker_md(text: str, fallback: str) -> str:
@@ -40,9 +53,27 @@ def task_id_from_worker_md(text: str, fallback: str) -> str:
     return fallback
 
 
+def classify(task_id: str, work_items: dict[str, str], age_days: float, min_age: float):
+    """Return ('archive' | 'keep', reason)."""
+    status = work_items.get(task_id)
+    if status in TERMINAL_STATUSES:
+        return "archive", f"work item is {status}"
+    if status is not None:
+        # Present in org-state but not terminal (IN_PROGRESS / REVIEW / BLOCKED / PENDING).
+        return "keep", f"work item is {status} (still live)"
+    # Orphan: not in org-state at all.
+    if age_days < min_age:
+        return "keep", f"orphan but too recent ({age_days:.1f}d < {min_age:.1f}d)"
+    return "archive-orphan", f"orphan, age {age_days:.1f}d"
+
+
 def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--include-orphans", action="store_true",
+                   help="Also archive workers whose task id is absent from org-state.md.")
+    p.add_argument("--orphan-min-age-days", type=float, default=7.0,
+                   help="Skip orphans modified within this many days (default 7).")
     p.add_argument("--repo-root", type=Path, default=Path(__file__).parent.parent)
     args = p.parse_args()
 
@@ -54,27 +85,37 @@ def main() -> int:
         print(f"no workers dir: {workers_dir}", file=sys.stderr)
         return 1
 
-    live = parse_live_task_ids(org_state)
-    print(f"live task ids ({len(live)}): {sorted(live) if live else '(none)'}")
+    work_items = parse_work_item_statuses(org_state)
+    print(f"work items in org-state: {len(work_items)}")
 
+    now = time.time()
     moved = kept = 0
     for md in sorted(workers_dir.glob("worker-*.md")):
         text = md.read_text(encoding="utf-8", errors="replace")
         fallback = md.stem.replace("worker-", "")
         task_id = task_id_from_worker_md(text, fallback)
-        if task_id in live:
+        age_days = (now - md.stat().st_mtime) / 86400.0
+
+        action, reason = classify(task_id, work_items, age_days, args.orphan_min_age_days)
+        if action == "archive-orphan" and not args.include_orphans:
+            action = "keep"
+            reason = f"{reason} (pass --include-orphans to archive)"
+
+        if action == "keep":
             kept += 1
+            print(f"keep    : {md.name} (task={task_id}; {reason})")
             continue
+
         target = archive_dir / md.name
         if args.dry_run:
-            print(f"[dry-run] archive: {md.name} (task={task_id})")
+            print(f"[dry-run] archive: {md.name} (task={task_id}; {reason})")
         else:
             archive_dir.mkdir(parents=True, exist_ok=True)
             md.rename(target)
-            print(f"archived: {md.name} (task={task_id})")
+            print(f"archived: {md.name} (task={task_id}; {reason})")
         moved += 1
 
-    print(f"\nsummary: moved={moved} kept_live={kept}")
+    print(f"\nsummary: {'would-move' if args.dry_run else 'moved'}={moved} kept={kept}")
     return 0
 
 

--- a/tools/test_sweep_stale_workers.py
+++ b/tools/test_sweep_stale_workers.py
@@ -8,35 +8,70 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from tools.sweep_stale_workers import parse_live_task_ids, task_id_from_worker_md
+from tools.sweep_stale_workers import (
+    classify,
+    parse_work_item_statuses,
+    task_id_from_worker_md,
+)
 
 
-class TestParseLiveTaskIds(unittest.TestCase):
+class TestParseWorkItemStatuses(unittest.TestCase):
 
-    def test_picks_only_non_terminal_statuses(self):
+    def test_collects_id_to_status(self):
+        import tempfile
         text = (
             "## Active Work Items\n"
-            "- live-a: live one [IN_PROGRESS]\n"
-            "- live-b: also live [REVIEW_PENDING]\n"
-            "- done: finished [COMPLETED]\n"
-            "- gone: abandoned [ABANDONED]\n"
-            "- review: in review [REVIEW]\n"
+            "- ip-task: 作業中 [IN_PROGRESS]\n"
+            "- rv-task: レビュー [REVIEW]\n"
+            "- done-task: 完了 [COMPLETED]\n"
+            "- gone-task: 中止 [ABANDONED]\n"
         )
-        out = self._parse_text(text)
-        self.assertEqual(out, {"live-a", "live-b"})
-
-    def test_missing_file(self):
-        self.assertEqual(parse_live_task_ids(Path("/no/such/file.md")), set())
-
-    def _parse_text(self, text: str) -> set[str]:
-        import tempfile
         with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
             f.write(text)
             p = Path(f.name)
         try:
-            return parse_live_task_ids(p)
+            out = parse_work_item_statuses(p)
         finally:
             p.unlink()
+        self.assertEqual(out, {
+            "ip-task": "IN_PROGRESS",
+            "rv-task": "REVIEW",
+            "done-task": "COMPLETED",
+            "gone-task": "ABANDONED",
+        })
+
+    def test_missing_file(self):
+        self.assertEqual(parse_work_item_statuses(Path("/no/such/file.md")), {})
+
+
+class TestClassify(unittest.TestCase):
+    """REVIEW must stay live; only COMPLETED/ABANDONED archive by default; orphans
+    only archive when caller opts in (handled in main, not classify)."""
+
+    def test_completed_archives(self):
+        a, _ = classify("t", {"t": "COMPLETED"}, age_days=1, min_age=7)
+        self.assertEqual(a, "archive")
+
+    def test_abandoned_archives(self):
+        a, _ = classify("t", {"t": "ABANDONED"}, age_days=1, min_age=7)
+        self.assertEqual(a, "archive")
+
+    def test_review_keeps(self):
+        a, reason = classify("t", {"t": "REVIEW"}, age_days=1, min_age=7)
+        self.assertEqual(a, "keep")
+        self.assertIn("REVIEW", reason)
+
+    def test_in_progress_keeps(self):
+        a, _ = classify("t", {"t": "IN_PROGRESS"}, age_days=1, min_age=7)
+        self.assertEqual(a, "keep")
+
+    def test_orphan_recent_keeps(self):
+        a, _ = classify("t", {}, age_days=1, min_age=7)
+        self.assertEqual(a, "keep")
+
+    def test_orphan_old_archive_orphan(self):
+        a, _ = classify("t", {}, age_days=30, min_age=7)
+        self.assertEqual(a, "archive-orphan")
 
 
 class TestTaskIdFromWorkerMd(unittest.TestCase):

--- a/tools/test_sweep_stale_workers.py
+++ b/tools/test_sweep_stale_workers.py
@@ -1,0 +1,53 @@
+"""Tests for tools/sweep_stale_workers.py."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools.sweep_stale_workers import parse_live_task_ids, task_id_from_worker_md
+
+
+class TestParseLiveTaskIds(unittest.TestCase):
+
+    def test_picks_only_non_terminal_statuses(self):
+        text = (
+            "## Active Work Items\n"
+            "- live-a: live one [IN_PROGRESS]\n"
+            "- live-b: also live [REVIEW_PENDING]\n"
+            "- done: finished [COMPLETED]\n"
+            "- gone: abandoned [ABANDONED]\n"
+            "- review: in review [REVIEW]\n"
+        )
+        out = self._parse_text(text)
+        self.assertEqual(out, {"live-a", "live-b"})
+
+    def test_missing_file(self):
+        self.assertEqual(parse_live_task_ids(Path("/no/such/file.md")), set())
+
+    def _parse_text(self, text: str) -> set[str]:
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
+            f.write(text)
+            p = Path(f.name)
+        try:
+            return parse_live_task_ids(p)
+        finally:
+            p.unlink()
+
+
+class TestTaskIdFromWorkerMd(unittest.TestCase):
+
+    def test_extracts_task_field(self):
+        text = "# Worker\nTask: my-task\nPane ID: pane-1\n"
+        self.assertEqual(task_id_from_worker_md(text, "fallback"), "my-task")
+
+    def test_falls_back_to_stem(self):
+        self.assertEqual(task_id_from_worker_md("no task field here\n", "stem-id"), "stem-id")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closed workers were rendered indefinitely on the dashboard because `.state/workers/*.md` accumulated forever and the existing filter only excluded tasks present in `work_items`. As of filing, 114 stale entries dated back to 2026-04-20.

## Design choice: option B (archive directory)

- (A) terminal-status marking — keeps the file flood, just relabels it. Doesn't address the root cause.
- (B) **archive subdirectory** — file-namespace separation, dashboard glob narrows naturally, history preserved for journal/retro. **Selected.**
- (C) journal-derived SoT — clean but requires ripping out the existing `.md` parse path. Out of scope for this issue.

## Changes

- `dashboard/server.py` — live-worker check switched from `work_items`-dependent filtering to a non-recursive glob of `.state/workers/`, so anything moved under `archive/` is excluded automatically.
- `.claude/skills/org-delegate/SKILL.md` — Step 5 (2b-ii) close-pane flow now includes `mv .state/workers/worker-{task_id}.md .state/workers/archive/`.
- `tools/sweep_stale_workers.py` (+ unit tests) — one-shot sweep for the existing accumulation. `REVIEW` stays live (it's a real state in the lifecycle); orphans (no entry in `org-state`) require explicit `--include-orphans` and a 7-day age threshold by default.
- `tests/test_parsers.py` — regression: archive entries excluded, REVIEW entries kept.

## Test plan

- [x] `pytest` (180 tests) green
- [x] dashboard `build_state()` smoke fixture: 2 live + 1 archived → 2 live shown
- [x] sweep `--dry-run` / live: COMPLETED archived, REVIEW/IN_PROGRESS kept, orphans gated by flag
- [ ] After merge: run `py -3 tools/sweep_stale_workers.py --dry-run` then `--include-orphans` to clean the existing 114 stale files
- [x] Codex self-review 3 rounds, no Blocker/Major remaining

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)