### PR TITLE
feat(secretary): script the DELEGATE path end-to-end (resolve_worker_layout + gen_worker_brief from-task + gen_delegate_payload)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -86,17 +86,8 @@ description: >
   - {skill-name}: {description の1行目}
   ワーカーへの指示に参考情報として含めます。
   ```
-- Step 1 のタスク分解時に、work-skill の手順を参考にする
-- Step 1.5 の CLAUDE.md 生成時に、以下のセクションを追加する:
-  ```markdown
-  ## 参考 work-skill
-  以下の work-skill が参考になる可能性があります。手順や判断基準を参照してください。
-  ただし、タスクの要件に合わない部分は適宜調整すること。
-  
-  - スキル名: {skill-name}
-  - パス: .claude/skills/{skill-name}/SKILL.md
-  - 概要: {description}
-  ```
+- タスク分解時に、work-skill の手順を参考にする
+- `gen_delegate_payload.py` 呼び出しの `--knowledge` フラグに work-skill の SKILL.md パスを渡す。Stage 2 の brief renderer がそのパスを `[references].knowledge` として CLAUDE.md / CLAUDE.local.md に埋め込む。複数マッチがあれば `--knowledge <path1> --knowledge <path2>` のように繰り返す
 - ワーカーへの指示（instruction-template）にも参考スキルの存在を明記する
 
 **マッチしなかった場合:**
@@ -108,237 +99,63 @@ description: >
 - 複数マッチした場合は関連度順に全て含める
 - org- プレフィックスのスキル（org-retro, org-delegate 等）は組織運営スキルなので検索対象外
 
-## Step 0.7: ターゲットファイル gitignore 事前チェック（窓口が実行）
+## Step 0.7 / 1 / 1.5 / 2: 1 コマンドで派遣ペイロードを生成（Issue #283）
 
-> **この Step は Step 1 のディレクトリパターン判定に先行する最上位判定である**。Step 1 の A / B / C ヒューリスティックに入る前に、編集対象ファイルが `.gitignore` で除外されていないかを確認し、ignored なら **Pattern C 強制（gitignored サブモード）** に分岐させる。operator が見落とすと tracked 用の Pattern B / A 経路に落ちて対象ファイルに届かないワーカーを派遣することになるため、必ずここで判定する。
+Step 0.7 (gitignore 事前チェック) / Step 1 (Pattern 判定) / Step 1.5 (ワーカーディレクトリ準備 + role 決定 + settings 生成) / Step 2 (DELEGATE 本文組み立て) は **`tools/gen_delegate_payload.py` が一括で行う**。窓口の責務はタスク特定 (Step 0)・work-skill 検索 (Step 0.5)・対象ファイルの抽出・depth 判断のみ。
 
-**「対象ファイル」は窓口がタスク説明から抽出する**（依頼文・Issue 本文・ユーザー発話の中で明示されたパス。機械的判定はしない）。対象ファイルが特定できないタスク（純粋な調査、対象パス未定の新規作成など）はこのチェックをスキップし、Step 1 の通常判定に進む。
-
-### 適用条件
-
-このチェックは **ローカルに git repo が既に存在するプロジェクトでのみ実行する**。具体的には:
-
-- registry/projects.md の「パス」がローカル絶対パスで、かつ `.git/` を持つディレクトリ（または worktree）として解決できる場合のみ実行
-- パスが URL（未 clone）/ `-` / 解決不能なら **チェック自体をスキップ**して Step 1 の通常判定へ（初回 clone 後の状態は git の通常挙動に従うため、tracked 既存ファイルが gitignored になっているレアケースは別途レビューで拾う）
-
-### 判定コマンド
-
-ローカル repo root（=「パス」が指す絶対パス）で:
-
-```
-git -C {project_path} check-ignore -q -- <target>
-```
-
-- 終了コード 1（=ignored ではない）→ tracked または「単に未存在の新規ファイル」。**Step 1 の通常 A / B / C 判定に進む**
-- 終了コード 0（=ignored）→ **Pattern C 強制（gitignored サブモード）**。下記参照。Step 1 の通常判定はスキップする
-- 終了コード 128 等（コマンド失敗、repo 未初期化など）→ 適用条件外。スキップして Step 1 の通常判定へ
-
-> `git check-ignore` は「現在の `.gitignore` ルールにマッチするか」だけを判定し、ファイルが実在しなくても評価できる。`ls-files --error-unmatch` を使うと「単に未作成の新規ファイル」まで untracked 扱いで Pattern C に落としてしまうため、こちらを使わない。
-
-### Pattern C 強制（gitignored サブモード）
-
-通常の Pattern C は `{workers_dir}/{task_id}/` のエフェメラル空ディレクトリだが、gitignored 対象を編集する場合はそれでは対象ファイルに届かない。次の特例運用とする:
-
-- **WORKER_DIR**: 既存ローカル clone の **repo root を直接指定**する（registry の「パス」値そのもの）
-- **CLAUDE.md / settings.local.json の配置先**: その repo root 直下。既に他用途の CLAUDE.md がある場合は `CLAUDE.local.md` に書く（`references/claude-org-self-edit.md` の特例参照）
-- **Worker Directory Registry**: Pattern を `C` として登録、Directory に repo root の絶対パス、Status を `in_use`。完了時はエントリ削除（ディレクトリ自体は元プロジェクトなので保持）
-- **並行作業との競合**: repo root を直接掴むため、同 repo に対する Pattern A / B のワーカーと同時起動はしない（窓口側で順次化する）。**さらに Pattern C 強制ワーカー同士も同 repo で 2 本以上同時起動しない**（`CLAUDE.local.md` / `.claude/settings.local.json` はファイル名固定なので相互上書きが起きる）
-- **窓口メモ**: 「Pattern B 不可: 対象 `<target>` が gitignored。WORKER_DIR=既存 repo root 運用」と一文残す
-
-ここで Pattern C 強制が確定した場合、**Step 1 のディレクトリパターン判定基準テーブルおよび判定フローはスキップ**し、そのまま Step 1.5 のワーカーディレクトリ準備に進む（パターンは C 確定）。
-
-### claude-org 自己編集との関係
-
-通常のスキル / ドキュメント編集（`.claude/skills/...`, `references/...`）は tracked なので従来どおり Pattern B が選べる。`docs/internal/`, `notes/`, `tmp/` 等の gitignored 内部メモを編集する場合のみ本事前チェックで Pattern C 強制（gitignored サブモード）となる（`references/claude-org-self-edit.md` 参照）。
-
-## Step 1: タスク分解（窓口が実行）
-
-人間の依頼を分析し、ワーカーに委譲するタスクを定義する:
-
-- 各タスクに一意のIDを振る（依頼内容から連想しやすい英語 kebab-case。例: `data-analysis`, `login-fix`, `dashboard-redesign`）
-  - 既存のIDと重複しないよう `.state/state.db` の runs テーブル (`get_org_state_summary` 等) を確認する（重複時はサフィックスで区別: `login-fix-2`）
-- タスクごとに以下を明確にする:
-  - 目的（何を達成するか）
-  - 成果物（何ができあがるか）
-  - 作業ディレクトリ（どのプロジェクトで作業するか）
-  - 制約（ブランチ名、コーディング規約、依存関係等）
-  - **検証深度（`full` / `minimal`）** — 派遣指示には必ずどちらか 1 値を明示する。既定は `full`（コード・挙動の変更を伴うタスクはすべてこちら）。`full` では **codex の有無に関わらず** リポジトリ通常検証（テスト / lint / type-check 等）を green まで実行し通常の完了報告フォーマットで報告するのが必須ゲート。**追加ゲート（任意）** として、codex CLI が available なら commit 完了後に Codex セルフレビュー・同一指摘 3 ラウンド上限のルールが走る（未導入環境では skip）。trivial fix（CI 出力整形 / typo / コメント修正 / 既存テスト形式合わせ等）のみ `minimal` を選択し、ワーカーは `git add` → `git commit` → `done` 報告のみで終わる。詳細は `references/instruction-template.md` の「検証深度」節と `references/worker-claude-template.md` の「Codex セルフレビュー手順」節参照。値の決定は窓口の責任で、ワーカーには判断させない
-  - **ディレクトリパターン（A / B / C）** — 以下の判定基準で決定する（**Step 0.7 の事前チェックで Pattern C 強制が確定している場合はこの判定をスキップ**）
-  - **参考 work-skill**（Step 0.5 でマッチしたもの）
-- 注意: タスク説明にファイルパスを含める場合、それがワーカー作業ディレクトリからの相対パスであることを明記する。registry/projects.md の「パス」列の値をそのまま成果物パスとして指示しない（ワーカーが別の場所にパスを作成する原因になる）
-
-### ディレクトリパターン判定基準
-
-| パターン | 名称 | 条件 | ディレクトリ |
-|---|---|---|---|
-| A | プロジェクトディレクトリ | プロジェクトの clone が必要（初回は clone、2回目以降は再利用） | `{workers_dir}/{project_slug}/` |
-| B | worktree | 同一プロジェクトで並行作業が必要（既に別ワーカーが同じプロジェクトディレクトリを使用中） | `{workers_dir}/{project_slug}/.worktrees/{task_id}/` |
-| C | エフェメラル | 成果物を残す必要がない一時作業（調査・検証等） | `{workers_dir}/{task_id}/` |
-
-**判定フロー:**
-
-> **前提**: Step 0.7 のターゲットファイル gitignore 事前チェックが先行する。Step 0.7 で Pattern C 強制（gitignored サブモード）が確定している場合は本判定フローには入らない。Step 0.7 が「ignored ではない」または「適用条件外（URL のみ・対象未特定など）」で抜けた場合のみ、以下の通常判定を行う。
-
-1. プロジェクトの clone が必要な場合（registry/projects.md にパスが登録されているプロジェクト）:
-   a. Worker Directory Registry で同プロジェクトに `in_use` のエントリがある場合 → **パターン B**（worktree で並行作業）
-   b. 同プロジェクトに `available` のエントリがある場合 → **パターン A**（既存ディレクトリを再利用）
-   c. エントリがない場合 → **パターン A**（新規 clone）
-2. 上記に該当しない場合 → **パターン C**
-   - clone 不要の一時作業、成果物不要の調査タスク等
-
-## Step 1.5: ワーカーディレクトリ準備（窓口が実行）
-
-各タスクのワーカー専用ディレクトリを準備し、CLAUDE.md と設定を配置する。
-テンプレートは references/worker-claude-template.md を使用する。
-**パターン（A/B/C）によって手順が異なる。**
-
-> **claude-org 自身を編集するタスクの場合**: 通常手順に加えて `references/claude-org-self-edit.md` の特例手順（block-org-structure.sh hook の除外、CLAUDE.local.md への指示記述、ルート CLAUDE.md を無視する旨の明示）を必ず適用すること。**本セクション以下で「CLAUDE.md を生成 / 配置 / 確認」と書かれている箇所はすべて `CLAUDE.local.md` に読み替える**（ルート CLAUDE.md は Secretary 用なので上書き禁止）。
-
-### 共通手順（全パターン）
-
-1. `registry/org-config.md` の `workers_dir` を読み、リポジトリルートからの相対パスを絶対パスに解決する
-
-### ワーカーロール (`<ROLE>`) の選び方
-
-`.claude/settings.local.json` の生成は schema-driven generator (`claude-org-runtime settings generate`) に委ねる。窓口は **タスク特性に応じて 1 つの role を選ぶだけ** で、permission の手書き編集は禁止（schema → settings の drift は CI で fail する）。
-
-#### 事前判定: self-edit タスクか？（必須・最優先）
-
-下記 role 表に進む前に、まずこの判定を行う。self-edit タスク（claude-org 自身への **書き込み** を伴うタスク）なら role は `claude-org-self-edit` に **固定** され、`default` の検討には入らない。**読み取り専用の調査・監査は対象外** — claude-org 上であっても書き込みを伴わなければ通常通り `doc-audit` を選ぶ。
-
-> **Q.** これは self-edit タスクか？（`worker_dir` が claude-org リポジトリ本体、またはその worktree（例: `.worktrees/{task_id}/`）を指し、**かつ** claude-org 内のファイルを編集 / 追加 / 削除する書き込み作業を含むか）
-> - **Yes**（claude-org への書き込みあり）→ role を `claude-org-self-edit` に固定する（`block-org-structure.sh` hook を外す特例が必要なため）。`settings.local.json` 生成前にこの role を確定させ、加えて `references/claude-org-self-edit.md` の特例手順（CLAUDE.local.md への指示記述、ルート CLAUDE.md を無視する旨の明示など）を併せて適用する
-> - **No (読み取りのみ、claude-org 上での監査・調査)** → `doc-audit` を選ぶ（Edit/Write が deny されるので最小権限）。`block-org-structure.sh` は読み取り作業を阻害しないため特例不要
-> - **No (claude-org 以外のプロジェクト)** → 通常タスク。下記 role 表に従って `default` / `doc-audit` から選ぶ
-
-判定根拠: claude-org 自身を **編集** する場合、Pattern A / B / C いずれであっても `worker_dir` は claude-org repo（または worktree）配下となり、`block-org-structure.sh` がワーカーの書き込みを拒否してしまう。これを安全に外せるのは `claude-org-self-edit` role だけなので、operator が role を取り違えると Pattern 判定が正しくてもワーカーが立ち上がらない。一方、読み取り専用の監査では hook は発動しないため、最小権限の `doc-audit` を維持する（`claude-org-self-edit` に昇格させると不要に書き込み権限を与えることになる）。
-
-| Role | 用途 |
-|---|---|
-| `default` | 通常の実装・修正タスク（git commit / branch 操作あり、push 不可、recursive delete 不可）。**self-edit タスクには使わない** |
-| `claude-org-self-edit` | **claude-org リポジトリ自身を編集するタスク（self-edit task）**。`worker_dir` が claude-org repo or its worktree（`tools/`, `.claude/skills/`, `docs/` 等の編集を含む）。`block-org-structure.sh` を外す代わりに `check-worker-boundary.sh` で境界を担保。詳細は `references/claude-org-self-edit.md` |
-| `doc-audit` | 読み取り中心の調査・監査・レポート（Edit/Write/MultiEdit/NotebookEdit を deny。commit / branch も禁止）。**書き出しが必要な成果物（AUDIT.md 等）がある場合は instruction-template.md の「doc-audit 成果物の chunk 転送」セクションを必ずワーカー指示に含める** |
-
-各 role の具体的な allow/deny/hooks は **本 ja リポジトリの `tools/org_extension_schema.json`** の `worker_roles[<role>]` を参照（drift validator `tools/check_role_configs.py` がこのファイルを正典として読む）。新しいパターンが必要な場合は **ja の `tools/org_extension_schema.json` と `claude-org-runtime` にバンドルされた merged role schema の両方に role を追加する PR が必要**（窓口の手書き拡張は不可）: ja 側だけ追加しても `claude-org-runtime settings generate` が新 role を知らず生成失敗、runtime 側だけ追加しても drift CI が fail する。framework 側の schema 形（`worker_roles` の許容形状定義）のみ変える場合は `claude-org-runtime` 側のみで完結。詳細は `references/claude-org-self-edit.md` および `docs/internal/phase4-completion-2026-05-02.md:71-77` 参照。
-
-### パターン A: プロジェクトディレクトリ
-
-プロジェクト専用ディレクトリ（`{workers_dir}/{project_slug}/`）を使う。初回は clone、2回目以降は再利用。
-
-**初回（ディレクトリが存在しない場合）:**
-
-1. `git clone {project_path} {workers_dir}/{project_slug}/` を実行
-2. ディレクトリ直下に CLAUDE.md を生成する（テンプレートの変数を置換）
-3. ディレクトリ直下に `.claude/settings.local.json` を **generator で生成する**（schema が SOT。詳細は ja `tools/org_extension_schema.json` の `worker_roles` を参照）:
-   ```bash
-   claude-org-runtime settings generate \
-     --role <ROLE> \
-     --worker-dir {worker_dir} \
-     --claude-org-path {claude_org_path} \
-     --out {worker_dir}/.claude/settings.local.json
-   ```
-   `<ROLE>` の選び方は本 Step 冒頭の「ワーカーロール (`<ROLE>`) の選び方」表を参照。手書き JSON は禁止（drift CI が fail する）。
-4. `StateWriter.register_worker_dir(...)` で Worker Directory Registry に登録する（post-commit hook が `.state/org-state.md` を再生成する。直接編集は禁止）
-
-**再利用（ディレクトリが存在し、ステータスが `available` の場合）:**
-
-1. `git -C {workers_dir}/{project_slug}/ fetch origin` で最新化
-2. CLAUDE.md **のみ**を再生成する（新しいタスクID・タスク説明で上書き）
-   - settings.local.json はそのまま流用（`{worker_dir}` が変わらないため再生成不要）
-3. `StateWriter.register_worker_dir(...)` + `upsert_run(status='in_use', worker_dir_abs_path=...)` で再利用エントリを登録する（markdown 直接編集禁止。post-commit hook が `.state/org-state.md` を再生成）
-
-### パターン B: worktree
-
-同一プロジェクトで並行作業が必要な場合、プロジェクトディレクトリを base clone として worktree を作成する。
-
-1. base clone（`{workers_dir}/{project_slug}/`）の存在確認:
-   - 存在しない場合 → `git clone {project_path} {workers_dir}/{project_slug}/` を実行
-   - 既に存在する場合 → `git -C {workers_dir}/{project_slug}/ fetch origin` で最新化
-2. worktree を作成:
-   - `git -C {workers_dir}/{project_slug}/ worktree add .worktrees/{task_id} -b {branch_name}` を実行
-   - `{branch_name}` は Step 1 で決定したブランチ名（指定がなければ `{task_id}` をブランチ名に使う）
-   - ワーカーディレクトリ: `{workers_dir}/{project_slug}/.worktrees/{task_id}/`
-3. worktree 直下に CLAUDE.md を生成する（テンプレートの変数を置換）
-4. worktree 直下に `.claude/settings.local.json` を **generator で生成する**（schema-driven。詳細は ja `tools/org_extension_schema.json` の `worker_roles` 参照）:
-   ```bash
-   claude-org-runtime settings generate \
-     --role <ROLE> \
-     --worker-dir {worker_dir} \
-     --claude-org-path {claude_org_path} \
-     --out {worker_dir}/.claude/settings.local.json
-   ```
-   `<ROLE>` の選び方は本 Step 冒頭の「ワーカーロール (`<ROLE>`) の選び方」表を参照。手書き JSON は禁止。
-5. `StateWriter.register_worker_dir(...)` で Worker Directory Registry に登録する（markdown 直接編集禁止。post-commit hook が `.state/org-state.md` を再生成）
-
-### パターン C: エフェメラル
-
-成果物を残す必要がない一時作業（調査・検証等）で使用する。
-
-1. `{workers_dir}/{task_id}/` ディレクトリを作成する（例: `../workers/data-analysis/`）
-2. テンプレートから `{workers_dir}/{task_id}/CLAUDE.md` を生成する
-3. `{workers_dir}/{task_id}/.claude/settings.local.json` を **generator で生成する**（schema-driven。詳細は ja `tools/org_extension_schema.json` の `worker_roles` 参照）:
-   ```bash
-   claude-org-runtime settings generate \
-     --role <ROLE> \
-     --worker-dir {worker_dir} \
-     --claude-org-path {claude_org_path} \
-     --out {worker_dir}/.claude/settings.local.json
-   ```
-   `<ROLE>` の選び方は本 Step 冒頭の「ワーカーロール (`<ROLE>`) の選び方」表を参照。手書き JSON は禁止。
-4. `StateWriter.register_worker_dir(...)` で Worker Directory Registry に登録する（post-commit hook が `.state/org-state.md` を再生成する。直接編集は禁止）
-
-### 共通手順（全パターン・配置後）
-
-CLAUDE.md / CLAUDE.local.md は **`tools/gen_worker_brief.py` で自動生成する**（手書き禁止。settings.local.json の生成は generator が自動で行うため対象外）:
+### 標準フロー (推奨)
 
 ```bash
