### PR TITLE
fix(dispatcher): match leading-space variant of 'Esc to cancel' in APPROVAL_BLOCKED detection

### DIFF
--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -202,7 +202,7 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
    - `^Do you want to make this edit to .+\?$`
    - `^❯\s*1\.\s*Yes\s*$`
    - `^Press .+ to continue`
-   - `^Esc to cancel`
+   - `^\s*Esc to cancel` (cursor 非表示時に leading space が付く variant ` Esc to cancel` も match させる。`\s*` で tab / NBSP 等の将来 variant にも対応)
 
    **新しいプロンプト形が観測されたら、この regex リストに追記**。Claude Code の version 更新で形が変わる可能性があるため、網羅は前提にしない。
 


### PR DESCRIPTION
## Summary

The dispatcher's APPROVAL_BLOCKED detection regex in `.dispatcher/CLAUDE.md` matched only `^Esc to cancel`, missing the leading-space variant ` Esc to cancel` that Claude Code emits when the cursor is hidden. In session #12 (Issue #267 live migration, Step 6 swap retry), this caused the worker pane stall to be classified as low-confidence and the dispatcher fell back to a manual notification, lagging the human-escalation path.

## Fix

Replace `^Esc to cancel` with `^\s*Esc to cancel`. This catches:
- bare `Esc to cancel` (current cursor-visible rendering)
- ` Esc to cancel` (single leading space, cursor-hidden rendering observed in session #12)
- multi-whitespace and future tab/NBSP variants

## Codex self-review

1 round, ended in LGTM with no Blocker/Major. The single Minor (no automated test) is intentionally left in place per the worker brief: this is a natural-language spec inside `.dispatcher/CLAUDE.md` consumed by the dispatcher Claude, with no executable code to assert against. Code review carries the verification.

## Test plan

- [x] Diff is a single regex character-class change in `.dispatcher/CLAUDE.md`
- [ ] Manual: next time a worker stalls at a permission prompt with cursor hidden, dispatcher should detect APPROVAL_BLOCKED and notify Secretary without manual intervention

Closes #281.