### PR TITLE
feat(state-db): M2 write API + schema cutover (foundation; skill flip + dogfood deferred to M2.1, Issue #267)

### DIFF
--- a/dashboard/org_state_converter.py
+++ b/dashboard/org_state_converter.py
@@ -236,32 +236,49 @@ def parse_org_state_db(db_path, md_path=None):
     """
     del md_path  # M2: no markdown overlay; arg kept for caller compat.
     from tools.state_db import connect
-    from tools.state_db.queries import get_org_state_summary
+    from tools.state_db.queries import (
+        get_org_state_summary,
+        list_runs_with_dirs,
+    )
 
     conn = connect(db_path)
     try:
         summary = get_org_state_summary(conn)
         session = summary.get("session") or {}
+        # WDR historically lists *every* run with a worker_dir
+        # (active + completed + failed + abandoned), so use the full
+        # listing rather than just the active runs from `summary`.
         registry = []
-        for r in summary["active_runs"]:
-            if not r.get("worker_dir"):
-                continue
+        for r in list_runs_with_dirs(conn):
             registry.append({
                 "taskId": r["task_id"],
                 "pattern": r["pattern"],
                 "directory": r["worker_dir"],
                 "project": r.get("project_slug") or "",
-                "status": r["status"],
+                "status": r.get("outcome_note") or r.get("status") or "",
             })
     finally:
         conn.close()
 
+    # Frontend (dashboard/app.js) renders icons keyed off IN_PROGRESS /
+    # REVIEW / PENDING / COMPLETED / BLOCKED / ABANDONED. Map the DB enum
+    # so a `_source: db` JSON renders the same as the markdown path.
+    _STATUS_MAP = {
+        "in_use": "IN_PROGRESS",
+        "review": "REVIEW",
+        "queued": "PENDING",
+        "completed": "COMPLETED",
+        "failed": "BLOCKED",
+        "suspended": "PENDING",
+        "abandoned": "ABANDONED",
+    }
     work_items = []
     for r in summary["active_runs"]:
+        raw = (r["status"] or "").lower()
         work_items.append({
             "id": r["task_id"],
             "title": r["title"] or r["task_id"],
-            "status": (r["status"] or "").upper(),
+            "status": _STATUS_MAP.get(raw, raw.upper()),
             "progress": r.get("outcome_note"),
             "worker": r.get("worker_dir"),
         })

--- a/dashboard/org_state_converter.py
+++ b/dashboard/org_state_converter.py
@@ -275,12 +275,15 @@ def parse_org_state_db(db_path, md_path=None):
     work_items = []
     for r in summary["active_runs"]:
         raw = (r["status"] or "").lower()
+        # Mirror dashboard/server.py:_work_items_from_db_runs — leave
+        # `progress` / `worker` empty rather than surfacing the raw
+        # status string and absolute worker_dir path through the UI.
         work_items.append({
             "id": r["task_id"],
             "title": r["title"] or r["task_id"],
             "status": _STATUS_MAP.get(raw, raw.upper()),
-            "progress": r.get("outcome_note"),
-            "worker": r.get("worker_dir"),
+            "progress": None,
+            "worker": None,
         })
 
     dispatcher = None
@@ -348,14 +351,31 @@ def convert(md_path=None, json_path=None, source="db", db_path=None):
             print(f"[org_state_converter] state.db not found: {db_path}",
                   file=sys.stderr)
             return False
-        data = parse_org_state_db(db_path, md_path=md_path)
-    elif chosen == "markdown":
+        try:
+            data = parse_org_state_db(db_path, md_path=md_path)
+        except Exception as exc:
+            # Match dashboard/server.py:_load_state_from_db semantics:
+            # in `auto` mode we must degrade to markdown when the DB
+            # itself is unreadable (e.g. corrupt file) rather than
+            # propagating a sqlite3 error to the caller.
+            if source != "auto":
+                raise
+            print(
+                f"[org_state_converter] DB read failed ({type(exc).__name__}: "
+                f"{exc}); falling back to markdown.",
+                file=sys.stderr,
+            )
+            chosen = "markdown"
+    if chosen == "markdown":
         if not md_path.exists():
             print(f"[org_state_converter] org-state.md not found: {md_path}",
                   file=sys.stderr)
             return False
         text = md_path.read_text(encoding="utf-8")
         data = parse_org_state_md(text)
+    elif chosen == "db":
+        # data was set in the `if chosen == "db":` block above.
+        pass
     else:
         print(f"[org_state_converter] unknown --source {source}", file=sys.stderr)
         return False

--- a/dashboard/org_state_converter.py
+++ b/dashboard/org_state_converter.py
@@ -11,20 +11,15 @@ Source of truth rule:
     org-state.md is canonical (human/AI-readable).
     org-state.json is derived (machine-readable for dashboard etc.).
 
-M1 (Issue #267) adds an optional DB read path:
-    --source markdown  : parse .state/org-state.md (default — non-lossy SoT).
-    --source db        : query .state/state.db via tools.state_db.queries.
-                         Falls back to a markdown overlay for fields the DB
-                         does not yet model (Status / Objective / Updated /
-                         Dispatcher / Curator / Resume Instructions).
-    --source auto      : try DB first; fall back to markdown if DB is missing
-                         or stale.
-
-The default stays `markdown` because the DB only models *active* runs and
-worker directories; emitting a JSON without completed/queued items or the
-full Worker Directory Registry would be lossy for downstream readers
-(dashboard JSON-first read, etc.). Use `--source db` explicitly when you
-want a DB-derived snapshot.
+M2 (Issue #267) makes the DB the canonical source:
+    --source db        : (default) query .state/state.db via
+                         tools.state_db.queries. The org_sessions table
+                         now carries Status / Objective / Updated /
+                         Dispatcher / Curator / Resume Instructions —
+                         no markdown overlay required.
+    --source markdown  : parse .state/org-state.md instead. Kept for
+                         debugging / pre-M2 DBs / disaster recovery.
+    --source auto      : DB if state.db exists, otherwise markdown.
 """
 
 import argparse
@@ -232,18 +227,21 @@ def parse_org_state_md(text):
 def parse_org_state_db(db_path, md_path=None):
     """Build the org-state.json shape from .state/state.db.
 
-    The DB does not yet model Status / Current Objective / Updated /
-    Dispatcher / Curator / Resume Instructions (M1 scope keeps markdown as
-    SoT for those). To stay non-lossy, this function ALSO parses the markdown
-    when present and merges the markdown-only fields into the output. The
-    workItems / workerDirectoryRegistry come from the DB.
+    M2 (Issue #267): all known fields come straight from the DB —
+    workItems / Worker Directory Registry from runs + worker_dirs,
+    Status / Updated / Suspended / Resumed / Current Objective /
+    Dispatcher / Curator / Resume Instructions from org_sessions.
+    The ``md_path`` parameter is accepted for backwards compatibility
+    but no longer consulted (the M1 markdown overlay is gone).
     """
+    del md_path  # M2: no markdown overlay; arg kept for caller compat.
     from tools.state_db import connect
     from tools.state_db.queries import get_org_state_summary
 
     conn = connect(db_path)
     try:
         summary = get_org_state_summary(conn)
+        session = summary.get("session") or {}
         registry = []
         for r in summary["active_runs"]:
             if not r.get("worker_dir"):
@@ -268,66 +266,44 @@ def parse_org_state_db(db_path, md_path=None):
             "worker": r.get("worker_dir"),
         })
 
-    # Merge markdown-only fields (Status, Objective, Updated, Dispatcher,
-    # Curator, Resume Instructions). Without this, an `auto`/`db` CLI run
-    # would overwrite .state/org-state.json with a lossy snapshot and the
-    # dashboard's JSON-first reader would lose those fields.
-    md_overlay = {}
-    md_path = Path(md_path) if md_path else _MD_PATH
-    if md_path.exists():
-        try:
-            md_overlay = parse_org_state_md(md_path.read_text(encoding="utf-8"))
-        except Exception as exc:
-            print(f"[org_state_converter] markdown overlay failed: {exc}",
-                  file=sys.stderr)
-            md_overlay = {}
+    dispatcher = None
+    if session.get("dispatcher_pane_id") or session.get("dispatcher_peer_id"):
+        dispatcher = {
+            "peerId": session.get("dispatcher_peer_id"),
+            "paneId": session.get("dispatcher_pane_id"),
+        }
+    curator = None
+    if session.get("curator_pane_id") or session.get("curator_peer_id"):
+        curator = {
+            "peerId": session.get("curator_peer_id"),
+            "paneId": session.get("curator_pane_id"),
+        }
 
-    def _pick(key, default=None):
-        return md_overlay.get(key, default) if md_overlay else default
+    status = (session.get("status")
+              or ("ACTIVE" if summary["active_runs"] else "IDLE"))
 
     return {
         "version": SCHEMA_VERSION,
-        "updated": _pick("updated"),
-        "status": _pick("status",
-                        "ACTIVE" if summary["active_runs"] else "IDLE"),
-        "currentObjective": _pick("currentObjective"),
+        "updated": session.get("updated_at"),
+        "status": status,
+        "currentObjective": session.get("objective"),
         "workItems": work_items,
         "workerDirectoryRegistry": registry,
-        "dispatcher": _pick("dispatcher"),
-        "curator": _pick("curator"),
-        "resumeInstructions": _pick("resumeInstructions"),
+        "dispatcher": dispatcher,
+        "curator": curator,
+        "resumeInstructions": session.get("resume_instructions"),
         "_source": "db",
     }
 
 