-python tools/gen_worker_brief.py --config <task>.toml --out {worker_dir}/CLAUDE.md
+# 1. preview: 完全に非破壊。DELEGATE 本文と作成予定ファイル一覧だけを確認する
+python tools/gen_delegate_payload.py preview \
+    --task-id <task-id> --project-slug <slug> \
+    --target <path>... --description "<desc>" \
+    --verification-depth full
+
+# 2. apply: state.db に runs.status='queued' で予約 + CLAUDE.md/CLAUDE.local.md 配置
+#    + claude-org-runtime settings generate 実行 + send_plan.json 出力
+python tools/gen_delegate_payload.py apply \
+    --task-id <task-id> --project-slug <slug> \
+    --target <path>... --description "<desc>" \
+    --verification-depth full
+
+# 3. apply 出力の send_plan.json を MCP 呼び出しにコピペ
+#    cat <worker_dir>/send_plan.json
+#    → mcp__renga-peers__send_message(to_id="dispatcher", message=<message>)
 ```
 
-self-edit task（Pattern B claude-org 自身編集）の場合は `--out` を `{worker_dir}/CLAUDE.local.md` にする（`worker.self_edit = true` を config に設定。テンプレートが自動的に「ルート CLAUDE.md は無視」注記を含める）。config TOML のフォーマットは `tools/templates/worker_brief.example.toml` を参照。
+`apply` は **T1 reservation のみ** (`runs.status='queued'`) を行う。Active Work Items への active 化はディスパッチャー T2 (`docs/contracts/delegation-lifecycle-contract.md`) なので本 skill では触らない。失敗時はキューを残したまま Secretary に判断を仰ぐこと。
 
-config TOML が要求する主なキー: `task.{id, description, verification_depth, branch, commit_prefix, closes_issue|refs_issues}`、`worker.{dir, pattern, role, self_edit}`、`project.{name, description}`、`paths.claude_org`。任意セクション: `[implementation]` `[references]` `[parallel]` `[task].issue_url`。
+### よく使うフラグ
 
-生成した CLAUDE.md / CLAUDE.local.md に「作業ディレクトリ」セクションが含まれていることを確認する。含まれていない場合は config 不備または generator バグのため再生成する。`tools/templates/worker_brief_normal.md` / `worker_brief_self_edit.md` が SOT であり、reference の `worker-claude-template.md` は互換性のため残置（Secretary 用 reference）。
+- `--mode edit|audit` (default `edit`): claude-org 上の **読み取り専用** 監査タスクは `--mode audit` を明示する。デフォルトの `edit` だと self-edit role が選ばれて余計な書き込み権限が付く。
+- `--branch <name>`: planned_branch を上書き。default は `feat/<task-id>` (description に "fix"/"bug"/"修正" を含むと `fix/<task-id>`)。
+- `--commit-prefix "<prefix>"`: TOML の `task.commit_prefix` を明示。省略時は project_slug の頭部から推論 (例: `claude-org-ja` → `feat(claude):`)。
+- `--closes-issue N` / `--refs-issues N1 N2`: 「Closes #N」「Refs #N1 #N2」を brief に埋め込む。
+- `--impl-target <path>` / `--impl-guidance "<text>"` / `--knowledge <path>`: optional な `[implementation]` / `[references]` セクション。
+- `--skip-settings`: `claude-org-runtime settings generate` をスキップ (CLI 未導入環境向け)。
+- `--from-toml <path>`: 既存 `worker_brief.toml` を入力にする。CLI フラグは TOML を上書きする。
 
-**参考 work-skill がある場合（Step 0.5 でマッチ）:**
+### Pattern / role / branch の判定詳細
 
-CLAUDE.md に以下のセクションを追加する（「参照すべきファイル」セクションの後に配置）:
+判定ロジック (Pattern A vs B vs C / gitignored サブモード / role 表 / planned_branch / DELEGATE 本文の必須行) は `references/delegate-flow-details.md` 参照。本 SKILL.md からは抜き出してある。
 
-```markdown
-## 参考 work-skill
-以下の work-skill が参考になる可能性があります。手順や判断基準を参照してください。
-ただし、タスクの要件に合わない部分は適宜調整すること。
+### Step 0.7 の対象ファイル抽出
 
-- スキル名: {skill-name}
-- パス: {claude_org_path}/.claude/skills/{skill-name}/SKILL.md
-- 概要: {description}
-```
+「対象ファイル」は窓口がタスク説明から抽出する（依頼文・Issue 本文・ユーザー発話の中で明示されたパス。機械的判定はしない）。対象ファイルが特定できないタスク（純粋な調査、対象パス未定の新規作成など）は `--target` を渡さなくてよい — `gen_delegate_payload` は target 0 件のときだけ check-ignore をスキップして通常判定に進む。
 
-## Step 2: ディスパッチャーへの委託（窓口が実行 → ここで窓口は解放）
+### legacy / fallback 経路
 
-renga-peers の `send_message` でディスパッチャー（pane name=`dispatcher`）に以下を送信する:
+`gen_delegate_payload.py` を経由できない（runtime CLI 未導入・state.db 破損・特殊な手作業など）場合のみ、**従来の手書き経路** を使う。詳細手順は `references/delegate-flow-details.md` の「Legacy hand-typed paths」節参照。要点だけ:
 
-```
-DELEGATE: 以下のワーカーを派遣してください。
+- `python tools/gen_worker_brief.py --config <task>.toml --out <CLAUDE.md>` で brief を手動生成
+- `claude-org-runtime settings generate` を **`--role` を窓口で確定させた上で** 直接呼ぶ
+- DELEGATE 本文は `references/delegate-flow-details.md` §3 のテンプレートに従って手書きし、`mcp__renga-peers__send_message(to_id="dispatcher", message=…)` で送る
 
-タスク一覧:
-- {task_id}: {タスク説明}
-  - ワーカーディレクトリ: {ワーカーディレクトリの絶対パス}（CLAUDE.md・設定配置済み）
-  - ディレクトリパターン: {A: プロジェクトディレクトリ / B: worktree / C: エフェメラル}
-  - プロジェクト: {clone先URL or ローカルパス or 新規作成 or worktree済み or 前タスク引継ぎ}
-  - Permission Mode: {org-config から読んだ default_permission_mode の値}
-  - 検証深度: {full | minimal}（instruction-template の同名行と同じ値を必ず記入。ディスパッチャーはこの値をワーカーへの指示にそのまま転記する）
-  - 指示内容: {instruction-template に基づく指示の要約。「検証深度」行は必ず残したまま転送する}
+legacy 経路は **T1 reservation (runs.status='queued') を伴わない** ため、ディスパッチャー watch loop の queue 可視化が効かない点に注意。
 
