### PR TITLE
fix(state-db): repair worktree gitlinks per-path on Windows (closes #278)

### DIFF
--- a/tools/state_db/migrate_workers.py
+++ b/tools/state_db/migrate_workers.py
@@ -493,18 +493,125 @@ def _count_active_runs(db_path: Path) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _list_worktree_paths(repo: Path) -> list[str]:
+    """Return every worktree path linked to `repo` (incl. the main one)."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo), "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, check=True, encoding="utf-8",
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    paths: list[str] = []
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            paths.append(line[len("worktree "):].strip())
+    return paths
+
+
+def _count_prunable_worktrees(repo: Path) -> int:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo), "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, check=True, encoding="utf-8",
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return 0
+    return sum(1 for line in out.splitlines() if line.startswith("prunable"))
+
+
+def _candidate_worktree_paths(repo: Path) -> list[Path]:
+    """Collect candidate worktree working-tree paths to repair.
+
+    Combines two sources:
+
+    1. The `<repo>/.worktrees/*/` convention used by claude-org-ja (and
+       this repo's own layout). When the main repo is renamed, the
+       `.git/worktrees/<name>/gitdir` file still points at the *old*
+       location, so `git worktree list --porcelain` reports stale paths
+       that no longer exist on disk — useless to feed back into
+       `git worktree repair`. Scanning the FS gives the *current*
+       location.
+    2. Any path from `git worktree list --porcelain` that still exists
+       on disk — this covers worktrees living outside the
+       `<repo>/.worktrees/` convention (when their gitlink is stale on
+       the worktree side rather than the main-repo side).
+    """
+    seen: set[str] = set()
+    out: list[Path] = []
+
+    wt_root = repo / ".worktrees"
+    if wt_root.is_dir():
+        for child in sorted(wt_root.iterdir()):
+            if not child.is_dir():
+                continue
+            if not (child / ".git").exists():
+                continue
+            key = str(child.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(child)
+
+    repo_key = str(repo.resolve())
+    for p in _list_worktree_paths(repo):
+        path = Path(p)
+        if not path.exists():
+            continue
+        try:
+            key = str(path.resolve())
+        except OSError:
+            continue
+        if key == repo_key or key in seen:
+            continue
+        seen.add(key)
+        out.append(path)
+
+    return out
+
+
 def _git_worktree_repair(repo: Path) -> None:
-    """Run `git worktree repair` inside `repo` — best effort, no raise on failure."""
+    """Repair every gitlink linked to `repo` — best effort, no raise.
+
+    Issue #278: on Windows, `git worktree repair` invoked once with no
+    path argument fails to update the gitlinks of linked worktrees that
+    sit under `<repo>/.worktrees/`. The fix enumerates each worktree's
+    *current* working-tree path (FS scan + porcelain crosscheck) and
+    calls `git worktree repair <path>` per entry, then re-checks for
+    `prunable` entries and emits a stderr warning if any remain.
+    """
     if not (repo / ".git").exists():
         return
+
+    targets = _candidate_worktree_paths(repo)
+
+    # Always run the unargumented form first. It's cheap and sometimes
+    # repairs entries we'd otherwise miss (e.g. worktrees moved on
+    # their side).
     try:
         subprocess.run(
             ["git", "-C", str(repo), "worktree", "repair"],
             capture_output=True, text=True, check=True, encoding="utf-8",
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
-        # Surface but don't abort — secretary inspects manifest + worktree list afterwards.
         pass
+
+    for path in targets:
+        try:
+            subprocess.run(
+                ["git", "-C", str(repo), "worktree", "repair", str(path)],
+                capture_output=True, text=True, check=True, encoding="utf-8",
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+
+    remaining = _count_prunable_worktrees(repo)
+    if remaining:
+        print(
+            f"warning: {remaining} prunable worktree(s) still reported under {repo} "
+            "after repair — gitlinks may be stale",
+            file=sys.stderr,
+        )
 
 
 def _make_junction(link: Path, target: Path) -> None:

--- a/tools/state_db/migrate_workers.py
+++ b/tools/state_db/migrate_workers.py
@@ -602,8 +602,20 @@ def _git_worktree_repair(repo: Path) -> None:
                 ["git", "-C", str(repo), "worktree", "repair", str(path)],
                 capture_output=True, text=True, check=True, encoding="utf-8",
             )
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except subprocess.CalledProcessError as e:
+            # External worktrees can fail to repair without showing up in
+            # the parent's `prunable` count (the parent's gitdir file
+            # still points at a path that exists), so swallowing here
+            # would hide real failures from the post-repair check below.
+            stderr = (e.stderr or "").strip()
+            print(
+                f"warning: git worktree repair {path} failed (rc={e.returncode}): {stderr}",
+                file=sys.stderr,
+            )
             continue
+        except FileNotFoundError:
+            # git CLI absent; subsequent calls will fail the same way.
+            break
 
     remaining = _count_prunable_worktrees(repo)
     if remaining:

--- a/tools/state_db/test_migrate_workers.py
+++ b/tools/state_db/test_migrate_workers.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path, PurePosixPath
@@ -302,6 +304,71 @@ class TestWorktreeFixup(unittest.TestCase):
             runner = FakeRunner()
             mw.apply_plan(plan, manifest_path=tmp / "m.json", runner=runner)
             self.assertTrue(any(c.endswith("renga") for c in runner.repair_calls))
+
+
+# ---------------------------------------------------------------------------
+# 3a. Issue #278: per-worktree repair on Windows
+# ---------------------------------------------------------------------------
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+@unittest.skipUnless(_git_available(), "git CLI not available")
+class TestGitWorktreeRepair(unittest.TestCase):
+    """Issue #278 regression: `_git_worktree_repair` must update gitlinks
+    of every linked worktree on Windows, not only the main repo.
+
+    Reproduces the failure mode from session #12: linked worktrees under
+    `<repo>/.worktrees/` are reported `prunable` after a parent rename
+    until each one is passed explicitly to `git worktree repair`.
+    """
+
+    @staticmethod
+    def _git(*args, cwd=None):
+        subprocess.run(
+            ["git", *args],
+            cwd=cwd, check=True, capture_output=True, text=True, encoding="utf-8",
+        )
+
+    def test_repair_clears_prunable_after_main_repo_rename(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            original = tmp / "main-repo"
+            original.mkdir()
+            self._git("init", "-q", "-b", "main", cwd=original)
+            self._git("config", "user.email", "test@example.com", cwd=original)
+            self._git("config", "user.name", "Test", cwd=original)
+            (original / "README.md").write_text("seed\n", encoding="utf-8")
+            self._git("add", "README.md", cwd=original)
+            self._git("commit", "-q", "-m", "seed", cwd=original)
+
+            wt_root = original / ".worktrees"
+            wt_root.mkdir()
+            for name in ("alpha", "beta", "gamma"):
+                self._git(
+                    "worktree", "add", "-q", "-b", f"feat/{name}",
+                    str(wt_root / name),
+                    cwd=original,
+                )
+
+            # Move the main repo to break gitlinks (each worktree's
+            # `.git` file points at the old absolute path).
+            renamed = tmp / "main-repo-renamed"
+            os.rename(original, renamed)
+
+            self.assertGreater(
+                mw._count_prunable_worktrees(renamed), 0,
+                "test setup: rename should have orphaned the linked worktrees",
+            )
+
+            mw._git_worktree_repair(renamed)
+
+            self.assertEqual(
+                mw._count_prunable_worktrees(renamed), 0,
+                "_git_worktree_repair must clear all prunable gitlinks",
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

During the Issue #267 live migration on Windows (session #12), `migrate_workers.py`'s `_git_worktree_repair(repo)` called `git worktree repair` once with no arguments. After the parent dir rename of `workers/claude-org` to `workers/claude-org-ja`, all 30 child worktrees in `claude-org-ja/.worktrees/` showed up as `prunable` in `git worktree list --porcelain`, even though their on-disk files were intact.

A manual loop calling `git -C <repo> worktree repair <each_path>` resolved every gitlink. This PR brings that workaround into the tool.

## Fix

`tools/state_db/migrate_workers.py:_git_worktree_repair`:
1. Enumerate worktrees via `git worktree list --porcelain`.
2. Call `git worktree repair <path>` for each child worktree.
3. Re-enumerate and warn (do not raise) if any `prunable` entries remain — keeps existing migrate_workers fail-soft posture.

## Tests

`tools/state_db/test_migrate_workers.py` adds a Windows-rename regression test that:
1. Builds a main repo with multiple `.worktrees/<name>/` worktrees.
2. Renames the main repo's parent dir to invalidate every gitlink.
3. Calls `_git_worktree_repair`.
4. Asserts `git worktree list --porcelain` reports zero `prunable` entries.

Existing suite: 19 passed, 1 skipped.

## Codex self-review

(to be performed against this PR by the worker after CI)

## Test plan

- [x] `pytest tools/state_db/test_migrate_workers.py` → 19 passed
- [ ] CI on this PR
- [ ] Manual: re-run `migrate_workers` Step 6 swap on a Windows test fixture, confirm no manual repair loop required

Closes #278.