-def _db_is_fresh(db_path, md_path):
-    """True if db_path is at least as new as md_path. Missing files = not fresh.
-
-    Uses max(state.db, state.db-wal) mtimes — WAL mode (tools.state_db
-    enables journal_mode=WAL) lets writes land in the -wal sidecar until
-    checkpoint, so the main file's mtime can lag.
-    """
-    db_path = Path(db_path)
-    md_path = Path(md_path)
-    if not db_path.exists():
-        return False
-    db_mtime = 0.0
-    for p in (db_path, Path(str(db_path) + "-wal")):
-        try:
-            db_mtime = max(db_mtime, p.stat().st_mtime)
-        except OSError:
-            continue
-    if db_mtime == 0.0:
-        return False
-    try:
-        md_mtime = md_path.stat().st_mtime
-    except OSError:
-        # No markdown to compare against → trust the DB.
-        return True
-    return db_mtime >= md_mtime
+def _db_available(db_path, md_path=None):
+    """True iff `.state/state.db` is on disk. M2: DB is the SoT, no
+    markdown-vs-DB freshness comparison required."""
+    del md_path  # kept for legacy call sites
+    return Path(db_path).exists()
 
 
-def convert(md_path=None, json_path=None, source="markdown", db_path=None):
+def convert(md_path=None, json_path=None, source="db", db_path=None):
     """Read state, build the org-state JSON dict, write it atomically.
 
     `source`:
@@ -348,7 +324,7 @@ def convert(md_path=None, json_path=None, source="markdown", db_path=None):
 
     chosen = source
     if chosen == "auto":
-        chosen = "db" if _db_is_fresh(db_path, md_path) else "markdown"
+        chosen = "db" if _db_available(db_path) else "markdown"
 
     if chosen == "db":
         if not db_path.exists():
@@ -391,11 +367,10 @@ def _main(argv=None):
     p.add_argument(
         "--source",
         choices=("auto", "db", "markdown"),
-        default="markdown",
-        help="Where to read org-state from. 'markdown' (default) preserves "
-             "all fields including completed/queued items. 'db' uses the "
-             "state DB and overlays markdown for fields the DB does not "
-             "model. 'auto' picks DB if it is fresh, else markdown.",
+        default="db",
+        help="Where to read org-state from. 'db' (default, M2 SoT) reads "
+             ".state/state.db. 'markdown' parses the legacy file. 'auto' "
+             "picks DB when the file is present, else markdown.",
     )
     p.add_argument("--md", default=str(_MD_PATH),
                    help="Path to org-state.md (markdown SoT)")

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -252,58 +252,10 @@ def _parse_knowledge(curated_dir):
     return result
 
 
-_DB_STALE_WARN_LOGGED = False
-
-
-def _db_is_fresh(state_dir):
-    """True if .state/state.db exists and is at least as fresh as the SoT markdown.
-
-    M1 keeps markdown as SoT; DB is a derived view rebuilt by the importer.
-    If the DB is older than its markdown source, treat it as stale and prefer
-    markdown — a one-time stderr warning nudges the operator to rerun
-    `python -m tools.state_db.importer --rebuild`.
-    """
-    global _DB_STALE_WARN_LOGGED
-    if not _DB_AVAILABLE or not STATE_DB_PATH.exists():
-        return False
-    # Take the max of state.db and state.db-wal mtimes. With WAL enabled
-    # (tools.state_db.__init__ sets journal_mode=WAL), in-flight writes
-    # land in -wal until checkpointed; the main file's mtime can lag.
-    db_mtime = 0.0
-    for p in (STATE_DB_PATH, Path(str(STATE_DB_PATH) + "-wal")):
-        try:
-            db_mtime = max(db_mtime, p.stat().st_mtime)
-        except OSError:
-            continue
-    if db_mtime == 0.0:
-        return False
-    sot_paths = [
-        state_dir / "org-state.md",
-        state_dir / "journal.jsonl",
-        BASE_DIR / "registry" / "projects.md",
-    ]
-    newest_sot = 0.0
-    for p in sot_paths:
-        try:
-            newest_sot = max(newest_sot, p.stat().st_mtime)
-        except OSError:
-            continue
-    # `>` not `>=`: equal mtimes (e.g. importer just rebuilt against current
-    # markdown) count as fresh. Matches `_db_is_fresh` in org_state_converter.
-    if newest_sot > db_mtime:
-        if not _DB_STALE_WARN_LOGGED:
-            print(
-                "[server] .state/state.db is older than markdown SoT — "
-                "falling back to markdown. Rebuild with: "
-                "python -m tools.state_db.importer "
-                f"--db {STATE_DB_PATH} --root {BASE_DIR} --rebuild",
-                file=sys.stderr,
-            )
-            _DB_STALE_WARN_LOGGED = True
-        return False
-    # Reset the warning latch so a subsequent rebuild clears the noise.
-    _DB_STALE_WARN_LOGGED = False
-    return True
+def _db_available():
+    """M2 (Issue #267): DB is the SoT — no markdown freshness comparison.
+    Just check the file exists and the imports succeeded."""
+    return _DB_AVAILABLE and STATE_DB_PATH.exists()
 
 
 _EVENT_LABELS_DB = {
@@ -393,7 +345,9 @@ def _work_items_from_db_runs(active_runs):
 
 
 def _load_state_from_db(state_dir):
-    """Return (work_items, activity) sourced from the state DB, or None on failure."""
+    """Return (status, objective, work_items, activity) from state.db,
+    or None on failure. M2: org_sessions carries Status / Current Objective
+    so we no longer need the markdown overlay for those fields."""
     try:
         conn = _db_connect(STATE_DB_PATH)
         try:
@@ -405,7 +359,12 @@ def _load_state_from_db(state_dir):
         print(f"[server] DB read failed, falling back to markdown: {exc}",
               file=sys.stderr)
         return None
+    session = summary.get("session") or {}
+    db_status = session.get("status")
+    db_objective = session.get("objective")
     return (
+        db_status,
+        db_objective,
         _work_items_from_db_runs(summary["active_runs"]),
         _activity_from_db_events(events),
     )
@@ -414,27 +373,43 @@ def _load_state_from_db(state_dir):
 def build_state():
     state_dir = BASE_DIR / ".state"
 
-    # Status / objective still come from the markdown JSON snapshot (the DB
-    # schema does not yet cover Status / Current Objective — M1 scope).
-    _json_result = _load_org_state_from_json(state_dir)
-    if _json_result is not None:
-        status, objective, md_work_items = _json_result
-    else:
-        org_state_text = _read(state_dir / "org-state.md")
-        status, objective, md_work_items = _parse_org_state(org_state_text)
-
-    # M1: DB is the primary source for active runs (workItems) and events
-    # (activity). Markdown remains the safety net.
-    work_items = md_work_items
+    # M2: DB is the primary source for everything the schema models —
+    # Status / Objective via org_sessions, workItems via active runs,
+    # activity via the events table. Markdown / JSON snapshot remain as a
+    # safety net for the very first run after a fresh clone (no DB yet).
+    status = "IDLE"
+    objective = None
+    work_items = []
     activity = None
-    if _db_is_fresh(state_dir):
+
+    if _db_available():
         db_result = _load_state_from_db(state_dir)
         if db_result is not None:
-            work_items, activity = db_result
+            db_status, db_objective, work_items, activity = db_result
+            if db_status:
+                status = db_status
+            if db_objective:
+                objective = db_objective
 
-    if activity is None:
-        journal_text = _read(state_dir / "journal.jsonl")
-        activity = _parse_journal(journal_text)
+    if not work_items or activity is None:
+        # Fall back to the legacy JSON / markdown path.
+        _json_result = _load_org_state_from_json(state_dir)
+        if _json_result is not None:
+            md_status, md_objective, md_work_items = _json_result
+        else:
+            org_state_text = _read(state_dir / "org-state.md")
+            md_status, md_objective, md_work_items = _parse_org_state(
+                org_state_text
+            )
+        if not work_items:
+            work_items = md_work_items
+            if md_status and status == "IDLE":
+                status = md_status
+            if objective is None:
+                objective = md_objective
+        if activity is None:
+            journal_text = _read(state_dir / "journal.jsonl")
+            activity = _parse_journal(journal_text)
 
     projects_text = _read(BASE_DIR / "registry" / "projects.md")
     projects = _parse_projects(projects_text)

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -375,12 +375,15 @@ def build_state():
 
     # M2: DB is the primary source for everything the schema models —
     # Status / Objective via org_sessions, workItems via active runs,
-    # activity via the events table. Markdown / JSON snapshot remain as a
-    # safety net for the very first run after a fresh clone (no DB yet).
+    # activity via the events table. Markdown / JSON snapshot is consulted
+    # only when the DB itself is unavailable (fresh clone, missing import,
+    # corrupt file). An *empty* DB is a legitimate state and must not
+    # resurrect ghost tasks from a stale dump.
     status = "IDLE"
     objective = None
-    work_items = []
+    work_items: list = []
     activity = None
+    db_succeeded = False
 
     if _db_available():
         db_result = _load_state_from_db(state_dir)
@@ -390,9 +393,9 @@ def build_state():
                 status = db_status
             if db_objective:
                 objective = db_objective
+            db_succeeded = True
 
-    if not work_items or activity is None:
-        # Fall back to the legacy JSON / markdown path.
+    if not db_succeeded:
         _json_result = _load_org_state_from_json(state_dir)
         if _json_result is not None:
             md_status, md_objective, md_work_items = _json_result
@@ -401,15 +404,13 @@ def build_state():
             md_status, md_objective, md_work_items = _parse_org_state(
                 org_state_text
             )
-        if not work_items:
-            work_items = md_work_items
-            if md_status and status == "IDLE":
-                status = md_status
-            if objective is None:
-                objective = md_objective
-        if activity is None:
-            journal_text = _read(state_dir / "journal.jsonl")
-            activity = _parse_journal(journal_text)
+        work_items = md_work_items
+        if md_status:
+            status = md_status
+        if md_objective is not None:
+            objective = md_objective
+        journal_text = _read(state_dir / "journal.jsonl")
+        activity = _parse_journal(journal_text)
 
     projects_text = _read(BASE_DIR / "registry" / "projects.md")
     projects = _parse_projects(projects_text)

--- a/tests/test_org_state_converter.py
+++ b/tests/test_org_state_converter.py
@@ -157,7 +157,10 @@ class TestConvertFileIO(unittest.TestCase):
             json_path = Path(tmpdir) / "org-state.json"
             md_path.write_text(SAMPLE_ORG_STATE_MD, encoding="utf-8")
 
-            ok = convert(md_path=md_path, json_path=json_path)
+            # M2 changed the default source to 'db'; this test exercises the
+            # markdown path explicitly (no DB present).
+            ok = convert(md_path=md_path, json_path=json_path,
+                          source="markdown")
             self.assertTrue(ok)
             self.assertTrue(json_path.exists())
 
@@ -170,7 +173,8 @@ class TestConvertFileIO(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             md_path = Path(tmpdir) / "nonexistent.md"
             json_path = Path(tmpdir) / "org-state.json"
-            ok = convert(md_path=md_path, json_path=json_path)
+            ok = convert(md_path=md_path, json_path=json_path,
+                          source="markdown")
             self.assertFalse(ok)
             self.assertFalse(json_path.exists())
 

--- a/tests/test_state_db_fallback.py
+++ b/tests/test_state_db_fallback.py
@@ -1,8 +1,12 @@
-"""M1 read-path fallback tests (Issue #267 review minor #2).
+"""DB read-path fallback tests (Issue #267, updated for M2).
 
-Covers the DB-missing / DB-corrupt / DB-stale branches of:
-- dashboard/server.py:_load_state_from_db + _db_is_fresh + build_state
+Covers the DB-missing / DB-corrupt branches of:
+- dashboard/server.py:_load_state_from_db + build_state
 - dashboard/org_state_converter.py:convert(source="auto")
+
+M2 (Issue #267) removed the M1 markdown-vs-DB staleness comparison —
+the DB is now the SoT and freshness is no longer a meaningful concept.
+The tests for staleness-driven fallback have been retired accordingly.
 
 Strategy: monkey-patch the module-level paths to point at a tempdir so the
 test suite never touches the real .state/ tree, then assert that each branch
@@ -92,7 +96,6 @@ class TestServerFallback(unittest.TestCase):
         # Redirect module-level paths at the tempdir.
         server.BASE_DIR = self.root
         server.STATE_DB_PATH = self.db_path
-        server._DB_STALE_WARN_LOGGED = False
 
     def test_db_missing_falls_back_to_markdown(self):
         """No .state/state.db → build_state still returns markdown-derived items."""
@@ -119,9 +122,9 @@ class TestServerFallback(unittest.TestCase):
         self.assertGreaterEqual(len(state["workItems"]), 1)
         self.assertEqual(state["workItems"][0]["id"], "task-1")
 
-    def test_db_stale_falls_back_with_warning(self):
-        """DB older than markdown → fresh check fails, no DB read, markdown wins."""
-        # Build a real DB, then bump markdown mtime so DB is older.
+    def test_db_present_is_preferred_regardless_of_mtime(self):
+        """M2: DB is the SoT. Older mtime than markdown is no longer a
+        fallback trigger; staleness has been retired as a concept."""
         import_full_rebuild(self.db_path, self.root)
         future = time.time() + 120
         import os
@@ -135,16 +138,12 @@ class TestServerFallback(unittest.TestCase):
         buf = StringIO()
         with contextlib.redirect_stderr(buf):
             state = self.server.build_state()
+        # Status comes from org_sessions in the DB. The fixture markdown
+        # has Status: ACTIVE, but the importer loads it into the DB row
+        # so the value flows through either path.
         self.assertEqual(state["status"], "ACTIVE")
-        warn = buf.getvalue().lower()
-        # Warning must point at the rebuild path so the operator can act on it.
-        self.assertIn("older", warn)
-        self.assertIn("rebuild", warn)
-        # Second invocation should not duplicate the warning (latch).
-        buf2 = StringIO()
-        with contextlib.redirect_stderr(buf2):
-            self.server.build_state()
-        self.assertEqual(buf2.getvalue(), "")
+        # No staleness warning expected.
+        self.assertNotIn("older", buf.getvalue().lower())
 
 
 # ---------------------------------------------------------------------------
@@ -182,9 +181,9 @@ class TestConverterAutoFallback(unittest.TestCase):
         self.assertEqual(data["status"], "ACTIVE")
         self.assertEqual(data["currentObjective"], "M1 read switch tests")
 
-    def test_auto_stale_db_uses_markdown(self):
+    def test_auto_db_present_is_preferred_regardless_of_mtime(self):
+        """M2: presence is the only criterion; mtime no longer matters."""
         import_full_rebuild(self.db_path, self.root)
-        # Make markdown newer than DB.
         future = time.time() + 120
         import os
         os.utime(self.md_path, (future, future))
@@ -193,34 +192,29 @@ class TestConverterAutoFallback(unittest.TestCase):
                                      source="auto", db_path=self.db_path)
         self.assertTrue(ok)
         data = self._read_json()
-        self.assertNotEqual(data.get("_source"), "db")
+        self.assertEqual(data.get("_source"), "db")
 
     def test_auto_fresh_db_uses_db(self):
         import_full_rebuild(self.db_path, self.root)
-        # Make DB newer than markdown.
-        future = time.time() + 120
-        import os
-        os.utime(self.db_path, (future, future))
         ok = self.converter.convert(md_path=self.md_path,
                                      json_path=self.json_path,
                                      source="auto", db_path=self.db_path)
         self.assertTrue(ok)
         data = self._read_json()
         self.assertEqual(data.get("_source"), "db")
-        # Markdown overlay still preserves the markdown-only fields.
+        # M2: status / objective now flow through org_sessions inside the DB.
         self.assertEqual(data["status"], "ACTIVE")
         self.assertEqual(data["currentObjective"], "M1 read switch tests")
 
-    def test_explicit_markdown_default_does_not_consult_db(self):
-        # Even if DB is fresh, default source='markdown' must produce the
-        # markdown shape (non-lossy, includes Resume Instructions etc.).
+    def test_default_source_is_db(self):
+        # M2 changed the converter's default --source to 'db'.
         import_full_rebuild(self.db_path, self.root)
         ok = self.converter.convert(md_path=self.md_path,
                                      json_path=self.json_path,
                                      db_path=self.db_path)  # default source
         self.assertTrue(ok)
         data = self._read_json()
-        self.assertNotIn("_source", data)
+        self.assertEqual(data.get("_source"), "db")
 
 
 if __name__ == "__main__":

--- a/tests/test_state_db_fallback.py
+++ b/tests/test_state_db_fallback.py
@@ -206,6 +206,18 @@ class TestConverterAutoFallback(unittest.TestCase):
         self.assertEqual(data["status"], "ACTIVE")
         self.assertEqual(data["currentObjective"], "M1 read switch tests")
 
+    def test_auto_corrupt_db_falls_back_to_markdown(self):
+        """Codex round-2: in `auto` mode a corrupt DB must degrade to
+        markdown rather than propagate a sqlite3 error."""
+        # Garbage bytes: makes connect succeed but any query raise.
+        self.db_path.write_bytes(b"not a sqlite database file")
+        ok = self.converter.convert(md_path=self.md_path,
+                                     json_path=self.json_path,
+                                     source="auto", db_path=self.db_path)
+        self.assertTrue(ok)
+        data = self._read_json()
+        self.assertNotEqual(data.get("_source"), "db")
+
     def test_default_source_is_db(self):
         # M2 changed the converter's default --source to 'db'.
         import_full_rebuild(self.db_path, self.root)

--- a/tools/journal_append.py
+++ b/tools/journal_append.py
@@ -54,9 +54,28 @@ def _legacy_append(journal_path: Path, event: str, payload: dict) -> None:
     Journal(journal_path).append(event, **payload)
 
 
+class _DBCommitted(Exception):
+    """Sentinel: DB COMMIT succeeded; the post-commit dump failed.
+
+    Raised from `_db_append` so the caller can distinguish "the canonical
+    write happened, only the dump regenerate is stale" (don't fall back —
+    that would double-record the event) from "nothing was written at all"
+    (do fall back to legacy file append)."""
+
+    def __init__(self, original: BaseException):
+        super().__init__(repr(original))
+        self.original = original
+
+
 def _db_append(repo_root: Path, journal_path: Path, event: str,
                 payload: dict) -> None:
-    """M2 canonical path: DB write → jsonl regenerate."""
+    """M2 canonical path: DB write → jsonl regenerate.
+
+    Raises ``_DBCommitted`` if the regenerate step fails after a
+    successful COMMIT — the event is durably recorded in the DB and the
+    next regenerate (e.g. cron, next dispatch) will catch up. The caller
+    must not re-append to the legacy jsonl in that case.
+    """
     from tools.state_db import apply_schema, connect
     from tools.state_db.snapshotter import regenerate_journal_jsonl
     from tools.state_db.writer import StateWriter
@@ -65,22 +84,26 @@ def _db_append(repo_root: Path, journal_path: Path, event: str,
     db_path.parent.mkdir(parents=True, exist_ok=True)
     is_new_db = not db_path.exists()
     conn = connect(db_path)
+    committed = False
     try:
         if is_new_db:
             apply_schema(conn)
         writer = StateWriter(conn)
-        # ``actor`` is conventionally an explicit payload field on the
-        # legacy wire format; promote it so the events table has the
-        # column populated even without per-call API change.
         actor = None
         if isinstance(payload, dict) and isinstance(payload.get("actor"),
                                                      str):
             actor = payload["actor"]
         writer.append_event(kind=event, actor=actor, payload=payload)
         writer.commit()
-        regenerate_journal_jsonl(conn, journal_path)
+        committed = True
+        try:
+            regenerate_journal_jsonl(conn, journal_path)
+        except Exception as exc:
+            raise _DBCommitted(exc) from exc
     finally:
         conn.close()
+    if not committed:  # pragma: no cover — defensive
+        raise RuntimeError("journal_append: DB write did not commit")
 
 
 def main(argv: "list[str] | None" = None) -> int:
@@ -134,9 +157,20 @@ def main(argv: "list[str] | None" = None) -> int:
     try:
         _db_append(repo_root, canonical_path, args.event, payload)
         return 0
+    except _DBCommitted as exc:
+        # DB has the event; only the dump regenerate failed. Do NOT
+        # double-write to the legacy jsonl — that would put the event in
+        # twice once the next regenerate succeeds. Surface the failure
+        # and exit 0 so the hook proceeds.
+        sys.stderr.write(
+            "tools/journal_append.py: event committed to DB but jsonl "
+            "regenerate failed "
+            f"({type(exc.original).__name__}: {exc.original}); the "
+            "next regenerate will catch up.\n"
+        )
+        return 0
     except Exception as exc:
-        # Don't let a DB-side hiccup take down the dispatcher hook —
-        # warn loudly and degrade to the legacy file append.
+        # No commit happened — safe to fall back to file append.
         sys.stderr.write(
             "tools/journal_append.py: DB-write path failed "
             f"({type(exc).__name__}: {exc}); falling back to file append.\n"

--- a/tools/journal_append.py
+++ b/tools/journal_append.py
@@ -1,35 +1,24 @@
 #!/usr/bin/env python3
-# Phase 5 shim audit: confirmed minimal as of 2026-05-04 (#130)
-"""claude-org-ja journal append wrapper (Step D shim).
+"""claude-org-ja journal append wrapper (M2 DB-write switch, Issue #267).
 
-Thin CLI around :class:`core_harness.audit.Journal` with the org-specific
-journal path (``.state/journal.jsonl``) baked in. Use this when payload
-values need types beyond string (numbers, booleans, nested objects) or
-when keys fall outside the bash helper's
-``[A-Za-z_][A-Za-z0-9_]*`` constraint; otherwise prefer
-``tools/journal_append.sh``.
-
-Usage::
+CLI shape kept compatible with the pre-M2 wrapper so existing hooks /
+SKILL.md references keep working::
 
     py -3 tools/journal_append.py <event> --json '{"k": 1, "nested": {...}}'
     py -3 tools/journal_append.py <event> k=v k2=v2
 
-The first form takes a JSON object on the command line and merges it
-into the payload. The second form is the same string-typed key=value
-shape as the bash helper. Both forms can be combined; explicit
-``--json`` payload wins on key conflicts.
+Behaviour change in M2: the canonical write target is the SQLite DB at
+``<repo_root>/.state/state.db`` (via :class:`tools.state_db.writer.StateWriter`);
+``.state/journal.jsonl`` is then regenerated from the events table by
+:mod:`tools.state_db.snapshotter`. The DB schema is auto-created if the
+file is absent so a fresh clone or CI run without a prior importer pass
+still works. Legacy ``--path`` / ``$JOURNAL_PATH`` overrides remain
+rejected at this ja boundary.
 
-The journal path is fixed at ``<repo_root>/.state/journal.jsonl``
-where ``<repo_root>`` is the directory one level above this script
-(``tools/..``). This keeps writes anchored to the org journal
-regardless of caller cwd (e.g. the dispatcher pane runs with
-cwd=.dispatcher/).
-
-Audit boundary (refs cross-review M3): the legacy ``--path`` CLI
-argument and ``JOURNAL_PATH`` environment variable are rejected at
-this ja boundary so off-canon writes can't be silently redirected. A
-stderr warning is emitted if either is set; the canonical path is
-used regardless.
+Fallback: if the DB write path raises (e.g. sqlite3 unavailable, the
+schema can't be created), we degrade to the legacy file-append via
+``core_harness.audit.Journal`` so downstream automation stays unblocked
+and the failure surfaces as a stderr warning instead of a hook abort.
 """
 
 from __future__ import annotations
@@ -40,7 +29,12 @@ import os
 import sys
 from pathlib import Path
 
-from core_harness.audit import Journal
+# Make `tools.state_db.*` importable when this script is invoked
+# directly (e.g. `py -3 tools/journal_append.py …`) without a prior
+# `pip install -e .`. The repo root is the directory above this file.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 
 def _parse_kv(pair: str) -> "tuple[str, str]":
@@ -54,10 +48,45 @@ def _parse_kv(pair: str) -> "tuple[str, str]":
     return key, val
 
 
+def _legacy_append(journal_path: Path, event: str, payload: dict) -> None:
+    """Pre-M2 file-append path. Used as a last-resort fallback only."""
+    from core_harness.audit import Journal
+    Journal(journal_path).append(event, **payload)
+
+
+def _db_append(repo_root: Path, journal_path: Path, event: str,
+                payload: dict) -> None:
+    """M2 canonical path: DB write → jsonl regenerate."""
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.snapshotter import regenerate_journal_jsonl
+    from tools.state_db.writer import StateWriter
+
+    db_path = repo_root / ".state" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+        writer = StateWriter(conn)
+        # ``actor`` is conventionally an explicit payload field on the
+        # legacy wire format; promote it so the events table has the
+        # column populated even without per-call API change.
+        actor = None
+        if isinstance(payload, dict) and isinstance(payload.get("actor"),
+                                                     str):
+            actor = payload["actor"]
+        writer.append_event(kind=event, actor=actor, payload=payload)
+        writer.commit()
+        regenerate_journal_jsonl(conn, journal_path)
+    finally:
+        conn.close()
+
+
 def main(argv: "list[str] | None" = None) -> int:
     parser = argparse.ArgumentParser(
         prog="tools/journal_append.py",
-        description="Append a JSON-Lines event to .state/journal.jsonl.",
+        description="Append a JSON-Lines event (M2: DB-first, jsonl regenerated).",
     )
     parser.add_argument("event", help="event name (free-form string)")
     parser.add_argument(
@@ -74,11 +103,7 @@ def main(argv: "list[str] | None" = None) -> int:
     )
     repo_root = Path(__file__).resolve().parent.parent
     canonical_path = repo_root / ".state" / "journal.jsonl"
-    parser.add_argument(
-        "--path",
-        default=None,
-        help=argparse.SUPPRESS,
-    )
+    parser.add_argument("--path", default=None, help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
 
     if args.path is not None:
@@ -93,12 +118,10 @@ def main(argv: "list[str] | None" = None) -> int:
             "rejected at ja boundary; writing to canonical "
             f"{canonical_path}\n"
         )
-    args.path = str(canonical_path)
 
     payload: "dict[str, object]" = {}
     for key, val in args.fields:
         payload[key] = val
-
     if args.json_payload is not None:
         try:
             extra = json.loads(args.json_payload)
@@ -108,8 +131,25 @@ def main(argv: "list[str] | None" = None) -> int:
             parser.error("--json must encode a JSON object")
         payload.update(extra)
 
-    Journal(Path(args.path)).append(args.event, **payload)
-    return 0
+    try:
+        _db_append(repo_root, canonical_path, args.event, payload)
+        return 0
+    except Exception as exc:
+        # Don't let a DB-side hiccup take down the dispatcher hook —
+        # warn loudly and degrade to the legacy file append.
+        sys.stderr.write(
+            "tools/journal_append.py: DB-write path failed "
+            f"({type(exc).__name__}: {exc}); falling back to file append.\n"
+        )
+        try:
+            _legacy_append(canonical_path, args.event, payload)
+            return 0
+        except Exception as exc2:
+            sys.stderr.write(
+                "tools/journal_append.py: legacy fallback also failed: "
+                f"{type(exc2).__name__}: {exc2}\n"
+            )
+            return 1
 
 
 if __name__ == "__main__":

--- a/tools/journal_append.sh
+++ b/tools/journal_append.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-# Phase 5 shim audit: confirmed minimal as of 2026-05-04 (#130)
-# claude-org-ja journal append wrapper (Step D shim, refs ja#128 /
-# core-harness 0.3.0).
+# claude-org-ja journal append wrapper (M2 DB-write switch, Issue #267).
 #
-# Wraps `core_harness.audit.journal_append` with the org-specific
-# journal path (`.state/journal.jsonl`) baked in. Locates the bash
-# companion library by asking the installed core-harness package where
-# it lives, so this script keeps working through `pip install -e .`,
-# `pip install` from the pinned git URL, and any future package
-# layout change in core-harness.
+# Pre-M2 this script sourced core_harness.audit's bash companion and
+# appended directly to journal.jsonl. M2 routes writes through SQLite
+# (`.state/state.db`) and regenerates the jsonl from the events table;
+# the Python wrapper does both. Keeping the .sh entry point because
+# CLAUDE.md / SKILL.md / hook configs still reference it by name.
 #
 # Usage:
 #   bash tools/journal_append.sh <event> [k=v ...]
@@ -18,21 +15,9 @@
 #       worker=worker-foo dir=workers/foo task=foo
 #   bash tools/journal_append.sh suspend reason=user_requested
 #
-# For arbitrary payload shapes (nested objects, typed values, keys
-# outside [A-Za-z_][A-Za-z0-9_]*), use the Python entry point:
-#
-#   py -3 tools/journal_append.py <event> --json '<payload>'
-#
-# The journal path is fixed at `<repo_root>/.state/journal.jsonl`
-# regardless of the caller's cwd, where `<repo_root>` is the directory
-# one level above this script (`tools/..`). This matters because the
-# dispatcher pane runs with cwd=.dispatcher/, where a cwd-relative
-# default would write to .dispatcher/.state/journal.jsonl by mistake.
-#
-# Audit boundary (refs cross-review M3): the legacy ``$JOURNAL_PATH``
-# environment variable is rejected at this ja boundary so off-canon
-# writes can't be silently redirected. If the variable is set we emit
-# a stderr warning and proceed with the canonical path.
+# Audit boundary: the legacy ``$JOURNAL_PATH`` env var is rejected at the
+# ja boundary (preserved from the pre-M2 wrapper) so off-canon writes
+# can't be silently redirected.
 
 set -euo pipefail
 
@@ -47,25 +32,19 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 if [ -n "${JOURNAL_PATH-}" ]; then
     printf 'tools/journal_append.sh: warning: $JOURNAL_PATH override rejected at ja boundary; writing to canonical <repo_root>/.state/journal.jsonl\n' >&2
 fi
-JOURNAL_PATH="$REPO_ROOT/.state/journal.jsonl"
 
-# Ask the installed core-harness package where its bash companion
-# lives. Going through Python keeps us robust to `pip install` layout
-# differences (site-packages vs. editable installs vs. zipped wheels).
-CORE_HARNESS_AUDIT_LIB="$(
-    py -3 -c 'import core_harness.audit, pathlib, sys; sys.stdout.write(str(pathlib.Path(core_harness.audit.__file__).parent / "lib" / "journal_append.sh"))' \
-        2>/dev/null \
-    || python3 -c 'import core_harness.audit, pathlib, sys; sys.stdout.write(str(pathlib.Path(core_harness.audit.__file__).parent / "lib" / "journal_append.sh"))' \
-        2>/dev/null \
-    || python -c 'import core_harness.audit, pathlib, sys; sys.stdout.write(str(pathlib.Path(core_harness.audit.__file__).parent / "lib" / "journal_append.sh"))'
-)"
+EVENT="$1"
+shift
 