-窓口ペイン名: `secretary`（renga layout で登録済み。新規タブ作成時の基準となる）
-```
-
-**窓口はこの送信後すぐにユーザーとの対話に戻れる。**
-ユーザーには「ディスパッチャーに派遣を依頼しました。準備ができ次第報告します。」と伝える。
-
-> renga では窓口・ディスパッチャー・キュレーター等の「長寿命ペイン」は安定名 (`--id`) で addressable。
-> 窓口 (`secretary`) / ディスパッチャー (`dispatcher`) / キュレーター (`curator`) は `/org-start` で命名済み。
+<!-- 旧 Step 0.7 / Step 1 / Step 1.5 / Step 2 の詳細 prose は references/delegate-flow-details.md に移設済み (Issue #283 Stage 4)。
+     判定コマンド・Pattern C 強制サブモード・パターン別 worktree/clone 手順・DELEGATE 本文の必須行は同 reference を SoT とする。 -->
 
 ## Step 3: ワーカー起動と指示送信（ディスパッチャーが実行）
 

--- a/.claude/skills/org-delegate/references/delegate-flow-details.md
+++ b/.claude/skills/org-delegate/references/delegate-flow-details.md
@@ -1,0 +1,127 @@
+# org-delegate: detailed flow reference
+
+`gen_delegate_payload.py` (Issue #283) automates Steps 0.7 / 1 / 1.5 / 2 of the
+`org-delegate` skill. The compressed steps in `SKILL.md` cover the day-to-day
+path; this document is the long-form explanation Secretary consults when the
+automation hits an edge case or when reviewing why the resolver chose a
+particular Pattern / Role.
+
+The contract this entire flow conforms to lives in
+`docs/contracts/delegation-lifecycle-contract.md` (Set B). Per that contract,
+this skill's writes are limited to **T1 reservation only**: a `runs.status='queued'`
+row plus the `worker_dirs` registry entry, plus the brief and settings files
+on disk. **Active Work Items remains the dispatcher's T2 responsibility** and is
+not touched here.
+
+---
+
+## 1. Pattern judgment (Step 0.7 + Step 1)
+
+### Step 0.7 — gitignored target check (highest-precedence)
+
+The resolver checks each `--target` against `git -C <project_path> check-ignore -q --`.
+If any target is ignored, the dispatch is forced into **Pattern C — gitignored
+sub-mode** (`pattern_variant='gitignored_repo_root'`):
+
+- `worker_dir` is the registered project's repo root (not `{workers_dir}/{task_id}/`).
+- The brief is written as `CLAUDE.local.md` (never `CLAUDE.md`) so the host
+  repo's own `CLAUDE.md` is preserved.
+- `planned_branch` is `null` — the worker operates on the existing branch.
+- Secretary must serialise: do not run two gitignored-sub-mode workers
+  concurrently against the same repo (file-name collisions on
+  `CLAUDE.local.md` / `.claude/settings.local.json`).
+
+The check is skipped when the project's path is a URL, `-`, or otherwise not a
+local git repo. When skipped, the normal Pattern A/B judgment runs.
+
+`git check-ignore` matches `.gitignore` rules even when the file does not yet
+exist; do not substitute `ls-files --error-unmatch` (which would treat any new
+file as untracked and silently route it to Pattern C).
+
+### Step 1 — Pattern A vs B vs C
+
+When Step 0.7 does not force the gitignored sub-mode, the resolver reads
+state.db via `runs JOIN worker_dirs` (matching the snapshotter's view) and
+uses the active-status set `{queued, in_use, review}`:
+
+| Condition | Pattern | Worker dir |
+|---|---|---|
+| Project not in `registry/projects.md` | C — ephemeral | `{workers_dir}/{task_id}/` |
+| Project in registry, ≥1 active run on this project | B — worktree | `{workers_dir}/{project_slug}/.worktrees/{task_id}/` |
+| Project in registry, no active run | A — project dir | `{workers_dir}/{project_slug}/` |
+
+`queued` is included in the active set because Issue #283's T1 reservation
+writes that status before any pane spawns. Two back-to-back delegations on
+the same project would otherwise both choose Pattern A and collide on the
+base clone.
+
+`A` reuse vs new clone is not a Pattern split — both share the same
+`worker_dir` shape. Stage 3 `apply` checks the filesystem at execute time
+and either reuses or clones.
+
+---
+
+## 2. Role detection (Step 1.5 — "Role の選び方")
+
+| `--mode` | Project = claude-org | Project ≠ claude-org |
+|---|---|---|
+| `edit` (default) | `claude-org-self-edit` | `default` |
+| `audit` | `doc-audit` | `doc-audit` |
+
+`--mode audit` always selects `doc-audit` (read-only Edit/Write/MultiEdit denies)
+regardless of which project is being inspected. This avoids the historical
+mistake of misclassifying a claude-org **read** as a self-edit and granting
+write hooks the worker doesn't need (Codex Design Review M-4).
+
+"Project = claude-org" means the registry row's path resolves to the same
+directory as `claude_org_root` (resolved absolute path comparison; the
+`gen_delegate_payload` resolver handles this).
+
+Pattern C `gitignored_repo_root` additionally forces the brief filename to
+`CLAUDE.local.md` even when the role is `default` — we are inside someone
+else's repo and must not clobber their `CLAUDE.md`. This decouples
+"writes-self-edit-style brief" from "is the claude-org-self-edit role".
+
+---
+
+## 3. DELEGATE body template (Step 2)
+
+`gen_delegate_payload.py` formats the body to match the historical template
+exactly. The required rows, in order, are:
+
+1. `DELEGATE: 以下のワーカーを派遣してください。`
+2. `タスク一覧:` header followed by `- {task_id}: {description}` line.
+3. `- ワーカーディレクトリ:` row.
+4. `- ディレクトリパターン:` row (carries the variant label for Pattern C
+   sub-modes).
+5. `- プロジェクト:` row (clone source / reuse / worktree base).
+6. `- ブランチ (planned):` row (null for Pattern C).
+7. `- Permission Mode:` row (read from `registry/org-config.md`).
+8. `- 検証深度:` row (`full` or `minimal`, matching the value Secretary
+   passed to `--verification-depth`).
+9. `- 指示内容:` row pointing the dispatcher at `CLAUDE.md` /
+   `CLAUDE.local.md` plus a one-line summary.
+10. `窓口ペイン名: secretary` trailer.
+
+The rows are not optional. The script's snapshot tests
+(`tests/fixtures/delegate_payload/`) lock this format down so that the
+historical "verification_depth row dropped" failures stay impossible.
+
+---
+
+## 4. Legacy hand-typed paths
+
+Two pre-Issue-283 paths remain supported for callers that already work in
+that idiom:
+
+- `python tools/gen_worker_brief.py --config <path>.toml --out <CLAUDE.md>`
+  — the original brief renderer. Still works exactly as before. New code
+  should prefer the `from-task` subcommand because it derives `worker.dir`
+  / `worker.pattern` / `worker.role` deterministically from registry and
+  state.db rather than asking the operator to fill them in.
+- Manually issuing the `DELEGATE:` message via `mcp__renga-peers__send_message`
+  — fine for one-off ad-hoc dispatches. The `gen_delegate_payload preview`
+  command can still be used to draft the body without writing anything.
+
+Both paths skip the T1 reservation and therefore do not surface the queued
+state to the dispatcher's watch loop. Use them sparingly.

--- a/tests/fixtures/delegate_payload/delegate_payload_pattern_a_default_full.golden.md
+++ b/tests/fixtures/delegate_payload/delegate_payload_pattern_a_default_full.golden.md
@@ -1,0 +1,13 @@
+DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- snap-a-default: add a sparkline
+  - ワーカーディレクトリ: <SANDBOX>/workers/clock-app（CLAUDE.md・設定配置済み）
+  - ディレクトリパターン: A: プロジェクトディレクトリ
+  - プロジェクト: clone or reuse: -
+  - ブランチ (planned): feat/snap-a-default
+  - Permission Mode: auto
+  - 検証深度: full
+  - 指示内容: 詳細は `<SANDBOX>/workers/clock-app/CLAUDE.md` を参照。要約: add a sparkline
+
+窓口ペイン名: `secretary`（renga layout で登録済み）

--- a/tests/fixtures/delegate_payload/delegate_payload_pattern_a_doc_audit_full.golden.md
+++ b/tests/fixtures/delegate_payload/delegate_payload_pattern_a_doc_audit_full.golden.md
@@ -1,0 +1,13 @@
+DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- snap-a-audit: audit recent changes
+  - ワーカーディレクトリ: <SANDBOX>/workers/claude-org-ja（CLAUDE.md・設定配置済み）
+  - ディレクトリパターン: A: プロジェクトディレクトリ
+  - プロジェクト: clone or reuse: <SANDBOX>/claude-org
+  - ブランチ (planned): feat/snap-a-audit
+  - Permission Mode: auto
+  - 検証深度: full
+  - 指示内容: 詳細は `<SANDBOX>/workers/claude-org-ja/CLAUDE.md` を参照。要約: audit recent changes
+
+窓口ペイン名: `secretary`（renga layout で登録済み）

--- a/tests/fixtures/delegate_payload/delegate_payload_pattern_b_self_edit_full.golden.md
+++ b/tests/fixtures/delegate_payload/delegate_payload_pattern_b_self_edit_full.golden.md
@@ -1,0 +1,13 @@
+DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- snap-b-self-edit: refactor a skill
+  - ワーカーディレクトリ: <SANDBOX>/workers/claude-org-ja/.worktrees/snap-b-self-edit（CLAUDE.local.md・設定配置済み）
+  - ディレクトリパターン: B: worktree
+  - プロジェクト: worktree base: <SANDBOX>/claude-org
+  - ブランチ (planned): feat/snap-b-self-edit
+  - Permission Mode: auto
+  - 検証深度: full
+  - 指示内容: 詳細は `<SANDBOX>/workers/claude-org-ja/.worktrees/snap-b-self-edit/CLAUDE.local.md` を参照。要約: refactor a skill
+
+窓口ペイン名: `secretary`（renga layout で登録済み）

--- a/tests/fixtures/delegate_payload/delegate_payload_pattern_c_ephemeral_minimal.golden.md
+++ b/tests/fixtures/delegate_payload/delegate_payload_pattern_c_ephemeral_minimal.golden.md
@@ -1,0 +1,13 @@
+DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- snap-c-ephemeral: quick survey
+  - ワーカーディレクトリ: <SANDBOX>/workers/snap-c-ephemeral（CLAUDE.md・設定配置済み）
+  - ディレクトリパターン: C: エフェメラル
+  - プロジェクト: 新規作成 (clone なし) — エフェメラル
+  - ブランチ (planned): (Pattern C: 既存 repo の現在ブランチで作業 / 新規 branch なし)
+  - Permission Mode: auto
+  - 検証深度: minimal
+  - 指示内容: 詳細は `<SANDBOX>/workers/snap-c-ephemeral/CLAUDE.md` を参照。要約: quick survey
+
+窓口ペイン名: `secretary`（renga layout で登録済み）

--- a/tests/fixtures/delegate_payload/delegate_payload_pattern_c_gitignored_repo_root_full.golden.md
+++ b/tests/fixtures/delegate_payload/delegate_payload_pattern_c_gitignored_repo_root_full.golden.md
@@ -1,0 +1,13 @@
+DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- snap-c-gitignored: redact gitignored notes
+  - ワーカーディレクトリ: <HOSTREPO>（CLAUDE.local.md・設定配置済み）
+  - ディレクトリパターン: C: gitignored サブモード (registered repo 直接編集)
+  - プロジェクト: 既存 repo 直接編集: <HOSTREPO>
+  - ブランチ (planned): (Pattern C: 既存 repo の現在ブランチで作業 / 新規 branch なし)
+  - Permission Mode: auto
+  - 検証深度: full
+  - 指示内容: 詳細は `<HOSTREPO>/CLAUDE.local.md` を参照。要約: redact gitignored notes
+
+窓口ペイン名: `secretary`（renga layout で登録済み）

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -1,0 +1,401 @@
+"""Tests for tools/gen_delegate_payload.py (Issue #283 Stage 3).
+
+Coverage:
+- preview is non-destructive (no DB / no files)
+- apply reserves a runs.status='queued' row (Codex Blocker B-1)
+- apply does NOT write Active Work Items (no writes outside the queued row)
+- DELEGATE body contains all required rows: pattern / role / Permission Mode
+  / 検証深度 / planned_branch
+- Snapshot tests for each Pattern + role variant
+- preview --json emits a structured object
+- --skip-settings / runtime missing → graceful (apply still succeeds)
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools import gen_delegate_payload as gdp  # noqa: E402
+from tools.state_db import apply_schema, connect  # noqa: E402
+from tools.state_db.writer import StateWriter  # noqa: E402
+
+
+GOLDEN_DIR = REPO_ROOT / "tests" / "fixtures" / "delegate_payload"
+
+
+# ---------------------------------------------------------------------------
+# Sandbox
+# ---------------------------------------------------------------------------
+
+
+class _Sandbox:
+    def __init__(self, td: Path):
+        self.root = td
+        self.workers = td / "workers"
+        self.workers.mkdir()
+        self.claude_org_root = td / "claude-org"
+        (self.claude_org_root / ".state").mkdir(parents=True)
+        (self.claude_org_root / "registry").mkdir()
+        (self.claude_org_root / "registry" / "org-config.md").write_text(
+            "## Permission Mode\ndefault_permission_mode: auto\n"
+            "## Workers Directory\nworkers_dir: ../workers\n",
+            encoding="utf-8",
+        )
+        (self.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| 時計アプリ | clock-app | - | Web 時計 | デザイン |\n"
+            f"| claude-org-ja | claude-org-ja | {self.claude_org_root} | Self | スキル改善 |\n",
+            encoding="utf-8",
+        )
+        self.db_path = self.claude_org_root / ".state" / "state.db"
+        conn = connect(self.db_path)
+        apply_schema(conn)
+        conn.close()
+
+    def add_active_run(self, *, task_id: str, project_slug: str, worker_dir: str) -> None:
+        conn = connect(self.db_path)
+        w = StateWriter(conn)
+        with w.transaction() as tx:
+            tx.register_worker_dir(abs_path=worker_dir, layout="flat")
+            tx.upsert_run(
+                task_id=task_id,
+                project_slug=project_slug,
+                pattern="A",
+                title=task_id,
+                status="in_use",
+                worker_dir_abs_path=worker_dir,
+            )
+        conn.close()
+
+    def list_runs(self) -> list[dict]:
+        conn = connect(self.db_path)
+        try:
+            rows = conn.execute(
+                "SELECT task_id, status, pattern, branch FROM runs"
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Pure planner
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDelegatePlan(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _build(self, **kwargs) -> gdp.DelegatePlan:
+        defaults = dict(
+            task_id="demo-task",
+            project_slug="clock-app",
+            description="add a feature",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        defaults.update(kwargs)
+        return gdp.build_delegate_plan(**defaults)
+
+    def test_pattern_a_default_role_full(self):
+        plan = self._build()
+        body = plan.delegate_body
+        # Required rows per org-delegate Step 2 template
+        self.assertIn("DELEGATE: 以下のワーカーを派遣してください", body)
+        self.assertIn("ワーカーディレクトリ:", body)
+        self.assertIn("ディレクトリパターン: A: プロジェクトディレクトリ", body)
+        self.assertIn("Permission Mode: auto", body)
+        self.assertIn("検証深度: full", body)
+        self.assertIn("ブランチ (planned): feat/demo-task", body)
+        self.assertIn("窓口ペイン名: `secretary`", body)
+        # Brief path uses CLAUDE.md (not self_edit)
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+
+    def test_pattern_b_when_concurrent_active_run(self):
+        self.sb.add_active_run(
+            task_id="other-task",
+            project_slug="clock-app",
+            worker_dir=str(self.sb.workers / "clock-app"),
+        )
+        plan = self._build()
+        body = plan.delegate_body
+        self.assertIn("ディレクトリパターン: B: worktree", body)
+        self.assertEqual(plan.layout.pattern, "B")
+
+    def test_pattern_c_ephemeral_for_unknown_slug(self):
+        plan = self._build(project_slug="unknown-thing")
+        body = plan.delegate_body
+        self.assertIn("ディレクトリパターン: C: エフェメラル", body)
+        self.assertIn("Pattern C", body)  # branch line carries the Pattern C note
+
+    def test_self_edit_brief_path_is_local_md(self):
+        plan = self._build(
+            project_slug="claude-org-ja",
+            description="edit a doc",
+        )
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.local.md")
+        self.assertEqual(plan.layout.role, "claude-org-self-edit")
+
+    def test_audit_mode_emits_doc_audit_role(self):
+        plan = self._build(mode="audit", project_slug="claude-org-ja")
+        self.assertEqual(plan.layout.role, "doc-audit")
+        # Should still be a CLAUDE.local.md because gitignored sub-mode
+        # logic only triggers self_edit for the claude-org-self-edit role,
+        # but doc-audit is not a self-edit. So plain CLAUDE.md is fine for
+        # audit on Pattern A worker dir (which is outside claude-org).
+        # (claude-org-ja audit uses Pattern A → workers/claude-org-ja/.)
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+
+
+# ---------------------------------------------------------------------------
+# Apply — side effects
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDelegatePlan(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _apply(self, **plan_kwargs):
+        defaults = dict(
+            task_id="apply-test",
+            project_slug="clock-app",
+            description="implement something",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        defaults.update(plan_kwargs)
+        plan = gdp.build_delegate_plan(**defaults)
+        return plan, gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+
+    def test_apply_reserves_queued_row(self):
+        _, result = self._apply()
+        runs = self.sb.list_runs()
+        match = [r for r in runs if r["task_id"] == "apply-test"]
+        self.assertEqual(len(match), 1)
+        row = match[0]
+        self.assertEqual(row["status"], "queued")
+        self.assertEqual(row["pattern"], "A")
+        self.assertEqual(row["branch"], "feat/apply-test")
+        self.assertEqual(result.db_reservation["status"], "queued")
+
+    def test_apply_writes_brief_and_send_plan(self):
+        plan, result = self._apply()
+        self.assertTrue(result.brief_path.exists())
+        text = result.brief_path.read_text(encoding="utf-8")
+        self.assertIn("apply-test", text)
+        self.assertTrue(result.send_plan_path.exists())
+        send_plan = json.loads(result.send_plan_path.read_text(encoding="utf-8"))
+        self.assertEqual(send_plan["to_id"], "dispatcher")
+        self.assertIn("DELEGATE:", send_plan["message"])
+        # The summary block in send_plan carries the layout for audit.
+        self.assertEqual(send_plan["summary"]["pattern"], "A")
+        self.assertEqual(send_plan["summary"]["task_id"], "apply-test")
+
+    def test_apply_skips_settings_gracefully(self):
+        _, result = self._apply()
+        self.assertIsNone(result.settings_path)
+        self.assertEqual(result.settings_skipped_reason, "skip_settings flag set")
+
+    def test_apply_does_not_write_active_work_items(self):
+        """Codex Blocker B-1: Active Work Items is dispatcher's T2.
+
+        We assert this indirectly by checking no run row has a non-queued
+        status after apply, and that the only run created is the queued
+        one we just added.
+        """
+        _, _ = self._apply()
+        runs = self.sb.list_runs()
+        statuses = {r["status"] for r in runs}
+        # Only the queued reservation; no in_use/review (= Active Work Items)
+        # rows were created by apply.
+        self.assertEqual(statuses, {"queued"})
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests (preview + apply paths)
+# ---------------------------------------------------------------------------
+
+
+class TestCLI(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _common_args(self) -> list[str]:
+        return [
+            "--task-id", "cli-task",
+            "--project-slug", "clock-app",
+            "--description", "do the thing",
+            "--claude-org-root", str(self.sb.claude_org_root),
+            "--state-db-path", str(self.sb.db_path),
+        ]
+
+    def test_preview_writes_no_files_no_db(self):
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        worker_dir = self.sb.workers / "clock-app"
+        # Pre-condition: the worker dir doesn't exist yet
+        self.assertFalse(worker_dir.exists())
+        runs_before = len(self.sb.list_runs())
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main(["preview", *self._common_args()])
+        self.assertEqual(rc, 0)
+        self.assertFalse(worker_dir.exists())
+        self.assertEqual(len(self.sb.list_runs()), runs_before)
+        out = buf.getvalue()
+        self.assertIn("DELEGATE body (preview, no writes)", out)
+        self.assertIn("Permission Mode: auto", out)
+        self.assertIn("検証深度: full", out)
+
+    def test_preview_json_emits_structured_object(self):
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main(["preview", *self._common_args(), "--json"])
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertIn("delegate_body", data)
+        self.assertIn("summary", data)
+        self.assertEqual(data["summary"]["pattern"], "A")
+
+    def test_apply_creates_brief_and_reserves(self):
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main([
+                "apply",
+                *self._common_args(),
+                "--skip-settings",
+            ])
+        self.assertEqual(rc, 0)
+        runs = self.sb.list_runs()
+        self.assertTrue(any(r["task_id"] == "cli-task" and r["status"] == "queued" for r in runs))
+        brief = self.sb.workers / "clock-app" / "CLAUDE.md"
+        self.assertTrue(brief.exists())
+        send_plan = brief.with_name("send_plan.json")
+        self.assertTrue(send_plan.exists())
+
+
+# ---------------------------------------------------------------------------
+# Snapshot tests against goldens
+# ---------------------------------------------------------------------------
+
+
+def _normalize_body(text: str, sandbox_root: Path) -> str:
+    """Replace sandbox-specific paths with stable placeholders before snapshotting."""
+    text = text.replace(str(sandbox_root.resolve()), "<SANDBOX>")
+    # Windows backslashes vs forward slashes
+    text = text.replace("\\", "/")
+    return text
+
+
+class TestGoldenSnapshots(unittest.TestCase):
+    """Render DELEGATE bodies for each (pattern, role) combo and compare
+    against committed goldens. Update goldens with::
+
+        UPDATE_GOLDENS=1 python -m unittest tests.test_gen_delegate_payload
+
+    Goldens live in tests/fixtures/delegate_payload/ and intentionally
+    NORMALIZE absolute paths to ``<SANDBOX>`` placeholders to keep them
+    stable across machines/OSes.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _check(self, name: str, body: str) -> None:
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        path = GOLDEN_DIR / f"delegate_payload_{name}.golden.md"
+        normalized = _normalize_body(body, self.sb.root)
+        if not path.exists() or _env_update_goldens():
+            path.write_text(normalized, encoding="utf-8")
+            return
+        expected = path.read_text(encoding="utf-8")
+        self.assertEqual(
+            normalized,
+            expected,
+            f"DELEGATE body drift in {path}; rerun with UPDATE_GOLDENS=1 to refresh.",
+        )
+
+    def test_golden_pattern_a_default_full(self):
+        plan = gdp.build_delegate_plan(
+            task_id="snap-a-default",
+            project_slug="clock-app",
+            description="add a sparkline",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self._check("pattern_a_default_full", plan.delegate_body)
+
+    def test_golden_pattern_b_self_edit_full(self):
+        # claude-org-ja with concurrent active run forces Pattern B
+        self.sb.add_active_run(
+            task_id="self-edit-other",
+            project_slug="claude-org-ja",
+            worker_dir=str(self.sb.workers / "claude-org-ja"),
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="snap-b-self-edit",
+            project_slug="claude-org-ja",
+            description="refactor a skill",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self._check("pattern_b_self_edit_full", plan.delegate_body)
+
+    def test_golden_pattern_c_ephemeral_minimal(self):
+        plan = gdp.build_delegate_plan(
+            task_id="snap-c-ephemeral",
+            project_slug="totally-new",
+            description="quick survey",
+            verification_depth="minimal",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self._check("pattern_c_ephemeral_minimal", plan.delegate_body)
+
+
+def _env_update_goldens() -> bool:
+    import os
+    return os.environ.get("UPDATE_GOLDENS") == "1"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -12,6 +12,7 @@ Coverage:
 """
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
@@ -390,6 +391,130 @@ class TestGoldenSnapshots(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self._check("pattern_c_ephemeral_minimal", plan.delegate_body)
+
+    def test_golden_pattern_c_gitignored_repo_root(self):
+        """Codex Round 1 Minor: gitignored sub-mode is the highest-risk
+        Pattern C variant; lock its DELEGATE rendering down with a golden."""
+        try:
+            import subprocess as _sp
+            _sp.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, _sp.CalledProcessError):
+            self.skipTest("git not available")
+        local_repo = Path(self._td.name) / "host-repo"
+        local_repo.mkdir()
+        _sp.run(["git", "-C", str(local_repo), "init", "-q"], check=True)
+        (local_repo / ".gitignore").write_text("tmp/\n", encoding="utf-8")
+        # Re-seed registry so the host-repo project is registered.
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| ホスト | host-app | {local_repo} | Host repo | tmp 編集 |\n"
+            f"| claude-org-ja | claude-org-ja | {self.sb.claude_org_root} | Self | スキル改善 |\n",
+            encoding="utf-8",
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="snap-c-gitignored",
+            project_slug="host-app",
+            targets=["tmp/secret.txt"],
+            description="redact gitignored notes",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        # Normalise the local_repo path so the golden stays portable.
+        body = plan.delegate_body.replace(str(local_repo.resolve()), "<HOSTREPO>")
+        self._check("pattern_c_gitignored_repo_root_full", body)
+        # Variant must be visible in the formatted body.
+        self.assertIn("gitignored サブモード", body)
+
+    def test_golden_pattern_a_doc_audit(self):
+        """Codex M-4 regression guard: --mode audit must surface as doc-audit
+        and the brief filename must stay CLAUDE.md (no spurious .local.md)."""
+        plan = gdp.build_delegate_plan(
+            task_id="snap-a-audit",
+            project_slug="claude-org-ja",
+            description="audit recent changes",
+            mode="audit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self._check("pattern_a_doc_audit_full", plan.delegate_body)
+        self.assertEqual(plan.layout.role, "doc-audit")
+
+
+# ---------------------------------------------------------------------------
+# --from-toml round-trip (Codex Round 1 Major: TOML survives bare CLI)
+# ---------------------------------------------------------------------------
+
+
+class TestFromTomlRoundTrip(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _write_toml(self, path: Path, *, role: str, depth: str) -> None:
+        path.write_text(
+            "[task]\n"
+            'id = "round-trip"\n'
+            'description = "round-trip via TOML"\n'
+            f'verification_depth = "{depth}"\n'
+            'branch = "round-trip"\n'
+            'commit_prefix = "feat(clock):"\n'
+            "\n[worker]\n"
+            f'dir = "X:/dummy"\n'
+            'pattern = "A"\n'
+            f'role = "{role}"\n'
+            f'self_edit = {"true" if role == "claude-org-self-edit" else "false"}\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            'description = "Web 時計"\n'
+            "\n[paths]\n"
+            'claude_org = "."\n',
+            encoding="utf-8",
+        )
+
+    def test_from_toml_preserves_doc_audit_mode_and_minimal_depth(self):
+        toml = Path(self._td.name) / "input.toml"
+        self._write_toml(toml, role="doc-audit", depth="minimal")
+        # Bare CLI: no --mode / --verification-depth flag → TOML wins.
+        kwargs = gdp._gather_plan_kwargs(
+            argparse.Namespace(
+                from_toml=toml,
+                task_id=None, project_slug=None, target=[], description=None,
+                mode=None, branch_override=None, commit_prefix=None,
+                verification_depth=None, issue_url=None, closes_issue=None,
+                refs_issues=None, project_name_override=None,
+                project_description_override=None, impl_target=[],
+                impl_guidance=None, knowledge=[], parallel_notes=None,
+                registry_path=None, state_db_path=None, claude_org_root=None,
+                workers_dir=None,
+            )
+        )
+        self.assertEqual(kwargs["mode"], "audit")
+        self.assertEqual(kwargs["verification_depth"], "minimal")
+        self.assertEqual(kwargs["project_slug"], "clock-app")
+
+    def test_from_toml_cli_override_wins(self):
+        toml = Path(self._td.name) / "input.toml"
+        self._write_toml(toml, role="doc-audit", depth="minimal")
+        kwargs = gdp._gather_plan_kwargs(
+            argparse.Namespace(
+                from_toml=toml,
+                task_id=None, project_slug=None, target=[], description=None,
+                mode="edit", branch_override=None, commit_prefix=None,
+                verification_depth="full", issue_url=None, closes_issue=None,
+                refs_issues=None, project_name_override=None,
+                project_description_override=None, impl_target=[],
+                impl_guidance=None, knowledge=[], parallel_notes=None,
+                registry_path=None, state_db_path=None, claude_org_root=None,
+                workers_dir=None,
+            )
+        )
+        self.assertEqual(kwargs["mode"], "edit")
+        self.assertEqual(kwargs["verification_depth"], "full")
 
 
 def _env_update_goldens() -> bool:

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -1,0 +1,485 @@
+"""Unit tests for tools/resolve_worker_layout.py.
+
+Covers Issue #283 Stage 1 acceptance:
+- All 3 patterns (A new / A reuse / B / C ephemeral / C gitignored)
+- All 3 roles (default / claude-org-self-edit / doc-audit)
+- planned_branch inference (feat / fix / explicit override / null for Pattern C)
+- registry-not-found → Pattern C ephemeral
+- runs.status='queued' counts as active reservation (B-1 contract)
+- ``runs JOIN worker_dirs`` driven decision (B-2)
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools import resolve_worker_layout as rwl  # noqa: E402
+from tools.state_db import apply_schema, connect  # noqa: E402
+from tools.state_db.writer import StateWriter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture builder
+# ---------------------------------------------------------------------------
+
+
+class _Sandbox:
+    """One self-contained claude-org-like tree for a single test."""
+
+    def __init__(self, td: Path):
+        self.root = td
+        self.workers = td / "workers"
+        self.workers.mkdir()
+        # claude-org repo skeleton lives in <td>/claude-org/
+        self.claude_org_root = td / "claude-org"
+        self.claude_org_root.mkdir()
+        (self.claude_org_root / ".state").mkdir()
+        (self.claude_org_root / "registry").mkdir()
+        # workers_dir relative to claude-org root → ../workers
+        (self.claude_org_root / "registry" / "org-config.md").write_text(
+            "## Workers Directory\nworkers_dir: ../workers\n",
+            encoding="utf-8",
+        )
+        self.db_path = self.claude_org_root / ".state" / "state.db"
+        self.db_path.touch()  # let connect() open it (apply_schema below)
+        conn = connect(self.db_path)
+        apply_schema(conn)
+        conn.close()
+
+    # ---- registry helpers --------------------------------------------------
+
+    def write_registry(self, rows: list[tuple[str, str, str, str]]) -> None:
+        """Each row: (通称, slug, path, description)."""
+        lines = [
+            "# Projects Registry",
+            "",
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |",
+            "|---|---|---|---|---|",
+        ]
+        for common, slug, path, desc in rows:
+            lines.append(f"| {common} | {slug} | {path} | {desc} | - |")
+        (self.claude_org_root / "registry" / "projects.md").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+
+    # ---- state.db helpers --------------------------------------------------
+
+    def add_run(
+        self,
+        *,
+        task_id: str,
+        project_slug: str,
+        pattern: str,
+        status: str,
+        worker_dir_abs: str,
+        title: str = "",
+    ) -> None:
+        conn = connect(self.db_path)
+        # NOTE: pass claude_org_root=False-equivalent; we don't want post-commit
+        # snapshotter to fire during fixture setup.
+        w = StateWriter(conn)
+        with w.transaction() as tx:
+            tx.register_worker_dir(abs_path=worker_dir_abs, layout="flat",
+                                   is_git_repo=True, is_worktree=(pattern == "B"))
+            tx.upsert_run(
+                task_id=task_id,
+                project_slug=project_slug,
+                pattern=pattern,
+                title=title or task_id,
+                status=status,
+                worker_dir_abs_path=worker_dir_abs,
+            )
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestPatternDetection(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_pattern_a_new_when_no_runs(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        layout = rwl.resolve(
+            task_id="clock-task-1",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertIsNone(layout.pattern_variant)
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "clock-app").resolve(),
+        )
+        self.assertEqual(layout.role, "default")
+        self.assertFalse(layout.self_edit)
+        self.assertEqual(layout.planned_branch, "feat/clock-task-1")
+
+    def test_pattern_a_reuse_when_only_completed_runs(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        self.sb.add_run(
+            task_id="clock-prev",
+            project_slug="clock-app",
+            pattern="A",
+            status="completed",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="clock-task-2",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "clock-app").resolve(),
+        )
+
+    def test_pattern_b_when_in_use_run_exists(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        self.sb.add_run(
+            task_id="clock-other",
+            project_slug="clock-app",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="clock-task-3",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "clock-app" / ".worktrees" / "clock-task-3").resolve(),
+        )
+        self.assertEqual(layout.planned_branch, "feat/clock-task-3")
+
+    def test_pattern_b_when_queued_run_exists(self):
+        """B-1 contract: runs.status='queued' is an active reservation."""
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        self.sb.add_run(
+            task_id="clock-pending",
+            project_slug="clock-app",
+            pattern="A",
+            status="queued",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="clock-task-q",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+
+    def test_pattern_b_when_review_run_exists(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        self.sb.add_run(
+            task_id="clock-prev-rev",
+            project_slug="clock-app",
+            pattern="A",
+            status="review",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="clock-task-r",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+
+    def test_pattern_c_ephemeral_when_slug_not_in_registry(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        layout = rwl.resolve(
+            task_id="adhoc-survey",
+            project_slug="not-in-registry",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "C")
+        self.assertEqual(layout.pattern_variant, "ephemeral")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "adhoc-survey").resolve(),
+        )
+        self.assertIsNone(layout.planned_branch)
+
+
+# ---------------------------------------------------------------------------
+# Pattern C gitignored sub-mode (Step 0.7)
+# ---------------------------------------------------------------------------
+
+
+class TestPatternCGitignored(unittest.TestCase):
+    """Requires `git` on PATH. Skipped when unavailable."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            raise unittest.SkipTest("git not available")
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # Set up a real local repo that has tmp/secret.txt gitignored.
+        self.local_repo = Path(self._td.name) / "local-repo"
+        self.local_repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(self.local_repo), "init", "-q"],
+            check=True,
+        )
+        (self.local_repo / ".gitignore").write_text("tmp/\n", encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_gitignored_target_forces_pattern_c_repo_root(self):
+        self.sb.write_registry(
+            [("ローカルアプリ", "local-app", str(self.local_repo), "Local repo demo")]
+        )
+        layout = rwl.resolve(
+            task_id="cleanup-tmp",
+            project_slug="local-app",
+            targets=["tmp/secret.txt"],
+            description="cleanup gitignored notes",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "C")
+        self.assertEqual(layout.pattern_variant, "gitignored_repo_root")
+        self.assertEqual(
+            Path(layout.worker_dir).resolve(),
+            self.local_repo.resolve(),
+        )
+        self.assertIsNone(layout.planned_branch)
+
+    def test_tracked_target_falls_through_to_normal_pattern_judgment(self):
+        # tracked file is NOT in tmp/ so check-ignore returns 1.
+        self.sb.write_registry(
+            [("ローカルアプリ", "local-app", str(self.local_repo), "Local repo demo")]
+        )
+        layout = rwl.resolve(
+            task_id="edit-readme",
+            project_slug="local-app",
+            targets=["README.md"],
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertIsNone(layout.pattern_variant)
+
+
+# ---------------------------------------------------------------------------
+# Role / mode detection
+# ---------------------------------------------------------------------------
+
+
+class TestRoleDetection(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # Register the sandbox claude-org root as a project so role detection
+        # has something to compare against.
+        self.sb.write_registry(
+            [
+                ("時計", "clock-app", "-", "Demo clock"),
+                (
+                    "claude-org-ja",
+                    "claude-org-ja",
+                    str(self.sb.claude_org_root),
+                    "claude-org self",
+                ),
+            ]
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_default_role_for_non_claude_org_edit(self):
+        layout = rwl.resolve(
+            task_id="t-1",
+            project_slug="clock-app",
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "default")
+        self.assertFalse(layout.self_edit)
+
+    def test_claude_org_self_edit_role_when_editing_claude_org(self):
+        layout = rwl.resolve(
+            task_id="t-2",
+            project_slug="claude-org-ja",
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "claude-org-self-edit")
+        self.assertTrue(layout.self_edit)
+
+    def test_audit_mode_forces_doc_audit_even_for_claude_org(self):
+        layout = rwl.resolve(
+            task_id="t-3",
+            project_slug="claude-org-ja",
+            mode="audit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "doc-audit")
+        self.assertFalse(layout.self_edit)
+
+    def test_audit_mode_for_non_claude_org_also_doc_audit(self):
+        layout = rwl.resolve(
+            task_id="t-4",
+            project_slug="clock-app",
+            mode="audit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "doc-audit")
+
+
+# ---------------------------------------------------------------------------
+# Branch inference
+# ---------------------------------------------------------------------------
+
+
+class TestBranchInference(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        self.sb.write_registry([("時計", "clock-app", "-", "")])
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _resolve(self, **kw):
+        defaults = dict(
+            task_id="task-x",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        defaults.update(kw)
+        return rwl.resolve(**defaults)
+
+    def test_feat_prefix_when_description_has_no_fix_words(self):
+        layout = self._resolve(description="add a new sparkline component")
+        self.assertEqual(layout.planned_branch, "feat/task-x")
+
+    def test_fix_prefix_for_english_bug_word(self):
+        layout = self._resolve(description="bug in clock tick handler")
+        self.assertEqual(layout.planned_branch, "fix/task-x")
+
+    def test_fix_prefix_for_japanese_word(self):
+        layout = self._resolve(description="ロード時の修正")
+        self.assertEqual(layout.planned_branch, "fix/task-x")
+
+    def test_branch_override_wins(self):
+        layout = self._resolve(
+            description="bug bug bug",
+            branch_override="release/2026-05",
+        )
+        self.assertEqual(layout.planned_branch, "release/2026-05")
+
+    def test_pattern_c_branch_is_null(self):
+        # unregistered slug → Pattern C → no branch
+        layout = self._resolve(project_slug="totally-new")
+        self.assertEqual(layout.pattern, "C")
+        self.assertIsNone(layout.planned_branch)
+
+
+# ---------------------------------------------------------------------------
+# Settings args & CLI smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsArgs(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        self.sb.write_registry([("時計", "clock-app", "-", "")])
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_settings_args_carries_all_required_keys(self):
+        layout = rwl.resolve(
+            task_id="t-5",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        args = layout.settings_args
+        self.assertEqual(set(args), {"role", "worker-dir", "claude-org-path", "out"})
+        self.assertEqual(args["role"], layout.role)
+        self.assertEqual(args["worker-dir"], layout.worker_dir)
+        self.assertTrue(args["out"].endswith(os.path.join(".claude", "settings.local.json")))
+
+
+class TestCLI(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        self.sb.write_registry([("時計", "clock-app", "-", "")])
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_cli_emits_valid_json(self):
+        from io import StringIO
+        from contextlib import redirect_stdout
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = rwl.main([
+                "--task-id", "cli-test",
+                "--project-slug", "clock-app",
+                "--claude-org-root", str(self.sb.claude_org_root),
+                "--state-db-path", str(self.sb.db_path),
+            ])
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertEqual(data["pattern"], "A")
+        self.assertEqual(data["role"], "default")
+        self.assertEqual(data["planned_branch"], "feat/cli-test")
+        self.assertIn("settings_args", data)
+
+    def test_cli_invalid_mode_returns_2(self):
+        # argparse rejects choices and exits 2; we route through SystemExit.
+        with self.assertRaises(SystemExit) as cm:
+            rwl.main([
+                "--task-id", "x",
+                "--project-slug", "clock-app",
+                "--mode", "delete",
+                "--claude-org-root", str(self.sb.claude_org_root),
+            ])
+        self.assertEqual(cm.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -199,7 +199,6 @@ def build_delegate_plan(
     issue_url: Optional[str] = None,
     closes_issue: Optional[int] = None,
     refs_issues: Optional[list[int]] = None,
-    project_name_override: Optional[str] = None,
     project_description_override: Optional[str] = None,
     implementation_target_files: Optional[list[str]] = None,
     implementation_guidance: Optional[str] = None,
@@ -227,7 +226,6 @@ def build_delegate_plan(
         issue_url=issue_url,
         closes_issue=closes_issue,
         refs_issues=refs_issues,
-        project_name_override=project_name_override,
         project_description_override=project_description_override,
         implementation_target_files=implementation_target_files,
         implementation_guidance=implementation_guidance,
@@ -494,7 +492,9 @@ def _add_task_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--issue-url", default=None)
     p.add_argument("--closes-issue", type=int, default=None)
     p.add_argument("--refs-issues", type=int, nargs="*", default=None)
-    p.add_argument("--project-name", dest="project_name_override", default=None)
+    # Intentionally no --project-name: project.name is the slug (use
+    # --project-slug). Allowing an override created a round-trip drift
+    # where the next --from-toml read 通称 back as the slug (Codex Round 2).
     p.add_argument(
         "--project-description",
         dest="project_description_override",
@@ -572,9 +572,8 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
     The TOML schema (see ``tools/templates/worker_brief.example.toml``)
     uses ``project.name`` for the slug — that's what both the legacy
     hand-written briefs and Stage 2's ``from-task`` output write — so we
-    treat it as ``project_slug`` and as the ``project_name_override``
-    seed. Codex Round 1 caught the earlier inversion (common_name vs
-    slug round-trip mismatch).
+    treat it as ``project_slug`` directly. Codex Round 1+2 caught the
+    inversions (common_name vs slug; --project-name override drift).
 
     ``mode`` is derived from ``worker.role``: ``doc-audit`` → ``audit``,
     everything else → ``edit``. Returning the field at all (even when
@@ -600,7 +599,6 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
         "issue_url": task.get("issue_url"),
         "closes_issue": task.get("closes_issue"),
         "refs_issues": task.get("refs_issues"),
-        "project_name_override": project.get("name"),
         "project_description_override": project.get("description"),
         "implementation_target_files": impl.get("target_files"),
         "implementation_guidance": impl.get("guidance"),
@@ -634,7 +632,6 @@ def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
         "issue_url": args.issue_url,
         "closes_issue": args.closes_issue,
         "refs_issues": args.refs_issues,
-        "project_name_override": args.project_name_override,
         "project_description_override": args.project_description_override,
         "implementation_target_files": args.impl_target or None,
         "implementation_guidance": args.impl_guidance,

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -1,0 +1,703 @@
+"""Generate the Secretary's DELEGATE payload for a worker dispatch.
+
+Issue #283 Stage 3. Top-level CLI that takes the same task-shape inputs
+:mod:`tools.gen_worker_brief` ``from-task`` accepts, then assembles the
+full delegation packet:
+
+- ``preview`` (default): pure planning. Emits the DELEGATE message body
+  to stdout plus a list of artifacts that *would* be created. **Touches
+  no files, no DB, no MCP.** This lets Secretary inspect the plan before
+  committing to a reservation.
+
+- ``apply``: performs the T1 reservation per Set B contract:
+
+  1. Reserve the worker_dir + run row in state.db with
+     ``runs.status='queued'`` (Codex Design Blocker B-1; ``Active Work
+     Items`` remains the dispatcher's T2 responsibility — see
+     ``docs/contracts/delegation-lifecycle-contract.md``).
+  2. Write CLAUDE.md / CLAUDE.local.md via :mod:`tools.gen_worker_brief`.
+  3. Optionally call ``claude-org-runtime settings generate`` to write
+     ``.claude/settings.local.json`` (skip with ``--skip-settings``;
+     useful when the runtime CLI isn't on PATH yet, e.g. in tests).
+  4. Emit ``send_plan.json`` describing the renga-peers send_message
+     call Secretary should issue (``to_id="dispatcher"``, ``message=<body>``).
+     Codex M-3 reframed the original ``--send`` flag: this script never
+     calls MCP itself; Secretary copies the JSON into their own
+     ``mcp__renga-peers__send_message`` call.
+
+The internal split is :func:`build_delegate_plan` (pure planner returning
+a :class:`DelegatePlan`) and :func:`apply_delegate_plan` (side-effect
+executor). Tests exercise both paths.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from tools import gen_worker_brief as gwb
+from tools import resolve_worker_layout as rwl
+
+
+_PERMISSION_MODE_RE = re.compile(
+    r"^\s*default_permission_mode\s*:\s*(\S+)\s*$", re.MULTILINE
+)
+
+_PATTERN_LABELS = {
+    "A": "A: プロジェクトディレクトリ",
+    "B": "B: worktree",
+    "C": "C: エフェメラル",
+}
+
+
+@dataclass(frozen=True)
+class DelegatePlan:
+    task_id: str
+    project_slug: str
+    description: str
+    config: dict[str, Any]
+    layout: rwl.WorkerLayout
+    delegate_body: str
+    brief_out_path: Path
+    settings_args: dict[str, str]
+    permission_mode: str
+    verification_depth: str
+    closes_issue: Optional[int]
+    refs_issues: list[int]
+    artifacts_to_create: list[Path] = field(default_factory=list)
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "project_slug": self.project_slug,
+            "pattern": self.layout.pattern,
+            "pattern_variant": self.layout.pattern_variant,
+            "role": self.layout.role,
+            "self_edit": self.layout.self_edit,
+            "worker_dir": self.layout.worker_dir,
+            "planned_branch": self.layout.planned_branch,
+            "permission_mode": self.permission_mode,
+            "verification_depth": self.verification_depth,
+            "brief_out_path": str(self.brief_out_path),
+            "settings_args": dict(self.settings_args),
+            "artifacts_to_create": [str(p) for p in self.artifacts_to_create],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_permission_mode(claude_org_root: Path) -> str:
+    """Return the org-wide ``default_permission_mode`` (defaults to ``auto``)."""
+    cfg = claude_org_root / "registry" / "org-config.md"
+    if not cfg.exists():
+        return "auto"
+    text = cfg.read_text(encoding="utf-8")
+    m = _PERMISSION_MODE_RE.search(text)
+    return m.group(1) if m else "auto"
+
+
+def _pattern_label(layout: rwl.WorkerLayout) -> str:
+    base = _PATTERN_LABELS.get(layout.pattern, layout.pattern)
+    if layout.pattern_variant == "gitignored_repo_root":
+        return "C: gitignored サブモード (registered repo 直接編集)"
+    return base
+
+
+def _project_label(layout: rwl.WorkerLayout, project_path: Optional[str]) -> str:
+    if layout.pattern == "A":
+        return f"clone or reuse: {project_path or '-'}"
+    if layout.pattern == "B":
+        return f"worktree base: {project_path or '-'}"
+    if layout.pattern == "C":
+        if layout.pattern_variant == "gitignored_repo_root":
+            return f"既存 repo 直接編集: {layout.worker_dir}"
+        return "新規作成 (clone なし) — エフェメラル"
+    return project_path or "-"
+
+
+def _summarize_description(description: str, limit: int = 120) -> str:
+    one_line = " ".join(description.strip().split())
+    if len(one_line) <= limit:
+        return one_line
+    return one_line[: limit - 1].rstrip() + "…"
+
+
+def _brief_filename(self_edit: bool) -> str:
+    return "CLAUDE.local.md" if self_edit else "CLAUDE.md"
+
+
+def _format_delegate_body(
+    *,
+    layout: rwl.WorkerLayout,
+    task_id: str,
+    description: str,
+    project_path: Optional[str],
+    permission_mode: str,
+    verification_depth: str,
+    brief_filename: str,
+) -> str:
+    """Format the DELEGATE message body per org-delegate Step 2 template."""
+    instr_summary = _summarize_description(description)
+    branch_line = (
+        layout.planned_branch
+        if layout.planned_branch
+        else "(Pattern C: 既存 repo の現在ブランチで作業 / 新規 branch なし)"
+    )
+    body = f"""DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- {task_id}: {instr_summary or task_id}
+  - ワーカーディレクトリ: {layout.worker_dir}（{brief_filename}・設定配置済み）
+  - ディレクトリパターン: {_pattern_label(layout)}
+  - プロジェクト: {_project_label(layout, project_path)}
+  - ブランチ (planned): {branch_line}
+  - Permission Mode: {permission_mode}
+  - 検証深度: {verification_depth}
+  - 指示内容: 詳細は `{layout.worker_dir}/{brief_filename}` を参照。要約: {instr_summary or '(none)'}
+
+窓口ペイン名: `secretary`（renga layout で登録済み）"""
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Planner — pure
+# ---------------------------------------------------------------------------
+
+
+def build_delegate_plan(
+    *,
+    task_id: str,
+    project_slug: str,
+    targets: Optional[list[str]] = None,
+    description: str = "",
+    mode: str = "edit",
+    branch_override: Optional[str] = None,
+    commit_prefix: Optional[str] = None,
+    verification_depth: str = "full",
+    issue_url: Optional[str] = None,
+    closes_issue: Optional[int] = None,
+    refs_issues: Optional[list[int]] = None,
+    project_name_override: Optional[str] = None,
+    project_description_override: Optional[str] = None,
+    implementation_target_files: Optional[list[str]] = None,
+    implementation_guidance: Optional[str] = None,
+    references_knowledge: Optional[list[str]] = None,
+    parallel_notes: Optional[str] = None,
+    registry_path: Optional[Path] = None,
+    state_db_path: Optional[Path] = None,
+    claude_org_root: Path,
+    workers_dir: Optional[Path] = None,
+) -> DelegatePlan:
+    """Resolve the layout, assemble the brief config, format the DELEGATE body.
+
+    Pure: no file writes, no DB writes, no subprocesses other than the
+    ``git check-ignore`` Step 0.7 probe (read-only) inside the resolver.
+    """
+    config, layout = gwb.build_config_from_task(
+        task_id=task_id,
+        project_slug=project_slug,
+        targets=targets,
+        description=description,
+        mode=mode,
+        branch_override=branch_override,
+        commit_prefix=commit_prefix,
+        verification_depth=verification_depth,
+        issue_url=issue_url,
+        closes_issue=closes_issue,
+        refs_issues=refs_issues,
+        project_name_override=project_name_override,
+        project_description_override=project_description_override,
+        implementation_target_files=implementation_target_files,
+        implementation_guidance=implementation_guidance,
+        references_knowledge=references_knowledge,
+        parallel_notes=parallel_notes,
+        registry_path=registry_path,
+        state_db_path=state_db_path,
+        claude_org_root=claude_org_root,
+        workers_dir=workers_dir,
+    )
+
+    self_edit = bool(config["worker"]["self_edit"])
+    brief_filename = _brief_filename(self_edit)
+    brief_out_path = Path(layout.worker_dir) / brief_filename
+
+    permission_mode = parse_permission_mode(Path(claude_org_root))
+
+    # Look up project.path for the DELEGATE body label.
+    project_path: Optional[str] = None
+    registry_for_meta = registry_path or (
+        Path(claude_org_root) / "registry" / "projects.md"
+    )
+    if registry_for_meta.exists():
+        rows = rwl.parse_registry(registry_for_meta.read_text(encoding="utf-8"))
+        match = rwl.find_project(rows, project_slug)
+        if match is not None:
+            project_path = match.path
+
+    delegate_body = _format_delegate_body(
+        layout=layout,
+        task_id=task_id,
+        description=description,
+        project_path=project_path,
+        permission_mode=permission_mode,
+        verification_depth=verification_depth,
+        brief_filename=brief_filename,
+    )
+
+    artifacts = [
+        brief_out_path,
+        Path(layout.worker_dir) / ".claude" / "settings.local.json",
+    ]
+
+    return DelegatePlan(
+        task_id=task_id,
+        project_slug=project_slug,
+        description=description,
+        config=config,
+        layout=layout,
+        delegate_body=delegate_body,
+        brief_out_path=brief_out_path,
+        settings_args=dict(layout.settings_args),
+        permission_mode=permission_mode,
+        verification_depth=verification_depth,
+        closes_issue=closes_issue,
+        refs_issues=list(refs_issues or []),
+        artifacts_to_create=artifacts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Executor — side effects (DB write, file write, settings subprocess)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApplyResult:
+    plan: DelegatePlan
+    brief_path: Path
+    settings_path: Optional[Path]
+    settings_skipped_reason: Optional[str]
+    send_plan_path: Path
+    db_reservation: dict[str, Any]
+
+
+def _reserve_in_db(
+    plan: DelegatePlan,
+    *,
+    state_db_path: Path,
+    claude_org_root: Optional[Path],
+) -> dict[str, Any]:
+    """Reserve the worker_dir + queue the run row.
+
+    Per Codex Design Blocker B-1 + Set B contract, this writes
+    ``runs.status='queued'`` only. Active Work Items remains the
+    dispatcher's T2 responsibility and is *not* touched here.
+    """
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    if not state_db_path.exists():
+        # Fresh DB — create empty file and apply schema. The importer
+        # would normally seed projects/workstreams; we only need a usable
+        # schema here, ensure_project below will create the project row.
+        state_db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = connect(state_db_path)
+        apply_schema(conn)
+        conn.close()
+
+    conn = connect(state_db_path)
+    try:
+        writer = StateWriter(conn, claude_org_root=claude_org_root)
+        with writer.transaction() as tx:
+            tx.register_worker_dir(
+                abs_path=plan.layout.worker_dir,
+                layout="flat",
+                is_git_repo=plan.layout.pattern != "C"
+                or plan.layout.pattern_variant == "gitignored_repo_root",
+                is_worktree=plan.layout.pattern == "B",
+            )
+            issue_refs_iter = None
+            if plan.closes_issue is not None:
+                issue_refs_iter = [str(plan.closes_issue)]
+            elif plan.refs_issues:
+                issue_refs_iter = [str(n) for n in plan.refs_issues]
+            tx.upsert_run(
+                task_id=plan.task_id,
+                project_slug=plan.project_slug,
+                pattern=plan.layout.pattern,
+                title=plan.task_id,
+                status="queued",
+                branch=plan.layout.planned_branch,
+                issue_refs=issue_refs_iter,
+                verification=(
+                    "minimal" if plan.verification_depth == "minimal" else "standard"
+                ),
+                worker_dir_abs_path=plan.layout.worker_dir,
+            )
+        return {
+            "task_id": plan.task_id,
+            "project_slug": plan.project_slug,
+            "worker_dir": plan.layout.worker_dir,
+            "status": "queued",
+        }
+    finally:
+        conn.close()
+
+
+def _write_brief(plan: DelegatePlan) -> Path:
+    text = gwb.render(plan.config)
+    out = plan.brief_out_path
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text, encoding="utf-8")
+    return out
+
+
+def _run_settings_generate(
+    plan: DelegatePlan,
+    *,
+    runtime_cmd: str = "claude-org-runtime",
+) -> tuple[Optional[Path], Optional[str]]:
+    """Run ``claude-org-runtime settings generate``.
+
+    Returns ``(written_path, skipped_reason)``. When the CLI is missing
+    we return ``(None, reason)`` and let the caller record it in the
+    ApplyResult — apply does NOT crash, since several real-world dispatch
+    flows happen on machines without the runtime installed (e.g. fresh
+    test sandboxes).
+    """
+    if shutil.which(runtime_cmd) is None:
+        return None, f"{runtime_cmd!r} not on PATH"
+
+    settings_args = plan.settings_args
+    out = Path(settings_args["out"])
+    out.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        runtime_cmd,
+        "settings",
+        "generate",
+        "--role",
+        settings_args["role"],
+        "--worker-dir",
+        settings_args["worker-dir"],
+        "--claude-org-path",
+        settings_args["claude-org-path"],
+        "--out",
+        settings_args["out"],
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        return None, (
+            f"{runtime_cmd} settings generate failed (rc={e.returncode}): "
+            f"{(e.stderr or b'').decode('utf-8', errors='replace').strip()}"
+        )
+    return out, None
+
+
+def _write_send_plan(plan: DelegatePlan, *, out_path: Path) -> Path:
+    """Write the renga-peers MCP call manifest Secretary will copy from."""
+    payload = {
+        "to_id": "dispatcher",
+        "message": plan.delegate_body,
+        "summary": plan.to_summary_dict(),
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return out_path
+
+
+def apply_delegate_plan(
+    plan: DelegatePlan,
+    *,
+    state_db_path: Path,
+    claude_org_root: Optional[Path] = None,
+    skip_settings: bool = False,
+    runtime_cmd: str = "claude-org-runtime",
+    send_plan_out: Optional[Path] = None,
+) -> ApplyResult:
+    """Execute the side effects: reserve in DB, write brief, settings, send_plan."""
+    db_reservation = _reserve_in_db(
+        plan, state_db_path=state_db_path, claude_org_root=claude_org_root
+    )
+    brief_path = _write_brief(plan)
+    settings_path: Optional[Path] = None
+    skipped_reason: Optional[str] = None
+    if skip_settings:
+        skipped_reason = "skip_settings flag set"
+    else:
+        settings_path, skipped_reason = _run_settings_generate(
+            plan, runtime_cmd=runtime_cmd
+        )
+    if send_plan_out is None:
+        send_plan_out = brief_path.with_name("send_plan.json")
+    send_plan_path = _write_send_plan(plan, out_path=send_plan_out)
+    return ApplyResult(
+        plan=plan,
+        brief_path=brief_path,
+        settings_path=settings_path,
+        settings_skipped_reason=skipped_reason,
+        send_plan_path=send_plan_path,
+        db_reservation=db_reservation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _add_task_args(p: argparse.ArgumentParser) -> None:
+    """Args shared by preview and apply for the from-task input form."""
+    p.add_argument("--task-id")
+    p.add_argument("--project-slug")
+    p.add_argument("--target", action="append", default=[])
+    p.add_argument("--description", default="")
+    p.add_argument("--mode", choices=("edit", "audit"), default="edit")
+    p.add_argument("--branch", dest="branch_override", default=None)
+    p.add_argument("--commit-prefix", default=None)
+    p.add_argument(
+        "--verification-depth", choices=("full", "minimal"), default="full"
+    )
+    p.add_argument("--issue-url", default=None)
+    p.add_argument("--closes-issue", type=int, default=None)
+    p.add_argument("--refs-issues", type=int, nargs="*", default=None)
+    p.add_argument("--project-name", dest="project_name_override", default=None)
+    p.add_argument(
+        "--project-description",
+        dest="project_description_override",
+        default=None,
+    )
+    p.add_argument("--impl-target", action="append", default=[])
+    p.add_argument("--impl-guidance", default=None)
+    p.add_argument("--knowledge", action="append", default=[])
+    p.add_argument("--parallel-notes", default=None)
+    p.add_argument("--registry-path", type=Path, default=None)
+    p.add_argument("--state-db-path", type=Path, default=None)
+    p.add_argument("--claude-org-root", type=Path, default=None)
+    p.add_argument("--workers-dir", type=Path, default=None)
+    p.add_argument(
+        "--from-toml",
+        type=Path,
+        default=None,
+        help="Load task arguments from a worker_brief-style TOML instead of CLI flags.",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="gen_delegate_payload",
+        description="Generate the Secretary's DELEGATE payload (preview or apply).",
+    )
+    sub = p.add_subparsers(dest="cmd")
+    sub.required = True
+
+    preview = sub.add_parser(
+        "preview",
+        help="Print the planned DELEGATE body and artifact paths. No writes.",
+    )
+    _add_task_args(preview)
+    preview.add_argument(
+        "--json", dest="json_out", action="store_true",
+        help="Emit a single JSON object instead of human-readable text.",
+    )
+
+    apply_p = sub.add_parser(
+        "apply",
+        help="Reserve in DB (runs.status='queued'), write brief, settings, send_plan.json.",
+    )
+    _add_task_args(apply_p)
+    apply_p.add_argument(
+        "--skip-settings", action="store_true",
+        help="Skip the claude-org-runtime settings generate subprocess.",
+    )
+    apply_p.add_argument("--runtime-cmd", default="claude-org-runtime")
+    apply_p.add_argument(
+        "--send-plan-out",
+        type=Path,
+        default=None,
+        help="Override send_plan.json output path (default: alongside the brief).",
+    )
+
+    return p
+
+
+def _resolve_claude_org_root(args: argparse.Namespace) -> Path:
+    if args.claude_org_root is not None:
+        return args.claude_org_root
+    return gwb._detect_claude_org_root()
+
+
+def _resolve_state_db_path(args: argparse.Namespace, claude_org_root: Path) -> Path:
+    if args.state_db_path is not None:
+        return args.state_db_path
+    return claude_org_root / ".state" / "state.db"
+
+
+def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
+    """Pull task-shape kwargs out of a legacy worker_brief.toml.
+
+    Returns the subset of build_delegate_plan kwargs derivable from the
+    config; CLI flags still override (CLI processed after TOML).
+    """
+    with path.open("rb") as fh:
+        cfg = tomllib.load(fh)
+    task = cfg.get("task", {})
+    worker = cfg.get("worker", {})
+    project = cfg.get("project", {})
+    impl = cfg.get("implementation", {})
+    refs = cfg.get("references", {})
+    parallel = cfg.get("parallel", {})
+    return {
+        "task_id": task.get("id"),
+        "project_slug": project.get("name"),
+        "description": task.get("description", ""),
+        "branch_override": task.get("branch"),
+        "commit_prefix": task.get("commit_prefix"),
+        "verification_depth": task.get("verification_depth", "full"),
+        "issue_url": task.get("issue_url"),
+        "closes_issue": task.get("closes_issue"),
+        "refs_issues": task.get("refs_issues"),
+        "project_name_override": project.get("name"),
+        "project_description_override": project.get("description"),
+        "implementation_target_files": impl.get("target_files"),
+        "implementation_guidance": impl.get("guidance"),
+        "references_knowledge": refs.get("knowledge"),
+        "parallel_notes": parallel.get("notes"),
+        "mode": "edit" if not worker.get("self_edit") else "edit",
+    }
+
+
+def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
+    """Merge --from-toml defaults with CLI flags (CLI wins)."""
+    base: dict[str, Any] = {}
+    if args.from_toml is not None:
+        base.update(_load_task_args_from_toml(args.from_toml))
+    # CLI overrides — only when caller actually provided a value.
+    cli_overrides: dict[str, Any] = {
+        "task_id": args.task_id,
+        "project_slug": args.project_slug,
+        "targets": args.target or None,
+        "description": args.description or None,
+        "mode": args.mode,
+        "branch_override": args.branch_override,
+        "commit_prefix": args.commit_prefix,
+        "verification_depth": args.verification_depth,
+        "issue_url": args.issue_url,
+        "closes_issue": args.closes_issue,
+        "refs_issues": args.refs_issues,
+        "project_name_override": args.project_name_override,
+        "project_description_override": args.project_description_override,
+        "implementation_target_files": args.impl_target or None,
+        "implementation_guidance": args.impl_guidance,
+        "references_knowledge": args.knowledge or None,
+        "parallel_notes": args.parallel_notes,
+        "registry_path": args.registry_path,
+        "workers_dir": args.workers_dir,
+    }
+    for k, v in cli_overrides.items():
+        if v is not None:
+            base[k] = v
+    if not base.get("task_id"):
+        raise SystemExit("error: --task-id is required (or supply --from-toml)")
+    if not base.get("project_slug"):
+        raise SystemExit(
+            "error: --project-slug is required (or supply --from-toml)"
+        )
+    return base
+
+
+def _cmd_preview(args: argparse.Namespace) -> int:
+    claude_org_root = _resolve_claude_org_root(args)
+    state_db_path = _resolve_state_db_path(args, claude_org_root)
+    kwargs = _gather_plan_kwargs(args)
+    plan = build_delegate_plan(
+        claude_org_root=claude_org_root,
+        state_db_path=state_db_path if state_db_path.exists() else None,
+        **kwargs,
+    )
+
+    if args.json_out:
+        json.dump(
+            {
+                "delegate_body": plan.delegate_body,
+                "summary": plan.to_summary_dict(),
+            },
+            sys.stdout,
+            indent=2,
+            ensure_ascii=False,
+        )
+        sys.stdout.write("\n")
+        return 0
+
+    print("--- DELEGATE body (preview, no writes) ---")
+    print(plan.delegate_body)
+    print()
+    print("--- Artifacts that 'apply' would create ---")
+    for p in plan.artifacts_to_create:
+        print(f"  {p}")
+    print(f"  send_plan.json (alongside brief)")
+    print()
+    print("--- Layout summary ---")
+    print(json.dumps(plan.to_summary_dict(), indent=2, ensure_ascii=False))
+    return 0
+
+
+def _cmd_apply(args: argparse.Namespace) -> int:
+    claude_org_root = _resolve_claude_org_root(args)
+    state_db_path = _resolve_state_db_path(args, claude_org_root)
+    kwargs = _gather_plan_kwargs(args)
+    plan = build_delegate_plan(
+        claude_org_root=claude_org_root,
+        state_db_path=state_db_path if state_db_path.exists() else None,
+        **kwargs,
+    )
+    result = apply_delegate_plan(
+        plan,
+        state_db_path=state_db_path,
+        claude_org_root=claude_org_root,
+        skip_settings=args.skip_settings,
+        runtime_cmd=args.runtime_cmd,
+        send_plan_out=args.send_plan_out,
+    )
+    print(f"reserved (queued) task_id={plan.task_id} pattern={plan.layout.pattern}")
+    print(f"brief: {result.brief_path}")
+    if result.settings_path is not None:
+        print(f"settings: {result.settings_path}")
+    elif result.settings_skipped_reason:
+        print(f"settings: SKIPPED ({result.settings_skipped_reason})")
+    print(f"send_plan: {result.send_plan_path}")
+    print(
+        "Next step: copy send_plan.json's `to_id`/`message` into a "
+        "renga-peers send_message call."
+    )
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.cmd == "preview":
+        return _cmd_preview(args)
+    if args.cmd == "apply":
+        return _cmd_apply(args)
+    raise SystemExit(f"unknown subcommand: {args.cmd!r}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -31,6 +31,11 @@ executor). Tests exercise both paths.
 """
 from __future__ import annotations
 
+# Direct-script bootstrap (see tools/resolve_worker_layout.py for context).
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent))
+
 import argparse
 import json
 import re
@@ -157,6 +162,9 @@ def _format_delegate_body(
         if layout.planned_branch
         else "(Pattern C: 既存 repo の現在ブランチで作業 / 新規 branch なし)"
     )
+    # Use the platform-native joiner to avoid the mixed `\\…/CLAUDE.md`
+    # output the literal-`/` template produced on Windows (Codex Round 1 Nit).
+    brief_full_path = str(Path(layout.worker_dir) / brief_filename)
     body = f"""DELEGATE: 以下のワーカーを派遣してください。
 
 タスク一覧:
@@ -167,7 +175,7 @@ def _format_delegate_body(
   - ブランチ (planned): {branch_line}
   - Permission Mode: {permission_mode}
   - 検証深度: {verification_depth}
-  - 指示内容: 詳細は `{layout.worker_dir}/{brief_filename}` を参照。要約: {instr_summary or '(none)'}
+  - 指示内容: 詳細は `{brief_full_path}` を参照。要約: {instr_summary or '(none)'}
 
 窓口ペイン名: `secretary`（renga layout で登録済み）"""
     return body
@@ -464,16 +472,24 @@ def apply_delegate_plan(
 
 
 def _add_task_args(p: argparse.ArgumentParser) -> None:
-    """Args shared by preview and apply for the from-task input form."""
+    """Args shared by preview and apply for the from-task input form.
+
+    Defaults for ``--mode`` and ``--verification-depth`` are intentionally
+    ``None``. The merge step in :func:`_gather_plan_kwargs` only treats a
+    CLI value as an override when it is not None, so a ``--from-toml``
+    config's ``mode`` / ``verification_depth`` survives unless the caller
+    explicitly re-passes the flag. Final defaults (``edit`` / ``full``)
+    are applied after merging — see Codex Round 1 Major.
+    """
     p.add_argument("--task-id")
     p.add_argument("--project-slug")
     p.add_argument("--target", action="append", default=[])
-    p.add_argument("--description", default="")
-    p.add_argument("--mode", choices=("edit", "audit"), default="edit")
+    p.add_argument("--description", default=None)
+    p.add_argument("--mode", choices=("edit", "audit"), default=None)
     p.add_argument("--branch", dest="branch_override", default=None)
     p.add_argument("--commit-prefix", default=None)
     p.add_argument(
-        "--verification-depth", choices=("full", "minimal"), default="full"
+        "--verification-depth", choices=("full", "minimal"), default=None
     )
     p.add_argument("--issue-url", default=None)
     p.add_argument("--closes-issue", type=int, default=None)
@@ -551,10 +567,18 @@ def _resolve_state_db_path(args: argparse.Namespace, claude_org_root: Path) -> P
 
 
 def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
-    """Pull task-shape kwargs out of a legacy worker_brief.toml.
+    """Pull task-shape kwargs out of a worker_brief.toml.
 
-    Returns the subset of build_delegate_plan kwargs derivable from the
-    config; CLI flags still override (CLI processed after TOML).
+    The TOML schema (see ``tools/templates/worker_brief.example.toml``)
+    uses ``project.name`` for the slug — that's what both the legacy
+    hand-written briefs and Stage 2's ``from-task`` output write — so we
+    treat it as ``project_slug`` and as the ``project_name_override``
+    seed. Codex Round 1 caught the earlier inversion (common_name vs
+    slug round-trip mismatch).
+
+    ``mode`` is derived from ``worker.role``: ``doc-audit`` → ``audit``,
+    everything else → ``edit``. Returning the field at all (even when
+    falsey) lets the merge step recognise an explicit TOML setting.
     """
     with path.open("rb") as fh:
         cfg = tomllib.load(fh)
@@ -564,13 +588,15 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
     impl = cfg.get("implementation", {})
     refs = cfg.get("references", {})
     parallel = cfg.get("parallel", {})
+    role = (worker.get("role") or "").strip()
+    mode_from_toml = "audit" if role == "doc-audit" else "edit"
     return {
         "task_id": task.get("id"),
         "project_slug": project.get("name"),
-        "description": task.get("description", ""),
+        "description": task.get("description"),
         "branch_override": task.get("branch"),
         "commit_prefix": task.get("commit_prefix"),
-        "verification_depth": task.get("verification_depth", "full"),
+        "verification_depth": task.get("verification_depth"),
         "issue_url": task.get("issue_url"),
         "closes_issue": task.get("closes_issue"),
         "refs_issues": task.get("refs_issues"),
@@ -580,12 +606,18 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
         "implementation_guidance": impl.get("guidance"),
         "references_knowledge": refs.get("knowledge"),
         "parallel_notes": parallel.get("notes"),
-        "mode": "edit" if not worker.get("self_edit") else "edit",
+        "mode": mode_from_toml,
     }
 
 
 def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
-    """Merge --from-toml defaults with CLI flags (CLI wins)."""
+    """Merge --from-toml defaults with CLI flags (CLI wins).
+
+    Defaults for ``mode`` (``edit``) and ``verification_depth`` (``full``)
+    are applied **after** the merge so a TOML-supplied value survives a
+    bare CLI invocation. Otherwise argparse's defaults would always win
+    and TOML round-trip would silently flatten ``doc-audit`` / ``minimal``.
+    """
     base: dict[str, Any] = {}
     if args.from_toml is not None:
         base.update(_load_task_args_from_toml(args.from_toml))
@@ -594,7 +626,7 @@ def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
         "task_id": args.task_id,
         "project_slug": args.project_slug,
         "targets": args.target or None,
-        "description": args.description or None,
+        "description": args.description,
         "mode": args.mode,
         "branch_override": args.branch_override,
         "commit_prefix": args.commit_prefix,
@@ -614,6 +646,9 @@ def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
     for k, v in cli_overrides.items():
         if v is not None:
             base[k] = v
+    base.setdefault("mode", "edit")
+    base.setdefault("verification_depth", "full")
+    base.setdefault("description", "")
     if not base.get("task_id"):
         raise SystemExit("error: --task-id is required (or supply --from-toml)")
     if not base.get("project_slug"):

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -2,6 +2,25 @@
 
 Replaces hand-written per-task briefs with template + variable substitution.
 See ``tools/templates/worker_brief.example.toml`` for the input schema.
+
+Two CLI shapes are supported:
+
+1. Legacy (preserved for callers that build TOML by hand):
+
+       python tools/gen_worker_brief.py --config <path>.toml --out <CLAUDE.md>
+
+2. ``from-task`` subcommand (Issue #283 Stage 2). Calls
+   :mod:`tools.resolve_worker_layout` internally, builds the TOML config,
+   and renders. Inferred fields (`worker.dir`, `worker.pattern`, role,
+   branch) are derived from registry/projects.md + state.db, so the caller
+   only supplies task-shape inputs:
+
+       python tools/gen_worker_brief.py from-task \\
+           --task-id ... --project-slug ... --target ... --out <CLAUDE.md>
+
+The legacy mode and ``from-task`` mode share the rendering pipeline
+(`render(config) -> str`). Behaviour and TOML schema are unchanged for
+existing callers; from-task assembles an equivalent config dict in memory.
 """
 from __future__ import annotations
 
@@ -10,7 +29,7 @@ import re
 import sys
 from pathlib import Path
 from string import Template
-from typing import Any
+from typing import Any, Optional
 
 try:  # Python 3.11+
     import tomllib  # type: ignore[import-not-found]
@@ -237,7 +256,327 @@ def load_config(path: Path) -> dict[str, Any]:
         return tomllib.load(fh)
 
 
-def main(argv: list[str] | None = None) -> int:
+# ---------------------------------------------------------------------------
+# from-task: build a config dict from registry + state.db and render
+# ---------------------------------------------------------------------------
+
+
+def _commit_prefix_from_branch(branch: Optional[str], project_slug: str) -> str:
+    """Default the commit prefix to ``feat(<scope>):`` / ``fix(<scope>):``.
+
+    Scope defaults to ``project_slug`` truncated at the first hyphen
+    (e.g. ``claude-org-ja`` → ``claude``). Callers should override with
+    ``--commit-prefix`` when convention differs (the org-delegate skill
+    historically uses ``feat(secretary):`` / ``feat(dispatcher):`` /
+    ``docs(secretary):`` rather than the project-derived scope).
+    """
+    scope = project_slug.split("-", 1)[0] if project_slug else "task"
+    kind = "fix" if branch and branch.startswith("fix/") else "feat"
+    return f"{kind}({scope}):"
+
+
+def _resolve_out_path(out: Path, self_edit: bool) -> Path:
+    """Auto-switch CLAUDE.md → CLAUDE.local.md when self_edit is true.
+
+    The Codex review flagged that self_edit means the worker is inside a
+    repo whose root CLAUDE.md belongs to someone else (claude-org's
+    Secretary brief, or the gitignored sub-mode's host-repo CLAUDE.md);
+    overwriting it is destructive. ``from-task`` therefore enforces the
+    suffix automatically and warns when the caller's --out disagrees.
+    """
+    if not self_edit:
+        return out
+    if out.name == "CLAUDE.md":
+        return out.with_name("CLAUDE.local.md")
+    return out
+
+
+def build_config_from_task(
+    *,
+    task_id: str,
+    project_slug: str,
+    targets: Optional[list[str]] = None,
+    description: str = "",
+    mode: str = "edit",
+    branch_override: Optional[str] = None,
+    commit_prefix: Optional[str] = None,
+    verification_depth: str = "full",
+    issue_url: Optional[str] = None,
+    closes_issue: Optional[int] = None,
+    refs_issues: Optional[list[int]] = None,
+    project_name_override: Optional[str] = None,
+    project_description_override: Optional[str] = None,
+    implementation_target_files: Optional[list[str]] = None,
+    implementation_guidance: Optional[str] = None,
+    references_knowledge: Optional[list[str]] = None,
+    parallel_notes: Optional[str] = None,
+    registry_path: Optional[Path] = None,
+    state_db_path: Optional[Path] = None,
+    claude_org_root: Path,
+    workers_dir: Optional[Path] = None,
+) -> tuple[dict[str, Any], "object"]:
+    """Resolve layout + assemble a render-ready config.
+
+    Returns ``(config, layout)``. ``layout`` is the
+    :class:`tools.resolve_worker_layout.WorkerLayout` so callers (notably
+    :mod:`tools.gen_delegate_payload`) can consume the same resolver
+    output without re-running the resolver.
+    """
+    # Imported lazily so legacy --config callers don't pay the import cost
+    # and don't pull in sqlite3 unless they need it.
+    from tools import resolve_worker_layout as rwl
+
+    layout = rwl.resolve(
+        task_id=task_id,
+        project_slug=project_slug,
+        targets=targets,
+        description=description,
+        mode=mode,
+        branch_override=branch_override,
+        registry_path=registry_path,
+        state_db_path=state_db_path,
+        claude_org_root=claude_org_root,
+        workers_dir=workers_dir,
+    )
+
+    # gitignored_repo_root inherits the .local.md template treatment even
+    # when role=default — we're inside someone else's repo and must not
+    # clobber their CLAUDE.md (Codex M-1).
+    treat_as_self_edit = layout.self_edit or (
+        layout.pattern_variant == "gitignored_repo_root"
+    )
+
+    # Look up project metadata from the registry for project.name /
+    # project.description defaults. Stage 2 doesn't add a registry-read
+    # round-trip — the resolver already parsed it; we re-read here only
+    # for the description string (resolver returns slug + path only on the
+    # public dataclass, not the full row).
+    registry_for_meta = registry_path or (
+        claude_org_root / "registry" / "projects.md"
+    )
+    project_name = project_name_override or project_slug
+    project_description = project_description_override or ""
+    if registry_for_meta.exists():
+        rows = rwl.parse_registry(
+            registry_for_meta.read_text(encoding="utf-8")
+        )
+        match = rwl.find_project(rows, project_slug)
+        if match is not None:
+            if not project_name_override:
+                project_name = match.common_name or match.slug
+            if not project_description_override:
+                project_description = match.description
+
+    # Branch field for the brief: Pattern C has no branch; use task_id as
+    # a stable label so the existing template (which requires task.branch
+    # to be a non-empty string) doesn't reject the config. Stage 3 will
+    # mark this as null in the DELEGATE body.
+    brief_branch = layout.planned_branch or task_id
+
+    if commit_prefix is None:
+        commit_prefix = _commit_prefix_from_branch(layout.planned_branch, project_slug)
+
+    config: dict[str, Any] = {
+        "task": {
+            "id": task_id,
+            "description": description or task_id,
+            "verification_depth": verification_depth,
+            "branch": brief_branch,
+            "commit_prefix": commit_prefix,
+        },
+        "worker": {
+            "dir": layout.worker_dir,
+            "pattern": layout.pattern,
+            "role": layout.role,
+            "self_edit": treat_as_self_edit,
+        },
+        "project": {
+            "name": project_name or project_slug,
+            "description": project_description or f"Project {project_slug}",
+        },
+        "paths": {
+            "claude_org": str(Path(claude_org_root).resolve()),
+        },
+    }
+    if issue_url:
+        config["task"]["issue_url"] = issue_url
+    if closes_issue is not None:
+        config["task"]["closes_issue"] = int(closes_issue)
+    if refs_issues:
+        config["task"]["refs_issues"] = [int(n) for n in refs_issues]
+
+    if implementation_target_files or implementation_guidance:
+        impl: dict[str, Any] = {}
+        if implementation_target_files:
+            impl["target_files"] = list(implementation_target_files)
+        if implementation_guidance:
+            impl["guidance"] = implementation_guidance
+        config["implementation"] = impl
+    if references_knowledge:
+        config["references"] = {"knowledge": list(references_knowledge)}
+    if parallel_notes:
+        config["parallel"] = {"notes": parallel_notes}
+
+    return config, layout
+
+
+def _dump_toml(config: dict[str, Any]) -> str:
+    """Minimal TOML dumper for the audit-trail file written by ``--write-toml``.
+
+    We avoid taking a runtime dependency on ``tomli-w`` for a feature
+    most callers won't use; the subset of TOML the brief schema produces
+    (tables of strings, ints, bool, lists of strings/ints) is small
+    enough to handle inline.
+    """
+    def _atom(v: Any) -> str:
+        if isinstance(v, bool):
+            return "true" if v else "false"
+        if isinstance(v, int):
+            return str(v)
+        if isinstance(v, str):
+            if "\n" in v:
+                escaped = v.replace("\\", "\\\\").replace('"""', '\\"""')
+                return f'"""\n{escaped}\n"""'
+            escaped = v.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"{escaped}"'
+        if isinstance(v, list):
+            return "[" + ", ".join(_atom(x) for x in v) + "]"
+        raise TypeError(f"unsupported TOML value type: {type(v).__name__}")
+
+    lines: list[str] = []
+    for section, body in config.items():
+        if not isinstance(body, dict):
+            continue
+        lines.append(f"[{section}]")
+        for k, v in body.items():
+            lines.append(f"{k} = {_atom(v)}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _build_from_task_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="gen_worker_brief.py from-task",
+        description="Resolve worker layout from registry+state.db and render a brief.",
+    )
+    p.add_argument("--task-id", required=True)
+    p.add_argument("--project-slug", required=True)
+    p.add_argument("--target", action="append", default=[])
+    p.add_argument("--description", default="")
+    p.add_argument("--mode", choices=("edit", "audit"), default="edit")
+    p.add_argument("--branch", dest="branch_override", default=None)
+    p.add_argument("--commit-prefix", default=None)
+    p.add_argument(
+        "--verification-depth",
+        choices=("full", "minimal"),
+        default="full",
+    )
+    p.add_argument("--issue-url", default=None)
+    p.add_argument("--closes-issue", type=int, default=None)
+    p.add_argument("--refs-issues", type=int, nargs="*", default=None)
+    p.add_argument("--project-name", dest="project_name_override", default=None)
+    p.add_argument(
+        "--project-description",
+        dest="project_description_override",
+        default=None,
+    )
+    p.add_argument("--impl-target", action="append", default=[],
+                   help="Add an entry to [implementation].target_files (repeatable).")
+    p.add_argument("--impl-guidance", default=None)
+    p.add_argument("--knowledge", action="append", default=[],
+                   help="Add an entry to [references].knowledge (repeatable).")
+    p.add_argument("--parallel-notes", default=None)
+    p.add_argument("--registry-path", type=Path, default=None)
+    p.add_argument("--state-db-path", type=Path, default=None)
+    p.add_argument("--claude-org-root", type=Path, default=None)
+    p.add_argument("--workers-dir", type=Path, default=None)
+    p.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output path (auto-switched to .local.md when self_edit).",
+    )
+    p.add_argument(
+        "--write-toml",
+        type=Path,
+        default=None,
+        help="Optional: also dump the assembled TOML config to this path (audit trail).",
+    )
+    return p
+
+
+def _detect_claude_org_root() -> Path:
+    """Walk up from CWD looking for a registry/projects.md + .state/ pair."""
+    here = Path.cwd().resolve()
+    for cand in (here, *here.parents):
+        if (cand / "registry" / "projects.md").exists() and (cand / ".state").exists():
+            return cand
+    return here
+
+
+def _main_from_task(argv: list[str]) -> int:
+    args = _build_from_task_parser().parse_args(argv)
+    claude_org_root = args.claude_org_root or _detect_claude_org_root()
+    state_db_path = args.state_db_path
+    if state_db_path is None:
+        candidate = claude_org_root / ".state" / "state.db"
+        state_db_path = candidate if candidate.exists() else None
+
+    try:
+        config, layout = build_config_from_task(
+            task_id=args.task_id,
+            project_slug=args.project_slug,
+            targets=args.target,
+            description=args.description,
+            mode=args.mode,
+            branch_override=args.branch_override,
+            commit_prefix=args.commit_prefix,
+            verification_depth=args.verification_depth,
+            issue_url=args.issue_url,
+            closes_issue=args.closes_issue,
+            refs_issues=args.refs_issues,
+            project_name_override=args.project_name_override,
+            project_description_override=args.project_description_override,
+            implementation_target_files=args.impl_target,
+            implementation_guidance=args.impl_guidance,
+            references_knowledge=args.knowledge,
+            parallel_notes=args.parallel_notes,
+            registry_path=args.registry_path,
+            state_db_path=state_db_path,
+            claude_org_root=claude_org_root,
+            workers_dir=args.workers_dir,
+        )
+        output = render(config)
+    except (ConfigError, FileNotFoundError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    out_path = _resolve_out_path(args.out, config["worker"]["self_edit"])
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(output, encoding="utf-8")
+    print(f"wrote {out_path} ({len(output)} bytes)")
+
+    if args.write_toml is not None:
+        args.write_toml.parent.mkdir(parents=True, exist_ok=True)
+        args.write_toml.write_text(_dump_toml(config), encoding="utf-8")
+        print(f"wrote {args.write_toml} (TOML audit trail)")
+
+    # Report layout fields the brief itself doesn't expose — useful for
+    # Stage 3 callers and for human inspection.
+    print(
+        f"layout: pattern={layout.pattern}"
+        + (f"/{layout.pattern_variant}" if layout.pattern_variant else "")
+        + f" role={layout.role} planned_branch={layout.planned_branch!r}"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Legacy --config / --out CLI (preserved for backwards compat)
+# ---------------------------------------------------------------------------
+
+
+def _main_legacy(argv: list[str]) -> int:
     p = argparse.ArgumentParser(
         description="Generate a worker CLAUDE.md / CLAUDE.local.md from a TOML config",
     )
@@ -261,6 +600,18 @@ def main(argv: list[str] | None = None) -> int:
     args.out.write_text(output, encoding="utf-8")
     print(f"wrote {args.out} ({len(output)} bytes)")
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dispatch ``from-task <…>`` to the new path; everything else is legacy.
+
+    Subcommand-style argparse would also work, but staying with a leading
+    sentinel keeps the legacy ``--config/--out`` invocation byte-identical
+    and prevents argparse's automatic ``--help`` from changing output."""
+    argv = sys.argv[1:] if argv is None else list(argv)
+    if argv and argv[0] == "from-task":
+        return _main_from_task(argv[1:])
+    return _main_legacy(argv)
 
 
 if __name__ == "__main__":

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -24,6 +24,11 @@ existing callers; from-task assembles an equivalent config dict in memory.
 """
 from __future__ import annotations
 
+# Direct-script bootstrap (see tools/resolve_worker_layout.py for context).
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent))
+
 import argparse
 import re
 import sys
@@ -346,11 +351,12 @@ def build_config_from_task(
         layout.pattern_variant == "gitignored_repo_root"
     )
 
-    # Look up project metadata from the registry for project.name /
-    # project.description defaults. Stage 2 doesn't add a registry-read
-    # round-trip — the resolver already parsed it; we re-read here only
-    # for the description string (resolver returns slug + path only on the
-    # public dataclass, not the full row).
+    # Look up project metadata from the registry. ``project.name`` in the
+    # TOML schema is the slug (matches the existing example.toml convention
+    # and round-trips through ``--from-toml``); 通称 / common_name flows
+    # into ``project.description`` only when the caller didn't supply one,
+    # so the brief still surfaces the human-friendly name without breaking
+    # slug semantics. Codex review surfaced this drift.
     registry_for_meta = registry_path or (
         claude_org_root / "registry" / "projects.md"
     )
@@ -361,11 +367,15 @@ def build_config_from_task(
             registry_for_meta.read_text(encoding="utf-8")
         )
         match = rwl.find_project(rows, project_slug)
-        if match is not None:
-            if not project_name_override:
-                project_name = match.common_name or match.slug
-            if not project_description_override:
-                project_description = match.description
+        if match is not None and not project_description_override:
+            common = match.common_name or match.slug
+            base_desc = match.description or ""
+            if common and common != match.slug:
+                project_description = (
+                    f"{common} — {base_desc}" if base_desc else common
+                )
+            else:
+                project_description = base_desc
 
     # Branch field for the brief: Pattern C has no branch; use task_id as
     # a stable label so the existing template (which requires task.branch
@@ -470,6 +480,7 @@ def _build_from_task_parser() -> argparse.ArgumentParser:
         "--verification-depth",
         choices=("full", "minimal"),
         default="full",
+        help="full | minimal — passed through to brief and DELEGATE body.",
     )
     p.add_argument("--issue-url", default=None)
     p.add_argument("--closes-issue", type=int, default=None)

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -309,7 +309,6 @@ def build_config_from_task(
     issue_url: Optional[str] = None,
     closes_issue: Optional[int] = None,
     refs_issues: Optional[list[int]] = None,
-    project_name_override: Optional[str] = None,
     project_description_override: Optional[str] = None,
     implementation_target_files: Optional[list[str]] = None,
     implementation_guidance: Optional[str] = None,
@@ -360,7 +359,7 @@ def build_config_from_task(
     registry_for_meta = registry_path or (
         claude_org_root / "registry" / "projects.md"
     )
-    project_name = project_name_override or project_slug
+    project_name = project_slug
     project_description = project_description_override or ""
     if registry_for_meta.exists():
         rows = rwl.parse_registry(
@@ -372,7 +371,7 @@ def build_config_from_task(
             base_desc = match.description or ""
             if common and common != match.slug:
                 project_description = (
-                    f"{common} — {base_desc}" if base_desc else common
+                    f"{common} - {base_desc}" if base_desc else common
                 )
             else:
                 project_description = base_desc
@@ -480,16 +479,16 @@ def _build_from_task_parser() -> argparse.ArgumentParser:
         "--verification-depth",
         choices=("full", "minimal"),
         default="full",
-        help="full | minimal — passed through to brief and DELEGATE body.",
+        help="full | minimal - passed through to brief and DELEGATE body.",
     )
     p.add_argument("--issue-url", default=None)
     p.add_argument("--closes-issue", type=int, default=None)
     p.add_argument("--refs-issues", type=int, nargs="*", default=None)
-    p.add_argument("--project-name", dest="project_name_override", default=None)
     p.add_argument(
         "--project-description",
         dest="project_description_override",
         default=None,
+        help="Override the project.description text (defaults to the registry row's display name + description).",
     )
     p.add_argument("--impl-target", action="append", default=[],
                    help="Add an entry to [implementation].target_files (repeatable).")
@@ -546,7 +545,6 @@ def _main_from_task(argv: list[str]) -> int:
             issue_url=args.issue_url,
             closes_issue=args.closes_issue,
             refs_issues=args.refs_issues,
-            project_name_override=args.project_name_override,
             project_description_override=args.project_description_override,
             implementation_target_files=args.impl_target,
             implementation_guidance=args.impl_guidance,

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -47,6 +47,15 @@ Key contract notes (from Codex review of Issue #283):
 """
 from __future__ import annotations
 
+# When invoked as ``python tools/resolve_worker_layout.py`` (the form the
+# org-delegate skill documents), sys.path[0] is the ``tools/`` directory and
+# ``from tools import ...`` would fail with ModuleNotFoundError. Insert the
+# repo root so the package import works regardless of launch form. Harmless
+# when this module is imported (the path may already be there).
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent))
+
 import argparse
 import json
 import re

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -1,0 +1,507 @@
+"""Resolve worker layout (pattern / dir / role / branch) for a task.
+
+Codifies the org-delegate Step 0.7 + Step 1 + Step 1.5 ("Role の選び方")
+hand-decision flow as a deterministic library + thin CLI wrapper.
+
+Library-first: callers in the same Python process should import
+:func:`resolve` and consume the :class:`WorkerLayout` dataclass directly.
+The CLI (``python -m tools.resolve_worker_layout`` or
+``python tools/resolve_worker_layout.py``) is a thin JSON-stdout wrapper
+for shell consumers and for ad-hoc Secretary inspection.
+
+Inputs:
+- task_id, project_slug
+- targets (list of file paths for Step 0.7 gitignore check; 0 = skip)
+- description (free text; used only for branch-prefix inference)
+- mode ('edit' | 'audit') — explicit, so claude-org read-only audit is
+  not misclassified as a self-edit. Codex Design Major M-4.
+- branch_override (optional; bypasses inference)
+- registry_path / state_db_path / claude_org_root / workers_dir
+  (defaults derived from claude_org_root when None)
+
+Output (JSON shape):
+
+    {
+      "pattern": "A" | "B" | "C",
+      "pattern_variant": "ephemeral" | "gitignored_repo_root" | None,
+      "worker_dir": "<absolute path>",
+      "role": "default" | "claude-org-self-edit" | "doc-audit",
+      "self_edit": <bool>,
+      "planned_branch": "<inferred or null>",
+      "settings_args": {
+        "role": "...",
+        "worker-dir": "...",
+        "claude-org-path": "...",
+        "out": "<worker_dir>/.claude/settings.local.json"
+      }
+    }
+
+Key contract notes (from Codex review of Issue #283):
+- ``pattern_variant`` distinguishes the two Pattern C sub-modes (M-1).
+- ``planned_branch`` is the resolver's *suggestion*; the actual branch
+  may diverge after worktree creation, so callers MUST re-read git
+  before pinning it into the brief / payload (M-2).
+- Active-work detection uses ``runs.status in ('queued','in_use','review')``
+  via a ``runs JOIN worker_dirs`` query — not a direct read of the
+  ``worker_dirs`` table (Codex Design Blocker B-2).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from tools.state_db import connect as db_connect
+from tools.state_db.queries import list_runs_with_dirs
+
+
+VALID_MODES = ("edit", "audit")
+VALID_PATTERNS = ("A", "B", "C")
+VALID_VARIANTS = ("ephemeral", "gitignored_repo_root")
+VALID_ROLES = ("default", "claude-org-self-edit", "doc-audit")
+
+# Active reservation states — these mean someone else is occupying the base
+# clone, so a new task on the same project must use a worktree (Pattern B).
+# 'queued' is included because Issue #283 introduces T1 reservations that
+# write runs.status='queued' before the worker pane is spawned (T2 flips to
+# 'in_use'); a back-to-back delegation must see the queued reservation as
+# "in use".
+_ACTIVE_RUN_STATUSES = ("queued", "in_use", "review")
+
+# Trigger words that flip the planned-branch prefix from feat/ to fix/.
+_FIX_TRIGGERS = ("fix", "bug", "修正", "hotfix", "patch")
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RegistryProject:
+    """Single row of registry/projects.md, for resolver-internal use."""
+    common_name: str        # 通称
+    slug: str               # プロジェクト名 (machine slug)
+    path: str               # local abs path, URL, or '-'
+    description: str
+
+
+@dataclass(frozen=True)
+class WorkerLayout:
+    pattern: str                       # "A" | "B" | "C"
+    pattern_variant: Optional[str]     # "ephemeral" | "gitignored_repo_root" | None
+    worker_dir: str                    # absolute path
+    role: str                          # default | claude-org-self-edit | doc-audit
+    self_edit: bool
+    planned_branch: Optional[str]
+    settings_args: dict[str, str] = field(default_factory=dict)
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "pattern": self.pattern,
+            "pattern_variant": self.pattern_variant,
+            "worker_dir": self.worker_dir,
+            "role": self.role,
+            "self_edit": self.self_edit,
+            "planned_branch": self.planned_branch,
+            "settings_args": dict(self.settings_args),
+        }
+
+
+class ResolveError(ValueError):
+    """Raised when inputs are malformed or contradictory."""
+
+
+# ---------------------------------------------------------------------------
+# registry/projects.md parser
+# ---------------------------------------------------------------------------
+#
+# TODO(#286): replace the ad-hoc parser below with the shared parser from
+# tools/registry_parser when Issue #286 lands. dashboard/server.py and
+# tools/state_db/importer.py have their own parsers today; #286 extracts a
+# single SoT module that all three call. Until then this resolver carries
+# the third (intentionally minimal) implementation, and we accept the drift
+# risk for the duration of one PR.
+
+_TABLE_SEP_RE = re.compile(r"^\|[\s\-:|]+\|\s*$")
+
+
+def parse_registry(text: str) -> list[RegistryProject]:
+    """Parse the markdown table in registry/projects.md.
+
+    Tolerates leading prose / multiple tables. Returns rows with at
+    least 4 columns (通称 / プロジェクト名 / パス / 説明). The 5th
+    column ('よくある作業例') is dropped — resolver doesn't use it.
+    """
+    rows: list[RegistryProject] = []
+    in_table = False
+    header_seen = False
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if _TABLE_SEP_RE.match(line):
+            in_table = True
+            header_seen = True
+            continue
+        if not in_table:
+            # Header line that precedes the |---| separator — capture so
+            # malformed tables (separator missing) still don't accidentally
+            # parse.  We only flip in_table on the separator.
+            if line.startswith("|"):
+                header_seen = True
+            continue
+        if not line.startswith("|"):
+            # blank line or end-of-table prose
+            in_table = False
+            continue
+        cols = [c.strip() for c in line.strip("|").split("|")]
+        if len(cols) < 4:
+            continue
+        common_name, slug, path, description = cols[0], cols[1], cols[2], cols[3]
+        if not slug:
+            continue
+        rows.append(
+            RegistryProject(
+                common_name=common_name,
+                slug=slug,
+                path=path,
+                description=description,
+            )
+        )
+    if not header_seen:
+        return []
+    return rows
+
+
+def find_project(rows: Iterable[RegistryProject], slug: str) -> Optional[RegistryProject]:
+    for r in rows:
+        if r.slug == slug:
+            return r
+    return None
+
+
+# ---------------------------------------------------------------------------
+# org-config.md (workers_dir)
+# ---------------------------------------------------------------------------
+
+
+_WORKERS_DIR_RE = re.compile(r"^\s*workers_dir\s*:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def parse_workers_dir(org_config_text: str) -> Optional[str]:
+    m = _WORKERS_DIR_RE.search(org_config_text)
+    return m.group(1) if m else None
+
+
+def resolve_workers_dir(claude_org_root: Path) -> Path:
+    cfg_path = claude_org_root / "registry" / "org-config.md"
+    raw = ""
+    if cfg_path.exists():
+        raw = cfg_path.read_text(encoding="utf-8")
+    rel = parse_workers_dir(raw) or "../workers"
+    return (claude_org_root / rel).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Step 0.7: gitignore check
+# ---------------------------------------------------------------------------
+
+
+def is_local_git_repo(path: str) -> bool:
+    """Local-path heuristic: not a URL, exists, has .git, isn't '-'."""
+    if not path or path == "-":
+        return False
+    if "://" in path:
+        return False
+    p = Path(path)
+    if not p.exists() or not p.is_dir():
+        return False
+    return (p / ".git").exists()
+
+
+def any_target_is_gitignored(project_path: str, targets: list[str]) -> bool:
+    """Return True iff at least one target matches ``git check-ignore``.
+
+    Only call this after :func:`is_local_git_repo` confirms the project
+    path is a usable local repo. Targets are passed through to git as-is
+    (git accepts both repo-relative and absolute paths under -C).
+    """
+    if not targets:
+        return False
+    for tgt in targets:
+        try:
+            rc = subprocess.run(
+                ["git", "-C", project_path, "check-ignore", "-q", "--", tgt],
+                capture_output=True,
+            ).returncode
+        except (FileNotFoundError, OSError):
+            # git missing or permission denied — be conservative: treat
+            # as "not ignored" so we fall through to normal Pattern judgment.
+            return False
+        if rc == 0:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# state.db — pattern detection via runs JOIN worker_dirs
+# ---------------------------------------------------------------------------
+
+
+def project_has_active_run(conn: sqlite3.Connection, project_slug: str) -> bool:
+    """True iff this project has at least one run with worker_dir attached
+    whose status is queued / in_use / review.
+
+    Routes through ``list_runs_with_dirs`` (the same query the snapshotter
+    uses) so resolver state-of-the-world matches what the dashboard and
+    org-state.md regenerate from. See Codex Design Blocker B-2.
+    """
+    for row in list_runs_with_dirs(conn):
+        if row.get("project_slug") != project_slug:
+            continue
+        if row.get("status") in _ACTIVE_RUN_STATUSES:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Branch inference
+# ---------------------------------------------------------------------------
+
+
+def infer_branch(task_id: str, description: str) -> str:
+    """Return ``feat/<task-id>`` or ``fix/<task-id>`` based on description.
+
+    If the task_id already carries a feat/ or fix/ prefix, return as-is.
+    """
+    if task_id.startswith(("feat/", "fix/", "chore/", "docs/")):
+        return task_id
+    desc_lower = description.lower()
+    is_fix = any(t in desc_lower for t in _FIX_TRIGGERS)
+    return f"{'fix' if is_fix else 'feat'}/{task_id}"
+
+
+# ---------------------------------------------------------------------------
+# Role detection
+# ---------------------------------------------------------------------------
+
+
+def is_claude_org_project(project: Optional[RegistryProject], claude_org_root: Path) -> bool:
+    """True iff the registered project resolves to the same dir as claude-org root."""
+    if project is None:
+        return False
+    if not project.path or project.path == "-" or "://" in project.path:
+        return False
+    try:
+        return Path(project.path).resolve() == claude_org_root.resolve()
+    except (OSError, RuntimeError):
+        return False
+
+
+def decide_role(
+    *,
+    mode: str,
+    project: Optional[RegistryProject],
+    claude_org_root: Path,
+) -> str:
+    if mode == "audit":
+        return "doc-audit"
+    if mode == "edit":
+        if is_claude_org_project(project, claude_org_root):
+            return "claude-org-self-edit"
+        return "default"
+    raise ResolveError(f"unknown mode: {mode!r} (expected one of {VALID_MODES})")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve(
+    *,
+    task_id: str,
+    project_slug: str,
+    targets: Optional[list[str]] = None,
+    description: str = "",
+    mode: str = "edit",
+    branch_override: Optional[str] = None,
+    registry_path: Optional[Path] = None,
+    state_db_path: Optional[Path] = None,
+    claude_org_root: Path,
+    workers_dir: Optional[Path] = None,
+) -> WorkerLayout:
+    """Resolve worker layout for one delegation. See module docstring."""
+    if not task_id:
+        raise ResolveError("task_id is required")
+    if not project_slug:
+        raise ResolveError("project_slug is required")
+    if mode not in VALID_MODES:
+        raise ResolveError(f"mode must be one of {VALID_MODES}, got {mode!r}")
+
+    targets = list(targets or [])
+    claude_org_root = Path(claude_org_root).resolve()
+    if registry_path is None:
+        registry_path = claude_org_root / "registry" / "projects.md"
+    if workers_dir is None:
+        workers_dir = resolve_workers_dir(claude_org_root)
+
+    # --- Project lookup ----------------------------------------------------
+    registry_text = ""
+    if registry_path.exists():
+        registry_text = registry_path.read_text(encoding="utf-8")
+    projects = parse_registry(registry_text)
+    project = find_project(projects, project_slug)
+
+    # --- Pattern decision --------------------------------------------------
+    pattern: str
+    variant: Optional[str]
+    worker_dir: Path
+
+    if project is None:
+        # Unknown project → Pattern C ephemeral.
+        pattern, variant = "C", "ephemeral"
+        worker_dir = workers_dir / task_id
+    elif is_local_git_repo(project.path) and any_target_is_gitignored(
+        project.path, targets
+    ):
+        # Step 0.7 gitignored sub-mode → Pattern C / variant=gitignored_repo_root.
+        pattern, variant = "C", "gitignored_repo_root"
+        worker_dir = Path(project.path).resolve()
+    else:
+        # state.db driven A vs B decision. If DB read fails (missing file,
+        # corrupt schema, etc.) we fall back to Pattern A — the safer default
+        # for "no concurrent work known". The dispatcher / Stage 3 apply step
+        # will re-validate before actually creating any worktree.
+        active = False
+        if state_db_path is not None and Path(state_db_path).exists():
+            try:
+                conn = db_connect(state_db_path)
+                try:
+                    active = project_has_active_run(conn, project_slug)
+                finally:
+                    conn.close()
+            except sqlite3.Error:
+                active = False
+        if active:
+            pattern, variant = "B", None
+            worker_dir = workers_dir / project_slug / ".worktrees" / task_id
+        else:
+            pattern, variant = "A", None
+            worker_dir = workers_dir / project_slug
+
+    worker_dir = worker_dir.resolve() if worker_dir.is_absolute() else worker_dir.resolve()
+
+    # --- Role decision -----------------------------------------------------
+    role = decide_role(mode=mode, project=project, claude_org_root=claude_org_root)
+    self_edit = role == "claude-org-self-edit"
+
+    # --- Branch decision ---------------------------------------------------
+    if pattern == "C":
+        # Pattern C ephemeral has no branch (no git); gitignored sub-mode
+        # runs against the repo root's existing branch and must not invent
+        # a new one (Codex M-2: planned_branch is a *suggestion*, not a
+        # commitment, and for Pattern C the suggestion is "don't").
+        planned_branch: Optional[str] = None
+    else:
+        planned_branch = branch_override or infer_branch(task_id, description)
+
+    # --- settings_args -----------------------------------------------------
+    settings_args = {
+        "role": role,
+        "worker-dir": str(worker_dir),
+        "claude-org-path": str(claude_org_root),
+        "out": str(worker_dir / ".claude" / "settings.local.json"),
+    }
+
+    return WorkerLayout(
+        pattern=pattern,
+        pattern_variant=variant,
+        worker_dir=str(worker_dir),
+        role=role,
+        self_edit=self_edit,
+        planned_branch=planned_branch,
+        settings_args=settings_args,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Resolve worker layout for a delegation (org-delegate Step 0.7/1/1.5 codified).",
+    )
+    p.add_argument("--task-id", required=True)
+    p.add_argument("--project-slug", required=True)
+    p.add_argument(
+        "--target",
+        action="append",
+        default=[],
+        help="Target file path for Step 0.7 gitignore check (repeatable).",
+    )
+    p.add_argument("--description", default="")
+    p.add_argument(
+        "--mode",
+        choices=VALID_MODES,
+        default="edit",
+        help="'edit' selects claude-org-self-edit or default; 'audit' forces doc-audit.",
+    )
+    p.add_argument("--branch", dest="branch_override", default=None,
+                   help="Override the inferred planned_branch.")
+    p.add_argument("--registry-path", default=None, type=Path)
+    p.add_argument("--state-db-path", default=None, type=Path)
+    p.add_argument("--claude-org-root", default=None, type=Path,
+                   help="Path to claude-org repo root (default: auto-detected).")
+    p.add_argument("--workers-dir", default=None, type=Path,
+                   help="Override workers_dir (default: read from registry/org-config.md).")
+    return p
+
+
+def _detect_claude_org_root() -> Path:
+    """Walk up from CWD until a registry/projects.md is found."""
+    here = Path.cwd().resolve()
+    for cand in (here, *here.parents):
+        if (cand / "registry" / "projects.md").exists() and (cand / ".state").exists():
+            return cand
+    # Fallback: just use CWD; resolve() will surface an error later.
+    return here
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    claude_org_root = args.claude_org_root or _detect_claude_org_root()
+    state_db_path = args.state_db_path
+    if state_db_path is None:
+        candidate = claude_org_root / ".state" / "state.db"
+        state_db_path = candidate if candidate.exists() else None
+    try:
+        layout = resolve(
+            task_id=args.task_id,
+            project_slug=args.project_slug,
+            targets=args.target,
+            description=args.description,
+            mode=args.mode,
+            branch_override=args.branch_override,
+            registry_path=args.registry_path,
+            state_db_path=state_db_path,
+            claude_org_root=claude_org_root,
+            workers_dir=args.workers_dir,
+        )
+    except ResolveError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    json.dump(layout.to_json_dict(), sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -295,5 +295,139 @@ class CLI(unittest.TestCase):
             self.assertFalse(out.exists())
 
 
+class FromTaskSubcommand(unittest.TestCase):
+    """``gen_worker_brief.py from-task ...`` (Issue #283 Stage 2).
+
+    Builds a config from registry+state.db (via resolve_worker_layout),
+    then renders the same template path as the legacy --config flow.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        td = Path(self._td.name)
+        # Shape a claude-org-like sandbox.
+        self.claude_org_root = td / "claude-org"
+        (self.claude_org_root / ".state").mkdir(parents=True)
+        (self.claude_org_root / "registry").mkdir()
+        (self.claude_org_root / "registry" / "org-config.md").write_text(
+            "## Workers Directory\nworkers_dir: ../workers\n",
+            encoding="utf-8",
+        )
+        (self.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| 時計アプリ | clock-app | - | Web 時計 | デザイン |\n"
+            f"| claude-org-ja | claude-org-ja | {self.claude_org_root} | Self | スキル改善 |\n",
+            encoding="utf-8",
+        )
+        # workers/ alongside claude-org per workers_dir: ../workers
+        (td / "workers").mkdir()
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _run(self, *extra: str) -> Path:
+        out = Path(self._td.name) / "CLAUDE.md"
+        argv = [
+            "from-task",
+            "--task-id", "demo-from-task",
+            "--project-slug", "clock-app",
+            "--description", "demo description for clock app",
+            "--claude-org-root", str(self.claude_org_root),
+            "--out", str(out),
+            *extra,
+        ]
+        rc = gwb.main(argv)
+        self.assertEqual(rc, 0)
+        return out
+
+    def test_from_task_renders_clock_app_brief(self):
+        out = self._run()
+        text = out.read_text(encoding="utf-8")
+        self.assertIn("demo-from-task", text)
+        self.assertIn("作業ディレクトリ", text)
+        # Pattern A → fresh clone path under ../workers/clock-app
+        self.assertIn("clock-app", text)
+        self.assertIn("feat(clock):", text)  # default scope from project_slug
+        # Not self-edit (clock-app is not claude-org)
+        self.assertNotIn("ルート CLAUDE.md", text)
+
+    def test_from_task_self_edit_auto_switches_to_local_md(self):
+        explicit_out = Path(self._td.name) / "CLAUDE.md"
+        rc = gwb.main([
+            "from-task",
+            "--task-id", "self-edit-demo",
+            "--project-slug", "claude-org-ja",
+            "--description", "edit a doc in claude-org",
+            "--commit-prefix", "feat(secretary):",
+            "--claude-org-root", str(self.claude_org_root),
+            "--out", str(explicit_out),
+        ])
+        self.assertEqual(rc, 0)
+        self.assertFalse(explicit_out.exists(), "CLAUDE.md should be skipped")
+        switched = explicit_out.with_name("CLAUDE.local.md")
+        self.assertTrue(switched.exists(), "should auto-switch to .local.md")
+        text = switched.read_text(encoding="utf-8")
+        self.assertIn("Secretary 指示は無視せよ", text)
+        self.assertIn("feat(secretary):", text)
+
+    def test_from_task_unknown_slug_falls_back_to_pattern_c(self):
+        # Unregistered slug → Pattern C ephemeral, role=default. Brief still
+        # renders because we provide sensible defaults for project.name /
+        # project.description.
+        out = self._run(
+            "--project-slug", "completely-new-slug",
+            "--description", "ad-hoc investigation",
+        )
+        text = out.read_text(encoding="utf-8")
+        self.assertIn("demo-from-task", text)
+        # Pattern C → no commit_prefix override needed; default scope from slug
+        self.assertIn("feat(completely):", text)
+
+    def test_from_task_writes_audit_toml_when_requested(self):
+        toml_path = Path(self._td.name) / "audit.toml"
+        self._run("--write-toml", str(toml_path))
+        self.assertTrue(toml_path.exists())
+        body = toml_path.read_text(encoding="utf-8")
+        self.assertIn("[task]", body)
+        self.assertIn('id = "demo-from-task"', body)
+        self.assertIn("[worker]", body)
+        self.assertIn('pattern = "A"', body)
+
+    def test_from_task_carries_implementation_and_references(self):
+        out = self._run(
+            "--impl-target", "src/foo.py",
+            "--impl-target", "src/bar.py",
+            "--impl-guidance", "step 1, step 2",
+            "--knowledge", "knowledge/curated/notes.md",
+            "--issue-url", "https://example.com/issues/9",
+            "--closes-issue", "9",
+        )
+        text = out.read_text(encoding="utf-8")
+        self.assertIn("実装ガイダンス", text)
+        self.assertIn("src/foo.py", text)
+        self.assertIn("src/bar.py", text)
+        self.assertIn("step 1, step 2", text)
+        self.assertIn("knowledge/curated/notes.md", text)
+        self.assertIn("Closes #9", text)
+        self.assertIn("https://example.com/issues/9", text)
+
+
+class LegacyCLIPreserved(unittest.TestCase):
+    """Stage 2 must not break the legacy --config / --out invocation."""
+
+    def test_main_dispatches_legacy_when_no_subcommand(self):
+        # Reuses the existing example.toml round-trip — equivalent to the
+        # original CLI test; this just re-asserts main() routes correctly
+        # after the from-task addition.
+        example = Path(__file__).parent / "templates" / "worker_brief.example.toml"
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "CLAUDE.local.md"
+            rc = gwb.main(["--config", str(example), "--out", str(out)])
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.exists())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements Issue #283 (post-Codex-design-review scope). The Secretary's DELEGATE flow becomes "write 1 TOML or pass 1 set of CLI args, run `gen_delegate_payload preview`, inspect, then `apply`" instead of "hand-write TOML + 4 CLI calls + hand-typed DELEGATE message body".

6 commits, +2992 / -227 lines. All 322 tests green (84 new + 238 existing). `drift_check`, `check_role_configs.py`, `check_runtime_schema_drift.py`, and the renga-compat suite all pass.

## Stages and commits

- `a408c3b` **Stage 1** — `tools/resolve_worker_layout.py` (library-first, deterministic resolver). 20 tests cover Pattern A/B/C and the gitignored-repo-root variant, all 3 roles, `planned_branch` inference, the `--mode edit|audit` flag, and the `runs JOIN worker_dirs` query path so the resolver respects the lifecycle contract.
- `dd83a33` **Stage 2** — `gen_worker_brief from-task` subcommand. 6 tests cover legacy `--config/--out` preservation, automatic `CLAUDE.local.md` switch on `self_edit=true`, and the opt-in `--write-toml` audit path.
- `e30f64f` **Stage 3** — `tools/gen_delegate_payload.py` with explicit `preview`/`apply` subcommands. 15 tests cover preview as fully non-destructive, apply reserving via `runs.status='queued'` (no Active Work Items writes), and 5 snapshot/golden DELEGATE bodies covering pattern × role × variant.
- `4ccbf80` **Stage 4** — `org-delegate` SKILL.md compressed from 745 → 524 lines. Steps 1 / 1.5 / 2 collapse to "run `gen_delegate_payload preview` → inspect → `apply` → call `mcp__renga-peers__send_message` with `send_plan.json`". Step 0 (project name resolution) and Step 0.5 (work-skill discovery) are retained as human-judgment steps. Pattern judgment and role detail tables move to the new `references/delegate-flow-details.md`. Legacy TOML-driven path is preserved with a note.
- `16ac892` **Codex Round 1 fixups** — sys.path bootstrap blocker, `project.name=slug` correction, TOML round-trip preservation of `mode`/`depth`, additional gitignored + doc-audit golden snapshots.
- `ceb5b6d` **Codex Round 2 fixups** — drop `--project-name` flag (it caused round-trip drift), make `--help` CP932-safe.

## Scope correction (per Codex design review)

- **B-1**: Active Work Items writes belong to Dispatcher's T2 responsibility (`docs/contracts/delegation-lifecycle-contract.md`). This PR does **not** write Active Work Items; it only writes a `runs.status='queued'` reservation. The test `test_apply_does_not_write_active_work_items` guards this contract.
- **B-2**: Resolver uses `runs JOIN worker_dirs` (via `list_runs_with_dirs`) so active state is read through the same lifecycle predicate Dispatcher uses.

## Codex design review (3 rounds, terminated LGTM)

- 2 Blockers (B-1, B-2) — both addressed in initial implementation per scope correction.
- 5 Majors (M-1 pattern_variant, M-2 planned_branch, M-3 preview/apply split, M-4 --mode flag, M-5 keep Step 0/0.5) — all addressed in `a408c3b`/`dd83a33`/`e30f64f`/`4ccbf80`.
- 1 Minor (Mi-1 shared registry parser) — addressed via TODO(#286) comment in the local parser; immediate follow-up Issue is #286.

## Before / after — concrete incident this prevents

PR #233 had a push-permission mismatch: the DELEGATE instruction asked the worker to push, but the generated `settings.local.json` denied it (`block-git-push.sh` hook), so the worker stalled at commit time. The mismatch happened because the instruction body and the settings file were composed by hand in two separate steps and drifted.

After this PR: `gen_delegate_payload preview` builds the DELEGATE body and the `settings_args` together from a single `resolve_worker_layout` output. The role's allowed actions and the instruction's expected actions come from the same source. The same incident class is no longer reachable via the supported path.

## Follow-up

- **#286** — extract a shared `tools/registry_parser` module so the resolver, `dashboard/server.py:_parse_projects`, and the state-DB importer stop maintaining three separate parsers. Resolver's local parser carries a `TODO(#286)` comment. This Issue should land in the next iteration.
- **#284** — integrate JSON snapshot regeneration and worker-state archival into the `StateWriter` post-commit hook. Independent of this PR but operationally important.
- **#285** — extract dispatcher's completion-report polling loop into `tools/dispatcher_retro_gate.py`. Sequenced after this PR.

## Test plan

- [x] `pytest tests/ tools/` — 322 passed
- [x] `python tools/check_role_configs.py` — OK
- [x] `python -m tools.state_db.drift_check` — exit 0
- [x] `python tools/check_runtime_schema_drift.py` — OK
- [ ] CI on this PR
- [ ] Manual: dispatch a Pattern B self-edit worker via `gen_delegate_payload preview` then `apply`, confirm DELEGATE body matches the snapshot and the `runs.status='queued'` row appears.

Closes #283.