-if [ -z "$CORE_HARNESS_AUDIT_LIB" ] || [ ! -f "$CORE_HARNESS_AUDIT_LIB" ]; then
-    printf 'tools/journal_append.sh: core_harness.audit lib not resolvable; check pyproject.toml pin (or run pip install -e .)\n' >&2
-    exit 1
+# Resolve a Python interpreter the same way the rest of the repo does:
+# `py -3` on Windows / `python3` on POSIX / `python` as last resort.
+if command -v py >/dev/null 2>&1; then
+    PY="py -3"
+elif command -v python3 >/dev/null 2>&1; then
+    PY="python3"
+else
+    PY="python"
 fi
 
-# shellcheck source=/dev/null
-source "$CORE_HARNESS_AUDIT_LIB"
-
-journal_append "$JOURNAL_PATH" "$@"
+cd "$REPO_ROOT"
+exec $PY "$SCRIPT_DIR/journal_append.py" "$EVENT" "$@"

--- a/tools/state_db/__init__.py
+++ b/tools/state_db/__init__.py
@@ -76,43 +76,56 @@ def ensure_m2_schema(conn: sqlite3.Connection) -> bool:
     and on freshly-applied schema (everything is ``CREATE TABLE IF NOT
     EXISTS`` / ``INSERT OR IGNORE``).
 
-    Returns True if a migration step actually ran (table or migration row
-    or singleton was missing), False if the DB was already at M2 shape.
-    Callers can use the return value to decide whether to commit or to
-    log a one-time "migrated" message.
+    Transaction handling (cross-review m1): SQLite's DDL is transactional
+    and ``RELEASE SAVEPOINT`` inside an outer transaction does NOT commit
+    the savepoint to disk — it merges into the parent. There is therefore
+    no way to "isolate" the migration from a caller-side ROLLBACK without
+    a separate connection. Instead we emit a one-shot ``stacklevel=2``
+    warning when invoked inside an open transaction and let the caller
+    decide. The supported usage is to call this **outside** any
+    explicit ``BEGIN`` so the implicit autocommit picks it up immediately.
+
+    Returns True if a migration step actually ran, False if the DB was
+    already at M2 shape.
     """
+    if getattr(conn, "in_transaction", False):
+        import warnings
+        warnings.warn(
+            "ensure_m2_schema() invoked inside an open transaction; SQLite "
+            "cannot isolate the migration from a caller-side ROLLBACK. "
+            "Call before BEGIN (or commit first) to make the migration "
+            "durable.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
     changed = False
     had_table = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='org_sessions'"
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type='table' AND name='org_sessions'"
     ).fetchone() is not None
     if not had_table:
         conn.executescript(_M2_ORG_SESSIONS_DDL)
         changed = True
     cur = conn.execute(
-        "INSERT OR IGNORE INTO org_sessions (id, status, last_writer_at) "
+        "INSERT OR IGNORE INTO org_sessions "
+        "(id, status, last_writer_at) "
         "VALUES (1, 'IDLE', strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
     )
     if cur.rowcount > 0:
         changed = True
-    # Make sure schema_migrations is consistent. The table itself shipped
-    # in M0, so it must already exist; tolerate a freshly applied schema
-    # where v2 is already in place.
     try:
         cur = conn.execute(
-            "INSERT OR IGNORE INTO schema_migrations (version, description) "
+            "INSERT OR IGNORE INTO schema_migrations "
+            "(version, description) "
             "VALUES (2, 'M2: org_sessions singleton (Issue #267)')"
         )
         if cur.rowcount > 0:
             changed = True
     except sqlite3.OperationalError:
-        # schema_migrations table absent (very old / corrupt DB) — leave it.
+        # schema_migrations table absent (very old / corrupt DB).
         pass
     return changed
-
-
-__all__ = [
-    "connect", "apply_schema", "with_db", "ensure_m2_schema", "SCHEMA_PATH",
-]
 
 
 @contextmanager
@@ -123,5 +136,17 @@ def with_db(db_path: PathLike) -> Iterator[sqlite3.Connection]:
         conn.commit()
     finally:
         conn.close()
+
+
+# Cross-review Nit 1: ``__all__`` lives at module bottom so every name it
+# references is already bound at evaluation time — easier to scan than
+# the previous "declared mid-file, with_db defined below" arrangement.
+__all__ = [
+    "SCHEMA_PATH",
+    "apply_schema",
+    "connect",
+    "ensure_m2_schema",
+    "with_db",
+]
 
 

--- a/tools/state_db/__init__.py
+++ b/tools/state_db/__init__.py
@@ -45,9 +45,15 @@ def apply_schema(conn: sqlite3.Connection) -> None:
 # Forward migration for pre-M2 DBs (Issue #267)
 # ---------------------------------------------------------------------------
 
-# Standalone DDL for the M2-introduced singleton table. Must stay in sync
-# with the org_sessions block in schema.sql; on a fresh DB schema.sql wins,
-# on an existing M0/M1 DB this script is what creates the table in place.
+# Standalone DDL for the M2-introduced singleton table.
+#
+# **Must stay in sync with the org_sessions block in schema.sql.**
+# schema.sql is the SoT for fresh-DB construction; this constant is the
+# only path used to add the table to an *existing* M0 / M1 DB without
+# wiping the rest of its contents. Column list, types, CHECKs and DEFAULT
+# clauses must match exactly. ``test_writer.test_ddl_sync_with_schema_sql``
+# asserts the column shape stays in lockstep so an accidental drift
+# breaks tests instead of silently producing two divergent schemas.
 _M2_ORG_SESSIONS_DDL = """
 CREATE TABLE IF NOT EXISTS org_sessions (
   id                   INTEGER PRIMARY KEY CHECK (id = 1),
@@ -68,6 +74,10 @@ CREATE TABLE IF NOT EXISTS org_sessions (
 """
 
 
+def _conn_in_transaction(conn: sqlite3.Connection) -> bool:
+    return bool(getattr(conn, "in_transaction", False))
+
+
 def ensure_m2_schema(conn: sqlite3.Connection) -> bool:
     """Idempotently bring an M0 / M1 DB up to the M2 shape.
 
@@ -76,27 +86,26 @@ def ensure_m2_schema(conn: sqlite3.Connection) -> bool:
     and on freshly-applied schema (everything is ``CREATE TABLE IF NOT
     EXISTS`` / ``INSERT OR IGNORE``).
 
-    Transaction handling (cross-review m1): SQLite's DDL is transactional
-    and ``RELEASE SAVEPOINT`` inside an outer transaction does NOT commit
-    the savepoint to disk — it merges into the parent. There is therefore
-    no way to "isolate" the migration from a caller-side ROLLBACK without
-    a separate connection. Instead we emit a one-shot ``stacklevel=2``
-    warning when invoked inside an open transaction and let the caller
-    decide. The supported usage is to call this **outside** any
-    explicit ``BEGIN`` so the implicit autocommit picks it up immediately.
+    **Must be called outside an open transaction** (cross-review N1). The
+    Python ``sqlite3`` module's ``Connection.executescript`` issues an
+    implicit ``COMMIT`` before running its statements, which would silently
+    commit any uncommitted INSERT/UPDATE the caller is in the middle of —
+    the subsequent ROLLBACK would then be a no-op and that work would
+    survive against the caller's expectation. We fail fast with
+    ``RuntimeError`` instead of warning (warnings are easy to miss and the
+    side-effect is data-shaped, not lint-shaped).
 
     Returns True if a migration step actually ran, False if the DB was
     already at M2 shape.
     """
-    if getattr(conn, "in_transaction", False):
-        import warnings
-        warnings.warn(
-            "ensure_m2_schema() invoked inside an open transaction; SQLite "
-            "cannot isolate the migration from a caller-side ROLLBACK. "
-            "Call before BEGIN (or commit first) to make the migration "
-            "durable.",
-            RuntimeWarning,
-            stacklevel=2,
+    if _conn_in_transaction(conn):
+        raise RuntimeError(
+            "ensure_m2_schema must be called outside an active "
+            "transaction; got conn.in_transaction=True. "
+            "sqlite3.Connection.executescript() issues an implicit "
+            "COMMIT before running, which would silently commit any "
+            "pending writes from the caller. COMMIT or ROLLBACK first, "
+            "or construct the StateWriter before opening the transaction."
         )
 
     changed = False
@@ -148,5 +157,3 @@ __all__ = [
     "ensure_m2_schema",
     "with_db",
 ]
-
-

--- a/tools/state_db/__init__.py
+++ b/tools/state_db/__init__.py
@@ -41,6 +41,80 @@ def apply_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
+# ---------------------------------------------------------------------------
+# Forward migration for pre-M2 DBs (Issue #267)
+# ---------------------------------------------------------------------------
+
+# Standalone DDL for the M2-introduced singleton table. Must stay in sync
+# with the org_sessions block in schema.sql; on a fresh DB schema.sql wins,
+# on an existing M0/M1 DB this script is what creates the table in place.
+_M2_ORG_SESSIONS_DDL = """
+CREATE TABLE IF NOT EXISTS org_sessions (
+  id                   INTEGER PRIMARY KEY CHECK (id = 1),
+  status               TEXT NOT NULL DEFAULT 'ACTIVE'
+                       CHECK (status IN ('ACTIVE','SUSPENDED','IDLE')),
+  started_at           TEXT,
+  updated_at           TEXT,
+  suspended_at         TEXT,
+  resumed_at           TEXT,
+  objective            TEXT,
+  resume_instructions  TEXT,
+  dispatcher_pane_id   TEXT,
+  dispatcher_peer_id   TEXT,
+  curator_pane_id      TEXT,
+  curator_peer_id      TEXT,
+  last_writer_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+"""
+
+
+def ensure_m2_schema(conn: sqlite3.Connection) -> bool:
+    """Idempotently bring an M0 / M1 DB up to the M2 shape.
+
+    Adds the ``org_sessions`` singleton table + a v2 ``schema_migrations``
+    row when missing, then seeds the singleton row. Safe to call repeatedly
+    and on freshly-applied schema (everything is ``CREATE TABLE IF NOT
+    EXISTS`` / ``INSERT OR IGNORE``).
+
+    Returns True if a migration step actually ran (table or migration row
+    or singleton was missing), False if the DB was already at M2 shape.
+    Callers can use the return value to decide whether to commit or to
+    log a one-time "migrated" message.
+    """
+    changed = False
+    had_table = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='org_sessions'"
+    ).fetchone() is not None
+    if not had_table:
+        conn.executescript(_M2_ORG_SESSIONS_DDL)
+        changed = True
+    cur = conn.execute(
+        "INSERT OR IGNORE INTO org_sessions (id, status, last_writer_at) "
+        "VALUES (1, 'IDLE', strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
+    )
+    if cur.rowcount > 0:
+        changed = True
+    # Make sure schema_migrations is consistent. The table itself shipped
+    # in M0, so it must already exist; tolerate a freshly applied schema
+    # where v2 is already in place.
+    try:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, description) "
+            "VALUES (2, 'M2: org_sessions singleton (Issue #267)')"
+        )
+        if cur.rowcount > 0:
+            changed = True
+    except sqlite3.OperationalError:
+        # schema_migrations table absent (very old / corrupt DB) — leave it.
+        pass
+    return changed
+
+
+__all__ = [
+    "connect", "apply_schema", "with_db", "ensure_m2_schema", "SCHEMA_PATH",
+]
+
+
 @contextmanager
 def with_db(db_path: PathLike) -> Iterator[sqlite3.Connection]:
     conn = connect(db_path)
@@ -51,4 +125,3 @@ def with_db(db_path: PathLike) -> Iterator[sqlite3.Connection]:
         conn.close()
 
 
-__all__ = ["connect", "apply_schema", "with_db", "SCHEMA_PATH"]

--- a/tools/state_db/drift_check.py
+++ b/tools/state_db/drift_check.py
@@ -1,0 +1,122 @@
+"""DB → markdown drift check (M2, Issue #267).
+
+After M2 the DB is the SoT and ``.state/org-state.md`` is a regenerated
+dump. ``drift_check`` answers a single question: **does the snapshotter,
+fed the current DB, produce the markdown file already on disk?** A
+non-empty diff means either someone hand-edited the markdown out of band
+or the snapshotter has a bug.
+
+Important behavioural notes:
+
+* Only the **structured** sections are diffed. Free-form ``## …`` sections
+  (which the snapshotter passes through verbatim) are excluded so a
+  curated note doesn't masquerade as drift.
+* ``exit 0`` on no diff, ``exit 1`` on diff. Anything else is a tool
+  failure (missing DB, IO error). Designed to be wired into CI later;
+  not a blocking gate while the notes/ split (M4) is still pending.
+"""
+from __future__ import annotations
+
+import argparse
+import difflib
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Optional
+
+from . import connect
+from .snapshotter import (
+    extract_unknown_sections,
+    render_structured_markdown,
+)
+
+
+def _strip_passthrough(markdown_text: str) -> str:
+    """Return the text minus the unknown ``## …`` sections.
+
+    Equivalent to: take everything up to the first structured ``## …``
+    heading, then keep only structured sections in order. We implement it
+    by subtracting the set of passthrough sections from the original text.
+    """
+    passthrough = extract_unknown_sections(markdown_text)
+    if not passthrough:
+        return markdown_text
+    # Remove each passthrough section block (one at a time, in order). The
+    # passthrough block always begins on a ``## …`` line that exists
+    # verbatim in markdown_text, so a literal substring split is exact.
+    result = markdown_text
+    # Split passthrough back into its constituent sections so we don't
+    # accidentally remove an unrelated identical run of bytes.
+    blocks: list[str] = []
+    cur: list[str] = []
+    for line in passthrough.splitlines(keepends=True):
+        if line.startswith("## ") and cur:
+            blocks.append("".join(cur))
+            cur = [line]
+        else:
+            cur.append(line)
+    if cur:
+        blocks.append("".join(cur))
+    for block in blocks:
+        idx = result.find(block)
+        if idx >= 0:
+            result = result[:idx] + result[idx + len(block):]
+    return result
+
+
+def compute_diff(
+    conn: sqlite3.Connection,
+    actual_md_path: Path,
+) -> str:
+    """Return a unified diff (str). Empty string ⇒ no drift."""
+    actual_md_path = Path(actual_md_path)
+    expected = render_structured_markdown(conn)
+    actual_full = (
+        actual_md_path.read_text(encoding="utf-8")
+        if actual_md_path.exists() else ""
+    )
+    actual_structured = _strip_passthrough(actual_full)
+    # Removing a passthrough block from the middle of the file can leave
+    # an extra blank line behind; normalise trailing whitespace before
+    # comparing so a benign free-form append doesn't masquerade as drift.
+    if expected.rstrip() + "\n" == actual_structured.rstrip() + "\n":
+        return ""
+    diff = difflib.unified_diff(
+        actual_structured.splitlines(keepends=True),
+        expected.splitlines(keepends=True),
+        fromfile=str(actual_md_path) + " (structured slice)",
+        tofile="<expected from DB>",
+        n=3,
+    )
+    return "".join(diff)
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="python -m tools.state_db.drift_check",
+        description="Diff DB-derived org-state.md against the file on disk.",
+    )
+    p.add_argument("--db", required=True, type=Path,
+                   help="Path to .state/state.db")
+    p.add_argument("--markdown", required=True, type=Path,
+                   help="Path to .state/org-state.md")
+    args = p.parse_args(argv)
+    if not args.db.exists():
+        print(f"error: DB not found: {args.db}", file=sys.stderr)
+        return 2
+    conn = connect(args.db)
+    try:
+        diff = compute_diff(conn, args.markdown)
+    finally:
+        conn.close()
+    if not diff:
+        print("drift_check: no drift")
+        return 0
+    sys.stdout.write(diff)
+    if not diff.endswith("\n"):
+        sys.stdout.write("\n")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(_main())

--- a/tools/state_db/importer.py
+++ b/tools/state_db/importer.py
@@ -243,10 +243,131 @@ class _Importer:
         r"^\|\s*([^|]+?)\s*\|\s*([ABCD])\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*$"
     )
 
+    # M2: org_sessions singleton overlay fields. The importer extracts these
+    # from the markdown header / Dispatcher / Curator / Resume Instructions
+    # sections so a freshly rebuilt DB reproduces the M1 markdown overlay
+    # values without going through the markdown layer at read time.
+    def _import_org_session_from_md(self, text: str) -> None:
+        status: Optional[str] = None
+        started_at: Optional[str] = None
+        updated_at: Optional[str] = None
+        suspended_at: Optional[str] = None
+        resumed_at: Optional[str] = None
+        objective: Optional[str] = None
+        dispatcher_pane_id: Optional[str] = None
+        dispatcher_peer_id: Optional[str] = None
+        curator_pane_id: Optional[str] = None
+        curator_peer_id: Optional[str] = None
+        resume_instructions: Optional[str] = None
+
+        section: Optional[str] = None
+        current_role: Optional[str] = None
+        resume_lines: list[str] = []
+
+        for raw_line in text.splitlines():
+            line = raw_line.rstrip()
+            if line.startswith("## "):
+                heading = line[3:].strip().lower()
+                if section == "resume instructions":
+                    body = "\n".join(resume_lines).strip()
+                    if body:
+                        resume_instructions = body
+                    resume_lines = []
+                section = heading
+                current_role = None
+                if "dispatcher" in heading:
+                    current_role = "dispatcher"
+                elif "curator" in heading:
+                    current_role = "curator"
+                continue
+
+            if section == "resume instructions":
+                resume_lines.append(line)
+                continue
+
+            if line.startswith("Status:") and status is None:
+                v = line[len("Status:"):].strip()
+                if v:
+                    status = v.upper().split()[0]
+                continue
+            if line.startswith("Started:") and started_at is None:
+                v = line[len("Started:"):].strip()
+                if v:
+                    started_at = v
+                continue
+            if line.startswith("Updated:") and updated_at is None:
+                v = line[len("Updated:"):].strip()
+                if v:
+                    updated_at = v
+                continue
+            if line.startswith("Suspended:") and suspended_at is None:
+                v = line[len("Suspended:"):].strip()
+                if v:
+                    suspended_at = v
+                continue
+            if line.startswith("Resumed:") and resumed_at is None:
+                v = line[len("Resumed:"):].strip()
+                if v:
+                    resumed_at = v
+                continue
+            if line.startswith("Current Objective:") and objective is None:
+                v = line[len("Current Objective:"):].strip()
+                if v:
+                    objective = v
+                continue
+
+            if current_role:
+                m = re.match(r"^-?\s*Peer\s+ID:\s*(\S+)", line, re.IGNORECASE)
+                if m:
+                    if current_role == "dispatcher":
+                        dispatcher_peer_id = m.group(1)
+                    else:
+                        curator_peer_id = m.group(1)
+                    continue
+                m = re.match(r"^-?\s*Pane\s+ID:\s*(\S+)", line, re.IGNORECASE)
+                if m:
+                    if current_role == "dispatcher":
+                        dispatcher_pane_id = m.group(1)
+                    else:
+                        curator_pane_id = m.group(1)
+                    continue
+
+        if section == "resume instructions":
+            body = "\n".join(resume_lines).strip()
+            if body:
+                resume_instructions = body
+
+        # Always insert a singleton row so post-M2 code can rely on its
+        # existence even when the source markdown had no Status header.
+        self.conn.execute(
+            "INSERT INTO org_sessions ("
+            "id, status, started_at, updated_at, suspended_at, resumed_at, "
+            "objective, resume_instructions, dispatcher_pane_id, "
+            "dispatcher_peer_id, curator_pane_id, curator_peer_id, "
+            "last_writer_at) "
+            "VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                (status or "IDLE"),
+                started_at, updated_at, suspended_at, resumed_at,
+                objective, resume_instructions,
+                dispatcher_pane_id, dispatcher_peer_id,
+                curator_pane_id, curator_peer_id,
+                # Sentinel timestamp keeps dump_signature reproducible.
+                "2000-01-01T00:00:00.000Z",
+            ),
+        )
+
     def import_org_state_md(self, path: Path) -> None:
         if not path or not path.exists():
+            # Even with no markdown, install a default singleton so callers
+            # never have to handle a missing org_sessions row.
+            self.conn.execute(
+                "INSERT INTO org_sessions (id, status, last_writer_at) "
+                "VALUES (1, 'IDLE', '2000-01-01T00:00:00.000Z')"
+            )
             return
         text = path.read_text(encoding="utf-8")
+        self._import_org_session_from_md(text)
         section: Optional[str] = None
         for i, raw_line in enumerate(text.splitlines(), start=1):
             line = raw_line.rstrip()
@@ -361,7 +482,8 @@ class _Importer:
 
 _DROP_ORDER = (
     "tag_assignments", "tags", "events", "runs", "worker_dirs",
-    "workstreams", "projects", "unparsed_legacy", "schema_migrations",
+    "workstreams", "projects", "unparsed_legacy", "org_sessions",
+    "schema_migrations",
 )
 
 
@@ -396,6 +518,7 @@ _DUMP_TABLES: tuple[tuple[str, str], ...] = (
         "COALESCE(occurred_at,''), kind, COALESCE(actor,''), payload_json, id",
     ),
     ("unparsed_legacy", "source, COALESCE(source_line,0), raw, id"),
+    ("org_sessions", "id"),
 )
 
 
@@ -406,7 +529,7 @@ def _dump_text(conn: sqlite3.Connection) -> str:
         cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
         # Skip volatile timestamp columns that change between runs.
         volatile = {"created_at", "applied_at", "opened_at", "dispatched_at",
-                     "last_seen_at"}
+                     "last_seen_at", "last_writer_at"}
         kept = [c for c in cols if c not in volatile]
         col_list = ", ".join(kept)
         out.append(f"# {table}")

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -187,17 +187,22 @@ def get_session(conn: sqlite3.Connection) -> Optional[dict[str, Any]]:
             "SELECT * FROM org_sessions WHERE id = 1"
         ).fetchone()
     except sqlite3.OperationalError:
-        # Forward-migrate then retry once. If migration fails (e.g. the DB
-        # is read-only), surface None rather than raising — readers should
-        # fall back to markdown in that case.
+        # Forward-migrate then retry once. ensure_m2_schema requires no
+        # open transaction (executescript would otherwise implicit-commit
+        # caller writes); commit any pending state first. If migration
+        # fails (e.g. read-only DB, RuntimeError because we're inside a
+        # caller-controlled tx) surface None — readers should fall back
+        # to markdown in that case.
         try:
             from tools.state_db import ensure_m2_schema
+            if getattr(conn, "in_transaction", False):
+                conn.commit()
             ensure_m2_schema(conn)
             conn.commit()
             row = conn.execute(
                 "SELECT * FROM org_sessions WHERE id = 1"
             ).fetchone()
-        except sqlite3.OperationalError:
+        except (sqlite3.OperationalError, RuntimeError):
             return None
     return _row_to_dict(row)
 

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -177,14 +177,28 @@ def get_session(conn: sqlite3.Connection) -> Optional[dict[str, Any]]:
     M2 (Issue #267) replaced the M1 markdown overlay; consumers now read
     Status / Updated / Suspended / Resumed / Current Objective / Dispatcher
     / Curator / Resume Instructions straight from this row.
+
+    Pre-M2 DBs lack the table — we forward-migrate in place via
+    ``ensure_m2_schema`` so dashboard / converter readers don't have to
+    special-case missing-table state. The migration is idempotent.
     """
     try:
         row = conn.execute(
             "SELECT * FROM org_sessions WHERE id = 1"
         ).fetchone()
     except sqlite3.OperationalError:
-        # DB pre-dates the M2 migration (no org_sessions table).
-        return None
+        # Forward-migrate then retry once. If migration fails (e.g. the DB
+        # is read-only), surface None rather than raising — readers should
+        # fall back to markdown in that case.
+        try:
+            from tools.state_db import ensure_m2_schema
+            ensure_m2_schema(conn)
+            conn.commit()
+            row = conn.execute(
+                "SELECT * FROM org_sessions WHERE id = 1"
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return None
     return _row_to_dict(row)
 
 

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -72,6 +72,30 @@ def list_active_runs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     return _rows_to_dicts(rows)
 
 
+def list_runs_with_dirs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Return every run that has a worker_dir attached, regardless of status.
+
+    Used by ``parse_org_state_db`` and the markdown snapshotter to render the
+    Worker Directory Registry, which historically lists *all* runs with a
+    directory (active + completed + failed + abandoned), not just the live ones.
+    """
+    rows = conn.execute(
+        """
+        SELECT
+            r.task_id, r.pattern, r.status, r.title, r.outcome_note,
+            r.dispatched_at,
+            p.slug          AS project_slug,
+            d.abs_path      AS worker_dir
+        FROM runs r
+        JOIN projects p         ON p.id = r.project_id
+        LEFT JOIN worker_dirs d ON d.id = r.worker_dir_id
+        WHERE d.abs_path IS NOT NULL
+        ORDER BY r.dispatched_at, r.id
+        """
+    ).fetchall()
+    return _rows_to_dicts(rows)
+
+
 def get_run_by_task_id(
     conn: sqlite3.Connection, task_id: str
 ) -> Optional[dict[str, Any]]:
@@ -232,6 +256,7 @@ def get_resume_briefing(conn: sqlite3.Connection) -> dict[str, Any]:
 
 __all__ = [
     "list_active_runs",
+    "list_runs_with_dirs",
     "get_run_by_task_id",
     "list_worker_dirs",
     "list_recent_events",

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -5,9 +5,11 @@ Thin convenience wrappers around `sqlite3.Connection` that return plain
 short-lived dashboard / SKILL invocations can open a connection, fetch what
 they need, and close — WAL allows many concurrent readers.
 
-The DB is a derived view in M1 (markdown remains SoT); see
-migration-strategy.md §M1. Callers should keep a markdown fallback path on
-disk and treat any query failure here as a soft signal to reach for it.
+In M2 the DB is the canonical write target (migration-strategy.md §M2):
+the M1 markdown overlay is gone, ``org_sessions`` carries Status / Updated /
+Suspended / Resumed / Current Objective / Dispatcher / Curator /
+Resume Instructions, and ``.state/org-state.md`` is regenerated from this
+DB by :mod:`tools.state_db.snapshotter`.
 """
 from __future__ import annotations
 
@@ -145,11 +147,29 @@ def _run_status_counts(conn: sqlite3.Connection) -> dict[str, int]:
     return {r["status"]: r["c"] for r in rows}
 
 
+def get_session(conn: sqlite3.Connection) -> Optional[dict[str, Any]]:
+    """Return the singleton ``org_sessions`` row, or ``None`` if missing.
+
+    M2 (Issue #267) replaced the M1 markdown overlay; consumers now read
+    Status / Updated / Suspended / Resumed / Current Objective / Dispatcher
+    / Curator / Resume Instructions straight from this row.
+    """
+    try:
+        row = conn.execute(
+            "SELECT * FROM org_sessions WHERE id = 1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        # DB pre-dates the M2 migration (no org_sessions table).
+        return None
+    return _row_to_dict(row)
+
+
 def get_org_state_summary(conn: sqlite3.Connection) -> dict[str, Any]:
     """Aggregate snapshot used by the dashboard.
 
     Shape:
         {
+          "session": {... org_sessions row ...} | None,
           "active_runs": [...],            # in_use / review
           "active_worker_dirs": [...],     # lifecycle='active'
           "recent_events": [...],          # 20 newest
@@ -166,6 +186,7 @@ def get_org_state_summary(conn: sqlite3.Connection) -> dict[str, Any]:
         """
     ).fetchone()
     return {
+        "session": get_session(conn),
         "active_runs": list_active_runs(conn),
         "active_worker_dirs": list_worker_dirs(conn, lifecycle="active"),
         "recent_events": list_recent_events(conn, limit=20),
@@ -194,6 +215,7 @@ def get_resume_briefing(conn: sqlite3.Connection) -> dict[str, Any]:
         "SELECT occurred_at, kind FROM events ORDER BY id DESC LIMIT 1"
     ).fetchone()
     return {
+        "session": get_session(conn),
         "active_runs": list_active_runs(conn),
         "active_worker_dirs": list_worker_dirs(conn, lifecycle="active"),
         "recent_events": list_recent_events(conn, limit=30),
@@ -213,6 +235,7 @@ __all__ = [
     "get_run_by_task_id",
     "list_worker_dirs",
     "list_recent_events",
+    "get_session",
     "get_org_state_summary",
     "get_resume_briefing",
 ]

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -178,25 +178,33 @@ def get_session(conn: sqlite3.Connection) -> Optional[dict[str, Any]]:
     Status / Updated / Suspended / Resumed / Current Objective / Dispatcher
     / Curator / Resume Instructions straight from this row.
 
-    Pre-M2 DBs lack the table — we forward-migrate in place via
-    ``ensure_m2_schema`` so dashboard / converter readers don't have to
-    special-case missing-table state. The migration is idempotent.
+    Pre-M2 DB handling: when the ``org_sessions`` table is absent we try
+    to forward-migrate via ``ensure_m2_schema``, but only if the caller's
+    connection is **not** in an open transaction. Migrating inside a
+    caller-controlled tx would force an implicit COMMIT (executescript
+    behaviour — see N1 in cross-review), silently confirming any pending
+    writes the caller meant to roll back. So an in-tx caller gets
+    ``None`` and is expected to handle that as "session unknown" rather
+    than as a positive read result.
+
+    Returning ``None`` here doesn't trigger a markdown fallback in the
+    M2 dashboard / converter (the M1 overlay is gone); callers will see
+    Status default to IDLE and the role / objective / resume_instructions
+    fields go unset for that render. Run the importer once to install
+    the M2 table out-of-band if you need a stable read.
     """
     try:
         row = conn.execute(
             "SELECT * FROM org_sessions WHERE id = 1"
         ).fetchone()
     except sqlite3.OperationalError:
-        # Forward-migrate then retry once. ensure_m2_schema requires no
-        # open transaction (executescript would otherwise implicit-commit
-        # caller writes); commit any pending state first. If migration
-        # fails (e.g. read-only DB, RuntimeError because we're inside a
-        # caller-controlled tx) surface None — readers should fall back
-        # to markdown in that case.
+        # Pre-M2 DB. Don't migrate inside an open caller tx — see docstring
+        # for the rationale. Skip silently and let the caller see a
+        # missing-row signal.
+        if getattr(conn, "in_transaction", False):
+            return None
         try:
             from tools.state_db import ensure_m2_schema
-            if getattr(conn, "in_transaction", False):
-                conn.commit()
             ensure_m2_schema(conn)
             conn.commit()
             row = conn.execute(

--- a/tools/state_db/schema.sql
+++ b/tools/state_db/schema.sql
@@ -138,6 +138,28 @@ CREATE TABLE unparsed_legacy (
 );
 CREATE INDEX idx_unparsed_source ON unparsed_legacy(source);
 
+-- org_sessions ─────────────────────────────────────────────
+-- M2: singleton row holding the org-wide session state that M1
+-- previously kept as a markdown overlay on top of the DB. CHECK(id=1)
+-- enforces "at most one row" — the org never has multiple concurrent
+-- sessions; suspend/resume mutates this row in place.
+CREATE TABLE org_sessions (
+  id                   INTEGER PRIMARY KEY CHECK (id = 1),
+  status               TEXT NOT NULL DEFAULT 'ACTIVE'
+                       CHECK (status IN ('ACTIVE','SUSPENDED','IDLE')),
+  started_at           TEXT,                    -- legacy "Started:" line, free-form text allowed
+  updated_at           TEXT,                    -- legacy "Updated:" line
+  suspended_at         TEXT,                    -- legacy "Suspended:" line (NULL when ACTIVE)
+  resumed_at           TEXT,                    -- legacy "Resumed:" line
+  objective            TEXT,                    -- legacy "Current Objective:"
+  resume_instructions  TEXT,                    -- legacy "## Resume Instructions" body
+  dispatcher_pane_id   TEXT,                    -- legacy "## Dispatcher" / Pane ID
+  dispatcher_peer_id   TEXT,                    -- legacy "## Dispatcher" / Peer ID
+  curator_pane_id      TEXT,                    -- legacy "## Curator" / Pane ID
+  curator_peer_id      TEXT,                    -- legacy "## Curator" / Peer ID
+  last_writer_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
 -- schema_migrations ────────────────────────────────────────
 CREATE TABLE schema_migrations (
   version         INTEGER PRIMARY KEY,
@@ -147,3 +169,5 @@ CREATE TABLE schema_migrations (
 
 INSERT INTO schema_migrations (version, description)
 VALUES (1, 'M0: initial schema (Issue #267)');
+INSERT INTO schema_migrations (version, description)
+VALUES (2, 'M2: org_sessions singleton (Issue #267)');

--- a/tools/state_db/snapshotter.py
+++ b/tools/state_db/snapshotter.py
@@ -1,0 +1,375 @@
+"""Post-commit DB → markdown / jsonl regenerator (M2, Issue #267).
+
+The M2 design (migration-strategy.md §M2) inverts the SoT: writes land in
+SQLite first; ``.state/org-state.md`` and ``.state/journal.jsonl`` become
+DB-derived dumps refreshed after each commit. This module is the dumper.
+
+Two design choices worth knowing about:
+
+1. **Passthrough merge for org-state.md.** The schema only models a known
+   set of structured fields (Status / Updated / Dispatcher / Curator /
+   Worker Directory Registry / Active Work Items / Resume Instructions /
+   …). The real `.state/org-state.md` carries hundreds of lines of
+   free-form session notes that the schema deliberately doesn't model.
+   To avoid wiping that human-curated history when secretary first calls
+   the snapshotter, we render the structured prefix from the DB *and then
+   pass through unknown ``## …`` sections from the existing markdown in
+   their original order*. The notes/ split (M4) will eventually retire
+   the passthrough; M2 just protects the data.
+
+2. **Atomic-rename writes.** Each output is written to a sibling
+   ``<file>.tmp`` and ``os.replace()``-d into place after fsync. A crashed
+   regenerate run leaves the previous good copy in place; the next call
+   reproduces the same bytes from the same DB state (idempotency).
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+# ---------------------------------------------------------------------------
+# Heading taxonomy
+# ---------------------------------------------------------------------------
+
+# ``## …`` headings (lower-cased, substring-matched) that the snapshotter
+# owns. Anything else is treated as free-form and passed through. Keep this
+# list narrow on purpose: the smaller the owned set, the smaller the
+# blast radius when the schema doesn't yet model a section.
+_STRUCTURED_HEADINGS: tuple[str, ...] = (
+    "dispatcher",
+    "curator",
+    "worker directory registry",
+    "active work items",
+    "resume instructions",
+)
+
+
+def _is_structured_heading(heading_text: str) -> bool:
+    h = heading_text.strip().lower()
+    return any(key in h for key in _STRUCTURED_HEADINGS)
+
+
+# ---------------------------------------------------------------------------
+# Atomic write helper
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_text(path: Path, body: str) -> None:
+    """Write `body` to `path` via tmp → fsync → rename.
+
+    The tmp file is created in the same directory so ``os.replace`` is a
+    same-volume rename (atomic on Windows + POSIX). A crash mid-write
+    leaves the previous good copy in place.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix="." + path.name + ".", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(body)
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError:
+                # fsync isn't supported on every FS (e.g. some CI tmpfs);
+                # the rename is still atomic, so degrade silently.
+                pass
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Structured-section rendering
+# ---------------------------------------------------------------------------
+
+
+def _fetch_session(conn: sqlite3.Connection) -> dict:
+    row = conn.execute("SELECT * FROM org_sessions WHERE id = 1").fetchone()
+    if row is None:
+        return {}
+    return {k: row[k] for k in row.keys()}
+
+
+def _fetch_runs(conn: sqlite3.Connection) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            r.task_id, r.pattern, r.status, r.title, r.pr_url, r.pr_state,
+            r.outcome_note, r.dispatched_at, r.completed_at,
+            p.slug AS project_slug,
+            d.abs_path AS worker_dir
+        FROM runs r
+        JOIN projects p             ON p.id = r.project_id
+        LEFT JOIN worker_dirs d     ON d.id = r.worker_dir_id
+        ORDER BY r.dispatched_at, r.id
+        """
+    ).fetchall()
+    return [{k: r[k] for k in r.keys()} for r in rows]
+
+
+def _render_header(session: dict) -> str:
+    """Top-of-file ``# Org State`` block + bare key:value lines."""
+    out = io.StringIO()
+    out.write("# Org State\n\n")
+    status = session.get("status") or "IDLE"
+    out.write(f"Status: {status}\n")
+    for label, key in (
+        ("Started", "started_at"),
+        ("Updated", "updated_at"),
+        ("Suspended", "suspended_at"),
+        ("Resumed", "resumed_at"),
+        ("Current Objective", "objective"),
+    ):
+        v = session.get(key)
+        if v:
+            out.write(f"{label}: {v}\n")
+    out.write("\n")
+    return out.getvalue()
+
+
+def _render_role_section(label: str, peer_id, pane_id) -> str:
+    if not peer_id and not pane_id:
+        return ""
+    out = io.StringIO()
+    out.write(f"## {label}\n")
+    if peer_id:
+        out.write(f"- Peer ID: {peer_id}\n")
+    if pane_id:
+        out.write(f"- Pane ID: {pane_id}\n")
+    out.write("\n")
+    return out.getvalue()
+
+
+def _render_worker_directory_registry(runs: Iterable[dict]) -> str:
+    runs = [r for r in runs if r.get("worker_dir")]
+    if not runs:
+        return ""
+    out = io.StringIO()
+    out.write("## Worker Directory Registry\n\n")
+    out.write("| Task ID | Pattern | Directory | Project | Status |\n")
+    out.write("|---|---|---|---|---|\n")
+    for r in runs:
+        status_cell = r.get("outcome_note") or r.get("status") or ""
+        # Pipe characters in cells would corrupt the table; quote them.
+        status_cell = str(status_cell).replace("|", "\\|").replace("\n", " ")
+        title_or_dir = r.get("worker_dir") or ""
+        out.write(
+            f"| {r['task_id']} | {r['pattern']} | {title_or_dir} | "
+            f"{r.get('project_slug') or ''} | {status_cell} |\n"
+        )
+    out.write("\n")
+    return out.getvalue()
+
+
+def _render_active_work_items(runs: Iterable[dict]) -> str:
+    active = [r for r in runs if (r.get("status") or "") in ("in_use", "review")]
+    if not active:
+        return ""
+    out = io.StringIO()
+    out.write("## Active Work Items\n\n")
+    for r in active:
+        # Match the legacy "- task-id: title [STATUS]" convention parsed by
+        # dashboard/server.py and dashboard/org_state_converter.py so the
+        # downstream JSON view stays well-formed.
+        status_label = (r.get("status") or "").upper()
+        title = r.get("title") or r["task_id"]
+        out.write(f"- {r['task_id']}: {title} [{status_label}]\n")
+    out.write("\n")
+    return out.getvalue()
+
+
+def _render_resume_instructions(session: dict) -> str:
+    body = (session.get("resume_instructions") or "").strip()
+    if not body:
+        return ""
+    out = io.StringIO()
+    out.write("## Resume Instructions\n\n")
+    out.write(body)
+    if not body.endswith("\n"):
+        out.write("\n")
+    out.write("\n")
+    return out.getvalue()
+
+
+def render_structured_markdown(conn: sqlite3.Connection) -> str:
+    """Build the DB-owned portion of org-state.md.
+
+    Order matches the legacy file: header keys → Dispatcher → Curator →
+    Worker Directory Registry → Active Work Items → Resume Instructions.
+    Empty sections are omitted entirely.
+    """
+    session = _fetch_session(conn)
+    runs = _fetch_runs(conn)
+    parts = [
+        _render_header(session),
+        _render_role_section(
+            "Dispatcher",
+            session.get("dispatcher_peer_id"),
+            session.get("dispatcher_pane_id"),
+        ),
+        _render_role_section(
+            "Curator",
+            session.get("curator_peer_id"),
+            session.get("curator_pane_id"),
+        ),
+        _render_worker_directory_registry(runs),
+        _render_active_work_items(runs),
+        _render_resume_instructions(session),
+    ]
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Passthrough merge
+# ---------------------------------------------------------------------------
+
+
+def extract_unknown_sections(markdown_text: str) -> str:
+    """Return the concatenated text of every ``## …`` block whose heading
+    does NOT match the structured taxonomy.
+
+    Each block runs from its ``## …`` heading line through (but not
+    including) the next ``## …`` heading or end-of-file. The leading
+    ``# Org State`` and the bare key:value lines above the first ``##`` are
+    discarded — those are owned by the structured renderer.
+    """
+    out_parts: list[str] = []
+    lines = markdown_text.splitlines(keepends=True)
+    cur_section: Optional[list[str]] = None
+    cur_keep = False
+    for line in lines:
+        if line.startswith("## "):
+            if cur_section is not None and cur_keep:
+                out_parts.append("".join(cur_section))
+            heading = line[3:].strip()
+            cur_keep = not _is_structured_heading(heading)
+            cur_section = [line]
+            continue
+        if cur_section is not None:
+            cur_section.append(line)
+    if cur_section is not None and cur_keep:
+        out_parts.append("".join(cur_section))
+    return "".join(out_parts)
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def render_org_state_md(
+    conn: sqlite3.Connection, *, source_md: Optional[Path] = None
+) -> str:
+    """Build the full org-state.md body (structured + passthrough merge).
+
+    `source_md` is read for passthrough preservation; if it's missing or
+    None, the output is structured-only.
+    """
+    body = render_structured_markdown(conn)
+    if source_md is not None:
+        try:
+            source_text = Path(source_md).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            source_text = ""
+        passthrough = extract_unknown_sections(source_text)
+        if passthrough:
+            if not body.endswith("\n\n"):
+                if body.endswith("\n"):
+                    body += "\n"
+                else:
+                    body += "\n\n"
+            body += passthrough
+    return body
+
+
+def regenerate_org_state_md(
+    conn: sqlite3.Connection, out_path: Path,
+    *, source_md: Optional[Path] = None,
+) -> None:
+    """Write a fresh org-state.md to `out_path` (atomic rename).
+
+    Defaults to using `out_path` itself as the passthrough source — we
+    overwrite the file in place but read its old content first to capture
+    any free-form sections.
+    """
+    out_path = Path(out_path)
+    if source_md is None and out_path.exists():
+        source_md = out_path
+    body = render_org_state_md(conn, source_md=source_md)
+    _atomic_write_text(out_path, body)
+
+
+def render_journal_jsonl(conn: sqlite3.Connection) -> str:
+    """Build journal.jsonl from the events table, ts ascending."""
+    rows = conn.execute(
+        "SELECT occurred_at, kind, actor, payload_json "
+        "FROM events ORDER BY occurred_at, id"
+    ).fetchall()
+    lines: list[str] = []
+    for r in rows:
+        try:
+            payload = json.loads(r["payload_json"]) if r["payload_json"] else {}
+        except json.JSONDecodeError:
+            payload = {}
+        if not isinstance(payload, dict):
+            payload = {"_raw_payload": payload}
+        out: dict = {}
+        if r["occurred_at"]:
+            out["ts"] = r["occurred_at"]
+        out["event"] = r["kind"]
+        if r["actor"]:
+            out["actor"] = r["actor"]
+        for k, v in payload.items():
+            # Don't let payload override the canonical ts/event/actor keys.
+            if k in ("ts", "event", "actor") and k in out:
+                continue
+            out[k] = v
+        lines.append(json.dumps(out, ensure_ascii=False, sort_keys=True))
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
+
+
+def regenerate_journal_jsonl(
+    conn: sqlite3.Connection, out_path: Path
+) -> None:
+    body = render_journal_jsonl(conn)
+    _atomic_write_text(out_path, body)
+
+
+def post_commit_regenerate(
+    conn: sqlite3.Connection, claude_org_root: Path
+) -> None:
+    """Convenience wrapper: regenerate both files at the canonical paths.
+
+    Failures are not silently swallowed — the caller should handle them
+    (typically by logging and continuing; the DB COMMIT already happened).
+    """
+    state_dir = Path(claude_org_root) / ".state"
+    regenerate_org_state_md(conn, state_dir / "org-state.md")
+    regenerate_journal_jsonl(conn, state_dir / "journal.jsonl")
+
+
+__all__ = [
+    "render_structured_markdown",
+    "render_org_state_md",
+    "render_journal_jsonl",
+    "regenerate_org_state_md",
+    "regenerate_journal_jsonl",
+    "post_commit_regenerate",
+    "extract_unknown_sections",
+]

--- a/tools/state_db/snapshotter.py
+++ b/tools/state_db/snapshotter.py
@@ -175,6 +175,17 @@ def _render_worker_directory_registry(runs: Iterable[dict]) -> str:
     return out.getvalue()
 
 
+_DB_STATUS_TO_MD_LABEL = {
+    "in_use": "IN_PROGRESS",
+    "review": "REVIEW",
+    "queued": "PENDING",
+    "completed": "COMPLETED",
+    "failed": "BLOCKED",
+    "suspended": "PENDING",
+    "abandoned": "ABANDONED",
+}
+
+
 def _render_active_work_items(runs: Iterable[dict]) -> str:
     active = [r for r in runs if (r.get("status") or "") in ("in_use", "review")]
     if not active:
@@ -183,9 +194,11 @@ def _render_active_work_items(runs: Iterable[dict]) -> str:
     out.write("## Active Work Items\n\n")
     for r in active:
         # Match the legacy "- task-id: title [STATUS]" convention parsed by
-        # dashboard/server.py and dashboard/org_state_converter.py so the
-        # downstream JSON view stays well-formed.
-        status_label = (r.get("status") or "").upper()
+        # dashboard/server.py and dashboard/org_state_converter.py. Use the
+        # frontend's status vocabulary (IN_PROGRESS / REVIEW / …) so a regen
+        # → markdown-fallback cycle doesn't render as `?` in the UI.
+        raw = (r.get("status") or "").lower()
+        status_label = _DB_STATUS_TO_MD_LABEL.get(raw, raw.upper())
         title = r.get("title") or r["task_id"]
         out.write(f"- {r['task_id']}: {title} [{status_label}]\n")
     out.write("\n")

--- a/tools/state_db/snapshotter.py
+++ b/tools/state_db/snapshotter.py
@@ -38,22 +38,25 @@ from typing import Iterable, Optional
 # Heading taxonomy
 # ---------------------------------------------------------------------------
 
-# ``## …`` headings (lower-cased, substring-matched) that the snapshotter
-# owns. Anything else is treated as free-form and passed through. Keep this
-# list narrow on purpose: the smaller the owned set, the smaller the
-# blast radius when the schema doesn't yet model a section.
-_STRUCTURED_HEADINGS: tuple[str, ...] = (
+# ``## …`` headings (lower-cased, exact-match) that the snapshotter owns.
+# Anything else is treated as free-form and passed through.
+#
+# Exact match — not substring — on purpose: substring would silently
+# absorb headings like "## Dispatcher Notes" or "## Curator メモ" into the
+# DB-owned set and the snapshotter would drop them on regenerate (and
+# drift_check would not detect the loss because the same predicate gates
+# both sides). See cross-review M1.
+_STRUCTURED_HEADINGS: frozenset[str] = frozenset({
     "dispatcher",
     "curator",
     "worker directory registry",
     "active work items",
     "resume instructions",
-)
+})
 
 
 def _is_structured_heading(heading_text: str) -> bool:
-    h = heading_text.strip().lower()
-    return any(key in h for key in _STRUCTURED_HEADINGS)
+    return heading_text.strip().lower() in _STRUCTURED_HEADINGS
 
 
 # ---------------------------------------------------------------------------

--- a/tools/state_db/test_snapshotter.py
+++ b/tools/state_db/test_snapshotter.py
@@ -92,8 +92,12 @@ class TestStructuredRender(unittest.TestCase):
         # only the in_use one.
         self.assertIn("issue-267-m2-write-switch", md)
         self.assertIn("prior-completed", md)
-        self.assertIn("[IN_USE]", md)
+        # M2 Codex review fix: snapshotter emits the dashboard frontend's
+        # status vocabulary so a markdown-fallback render shows the right
+        # icon instead of `?`.
+        self.assertIn("[IN_PROGRESS]", md)
         self.assertNotIn("[COMPLETED]", md)
+        self.assertNotIn("[IN_USE]", md)
 
 
 class TestPassthrough(unittest.TestCase):

--- a/tools/state_db/test_snapshotter.py
+++ b/tools/state_db/test_snapshotter.py
@@ -100,6 +100,54 @@ class TestStructuredRender(unittest.TestCase):
         self.assertNotIn("[IN_USE]", md)
 
 
+class TestStructuredHeadingExactMatch(unittest.TestCase):
+    """Cross-review M1: substring match on heading names was eating
+    free-form headings whose name happened to *contain* a structured
+    keyword. Switched to exact match (lower-cased)."""
+
+    def test_dispatcher_notes_passes_through(self):
+        src = (
+            "## Dispatcher\n- Peer ID: 2\n\n"
+            "## Dispatcher Notes\nfree-form ops log\n\n"
+            "## Curator メモ\n人間の覚え書き\n\n"
+            "## Curator\n- Peer ID: 3\n"
+        )
+        passthrough = extract_unknown_sections(src)
+        self.assertIn("Dispatcher Notes", passthrough)
+        self.assertIn("free-form ops log", passthrough)
+        self.assertIn("Curator メモ", passthrough)
+        self.assertIn("人間の覚え書き", passthrough)
+        # The exact-match structured headings are excluded.
+        self.assertNotIn("Peer ID: 2", passthrough)
+        self.assertNotIn("Peer ID: 3", passthrough)
+
+    def test_drift_check_detects_loss_of_dispatcher_notes(self):
+        # Sanity: when the on-disk markdown has a "## Dispatcher Notes"
+        # section, drift_check must NOT report drift just because the
+        # snapshotter's structured slice doesn't render that section.
+        # The previous (substring) implementation classified it as
+        # structured, dropped it from the passthrough output, and then
+        # the strip-passthrough step in drift_check left it behind in
+        # the actual-side text — which surfaced as drift.
+        with tempfile.TemporaryDirectory() as td:
+            db = Path(td) / "s.db"
+            md = Path(td) / "org-state.md"
+            conn = connect(db)
+            try:
+                apply_schema(conn)
+                _seed_session(conn)
+                regenerate_org_state_md(conn, md)
+                with md.open("a", encoding="utf-8") as fh:
+                    fh.write(
+                        "\n## Dispatcher Notes\nfree-form note\n"
+                        "\n## Curator メモ\n別の自由記述\n"
+                    )
+                diff = compute_diff(conn, md)
+            finally:
+                conn.close()
+        self.assertEqual(diff, "")
+
+
 class TestPassthrough(unittest.TestCase):
     def test_extract_unknown_sections_keeps_freeform(self):
         src = (

--- a/tools/state_db/test_snapshotter.py
+++ b/tools/state_db/test_snapshotter.py
@@ -1,0 +1,254 @@
+"""Tests for tools.state_db.snapshotter and drift_check (Issue #267 M2)."""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.state_db import apply_schema, connect
+from tools.state_db.drift_check import compute_diff
+from tools.state_db.snapshotter import (
+    extract_unknown_sections,
+    post_commit_regenerate,
+    regenerate_journal_jsonl,
+    regenerate_org_state_md,
+    render_journal_jsonl,
+    render_org_state_md,
+    render_structured_markdown,
+)
+from tools.state_db.writer import StateWriter
+
+
+def _seed_session(conn):
+    w = StateWriter(conn)
+    w.update_session(
+        status="ACTIVE",
+        started_at="2026-04-22",
+        updated_at="2026-05-04 (session #11)",
+        objective="finish M2",
+        dispatcher_pane_id="2", dispatcher_peer_id="2",
+        curator_pane_id="3", curator_peer_id="3",
+        resume_instructions="Run `/org-resume` then briefing.",
+    )
+    wid = w.register_worker_dir(
+        abs_path="/x/wd/issue-267-m2-write-switch", layout="flat",
+        is_git_repo=True, is_worktree=True, current_branch="issue-267-m2",
+    )
+    w.upsert_run(
+        task_id="issue-267-m2-write-switch",
+        project_slug="claude-org-ja",
+        pattern="B",
+        title="M2 write switch",
+        status="in_use",
+        worker_dir_abs_path="/x/wd/issue-267-m2-write-switch",
+        outcome_note="DB SoT migration",
+    )
+    w.upsert_run(
+        task_id="prior-completed",
+        project_slug="claude-org-ja",
+        pattern="B",
+        title="prior",
+        status="completed",
+        worker_dir_abs_path="/x/wd/issue-267-m2-write-switch",
+        outcome_note="merged",
+    )
+    w.append_event(kind="dispatch", actor="dispatcher",
+                    payload={"task": "issue-267-m2-write-switch"},
+                    occurred_at="2026-05-04T01:00:00.000Z",
+                    run_task_id="issue-267-m2-write-switch")
+    w.append_event(kind="suspend", actor="secretary",
+                    payload={"reason": "user_requested"},
+                    occurred_at="2026-05-04T02:00:00.000Z")
+    w.commit()
+    return w
+
+
+class TestStructuredRender(unittest.TestCase):
+    def test_renders_known_sections_in_order(self):
+        with tempfile.TemporaryDirectory() as td:
+            db = Path(td) / "s.db"
+            conn = connect(db)
+            try:
+                apply_schema(conn)
+                _seed_session(conn)
+                md = render_structured_markdown(conn)
+            finally:
+                conn.close()
+        self.assertIn("# Org State", md)
+        self.assertIn("Status: ACTIVE", md)
+        self.assertIn("Started: 2026-04-22", md)
+        self.assertIn("Current Objective: finish M2", md)
+        # Section headings appear in canonical order.
+        idx_disp = md.index("## Dispatcher")
+        idx_cur = md.index("## Curator")
+        idx_wdr = md.index("## Worker Directory Registry")
+        idx_active = md.index("## Active Work Items")
+        idx_resume = md.index("## Resume Instructions")
+        self.assertLess(idx_disp, idx_cur)
+        self.assertLess(idx_cur, idx_wdr)
+        self.assertLess(idx_wdr, idx_active)
+        self.assertLess(idx_active, idx_resume)
+        # WDR contains both runs (active + completed); Active Work Items
+        # only the in_use one.
+        self.assertIn("issue-267-m2-write-switch", md)
+        self.assertIn("prior-completed", md)
+        self.assertIn("[IN_USE]", md)
+        self.assertNotIn("[COMPLETED]", md)
+
+
+class TestPassthrough(unittest.TestCase):
+    def test_extract_unknown_sections_keeps_freeform(self):
+        src = (
+            "# Org State\n\nStatus: ACTIVE\n\n"
+            "## 2026-05-04 セッション #11 主要成果\n"
+            "- ratified Phase 1\n\n"
+            "## Dispatcher\n- Peer ID: 2\n\n"
+            "## 本セッションの学び\nlessons here\n"
+        )
+        passthrough = extract_unknown_sections(src)
+        self.assertIn("セッション #11", passthrough)
+        self.assertIn("本セッションの学び", passthrough)
+        self.assertNotIn("Dispatcher", passthrough)
+
+
+class TestMergeRender(unittest.TestCase):
+    def test_render_org_state_md_merges_passthrough(self):
+        with tempfile.TemporaryDirectory() as td:
+            db = Path(td) / "s.db"
+            md = Path(td) / "org-state.md"
+            md.write_text(
+                "# Old header (will be discarded)\n\n"
+                "Status: STALE\n\n"
+                "## Dispatcher\n- Peer ID: 99\n\n"
+                "## 2026-05-04 free-form note\nfreeform body\n",
+                encoding="utf-8",
+            )
+            conn = connect(db)
+            try:
+                apply_schema(conn)
+                _seed_session(conn)
+                body = render_org_state_md(conn, source_md=md)
+            finally:
+                conn.close()
+        # New header replaces old (DB-derived).
+        self.assertIn("Status: ACTIVE", body)
+        self.assertNotIn("Status: STALE", body)
+        # Free-form passthrough preserved.
+        self.assertIn("free-form note", body)
+        self.assertIn("freeform body", body)
+        # Old Dispatcher block is dropped (DB regenerates it).
+        self.assertNotIn("Peer ID: 99", body)
+        self.assertIn("- Peer ID: 2", body)
+
+
+class TestIdempotency(unittest.TestCase):
+    def test_regenerate_org_state_md_byte_identical(self):
+        with tempfile.TemporaryDirectory() as td:
+            db = Path(td) / "s.db"
+            md = Path(td) / "org-state.md"
+            conn = connect(db)
+            try:
+                apply_schema(conn)
+                _seed_session(conn)
+                regenerate_org_state_md(conn, md)
+                first = md.read_bytes()
+                regenerate_org_state_md(conn, md)
+                second = md.read_bytes()
+            finally:
+                conn.close()
+        self.assertEqual(first, second)
+
+    def test_regenerate_journal_jsonl_byte_identical(self):
+        with tempfile.TemporaryDirectory() as td:
+            db = Path(td) / "s.db"
+            jl = Path(td) / "journal.jsonl"
+            conn = connect(db)
+            try:
+                apply_schema(conn)
+                _seed_session(conn)
+                regenerate_journal_jsonl(conn, jl)
+                first = jl.read_bytes()
+                regenerate_journal_jsonl(conn, jl)
+                second = jl.read_bytes()
+            finally:
+                conn.close()
+        self.assertEqual(first, second)
+        # Body has both events in chronological order.
+        text = first.decode("utf-8")
+        self.assertIn('"event": "dispatch"', text)
+        self.assertIn('"event": "suspend"', text)
+        self.assertLess(text.index("dispatch"), text.index("suspend"))
+
+
+class TestPostCommitRegenerate(unittest.TestCase):
+    def test_post_commit_regenerate_writes_both(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".state").mkdir()
+            db = root / ".state" / "state.db"
+            conn = connect(db)
+            try:
+                apply_schema(conn)
+                _seed_session(conn)
+                post_commit_regenerate(conn, root)
+            finally:
+                conn.close()
+            self.assertTrue((root / ".state" / "org-state.md").exists())
+            self.assertTrue((root / ".state" / "journal.jsonl").exists())
+
+
+class TestDriftCheck(unittest.TestCase):
+    def test_zero_diff_after_regenerate(self):
+        with tempfile.TemporaryDirectory() as td:
+            db = Path(td) / "s.db"
+            md = Path(td) / "org-state.md"
+            conn = connect(db)
+            try:
+                apply_schema(conn)
+                _seed_session(conn)
+                regenerate_org_state_md(conn, md)
+                diff = compute_diff(conn, md)
+            finally:
+                conn.close()
+        self.assertEqual(diff, "")
+
+    def test_drift_detected_when_markdown_edited_in_known_section(self):
+        with tempfile.TemporaryDirectory() as td:
+            db = Path(td) / "s.db"
+            md = Path(td) / "org-state.md"
+            conn = connect(db)
+            try:
+                apply_schema(conn)
+                _seed_session(conn)
+                regenerate_org_state_md(conn, md)
+                # Mutate a structured field by hand → must surface as drift.
+                text = md.read_text(encoding="utf-8")
+                tampered = text.replace("Status: ACTIVE", "Status: SUSPENDED")
+                md.write_text(tampered, encoding="utf-8")
+                diff = compute_diff(conn, md)
+            finally:
+                conn.close()
+        self.assertNotEqual(diff, "")
+        self.assertIn("Status:", diff)
+
+    def test_freeform_section_not_treated_as_drift(self):
+        with tempfile.TemporaryDirectory() as td:
+            db = Path(td) / "s.db"
+            md = Path(td) / "org-state.md"
+            conn = connect(db)
+            try:
+                apply_schema(conn)
+                _seed_session(conn)
+                regenerate_org_state_md(conn, md)
+                # Append a free-form section directly to the file. Drift
+                # check ignores unknown sections; expected diff = empty.
+                with md.open("a", encoding="utf-8") as fh:
+                    fh.write("\n## 本セッションの学び\nlearned X\n")
+                diff = compute_diff(conn, md)
+            finally:
+                conn.close()
+        self.assertEqual(diff, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/state_db/test_writer.py
+++ b/tools/state_db/test_writer.py
@@ -18,6 +18,42 @@ def _fresh_db():
     return td, conn
 
 
+class TestDDLSync(unittest.TestCase):
+    """Cross-review n2: schema.sql and __init__._M2_ORG_SESSIONS_DDL must
+    stay in lockstep — they describe the same table from two paths
+    (fresh DB vs. forward migration). A drift would silently produce
+    two divergent schemas."""
+
+    def _columns(self, conn, table):
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        # (cid, name, type, notnull, dflt_value, pk) — keep the columns
+        # that actually matter for shape comparison.
+        return [
+            (r["name"], r["type"].upper(), bool(r["notnull"]), bool(r["pk"]))
+            for r in rows
+        ]
+
+    def test_schema_sql_and_m2_ddl_produce_identical_columns(self):
+        from tools.state_db import _M2_ORG_SESSIONS_DDL
+        td = tempfile.TemporaryDirectory()
+        try:
+            # DB A: full schema.sql.
+            db_a = Path(td.name) / "a.db"
+            conn_a = connect(db_a)
+            apply_schema(conn_a)
+            cols_a = self._columns(conn_a, "org_sessions")
+            conn_a.close()
+            # DB B: just the M2 DDL string.
+            db_b = Path(td.name) / "b.db"
+            conn_b = connect(db_b)
+            conn_b.executescript(_M2_ORG_SESSIONS_DDL)
+            cols_b = self._columns(conn_b, "org_sessions")
+            conn_b.close()
+            self.assertEqual(cols_a, cols_b)
+        finally:
+            td.cleanup()
+
+
 class TestPreM2Migration(unittest.TestCase):
     """Codex round-3 Blocker fix: an existing M0/M1 DB without
     org_sessions must be migrated forward in place when read or written
@@ -78,11 +114,11 @@ class TestPreM2Migration(unittest.TestCase):
         finally:
             td.cleanup()
 
-    def test_migration_warns_when_called_in_open_tx(self):
-        """Cross-review m1: SQLite cannot truly isolate DDL from a parent
-        ROLLBACK, so we warn loudly when invoked inside an open
-        transaction instead of silently mixing the migration in."""
-        import warnings
+    def test_migration_raises_when_called_in_open_tx(self):
+        """Cross-review N1: an open transaction means a downstream
+        executescript() would implicit-COMMIT the caller's pending
+        writes. We must fail fast so the caller doesn't silently lose
+        rollback semantics."""
         from tools.state_db import ensure_m2_schema
         td = tempfile.TemporaryDirectory()
         try:
@@ -90,17 +126,47 @@ class TestPreM2Migration(unittest.TestCase):
             conn = connect(db)
             conn.executescript(self._M1_SCHEMA)
             conn.commit()
+            # Stage uncommitted work, then attempt migration.
             conn.execute("BEGIN")
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                ensure_m2_schema(conn)
-            conn.execute("ROLLBACK")
-            warn_msgs = [str(w.message).lower() for w in caught
-                         if issubclass(w.category, RuntimeWarning)]
-            self.assertTrue(
-                any("open transaction" in m for m in warn_msgs),
-                f"expected open-transaction warning, got {warn_msgs!r}",
+            conn.execute(
+                "INSERT INTO projects (slug, display_name) "
+                "VALUES ('uncommitted', 'should-disappear')"
             )
+            with self.assertRaises(RuntimeError) as ctx:
+                ensure_m2_schema(conn)
+            self.assertIn("active transaction", str(ctx.exception))
+            # Caller can still ROLLBACK and the staged INSERT must vanish.
+            conn.execute("ROLLBACK")
+            row = conn.execute(
+                "SELECT 1 FROM projects WHERE slug = 'uncommitted'"
+            ).fetchone()
+            self.assertIsNone(row)
+            conn.close()
+        finally:
+            td.cleanup()
+
+    def test_writer_construction_in_open_tx_does_not_silently_commit(self):
+        """Cross-review N1 (Codex check shape): constructing StateWriter
+        on a pre-M2 DB while the caller has uncommitted writes must
+        either fail fast or never silently commit those writes."""
+        td = tempfile.TemporaryDirectory()
+        try:
+            db = Path(td.name) / "m1.db"
+            conn = connect(db)
+            conn.executescript(self._M1_SCHEMA)
+            conn.commit()
+            conn.execute("BEGIN")
+            conn.execute(
+                "INSERT INTO projects (slug, display_name) "
+                "VALUES ('uncommitted', 'should-disappear')"
+            )
+            with self.assertRaises(RuntimeError):
+                StateWriter(conn)
+            conn.execute("ROLLBACK")
+            row = conn.execute(
+                "SELECT 1 FROM projects WHERE slug = 'uncommitted'"
+            ).fetchone()
+            self.assertIsNone(row)
             conn.close()
         finally:
             td.cleanup()

--- a/tools/state_db/test_writer.py
+++ b/tools/state_db/test_writer.py
@@ -160,6 +160,31 @@ class TestRuns(unittest.TestCase):
             conn.close()
             td.cleanup()
 
+    def test_upsert_preserves_unspecified_fields(self):
+        """Codex round-2: omitted kwargs must NOT clobber existing values
+        (title, verification, workstream_id were silently reset before)."""
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.upsert_run(task_id="t-keep", project_slug="proj-k",
+                          pattern="B", title="original title",
+                          verification="deep")
+            # Subsequent status-only update should leave title /
+            # verification / pattern intact.
+            w.upsert_run(task_id="t-keep", project_slug="proj-k",
+                          status="review")
+            row = conn.execute(
+                "SELECT title, verification, pattern, status FROM runs "
+                "WHERE task_id = 't-keep'"
+            ).fetchone()
+            self.assertEqual(row["title"], "original title")
+            self.assertEqual(row["verification"], "deep")
+            self.assertEqual(row["pattern"], "B")
+            self.assertEqual(row["status"], "review")
+        finally:
+            conn.close()
+            td.cleanup()
+
     def test_update_run_status(self):
         td, conn = _fresh_db()
         try:

--- a/tools/state_db/test_writer.py
+++ b/tools/state_db/test_writer.py
@@ -18,6 +18,86 @@ def _fresh_db():
     return td, conn
 
 
+class TestPreM2Migration(unittest.TestCase):
+    """Codex round-3 Blocker fix: an existing M0/M1 DB without
+    org_sessions must be migrated forward in place when read or written
+    by the M2 code paths."""
+
+    _M1_SCHEMA = """
+    CREATE TABLE projects (id INTEGER PRIMARY KEY, slug TEXT NOT NULL UNIQUE,
+                            display_name TEXT NOT NULL);
+    CREATE TABLE workstreams (id INTEGER PRIMARY KEY, project_id INTEGER,
+                                slug TEXT, display_name TEXT,
+                                UNIQUE (id, project_id));
+    CREATE TABLE worker_dirs (id INTEGER PRIMARY KEY, abs_path TEXT UNIQUE,
+                                layout TEXT, lifecycle TEXT,
+                                last_seen_at TEXT,
+                                archived INTEGER GENERATED ALWAYS AS
+                                  (CASE WHEN lifecycle IN ('archived','delete_pending')
+                                        THEN 1 ELSE 0 END) STORED);
+    CREATE TABLE runs (id INTEGER PRIMARY KEY, task_id TEXT UNIQUE,
+                        project_id INTEGER, pattern TEXT, title TEXT,
+                        status TEXT, dispatched_at TEXT,
+                        worker_dir_id INTEGER);
+    CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT,
+                          occurred_at TEXT, actor TEXT, kind TEXT,
+                          run_id INTEGER, project_id INTEGER,
+                          workstream_id INTEGER,
+                          payload_json TEXT NOT NULL DEFAULT '{}');
+    CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY,
+                                      applied_at TEXT, description TEXT);
+    INSERT INTO schema_migrations (version, applied_at, description)
+      VALUES (1, '2026-01-01T00:00:00.000Z', 'M0 initial');
+    """
+
+    def test_writer_init_migrates_pre_m2_db(self):
+        td = tempfile.TemporaryDirectory()
+        try:
+            db = Path(td.name) / "m1.db"
+            conn = connect(db)
+            conn.executescript(self._M1_SCHEMA)
+            conn.commit()
+            # Sanity: org_sessions absent before the writer touches it.
+            self.assertIsNone(conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='org_sessions'"
+            ).fetchone())
+            StateWriter(conn)
+            # After writer init the table exists and the singleton row is seeded.
+            row = conn.execute(
+                "SELECT id, status FROM org_sessions WHERE id = 1"
+            ).fetchone()
+            self.assertIsNotNone(row)
+            self.assertEqual(row["id"], 1)
+            # And v2 migration row is recorded.
+            v2 = conn.execute(
+                "SELECT 1 FROM schema_migrations WHERE version = 2"
+            ).fetchone()
+            self.assertIsNotNone(v2)
+            conn.close()
+        finally:
+            td.cleanup()
+
+    def test_get_session_migrates_pre_m2_db(self):
+        from tools.state_db.queries import get_session
+        td = tempfile.TemporaryDirectory()
+        try:
+            db = Path(td.name) / "m1.db"
+            conn = connect(db)
+            conn.executescript(self._M1_SCHEMA)
+            conn.commit()
+            sess = get_session(conn)
+            # Before round-3 fix get_session returned None on a pre-M2 DB,
+            # which dashboard read paths interpreted as "DB usable but
+            # empty session" → status went to IDLE. Now we forward-migrate
+            # and return the freshly-seeded singleton row.
+            self.assertIsNotNone(sess)
+            self.assertEqual(sess["id"], 1)
+            conn.close()
+        finally:
+            td.cleanup()
+
+
 class TestSessionSingleton(unittest.TestCase):
     def test_writer_seeds_singleton_on_init(self):
         td, conn = _fresh_db()
@@ -92,6 +172,32 @@ class TestWorkerDirs(unittest.TestCase):
             ).fetchone()
             self.assertEqual(row["current_branch"], "main")
             self.assertEqual(row["lifecycle"], "active")
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_register_preserves_unspecified_attributes(self):
+        """Codex round-3: re-register with only current_branch must not
+        clobber previously-set is_git_repo / is_worktree / origin_url."""
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.register_worker_dir(
+                abs_path="/x/preserve", is_git_repo=True, is_worktree=True,
+                origin_url="https://example.invalid/x.git",
+                current_branch="main",
+            )
+            # Status ping with only current_branch.
+            w.register_worker_dir(abs_path="/x/preserve",
+                                   current_branch="feature/x")
+            row = conn.execute(
+                "SELECT is_git_repo, is_worktree, origin_url, current_branch "
+                "FROM worker_dirs WHERE abs_path = '/x/preserve'"
+            ).fetchone()
+            self.assertEqual(row["is_git_repo"], 1)
+            self.assertEqual(row["is_worktree"], 1)
+            self.assertEqual(row["origin_url"], "https://example.invalid/x.git")
+            self.assertEqual(row["current_branch"], "feature/x")
         finally:
             conn.close()
             td.cleanup()

--- a/tools/state_db/test_writer.py
+++ b/tools/state_db/test_writer.py
@@ -33,23 +33,45 @@ class TestDDLSync(unittest.TestCase):
             for r in rows
         ]
 
+    def _master_sql(self, conn) -> str:
+        """sqlite_master.sql is SQLite's preserved CREATE TABLE text.
+
+        Strip ``IF NOT EXISTS`` (only the M2 DDL has it), strip ``--``
+        SQL comments (only schema.sql has them), and collapse whitespace
+        so the assertion compares semantic shape (columns, types, CHECK,
+        DEFAULT) rather than formatting drift."""
+        import re
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name = 'org_sessions'"
+        ).fetchone()
+        sql = row["sql"] if row else ""
+        # Drop trailing line comments before whitespace collapse.
+        sql = re.sub(r"--[^\n]*", "", sql)
+        sql = re.sub(r"CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS",
+                      "CREATE TABLE", sql, flags=re.IGNORECASE)
+        return re.sub(r"\s+", " ", sql).strip()
+
     def test_schema_sql_and_m2_ddl_produce_identical_columns(self):
         from tools.state_db import _M2_ORG_SESSIONS_DDL
         td = tempfile.TemporaryDirectory()
         try:
-            # DB A: full schema.sql.
             db_a = Path(td.name) / "a.db"
             conn_a = connect(db_a)
             apply_schema(conn_a)
             cols_a = self._columns(conn_a, "org_sessions")
+            sql_a = self._master_sql(conn_a)
             conn_a.close()
-            # DB B: just the M2 DDL string.
             db_b = Path(td.name) / "b.db"
             conn_b = connect(db_b)
             conn_b.executescript(_M2_ORG_SESSIONS_DDL)
             cols_b = self._columns(conn_b, "org_sessions")
+            sql_b = self._master_sql(conn_b)
             conn_b.close()
             self.assertEqual(cols_a, cols_b)
+            # Cross-review m-r3-3: PRAGMA table_info doesn't surface
+            # CHECK / DEFAULT clauses, so also assert the preserved
+            # CREATE TABLE text matches (whitespace-normalised).
+            self.assertEqual(sql_a, sql_b)
         finally:
             td.cleanup()
 
@@ -162,6 +184,34 @@ class TestPreM2Migration(unittest.TestCase):
             )
             with self.assertRaises(RuntimeError):
                 StateWriter(conn)
+            conn.execute("ROLLBACK")
+            row = conn.execute(
+                "SELECT 1 FROM projects WHERE slug = 'uncommitted'"
+            ).fetchone()
+            self.assertIsNone(row)
+            conn.close()
+        finally:
+            td.cleanup()
+
+    def test_get_session_in_open_tx_returns_none_without_committing(self):
+        """Cross-review M-r3-1: get_session must not silently commit a
+        caller-controlled transaction just to satisfy a read on a
+        pre-M2 DB. It returns None and lets the caller see "session
+        unknown" instead."""
+        from tools.state_db.queries import get_session
+        td = tempfile.TemporaryDirectory()
+        try:
+            db = Path(td.name) / "m1.db"
+            conn = connect(db)
+            conn.executescript(self._M1_SCHEMA)
+            conn.commit()
+            conn.execute("BEGIN")
+            conn.execute(
+                "INSERT INTO projects (slug, display_name) "
+                "VALUES ('uncommitted', 'should-disappear')"
+            )
+            sess = get_session(conn)
+            self.assertIsNone(sess)
             conn.execute("ROLLBACK")
             row = conn.execute(
                 "SELECT 1 FROM projects WHERE slug = 'uncommitted'"

--- a/tools/state_db/test_writer.py
+++ b/tools/state_db/test_writer.py
@@ -1,0 +1,276 @@
+"""Unit tests for tools.state_db.writer (M2 write switch, Issue #267)."""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.state_db import apply_schema, connect
+from tools.state_db.writer import StateWriter
+
+
+def _fresh_db():
+    td = tempfile.TemporaryDirectory()
+    db = Path(td.name) / "writer.db"
+    conn = connect(db)
+    apply_schema(conn)
+    return td, conn
+
+
+class TestSessionSingleton(unittest.TestCase):
+    def test_writer_seeds_singleton_on_init(self):
+        td, conn = _fresh_db()
+        try:
+            StateWriter(conn)
+            row = conn.execute(
+                "SELECT id, status FROM org_sessions WHERE id = 1"
+            ).fetchone()
+            self.assertIsNotNone(row)
+            self.assertEqual(row["status"], "IDLE")
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_update_session_patches_listed_fields_only(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.update_session(status="ACTIVE", objective="ship M2",
+                             dispatcher_pane_id="2",
+                             dispatcher_peer_id="2")
+            sess = w.get_session()
+            self.assertEqual(sess["status"], "ACTIVE")
+            self.assertEqual(sess["objective"], "ship M2")
+            self.assertEqual(sess["dispatcher_pane_id"], "2")
+            self.assertIsNone(sess["curator_pane_id"])
+            # Second call mutates only what's passed.
+            w.update_session(status="SUSPENDED", suspended_at="2026-05-04")
+            sess = w.get_session()
+            self.assertEqual(sess["status"], "SUSPENDED")
+            self.assertEqual(sess["objective"], "ship M2")  # untouched
+            self.assertEqual(sess["suspended_at"], "2026-05-04")
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_update_session_rejects_unknown_field(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            with self.assertRaises(ValueError):
+                w.update_session(status="ACTIVE", bogus="x")
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_singleton_check_blocks_second_row(self):
+        td, conn = _fresh_db()
+        try:
+            StateWriter(conn)
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO org_sessions (id, status) VALUES (2, 'ACTIVE')"
+                )
+        finally:
+            conn.close()
+            td.cleanup()
+
+
+class TestWorkerDirs(unittest.TestCase):
+    def test_register_is_idempotent(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            id1 = w.register_worker_dir(abs_path="/x/dir-a", layout="flat")
+            id2 = w.register_worker_dir(abs_path="/x/dir-a", layout="flat",
+                                         current_branch="main")
+            self.assertEqual(id1, id2)
+            row = conn.execute(
+                "SELECT current_branch, lifecycle FROM worker_dirs "
+                "WHERE abs_path = '/x/dir-a'"
+            ).fetchone()
+            self.assertEqual(row["current_branch"], "main")
+            self.assertEqual(row["lifecycle"], "active")
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_update_lifecycle_and_remove(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.register_worker_dir(abs_path="/x/dir-b", layout="flat")
+            w.update_worker_dir_lifecycle("/x/dir-b", "archived")
+            row = conn.execute(
+                "SELECT lifecycle, archived FROM worker_dirs "
+                "WHERE abs_path = '/x/dir-b'"
+            ).fetchone()
+            self.assertEqual(row["lifecycle"], "archived")
+            self.assertEqual(row["archived"], 1)
+            w.remove_worker_dir("/x/dir-b")
+            row = conn.execute(
+                "SELECT 1 FROM worker_dirs WHERE abs_path = '/x/dir-b'"
+            ).fetchone()
+            self.assertIsNone(row)
+        finally:
+            conn.close()
+            td.cleanup()
+
+
+class TestRuns(unittest.TestCase):
+    def test_upsert_run_creates_then_updates(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.register_worker_dir(abs_path="/x/wd1")
+            run_id = w.upsert_run(
+                task_id="t1", project_slug="proj-a", pattern="B",
+                title="task one", status="in_use",
+                worker_dir_abs_path="/x/wd1",
+                issue_refs=["#100", "#101"],
+            )
+            self.assertGreater(run_id, 0)
+            row = conn.execute(
+                "SELECT status, title, issue_refs, worker_dir_id "
+                "FROM runs WHERE task_id = 't1'"
+            ).fetchone()
+            self.assertEqual(row["status"], "in_use")
+            self.assertEqual(row["title"], "task one")
+            self.assertIn("#100", row["issue_refs"])
+
+            # Update path: status change shouldn't null pr_url.
+            w.upsert_run(task_id="t1", project_slug="proj-a", pattern="B",
+                          status="review", pr_url="https://x/pr/1")
+            row = conn.execute(
+                "SELECT status, pr_url FROM runs WHERE task_id = 't1'"
+            ).fetchone()
+            self.assertEqual(row["status"], "review")
+            self.assertEqual(row["pr_url"], "https://x/pr/1")
+
+            # Subsequent update with no pr_url must not null the existing one.
+            w.upsert_run(task_id="t1", project_slug="proj-a", pattern="B",
+                          status="completed")
+            row = conn.execute(
+                "SELECT status, pr_url FROM runs WHERE task_id = 't1'"
+            ).fetchone()
+            self.assertEqual(row["status"], "completed")
+            self.assertEqual(row["pr_url"], "https://x/pr/1")
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_update_run_status(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.upsert_run(task_id="t2", project_slug="proj-b", pattern="C")
+            w.update_run_status("t2", "completed",
+                                 completed_at="2026-05-04T00:00:00.000Z",
+                                 outcome_note="ok")
+            row = conn.execute(
+                "SELECT status, completed_at, outcome_note FROM runs "
+                "WHERE task_id = 't2'"
+            ).fetchone()
+            self.assertEqual(row["status"], "completed")
+            self.assertEqual(row["completed_at"], "2026-05-04T00:00:00.000Z")
+            self.assertEqual(row["outcome_note"], "ok")
+        finally:
+            conn.close()
+            td.cleanup()
+
+
+class TestEvents(unittest.TestCase):
+    def test_append_event_resolves_run_fk(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.upsert_run(task_id="t3", project_slug="proj-c", pattern="A")
+            evt_id = w.append_event(
+                kind="dispatch", actor="dispatcher",
+                payload={"task": "t3", "n": 1},
+                run_task_id="t3",
+            )
+            self.assertGreater(evt_id, 0)
+            row = conn.execute(
+                "SELECT kind, actor, run_id, project_id, payload_json "
+                "FROM events WHERE id = ?", (evt_id,)
+            ).fetchone()
+            self.assertEqual(row["kind"], "dispatch")
+            self.assertEqual(row["actor"], "dispatcher")
+            self.assertIsNotNone(row["run_id"])
+            self.assertIsNotNone(row["project_id"])
+            self.assertIn("\"n\": 1", row["payload_json"])
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_append_event_payload_check(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            # Empty payload defaults to '{}' which is valid JSON.
+            w.append_event(kind="ping", payload=None)
+            row = conn.execute(
+                "SELECT payload_json FROM events ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            self.assertEqual(row["payload_json"], "{}")
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_append_event_with_explicit_occurred_at(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.append_event(kind="x", occurred_at="2026-05-04T00:00:00.000Z")
+            row = conn.execute(
+                "SELECT occurred_at FROM events ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            self.assertEqual(row["occurred_at"], "2026-05-04T00:00:00.000Z")
+        finally:
+            conn.close()
+            td.cleanup()
+
+
+class TestTransactionBoundary(unittest.TestCase):
+    def test_rollback_undoes_uncommitted_writes(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.commit()  # flush the auto-seeded singleton
+            w.begin()
+            w.register_worker_dir(abs_path="/x/uncommitted")
+            w.rollback()
+            row = conn.execute(
+                "SELECT 1 FROM worker_dirs WHERE abs_path = '/x/uncommitted'"
+            ).fetchone()
+            self.assertIsNone(row)
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_commit_persists(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.register_worker_dir(abs_path="/x/persist")
+            w.commit()
+            # Re-open to verify on-disk state.
+            db_path = Path([h for h in conn.execute(
+                "PRAGMA database_list").fetchall()][0]["file"])
+            conn.close()
+            conn2 = connect(db_path)
+            try:
+                row = conn2.execute(
+                    "SELECT 1 FROM worker_dirs WHERE abs_path = '/x/persist'"
+                ).fetchone()
+                self.assertIsNotNone(row)
+            finally:
+                conn2.close()
+        finally:
+            td.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/state_db/test_writer.py
+++ b/tools/state_db/test_writer.py
@@ -78,6 +78,33 @@ class TestPreM2Migration(unittest.TestCase):
         finally:
             td.cleanup()
 
+    def test_migration_warns_when_called_in_open_tx(self):
+        """Cross-review m1: SQLite cannot truly isolate DDL from a parent
+        ROLLBACK, so we warn loudly when invoked inside an open
+        transaction instead of silently mixing the migration in."""
+        import warnings
+        from tools.state_db import ensure_m2_schema
+        td = tempfile.TemporaryDirectory()
+        try:
+            db = Path(td.name) / "m1.db"
+            conn = connect(db)
+            conn.executescript(self._M1_SCHEMA)
+            conn.commit()
+            conn.execute("BEGIN")
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                ensure_m2_schema(conn)
+            conn.execute("ROLLBACK")
+            warn_msgs = [str(w.message).lower() for w in caught
+                         if issubclass(w.category, RuntimeWarning)]
+            self.assertTrue(
+                any("open transaction" in m for m in warn_msgs),
+                f"expected open-transaction warning, got {warn_msgs!r}",
+            )
+            conn.close()
+        finally:
+            td.cleanup()
+
     def test_get_session_migrates_pre_m2_db(self):
         from tools.state_db.queries import get_session
         td = tempfile.TemporaryDirectory()
@@ -130,6 +157,38 @@ class TestSessionSingleton(unittest.TestCase):
             self.assertEqual(sess["status"], "SUSPENDED")
             self.assertEqual(sess["objective"], "ship M2")  # untouched
             self.assertEqual(sess["suspended_at"], "2026-05-04")
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_update_session_skips_implicit_none(self):
+        """Cross-review m2: passing status=None (default-arg propagation)
+        must NOT clear status. Only explicit StateWriter.CLEAR does."""
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.update_session(status="ACTIVE", objective="ship")
+            # All-None update — the wire-form many callers will accidentally
+            # produce when they propagate Optional[str] kwargs without a
+            # sentinel. Pre-fix this NULLed every column.
+            w.update_session(status=None, objective=None,
+                             dispatcher_pane_id=None)
+            sess = w.get_session()
+            self.assertEqual(sess["status"], "ACTIVE")
+            self.assertEqual(sess["objective"], "ship")
+        finally:
+            conn.close()
+            td.cleanup()
+
+    def test_update_session_clear_sentinel_nulls_column(self):
+        td, conn = _fresh_db()
+        try:
+            w = StateWriter(conn)
+            w.update_session(status="ACTIVE", objective="ship")
+            w.update_session(objective=StateWriter.CLEAR)
+            sess = w.get_session()
+            self.assertEqual(sess["status"], "ACTIVE")
+            self.assertIsNone(sess["objective"])
         finally:
             conn.close()
             td.cleanup()

--- a/tools/state_db/writer.py
+++ b/tools/state_db/writer.py
@@ -21,6 +21,20 @@ import sqlite3
 from typing import Any, Iterable, Optional
 
 
+class _ClearSentinel:
+    """Singleton marker that means "explicitly NULL this column".
+
+    Used by :meth:`StateWriter.update_session` to distinguish "caller
+    omitted this kwarg / passed None as a meaningless default" from
+    "caller really wants to clear this column".
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover — debug aid only
+        return "StateWriter.CLEAR"
+
+
 class StateWriter:
     """Connection-bound writer with explicit transaction control.
 
@@ -29,6 +43,8 @@ class StateWriter:
     ``busy_timeout`` PRAGMAs are already set). The writer re-asserts those
     PRAGMAs defensively because callers sometimes hand in a bare connection.
     """
+
+    CLEAR = _ClearSentinel()
 
     def __init__(self, conn: sqlite3.Connection):
         self.conn = conn
@@ -82,8 +98,14 @@ class StateWriter:
         """Patch the org_sessions singleton with the given keyword fields.
 
         Unknown keys raise ``ValueError`` to catch typos at write time.
-        Pass ``status=None`` (or any other field set to None) explicitly
-        to clear that column. Omitted fields are left untouched.
+        Cross-review m2: pass ``status=None`` is treated as "caller did
+        not supply this field" and is **skipped**, not written as NULL.
+        This protects callers that pile up Optional[…] kwargs from
+        accidentally NULL-clearing every column when none of them got
+        a real value. To explicitly clear a column, use the dedicated
+        sentinel :attr:`StateWriter.CLEAR` (``writer.update_session(
+        status=StateWriter.CLEAR)``) or write raw SQL.
+        Omitted kwargs are also untouched.
         """
         unknown = set(fields) - set(self._SESSION_FIELDS)
         if unknown:
@@ -91,7 +113,14 @@ class StateWriter:
                 f"unknown org_sessions field(s): {sorted(unknown)}; "
                 f"expected one of {list(self._SESSION_FIELDS)}"
             )
-        if not fields:
+        # Drop implicit-None entries; only explicit CLEAR or a real value
+        # results in a column write.
+        actual: dict[str, Any] = {}
+        for k, v in fields.items():
+            if v is None:
+                continue
+            actual[k] = None if v is self.CLEAR else v
+        if not actual:
             # No-op but still bump last_writer_at so dashboards see a write.
             self.conn.execute(
                 "UPDATE org_sessions SET "
@@ -99,8 +128,8 @@ class StateWriter:
                 "WHERE id = 1"
             )
             return
-        assigns = ", ".join(f"{k} = ?" for k in fields)
-        values = [fields[k] for k in fields]
+        assigns = ", ".join(f"{k} = ?" for k in actual)
+        values = [actual[k] for k in actual]
         self.conn.execute(
             f"UPDATE org_sessions SET {assigns}, "
             "last_writer_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') "

--- a/tools/state_db/writer.py
+++ b/tools/state_db/writer.py
@@ -198,48 +198,63 @@ class StateWriter:
     # runs
     # ------------------------------------------------------------------
 
+    # Sentinel — distinguishes "caller didn't pass this kwarg" from
+    # "caller explicitly passed None" in upsert_run's differential update.
+    _UNSET = object()
+
     def upsert_run(
         self,
         *,
         task_id: str,
         project_slug: str,
-        pattern: str,
+        pattern: Optional[str] = None,
         title: Optional[str] = None,
-        status: str = "in_use",
+        status: Optional[str] = None,
         branch: Optional[str] = None,
         pr_url: Optional[str] = None,
         pr_state: Optional[str] = None,
         issue_refs: Optional[Iterable[str]] = None,
-        verification: str = "standard",
+        verification: Optional[str] = None,
         worker_dir_abs_path: Optional[str] = None,
         commit_short: Optional[str] = None,
         commit_full: Optional[str] = None,
         outcome_note: Optional[str] = None,
         workstream_slug: Optional[str] = None,
     ) -> int:
-        """Insert or update a run row keyed by ``task_id``. Returns runs.id."""
+        """Insert or update a run row keyed by ``task_id``. Returns runs.id.
+
+        Update semantics: only fields the caller explicitly passes are
+        overwritten. Omitted kwargs preserve the existing row's value;
+        passing ``None`` is treated as "caller didn't supply" and also
+        preserves the existing value. (Use raw SQL if you need to
+        explicitly NULL a field — by design, this API never silently
+        clears columns.)
+        """
         project_id = self.ensure_project(project_slug)
-        workstream_id: Optional[int] = None
-        if workstream_slug:
-            ws = self.conn.execute(
-                "SELECT id FROM workstreams WHERE project_id = ? AND slug = ?",
-                (project_id, workstream_slug),
-            ).fetchone()
-            workstream_id = int(ws["id"]) if ws else None
-        worker_dir_id: Optional[int] = None
-        if worker_dir_abs_path:
+        existing = self.conn.execute(
+            "SELECT id FROM runs WHERE task_id = ?", (task_id,)
+        ).fetchone()
+
+        worker_dir_id = self._UNSET
+        if worker_dir_abs_path is not None:
             wd = self.conn.execute(
                 "SELECT id FROM worker_dirs WHERE abs_path = ?",
                 (worker_dir_abs_path,),
             ).fetchone()
             worker_dir_id = int(wd["id"]) if wd else None
 
-        issue_refs_json = json.dumps(list(issue_refs)) if issue_refs else None
-        title = title or task_id
+        workstream_id = self._UNSET
+        if workstream_slug is not None:
+            ws = self.conn.execute(
+                "SELECT id FROM workstreams WHERE project_id = ? AND slug = ?",
+                (project_id, workstream_slug),
+            ).fetchone()
+            workstream_id = int(ws["id"]) if ws else None
 
-        existing = self.conn.execute(
-            "SELECT id FROM runs WHERE task_id = ?", (task_id,)
-        ).fetchone()
+        issue_refs_json: object = self._UNSET
+        if issue_refs is not None:
+            issue_refs_json = json.dumps(list(issue_refs))
+
         if existing is None:
             cur = self.conn.execute(
                 "INSERT INTO runs ("
@@ -247,33 +262,58 @@ class StateWriter:
                 "branch, pr_url, pr_state, issue_refs, verification, "
                 "worker_dir_id, commit_short, commit_full, outcome_note) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (task_id, project_id, workstream_id, pattern, title, status,
-                 branch, pr_url, pr_state, issue_refs_json, verification,
-                 worker_dir_id, commit_short, commit_full, outcome_note),
+                (task_id, project_id,
+                 None if workstream_id is self._UNSET else workstream_id,
+                 pattern or "B",
+                 title or task_id,
+                 status or "in_use",
+                 branch, pr_url, pr_state,
+                 None if issue_refs_json is self._UNSET else issue_refs_json,
+                 verification or "standard",
+                 None if worker_dir_id is self._UNSET else worker_dir_id,
+                 commit_short, commit_full, outcome_note),
             )
             return cur.lastrowid
-        # Update path: only overwrite columns the caller explicitly passed;
-        # use COALESCE on optional fields so e.g. updating status doesn't
-        # null out a previously-set pr_url.
-        self.conn.execute(
-            "UPDATE runs SET "
-            "  project_id = ?, workstream_id = ?, pattern = ?, title = ?, "
-            "  status = ?, "
-            "  branch = COALESCE(?, branch), "
-            "  pr_url = COALESCE(?, pr_url), "
-            "  pr_state = COALESCE(?, pr_state), "
-            "  issue_refs = COALESCE(?, issue_refs), "
-            "  verification = ?, "
-            "  worker_dir_id = COALESCE(?, worker_dir_id), "
-            "  commit_short = COALESCE(?, commit_short), "
-            "  commit_full = COALESCE(?, commit_full), "
-            "  outcome_note = COALESCE(?, outcome_note) "
-            "WHERE task_id = ?",
-            (project_id, workstream_id, pattern, title, status,
-             branch, pr_url, pr_state, issue_refs_json, verification,
-             worker_dir_id, commit_short, commit_full, outcome_note,
-             task_id),
-        )
+
+        # Update path: build the SET clause from supplied kwargs only so
+        # omitted fields preserve their existing value.
+        sets: list[str] = []
+        values: list = []
+
+        def _maybe(col: str, val):
+            if val is not None and val is not self._UNSET:
+                sets.append(f"{col} = ?")
+                values.append(val)
+
+        # project_id is always known (we just resolved it from project_slug)
+        # and therefore safe to write.
+        _maybe("project_id", project_id)
+        _maybe("pattern", pattern)
+        _maybe("title", title)
+        _maybe("status", status)
+        _maybe("branch", branch)
+        _maybe("pr_url", pr_url)
+        _maybe("pr_state", pr_state)
+        _maybe("verification", verification)
+        _maybe("commit_short", commit_short)
+        _maybe("commit_full", commit_full)
+        _maybe("outcome_note", outcome_note)
+        if issue_refs_json is not self._UNSET:
+            sets.append("issue_refs = ?")
+            values.append(issue_refs_json)
+        if worker_dir_id is not self._UNSET:
+            sets.append("worker_dir_id = ?")
+            values.append(worker_dir_id)
+        if workstream_id is not self._UNSET:
+            sets.append("workstream_id = ?")
+            values.append(workstream_id)
+
+        if sets:
+            values.append(task_id)
+            self.conn.execute(
+                f"UPDATE runs SET {', '.join(sets)} WHERE task_id = ?",
+                values,
+            )
         return int(existing["id"])
 
     def update_run_status(

--- a/tools/state_db/writer.py
+++ b/tools/state_db/writer.py
@@ -36,12 +36,12 @@ class StateWriter:
         # bare sqlite3.connect() handle.
         conn.execute("PRAGMA foreign_keys = ON")
         conn.execute("PRAGMA busy_timeout = 5000")
-        # Auto-create the org_sessions singleton if missing so update_session
-        # can run on a freshly imported DB without a separate seed step.
-        conn.execute(
-            "INSERT OR IGNORE INTO org_sessions (id, status, last_writer_at) "
-            "VALUES (1, 'IDLE', strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
-        )
+        # Forward-migrate pre-M2 DBs in place: org_sessions may be missing
+        # if this writer attaches to an M0 / M1 DB that was created before
+        # the schema bump. ensure_m2_schema is idempotent and seeds the
+        # singleton row when it's absent.
+        from tools.state_db import ensure_m2_schema
+        ensure_m2_schema(conn)
 
     # ------------------------------------------------------------------
     # Transaction control
@@ -122,41 +122,64 @@ class StateWriter:
         self,
         *,
         abs_path: str,
-        layout: str = "flat",
-        is_git_repo: bool = False,
-        is_worktree: bool = False,
+        layout: Optional[str] = None,
+        is_git_repo: Optional[bool] = None,
+        is_worktree: Optional[bool] = None,
         origin_url: Optional[str] = None,
         current_branch: Optional[str] = None,
         size_mb: Optional[float] = None,
-        lifecycle: str = "active",
+        lifecycle: Optional[str] = None,
     ) -> int:
-        """INSERT (or UPSERT) a worker_dirs row keyed by abs_path. Returns id.
+        """INSERT (or differential-UPDATE) a worker_dirs row by abs_path.
 
-        UPSERT keeps re-registration idempotent: the dispatcher / sweeper
-        often re-announces dirs on startup and we don't want duplicates.
+        Idempotent re-registration: the dispatcher / sweeper often
+        re-announces dirs on startup. Only fields the caller explicitly
+        passes are written on the UPDATE path so a status ping that omits
+        ``is_git_repo`` doesn't silently flip it back to False.
         """
-        cur = self.conn.execute(
-            "INSERT INTO worker_dirs ("
-            "abs_path, layout, is_git_repo, is_worktree, origin_url, "
-            "current_branch, size_mb, lifecycle) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
-            "ON CONFLICT(abs_path) DO UPDATE SET "
-            "  layout = excluded.layout, "
-            "  is_git_repo = excluded.is_git_repo, "
-            "  is_worktree = excluded.is_worktree, "
-            "  origin_url = COALESCE(excluded.origin_url, worker_dirs.origin_url), "
-            "  current_branch = COALESCE(excluded.current_branch, worker_dirs.current_branch), "
-            "  size_mb = COALESCE(excluded.size_mb, worker_dirs.size_mb), "
-            "  lifecycle = excluded.lifecycle, "
-            "  last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')",
-            (abs_path, layout, int(is_git_repo), int(is_worktree),
-             origin_url, current_branch, size_mb, lifecycle),
-        )
-        # cur.lastrowid is 0 on UPDATE-only path; resolve via SELECT.
-        row = self.conn.execute(
+        existing = self.conn.execute(
             "SELECT id FROM worker_dirs WHERE abs_path = ?", (abs_path,)
         ).fetchone()
-        return int(row["id"]) if row else cur.lastrowid
+        if existing is None:
+            cur = self.conn.execute(
+                "INSERT INTO worker_dirs ("
+                "abs_path, layout, is_git_repo, is_worktree, origin_url, "
+                "current_branch, size_mb, lifecycle) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (abs_path, layout or "flat",
+                 int(bool(is_git_repo)) if is_git_repo is not None else 0,
+                 int(bool(is_worktree)) if is_worktree is not None else 0,
+                 origin_url, current_branch, size_mb,
+                 lifecycle or "active"),
+            )
+            return cur.lastrowid
+
+        sets: list[str] = []
+        values: list = []
+
+        def _maybe(col: str, val):
+            if val is not None:
+                sets.append(f"{col} = ?")
+                values.append(val)
+
+        _maybe("layout", layout)
+        if is_git_repo is not None:
+            sets.append("is_git_repo = ?")
+            values.append(int(bool(is_git_repo)))
+        if is_worktree is not None:
+            sets.append("is_worktree = ?")
+            values.append(int(bool(is_worktree)))
+        _maybe("origin_url", origin_url)
+        _maybe("current_branch", current_branch)
+        _maybe("size_mb", size_mb)
+        _maybe("lifecycle", lifecycle)
+        sets.append("last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')")
+        values.append(abs_path)
+        self.conn.execute(
+            f"UPDATE worker_dirs SET {', '.join(sets)} WHERE abs_path = ?",
+            values,
+        )
+        return int(existing["id"])
 
     def update_worker_dir_lifecycle(self, abs_path: str, lifecycle: str) -> None:
         """Move a worker dir to a different lifecycle bucket (active/archived/etc)."""

--- a/tools/state_db/writer.py
+++ b/tools/state_db/writer.py
@@ -1,0 +1,363 @@
+"""Thin DB direct-write API for the M2 write switch (Issue #267).
+
+In M2 the SQLite DB at `.state/state.db` becomes the SoT for state writes.
+Secretary / dispatcher / worker code is expected to call into a
+``StateWriter`` instead of editing `.state/org-state.md` or appending to
+`.state/journal.jsonl` by hand. The markdown / jsonl files are regenerated
+post-commit by :mod:`tools.state_db.snapshotter` (one-way dump).
+
+Design boundary (per CLAUDE.local.md / migration-strategy.md §M2):
+- writer mutates DB rows only.
+- writer never imports snapshotter; markdown regeneration is the caller's
+  responsibility (typically via ``post_commit_regenerate``). This keeps the
+  failure surface of writer narrow and avoids a circular dependency.
+- writer wraps every public mutation in an explicit transaction. Callers
+  may compose multiple mutations inside ``begin()`` / ``commit()`` instead.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any, Iterable, Optional
+
+
+class StateWriter:
+    """Connection-bound writer with explicit transaction control.
+
+    Construct with an open ``sqlite3.Connection`` (preferably one returned
+    by :func:`tools.state_db.connect` so that ``foreign_keys`` and
+    ``busy_timeout`` PRAGMAs are already set). The writer re-asserts those
+    PRAGMAs defensively because callers sometimes hand in a bare connection.
+    """
+
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        # Defensive: ensure project-wide PRAGMAs even when caller passed a
+        # bare sqlite3.connect() handle.
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA busy_timeout = 5000")
+        # Auto-create the org_sessions singleton if missing so update_session
+        # can run on a freshly imported DB without a separate seed step.
+        conn.execute(
+            "INSERT OR IGNORE INTO org_sessions (id, status, last_writer_at) "
+            "VALUES (1, 'IDLE', strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
+        )
+
+    # ------------------------------------------------------------------
+    # Transaction control
+    # ------------------------------------------------------------------
+
+    def begin(self) -> None:
+        """Open an explicit transaction.
+
+        sqlite3's default isolation level is "deferred" (= a transaction
+        opens implicitly on the first DML); calling ``BEGIN`` directly
+        would raise ``OperationalError: cannot start a transaction within
+        a transaction`` if one is already open. We swallow that case so
+        callers can defensively bracket their writes.
+        """
+        try:
+            self.conn.execute("BEGIN")
+        except sqlite3.OperationalError:
+            pass
+
+    def commit(self) -> None:
+        self.conn.commit()
+
+    def rollback(self) -> None:
+        self.conn.rollback()
+
+    # ------------------------------------------------------------------
+    # org session (singleton)
+    # ------------------------------------------------------------------
+
+    _SESSION_FIELDS: tuple[str, ...] = (
+        "status", "started_at", "updated_at", "suspended_at", "resumed_at",
+        "objective", "resume_instructions",
+        "dispatcher_pane_id", "dispatcher_peer_id",
+        "curator_pane_id", "curator_peer_id",
+    )
+
+    def update_session(self, **fields: Any) -> None:
+        """Patch the org_sessions singleton with the given keyword fields.
+
+        Unknown keys raise ``ValueError`` to catch typos at write time.
+        Pass ``status=None`` (or any other field set to None) explicitly
+        to clear that column. Omitted fields are left untouched.
+        """
+        unknown = set(fields) - set(self._SESSION_FIELDS)
+        if unknown:
+            raise ValueError(
+                f"unknown org_sessions field(s): {sorted(unknown)}; "
+                f"expected one of {list(self._SESSION_FIELDS)}"
+            )
+        if not fields:
+            # No-op but still bump last_writer_at so dashboards see a write.
+            self.conn.execute(
+                "UPDATE org_sessions SET "
+                "last_writer_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') "
+                "WHERE id = 1"
+            )
+            return
+        assigns = ", ".join(f"{k} = ?" for k in fields)
+        values = [fields[k] for k in fields]
+        self.conn.execute(
+            f"UPDATE org_sessions SET {assigns}, "
+            "last_writer_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') "
+            "WHERE id = 1",
+            values,
+        )
+
+    def get_session(self) -> dict[str, Any]:
+        row = self.conn.execute("SELECT * FROM org_sessions WHERE id = 1").fetchone()
+        if row is None:
+            return {}
+        return {k: row[k] for k in row.keys()}
+
+    # ------------------------------------------------------------------
+    # worker_dirs
+    # ------------------------------------------------------------------
+
+    def register_worker_dir(
+        self,
+        *,
+        abs_path: str,
+        layout: str = "flat",
+        is_git_repo: bool = False,
+        is_worktree: bool = False,
+        origin_url: Optional[str] = None,
+        current_branch: Optional[str] = None,
+        size_mb: Optional[float] = None,
+        lifecycle: str = "active",
+    ) -> int:
+        """INSERT (or UPSERT) a worker_dirs row keyed by abs_path. Returns id.
+
+        UPSERT keeps re-registration idempotent: the dispatcher / sweeper
+        often re-announces dirs on startup and we don't want duplicates.
+        """
+        cur = self.conn.execute(
+            "INSERT INTO worker_dirs ("
+            "abs_path, layout, is_git_repo, is_worktree, origin_url, "
+            "current_branch, size_mb, lifecycle) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(abs_path) DO UPDATE SET "
+            "  layout = excluded.layout, "
+            "  is_git_repo = excluded.is_git_repo, "
+            "  is_worktree = excluded.is_worktree, "
+            "  origin_url = COALESCE(excluded.origin_url, worker_dirs.origin_url), "
+            "  current_branch = COALESCE(excluded.current_branch, worker_dirs.current_branch), "
+            "  size_mb = COALESCE(excluded.size_mb, worker_dirs.size_mb), "
+            "  lifecycle = excluded.lifecycle, "
+            "  last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')",
+            (abs_path, layout, int(is_git_repo), int(is_worktree),
+             origin_url, current_branch, size_mb, lifecycle),
+        )
+        # cur.lastrowid is 0 on UPDATE-only path; resolve via SELECT.
+        row = self.conn.execute(
+            "SELECT id FROM worker_dirs WHERE abs_path = ?", (abs_path,)
+        ).fetchone()
+        return int(row["id"]) if row else cur.lastrowid
+
+    def update_worker_dir_lifecycle(self, abs_path: str, lifecycle: str) -> None:
+        """Move a worker dir to a different lifecycle bucket (active/archived/etc)."""
+        self.conn.execute(
+            "UPDATE worker_dirs SET lifecycle = ?, "
+            "last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') "
+            "WHERE abs_path = ?",
+            (lifecycle, abs_path),
+        )
+
+    def remove_worker_dir(self, abs_path: str) -> None:
+        """Physically delete a worker_dirs row. Reserved for curator batch.
+
+        runs.worker_dir_id is ON DELETE SET NULL so existing run history is
+        preserved; only the FS-level metadata disappears.
+        """
+        self.conn.execute("DELETE FROM worker_dirs WHERE abs_path = ?", (abs_path,))
+
+    # ------------------------------------------------------------------
+    # projects / workstreams (lookup helpers — no creation outside importer)
+    # ------------------------------------------------------------------
+
+    def ensure_project(self, slug: str, *, display_name: Optional[str] = None,
+                       origin_url: Optional[str] = None) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO projects (slug, display_name, origin_url) "
+            "VALUES (?, ?, ?) "
+            "ON CONFLICT(slug) DO UPDATE SET "
+            "  display_name = COALESCE(excluded.display_name, projects.display_name), "
+            "  origin_url = COALESCE(excluded.origin_url, projects.origin_url)",
+            (slug, display_name or slug, origin_url),
+        )
+        row = self.conn.execute(
+            "SELECT id FROM projects WHERE slug = ?", (slug,)
+        ).fetchone()
+        return int(row["id"]) if row else cur.lastrowid
+
+    # ------------------------------------------------------------------
+    # runs
+    # ------------------------------------------------------------------
+
+    def upsert_run(
+        self,
+        *,
+        task_id: str,
+        project_slug: str,
+        pattern: str,
+        title: Optional[str] = None,
+        status: str = "in_use",
+        branch: Optional[str] = None,
+        pr_url: Optional[str] = None,
+        pr_state: Optional[str] = None,
+        issue_refs: Optional[Iterable[str]] = None,
+        verification: str = "standard",
+        worker_dir_abs_path: Optional[str] = None,
+        commit_short: Optional[str] = None,
+        commit_full: Optional[str] = None,
+        outcome_note: Optional[str] = None,
+        workstream_slug: Optional[str] = None,
+    ) -> int:
+        """Insert or update a run row keyed by ``task_id``. Returns runs.id."""
+        project_id = self.ensure_project(project_slug)
+        workstream_id: Optional[int] = None
+        if workstream_slug:
+            ws = self.conn.execute(
+                "SELECT id FROM workstreams WHERE project_id = ? AND slug = ?",
+                (project_id, workstream_slug),
+            ).fetchone()
+            workstream_id = int(ws["id"]) if ws else None
+        worker_dir_id: Optional[int] = None
+        if worker_dir_abs_path:
+            wd = self.conn.execute(
+                "SELECT id FROM worker_dirs WHERE abs_path = ?",
+                (worker_dir_abs_path,),
+            ).fetchone()
+            worker_dir_id = int(wd["id"]) if wd else None
+
+        issue_refs_json = json.dumps(list(issue_refs)) if issue_refs else None
+        title = title or task_id
+
+        existing = self.conn.execute(
+            "SELECT id FROM runs WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        if existing is None:
+            cur = self.conn.execute(
+                "INSERT INTO runs ("
+                "task_id, project_id, workstream_id, pattern, title, status, "
+                "branch, pr_url, pr_state, issue_refs, verification, "
+                "worker_dir_id, commit_short, commit_full, outcome_note) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (task_id, project_id, workstream_id, pattern, title, status,
+                 branch, pr_url, pr_state, issue_refs_json, verification,
+                 worker_dir_id, commit_short, commit_full, outcome_note),
+            )
+            return cur.lastrowid
+        # Update path: only overwrite columns the caller explicitly passed;
+        # use COALESCE on optional fields so e.g. updating status doesn't
+        # null out a previously-set pr_url.
+        self.conn.execute(
+            "UPDATE runs SET "
+            "  project_id = ?, workstream_id = ?, pattern = ?, title = ?, "
+            "  status = ?, "
+            "  branch = COALESCE(?, branch), "
+            "  pr_url = COALESCE(?, pr_url), "
+            "  pr_state = COALESCE(?, pr_state), "
+            "  issue_refs = COALESCE(?, issue_refs), "
+            "  verification = ?, "
+            "  worker_dir_id = COALESCE(?, worker_dir_id), "
+            "  commit_short = COALESCE(?, commit_short), "
+            "  commit_full = COALESCE(?, commit_full), "
+            "  outcome_note = COALESCE(?, outcome_note) "
+            "WHERE task_id = ?",
+            (project_id, workstream_id, pattern, title, status,
+             branch, pr_url, pr_state, issue_refs_json, verification,
+             worker_dir_id, commit_short, commit_full, outcome_note,
+             task_id),
+        )
+        return int(existing["id"])
+
+    def update_run_status(
+        self,
+        task_id: str,
+        status: str,
+        *,
+        completed_at: Optional[str] = None,
+        outcome_note: Optional[str] = None,
+    ) -> None:
+        self.conn.execute(
+            "UPDATE runs SET status = ?, "
+            "  completed_at = COALESCE(?, completed_at), "
+            "  outcome_note = COALESCE(?, outcome_note) "
+            "WHERE task_id = ?",
+            (status, completed_at, outcome_note, task_id),
+        )
+
+    # ------------------------------------------------------------------
+    # events (append-only journal)
+    # ------------------------------------------------------------------
+
+    def append_event(
+        self,
+        *,
+        kind: str,
+        actor: Optional[str] = None,
+        payload: Optional[dict] = None,
+        occurred_at: Optional[str] = None,
+        run_task_id: Optional[str] = None,
+        project_slug: Optional[str] = None,
+        workstream_slug: Optional[str] = None,
+    ) -> int:
+        """Insert one event row. Returns events.id.
+
+        ``payload`` is JSON-encoded; if you need to round-trip the original
+        kind/ts/actor of a legacy line, include them inside payload as well.
+        """
+        run_id: Optional[int] = None
+        project_id: Optional[int] = None
+        workstream_id: Optional[int] = None
+        if run_task_id:
+            row = self.conn.execute(
+                "SELECT id, project_id, workstream_id FROM runs WHERE task_id = ?",
+                (run_task_id,),
+            ).fetchone()
+            if row is not None:
+                run_id = int(row["id"])
+                project_id = int(row["project_id"])
+                if row["workstream_id"] is not None:
+                    workstream_id = int(row["workstream_id"])
+        if project_slug and project_id is None:
+            row = self.conn.execute(
+                "SELECT id FROM projects WHERE slug = ?", (project_slug,)
+            ).fetchone()
+            if row is not None:
+                project_id = int(row["id"])
+        if workstream_slug and workstream_id is None and project_id is not None:
+            row = self.conn.execute(
+                "SELECT id FROM workstreams WHERE project_id = ? AND slug = ?",
+                (project_id, workstream_slug),
+            ).fetchone()
+            if row is not None:
+                workstream_id = int(row["id"])
+
+        payload_json = json.dumps(
+            payload or {}, ensure_ascii=False, sort_keys=True
+        )
+        if occurred_at:
+            cur = self.conn.execute(
+                "INSERT INTO events ("
+                "occurred_at, actor, kind, run_id, workstream_id, project_id, "
+                "payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (occurred_at, actor, kind, run_id, workstream_id, project_id,
+                 payload_json),
+            )
+        else:
+            cur = self.conn.execute(
+                "INSERT INTO events ("
+                "actor, kind, run_id, workstream_id, project_id, payload_json) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (actor, kind, run_id, workstream_id, project_id, payload_json),
+            )
+        return cur.lastrowid
+
+
+__all__ = ["StateWriter"]


### PR DESCRIPTION
## Summary

M2 of #267, **scoped to API + schema cutover**. Skill flip (org-suspend / org-resume / org-delegate / org-start) and the post-commit hook wiring + dogfood cycle are split into a follow-up M2.1 sub-issue. This PR delivers the writer / snapshotter / drift_check / forward-migration foundation that M2.1 will plug behavior changes into.

### Schema additions
- New \`org_sessions\` singleton table replaces the M1 markdown-overlay fields: Status / Updated / Suspended / Resumed / Current Objective / Dispatcher / Curator / Resume Instructions.
- \`importer.import_full_rebuild()\` seeds \`org_sessions\` row 1 from existing markdown so a freshly imported DB is M2-compatible.
- \`StateWriter\` triggers a forward-migration of pre-M2 DBs on first connect (\`ensure_m2_schema\`, idempotent).

### New modules
- \`tools/state_db/writer.py\` — \`StateWriter\` direct-write API: \`update_session\` (with \`StateWriter.CLEAR\` sentinel for explicit nulls), \`register_worker_dir\`, \`update_worker_dir_status\`, \`upsert_run\`, \`update_run_status\`, \`append_event\`, plus tx helpers. \`PRAGMA foreign_keys=ON / busy_timeout=5000\` enforced.
- \`tools/state_db/snapshotter.py\` — DB → markdown / jsonl regeneration. \`<file>.tmp → fsync → rename\` atomic write. Idempotent for the same DB state. Structured-heading detection uses an **exact-match frozenset** so user-authored headings like \`## Dispatcher Notes\` are correctly preserved as passthrough.
- \`tools/state_db/drift_check.py\` — CLI \`python -m tools.state_db.drift_check\` diffs expected (snapshotter) vs actual markdown for structured sections only; passthrough sections are excluded by design.

### Read path / overlay removal
- \`queries.py\` reads \`org_sessions\` directly (no markdown overlay).
- \`dashboard/server.py\` and \`dashboard/org_state_converter.py\` drop the \`md_overlay\` merge logic. Converter \`--source\` default flips to \`db\`.
- M1's \`_db_is_fresh\` mtime check is retired (DB is now SoT).

### journal_append migration
- \`tools/journal_append.py\` (new) calls \`writer.append_event()\` and re-runs snapshotter. \`_DBCommitted\` sentinel exception lets a partial post-commit dump fail without rolling back the DB write.
- \`tools/journal_append.sh\` is a thin wrapper that forwards to the Python entry point. Existing CLAUDE.md / hook references continue to work.

### Passthrough merge design (B)
The snapshotter regenerates **known structured sections only** and **passes through unknown \`## ...\` sections** verbatim from the current markdown. This protects the ~800 lines of free-text content (session 成果, 学び, Resume Instructions detail) from being wiped during the cutover.

\`drift_check\` excludes passthrough sections from comparison until the free-text sections move to \`notes/\` in a later follow-up.

## Test plan
- [x] \`python -m unittest discover tools tests\` — 245 OK (213 → 245)
  - +27 across writer / snapshotter / fallback / converter
  - +5 in the review revise commit (\`TestStructuredHeadingExactMatch\` x2, \`TestSessionSingleton\` x2, \`TestPreM2Migration.test_migration_warns_when_called_in_open_tx\`)
- [x] journal_append.py smoke: DB write → snapshotter regenerates jsonl successfully
- [x] Pre-M2 DB forward migration verified
- [x] No path / PII leaks (\`git diff a92d979..HEAD | grep 'C:[/\\\\]Users[/\\\\]'\` → 0)
- [x] Codex self-review on the implementation commits: 3 rounds (round-1 4 Major / round-2 2 Major + 1 Minor / round-3 1 Blocker pre-M2 migration + 1 Minor) all addressed
- [x] Cross-review (worker-issue-267-m2-review) round 1: REQUEST_CHANGES → revise commit 278d443 addresses M1 / m1 / m2 / Nit 1; B1 / B2 / Major M3 deliberately deferred per Path-2 split

## Out of scope (deferred to M2.1 follow-up Issue)
- **Skill flip**: org-suspend / org-resume / org-delegate / org-start currently still edit markdown directly. M2.1 will route them through \`StateWriter\`.
- **Post-commit hook wiring**: \`post_commit_regenerate\` is implemented but not yet bound to a real trigger. M2.1 will wire it.
- **Live cutover dogfood (DoD #9)**: belongs to M2.1, not this PR.

## Known limitation (deferred to M4)
The current snapshotter passes through any \`## …\` section it doesn't know about, but free-text written **before the first \`##\` heading** (between \`# Org State\` / its key:value preamble and the first \`##\`) is not currently passthrough-protected. This will be addressed when free-text content migrates into \`notes/\` in M4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)