### PR TITLE
refactor(registry): unify projects.md parser into tools/registry_parser

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -35,7 +35,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from tools.registry_parser import parse_projects as _parse_projects_shared
+from tools.registry_parser import parse_projects_text as _parse_projects_shared
 from tools.state_db import connect as _db_connect
 from tools.state_db.queries import (
     get_org_state_summary as _db_org_state_summary,

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -35,6 +35,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from tools.registry_parser import parse_projects as _parse_projects_shared
 from tools.state_db import connect as _db_connect
 from tools.state_db.queries import (
     get_org_state_summary as _db_org_state_summary,
@@ -64,27 +65,18 @@ def _read(path, default=""):
 
 
 def _parse_projects(text):
-    projects = []
-    in_table = False
-    for line in text.splitlines():
-        if line.startswith("|---") or line.startswith("| ---"):
-            in_table = True
-            continue
-        if not in_table:
-            continue
-        if not line.startswith("|"):
-            continue
-        cols = [c.strip() for c in line.strip("|").split("|")]
-        if len(cols) >= 4:
-            tasks = [t.strip() for t in cols[4].split("、")] if len(cols) >= 5 else []
-            tasks = [t for t in tasks if t and t != "-"]
-            projects.append({
-                "name": cols[0],
-                "path": cols[2] if len(cols) > 2 else "",
-                "description": cols[3] if len(cols) > 3 else "",
-                "tasks": tasks,
-            })
-    return projects
+    return [
+        {
+            "name": p.nickname,
+            "path": p.path,
+            "description": p.description,
+            "tasks": [
+                t for t in (s.strip() for s in p.common_tasks.split("、"))
+                if t and t != "-"
+            ],
+        }
+        for p in _parse_projects_shared(text)
+    ]
 
 
 def _parse_workers(workers_dir):

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -1,0 +1,122 @@
+"""Tests for the shared registry/projects.md parser (Issue #286)."""
+
+import logging
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.registry_parser import (  # noqa: E402
+    Project,
+    iter_rows,
+    parse_projects,
+)
+
+
+HEADER = "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |"
+SEPARATOR = "|---|---|---|---|---|"
+
+
+def _build(*body_lines: str, intro: str = "# Projects Registry\n\n") -> str:
+    return intro + HEADER + "\n" + SEPARATOR + "\n" + "\n".join(body_lines) + "\n"
+
+
+class TestParseProjects(unittest.TestCase):
+
+    def test_real_registry_fixture(self):
+        path = PROJECT_ROOT / "registry" / "projects.md"
+        projects = parse_projects(path)
+        # The actual checked-in registry has at least the 3 well-known
+        # projects (clock-app, renga, claude-org-ja).
+        names = [p.name for p in projects]
+        self.assertIn("clock-app", names)
+        self.assertIn("renga", names)
+        self.assertIn("claude-org-ja", names)
+        # All rows are fully populated Project instances.
+        for p in projects:
+            self.assertIsInstance(p, Project)
+            self.assertTrue(p.nickname)
+            self.assertTrue(p.name)
+
+    def test_happy_path(self):
+        text = _build(
+            "| 時計アプリ | clock-app | apps/clock | demo clock | a、b |",
+            "| ブログ | blog-site | sites/blog | blog | c |",
+        )
+        projects = parse_projects(text)
+        self.assertEqual(len(projects), 2)
+        self.assertEqual(projects[0].nickname, "時計アプリ")
+        self.assertEqual(projects[0].name, "clock-app")
+        self.assertEqual(projects[0].path, "apps/clock")
+        self.assertEqual(projects[0].common_tasks, "a、b")
+        self.assertEqual(projects[1].name, "blog-site")
+
+    def test_no_trailing_newline(self):
+        text = _build("| n | slug | / | d | t |").rstrip("\n")
+        self.assertEqual(parse_projects(text)[0].name, "slug")
+
+    def test_crlf_line_endings(self):
+        text = _build("| n | slug | / | d | t |").replace("\n", "\r\n")
+        projects = parse_projects(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].name, "slug")
+
+    def test_bom_prefix(self):
+        text = "﻿" + _build("| n | slug | / | d | t |")
+        projects = parse_projects(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].name, "slug")
+
+    def test_malformed_row_graceful_skip(self):
+        text = _build(
+            "| n | slug | / | d | t |",
+            "| only | three | cols |",  # too few cells
+            "| n2 | slug2 | / | d2 | t2 |",
+        )
+        with self.assertLogs("tools.registry_parser", level="WARNING") as cm:
+            projects = parse_projects(text)
+        self.assertEqual([p.name for p in projects], ["slug", "slug2"])
+        self.assertTrue(any("malformed row" in m for m in cm.output))
+
+    def test_empty_text(self):
+        self.assertEqual(parse_projects(""), [])
+
+    def test_header_only_no_data(self):
+        text = HEADER + "\n" + SEPARATOR + "\n"
+        self.assertEqual(parse_projects(text), [])
+
+    def test_empty_optional_fifth_column(self):
+        text = _build("| n | slug | / | d |  |")
+        projects = parse_projects(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].common_tasks, "")
+
+    def test_accepts_path_input(self):
+        path = PROJECT_ROOT / "tests" / "fixtures" / "projects-sample.md"
+        projects = parse_projects(path)
+        names = [p.name for p in projects]
+        self.assertIn("clock-app", names)
+        self.assertIn("blog-site", names)
+
+
+class TestIterRows(unittest.TestCase):
+
+    def test_classifies_lines(self):
+        text = _build(
+            "| n | slug | / | d | t |",
+            "| only | three |",
+        )
+        kinds = [r.kind for r in iter_rows(text)]
+        # intro + blank + header + separator + data + mismatch
+        self.assertIn("header", kinds)
+        self.assertIn("separator", kinds)
+        self.assertIn("data", kinds)
+        self.assertIn("mismatch", kinds)
+        self.assertIn("non_table", kinds)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    logging.basicConfig(level=logging.WARNING)
+    unittest.main()

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -12,7 +12,12 @@ from tools.registry_parser import (  # noqa: E402
     Project,
     iter_rows,
     parse_projects,
+    parse_projects_text,
 )
+
+
+def parse(text: str):  # convenience for in-memory tests
+    return parse_projects_text(text)
 
 
 HEADER = "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |"
@@ -45,7 +50,7 @@ class TestParseProjects(unittest.TestCase):
             "| 時計アプリ | clock-app | apps/clock | demo clock | a、b |",
             "| ブログ | blog-site | sites/blog | blog | c |",
         )
-        projects = parse_projects(text)
+        projects = parse_projects_text(text)
         self.assertEqual(len(projects), 2)
         self.assertEqual(projects[0].nickname, "時計アプリ")
         self.assertEqual(projects[0].name, "clock-app")
@@ -55,17 +60,17 @@ class TestParseProjects(unittest.TestCase):
 
     def test_no_trailing_newline(self):
         text = _build("| n | slug | / | d | t |").rstrip("\n")
-        self.assertEqual(parse_projects(text)[0].name, "slug")
+        self.assertEqual(parse_projects_text(text)[0].name, "slug")
 
     def test_crlf_line_endings(self):
         text = _build("| n | slug | / | d | t |").replace("\n", "\r\n")
-        projects = parse_projects(text)
+        projects = parse_projects_text(text)
         self.assertEqual(len(projects), 1)
         self.assertEqual(projects[0].name, "slug")
 
     def test_bom_prefix(self):
         text = "﻿" + _build("| n | slug | / | d | t |")
-        projects = parse_projects(text)
+        projects = parse_projects_text(text)
         self.assertEqual(len(projects), 1)
         self.assertEqual(projects[0].name, "slug")
 
@@ -76,20 +81,34 @@ class TestParseProjects(unittest.TestCase):
             "| n2 | slug2 | / | d2 | t2 |",
         )
         with self.assertLogs("tools.registry_parser", level="WARNING") as cm:
-            projects = parse_projects(text)
+            projects = parse_projects_text(text)
         self.assertEqual([p.name for p in projects], ["slug", "slug2"])
         self.assertTrue(any("malformed row" in m for m in cm.output))
 
     def test_empty_text(self):
-        self.assertEqual(parse_projects(""), [])
+        self.assertEqual(parse_projects_text(""), [])
 
     def test_header_only_no_data(self):
         text = HEADER + "\n" + SEPARATOR + "\n"
-        self.assertEqual(parse_projects(text), [])
+        self.assertEqual(parse_projects_text(text), [])
+
+    def test_four_column_table_still_parses(self):
+        # Regression for Codex review M: the legacy resolver accepted 4-col
+        # tables (no 「よくある作業例」 column). Hand-edited registries in the
+        # wild may omit the 5th column; we must not silently drop them.
+        text = (
+            "| 通称 | プロジェクト名 | パス | 説明 |\n"
+            "|---|---|---|---|\n"
+            "| 時計 | clock-app | - | Demo |\n"
+        )
+        projects = parse_projects_text(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].name, "clock-app")
+        self.assertEqual(projects[0].common_tasks, "")
 
     def test_empty_optional_fifth_column(self):
         text = _build("| n | slug | / | d |  |")
-        projects = parse_projects(text)
+        projects = parse_projects_text(text)
         self.assertEqual(len(projects), 1)
         self.assertEqual(projects[0].common_tasks, "")
 

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -249,7 +249,7 @@ def build_delegate_plan(
         Path(claude_org_root) / "registry" / "projects.md"
     )
     if registry_for_meta.exists():
-        rows = rwl.parse_registry(registry_for_meta.read_text(encoding="utf-8"))
+        rows = rwl.parse_projects(registry_for_meta)
         match = rwl.find_project(rows, project_slug)
         if match is not None:
             project_path = match.path

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -362,14 +362,12 @@ def build_config_from_task(
     project_name = project_slug
     project_description = project_description_override or ""
     if registry_for_meta.exists():
-        rows = rwl.parse_registry(
-            registry_for_meta.read_text(encoding="utf-8")
-        )
+        rows = rwl.parse_projects(registry_for_meta)
         match = rwl.find_project(rows, project_slug)
         if match is not None and not project_description_override:
-            common = match.common_name or match.slug
+            common = match.nickname or match.name
             base_desc = match.description or ""
-            if common and common != match.slug:
+            if common and common != match.name:
                 project_description = (
                     f"{common} - {base_desc}" if base_desc else common
                 )

--- a/tools/registry_parser.py
+++ b/tools/registry_parser.py
@@ -1,0 +1,133 @@
+"""Shared parser for ``registry/projects.md``.
+
+Single source of truth for the markdown-table parsing previously
+duplicated across:
+
+- ``dashboard/server.py:_parse_projects``
+- ``tools/state_db/importer.py``
+- ``tools/resolve_worker_layout.py`` (Issue #283 minimal parser)
+
+The parser handles BOM, CRLF, missing trailing newline, leading prose,
+and gracefully skips malformed rows (logs a warning instead of raising).
+
+Two entry points:
+
+- :func:`parse_projects` — convenience API returning only the successfully
+  parsed :class:`Project` rows. Use this from regular consumers.
+- :func:`iter_rows` — per-line classification for callers (importer) that
+  need to record unparsed rows in their own bookkeeping.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+# The projects table is a fixed-width 5-column shape.
+COLUMN_COUNT = 5
+
+# Header rows (above the |---| separator) sometimes literally contain these
+# words in the second column. Catch them when the separator is missing or
+# malformed so we never mis-emit the table header as a Project row.
+_HEADER_KEYWORDS = frozenset({"プロジェクト名", "name", "project"})
+
+_SEPARATOR_RE = re.compile(r"^\|[\s\-:|]+\|\s*$")
+
+
+@dataclass(frozen=True)
+class Project:
+    """One row of ``registry/projects.md``."""
+
+    nickname: str       # 通称
+    name: str           # プロジェクト名 (slug)
+    path: str           # URL, local path, or '-'
+    description: str
+    common_tasks: str   # 「よくある作業例」 raw column value (may be empty)
+
+
+# Per-line classification. ``kind`` values:
+#   'data'      — a successfully parsed Project row (``project`` populated)
+#   'separator' — Markdown table separator (``|---|---|...|``)
+#   'header'    — Markdown table header row (above the separator)
+#   'mismatch'  — line starts with '|' but doesn't conform to the schema
+#   'non_table' — line outside any table (prose, blank, etc.)
+@dataclass(frozen=True)
+class ParsedRow:
+    line_no: int
+    raw: str
+    kind: str
+    project: Optional[Project] = None
+
+
+def _split_cells(line: str) -> list[str]:
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def iter_rows(text: str) -> Iterator[ParsedRow]:
+    """Yield a :class:`ParsedRow` for every line in ``text``.
+
+    Lines outside any table are emitted as ``kind='non_table'`` so callers
+    can iterate the file once and drive their own bookkeeping.
+    """
+    text = text.lstrip("﻿")
+    in_table = False
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        stripped = raw_line.rstrip()
+        if not stripped.startswith("|"):
+            in_table = False
+            yield ParsedRow(line_no, raw_line, "non_table")
+            continue
+        if _SEPARATOR_RE.match(stripped):
+            in_table = True
+            yield ParsedRow(line_no, raw_line, "separator")
+            continue
+        cells = _split_cells(stripped)
+        is_header_keyword = (
+            len(cells) >= 2 and cells[1].lower() in _HEADER_KEYWORDS
+        )
+        if not in_table or is_header_keyword:
+            # Header row (above the separator, or a stray repeat header).
+            yield ParsedRow(line_no, raw_line, "header")
+            continue
+        # Schema check: exactly 5 cells, and the machine slug column must be
+        # populated. Other columns are allowed to be empty so authors can omit
+        # description / common_tasks for early-stage entries (matches the
+        # legacy resolver's tolerant parse).
+        if len(cells) != COLUMN_COUNT or not cells[1]:
+            yield ParsedRow(line_no, raw_line, "mismatch")
+            continue
+        project = Project(
+            nickname=cells[0],
+            name=cells[1],
+            path=cells[2],
+            description=cells[3],
+            common_tasks=cells[4],
+        )
+        yield ParsedRow(line_no, raw_line, "data", project)
+
+
+def parse_projects(source: Union[str, Path]) -> list[Project]:
+    """Return successfully parsed :class:`Project` rows from ``source``.
+
+    ``source`` may be either the raw markdown text or a path-like object
+    pointing at ``registry/projects.md``. Malformed rows are skipped with a
+    warning log; this function never raises on parsing errors.
+    """
+    if isinstance(source, (str, bytes)):
+        text = source.decode("utf-8") if isinstance(source, bytes) else source
+    else:
+        text = Path(source).read_text(encoding="utf-8")
+    out: list[Project] = []
+    for row in iter_rows(text):
+        if row.kind == "data" and row.project is not None:
+            out.append(row.project)
+        elif row.kind == "mismatch":
+            logger.warning(
+                "registry_parser: skipping malformed row at line %d: %r",
+                row.line_no, row.raw,
+            )
+    return out

--- a/tools/registry_parser.py
+++ b/tools/registry_parser.py
@@ -93,11 +93,11 @@ def iter_rows(text: str) -> Iterator[ParsedRow]:
             # Header row (above the separator, or a stray repeat header).
             yield ParsedRow(line_no, raw_line, "header")
             continue
-        # Schema check: exactly 5 cells, and the machine slug column must be
-        # populated. Other columns are allowed to be empty so authors can omit
-        # description / common_tasks for early-stage entries (matches the
-        # legacy resolver's tolerant parse).
-        if len(cells) != COLUMN_COUNT or not cells[1]:
+        # Schema check: at least 4 cells (通称/slug/パス/説明) and the slug
+        # column populated. The 5th 「よくある作業例」 column is optional —
+        # the legacy resolver accepted 4-column tables so dropping them here
+        # would silently break manually-edited registries (Codex review M).
+        if len(cells) < 4 or not cells[1]:
             yield ParsedRow(line_no, raw_line, "mismatch")
             continue
         project = Project(
@@ -105,22 +105,24 @@ def iter_rows(text: str) -> Iterator[ParsedRow]:
             name=cells[1],
             path=cells[2],
             description=cells[3],
-            common_tasks=cells[4],
+            common_tasks=cells[4] if len(cells) >= COLUMN_COUNT else "",
         )
         yield ParsedRow(line_no, raw_line, "data", project)
 
 
-def parse_projects(source: Union[str, Path]) -> list[Project]:
-    """Return successfully parsed :class:`Project` rows from ``source``.
+def parse_projects(path: Union[str, Path]) -> list[Project]:
+    """Return successfully parsed :class:`Project` rows from a file path.
 
-    ``source`` may be either the raw markdown text or a path-like object
-    pointing at ``registry/projects.md``. Malformed rows are skipped with a
-    warning log; this function never raises on parsing errors.
+    ``path`` is always treated as a filesystem path (``str | Path``).
+    Callers that already have the markdown text in memory should use
+    :func:`parse_projects_text` instead.
     """
-    if isinstance(source, (str, bytes)):
-        text = source.decode("utf-8") if isinstance(source, bytes) else source
-    else:
-        text = Path(source).read_text(encoding="utf-8")
+    return parse_projects_text(Path(path).read_text(encoding="utf-8"))
+
+
+def parse_projects_text(text: str) -> list[Project]:
+    """Parse already-loaded markdown text. Malformed rows are skipped with
+    a warning; this function never raises on parsing errors."""
     out: list[Project] = []
     for row in iter_rows(text):
         if row.kind == "data" and row.project is not None:

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -66,6 +66,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from tools.registry_parser import Project as RegistryProject, parse_projects
 from tools.state_db import connect as db_connect
 from tools.state_db.queries import list_runs_with_dirs
 
@@ -90,15 +91,11 @@ _FIX_TRIGGERS = ("fix", "bug", "修正", "hotfix", "patch")
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class RegistryProject:
-    """Single row of registry/projects.md, for resolver-internal use."""
-    common_name: str        # 通称
-    slug: str               # プロジェクト名 (machine slug)
-    path: str               # local abs path, URL, or '-'
-    description: str
+#
+# ``RegistryProject`` is re-exported from :mod:`tools.registry_parser` so
+# downstream callers keep working without churn; the shared dataclass uses
+# ``name`` (slug) / ``nickname`` (通称) instead of the legacy ``slug`` /
+# ``common_name`` field names.
 
 
 @dataclass(frozen=True)
@@ -128,68 +125,13 @@ class ResolveError(ValueError):
 
 
 # ---------------------------------------------------------------------------
-# registry/projects.md parser
+# registry/projects.md lookup
 # ---------------------------------------------------------------------------
-#
-# TODO(#286): replace the ad-hoc parser below with the shared parser from
-# tools/registry_parser when Issue #286 lands. dashboard/server.py and
-# tools/state_db/importer.py have their own parsers today; #286 extracts a
-# single SoT module that all three call. Until then this resolver carries
-# the third (intentionally minimal) implementation, and we accept the drift
-# risk for the duration of one PR.
-
-_TABLE_SEP_RE = re.compile(r"^\|[\s\-:|]+\|\s*$")
-
-
-def parse_registry(text: str) -> list[RegistryProject]:
-    """Parse the markdown table in registry/projects.md.
-
-    Tolerates leading prose / multiple tables. Returns rows with at
-    least 4 columns (通称 / プロジェクト名 / パス / 説明). The 5th
-    column ('よくある作業例') is dropped — resolver doesn't use it.
-    """
-    rows: list[RegistryProject] = []
-    in_table = False
-    header_seen = False
-    for raw in text.splitlines():
-        line = raw.rstrip()
-        if _TABLE_SEP_RE.match(line):
-            in_table = True
-            header_seen = True
-            continue
-        if not in_table:
-            # Header line that precedes the |---| separator — capture so
-            # malformed tables (separator missing) still don't accidentally
-            # parse.  We only flip in_table on the separator.
-            if line.startswith("|"):
-                header_seen = True
-            continue
-        if not line.startswith("|"):
-            # blank line or end-of-table prose
-            in_table = False
-            continue
-        cols = [c.strip() for c in line.strip("|").split("|")]
-        if len(cols) < 4:
-            continue
-        common_name, slug, path, description = cols[0], cols[1], cols[2], cols[3]
-        if not slug:
-            continue
-        rows.append(
-            RegistryProject(
-                common_name=common_name,
-                slug=slug,
-                path=path,
-                description=description,
-            )
-        )
-    if not header_seen:
-        return []
-    return rows
 
 
 def find_project(rows: Iterable[RegistryProject], slug: str) -> Optional[RegistryProject]:
     for r in rows:
-        if r.slug == slug:
+        if r.name == slug:
             return r
     return None
 
@@ -361,10 +303,10 @@ def resolve(
         workers_dir = resolve_workers_dir(claude_org_root)
 
     # --- Project lookup ----------------------------------------------------
-    registry_text = ""
     if registry_path.exists():
-        registry_text = registry_path.read_text(encoding="utf-8")
-    projects = parse_registry(registry_text)
+        projects = parse_projects(registry_path)
+    else:
+        projects = []
     project = find_project(projects, project_slug)
 
     # --- Pattern decision --------------------------------------------------

--- a/tools/state_db/importer.py
+++ b/tools/state_db/importer.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Iterable, Optional
 
+from tools.registry_parser import iter_rows as _iter_registry_rows
+
 from . import apply_schema, connect
 
 
@@ -189,43 +191,37 @@ class _Importer:
 
     # -- registry/projects.md --------------------------------------------
 
-    _PROJ_ROW_RE = re.compile(r"^\|([^|]+)\|([^|]+)\|([^|]+)\|([^|]+)\|([^|]*)\|\s*$")
+    # Reason strings recorded against ``unparsed_legacy`` for non-data lines.
+    # Kept as constants so the dump_signature contract (M0 DoD: every input
+    # line accounted for) is auditable from one place.
+    _UNPARSED_REASONS = {
+        "separator": "table separator",
+        "header": "header row",
+        "mismatch": "row regex mismatch",
+    }
 
     def import_projects_md(self, path: Path) -> None:
         if not path or not path.exists():
             return
         text = path.read_text(encoding="utf-8")
-        in_table = False
-        for i, raw_line in enumerate(text.splitlines(), start=1):
-            line = raw_line.rstrip()
-            if not line.startswith("|"):
-                in_table = False
+        for row in _iter_registry_rows(text):
+            if row.kind == "non_table":
                 continue
             self.summary.input_lines_total += 1
-            # separator row → record so the line is accounted for.
-            if re.match(r"^\|\s*-+", line):
-                in_table = True
-                self._record_unparsed("projects.md", i, raw_line,
-                                       "table separator")
-                continue
-            m = self._PROJ_ROW_RE.match(line)
-            if not m:
-                self._record_unparsed("projects.md", i, raw_line,
-                                       "row regex mismatch")
-                continue
-            cells = [c.strip() for c in m.groups()]
-            common, project_slug, src, desc, _examples = cells
-            if not in_table or project_slug.lower() in ("プロジェクト名", "name", "project"):
-                # header row — keep counted but mark as schema row
-                self._record_unparsed("projects.md", i, raw_line, "header row")
-                continue
-            origin_url = src if src.startswith("http") else None
-            self._ensure_project(
-                project_slug,
-                display_name=common or project_slug,
-                origin_url=origin_url,
-                notes=desc or None,
-            )
+            if row.kind == "data" and row.project is not None:
+                proj = row.project
+                origin_url = proj.path if proj.path.startswith("http") else None
+                self._ensure_project(
+                    proj.name,
+                    display_name=proj.nickname or proj.name,
+                    origin_url=origin_url,
+                    notes=proj.description or None,
+                )
+            else:
+                self._record_unparsed(
+                    "projects.md", row.line_no, row.raw,
+                    self._UNPARSED_REASONS[row.kind],
+                )
 
     # -- inventory.json ---------------------------------------------------
 


### PR DESCRIPTION
## Summary

Immediate follow-up to PR #288 (Issue #283). Closes #286.

Extracts `registry/projects.md` parsing into a single shared module (`tools/registry_parser.py`) and routes the three existing call sites through it. Removes the `TODO(#286)` placeholder parser left in `tools/resolve_worker_layout.py`.

## Behavioral compatibility

The state-DB importer's `dump_signature` is byte-identical pre/post (`919952e3d75a34b3cc3a532456addbd420427e3feba58f85328debabd4512d33`) for the current `registry/projects.md` (3 projects, 2 unparsed legacy entries), so the importer's effect on the DB is unchanged.

## Changes

- **New**: `tools/registry_parser.py` — `Project` dataclass plus `parse_projects(path)`, `parse_projects_text(text)`, `iter_rows(text)` API.
- **New**: `tests/test_registry_parser.py` — 12 cases: happy path, BOM, CRLF, missing trailing newline, 4-column legacy table compatibility, malformed-row graceful skip, empty file, header-only, 5-column with empty cell, str/Path input.
- **Replaced**: `dashboard/server.py:_parse_projects` is now a 6-line wrapper around the shared parser; HTTP routing is unchanged.
- **Replaced**: `tools/state_db/importer.py` drops `_PROJ_ROW_RE` and reads via `iter_rows`.
- **Replaced**: `tools/resolve_worker_layout.py` drops its local `parse_registry`/`RegistryProject` and reuses the shared parser. The `TODO(#286)` comment is removed.
- **Replaced**: `tools/gen_worker_brief.py` and `tools/gen_delegate_payload.py` migrate from `rwl.parse_registry` / `.slug` / `.common_name` to `rwl.parse_projects` / `.name` / `.nickname`.

## Codex self-review (2 rounds, terminated LGTM)

- Round 1 — Major: parser rejected legacy 4-column tables that omit the trailing "common tasks" column. Fixed in `c7af113`. Minor: `parse_projects` accepted `str | Path`; the test fixtures used both. Tightened the API doc.
- Round 2 — no Blocker / Major / Minor / Nit.

## Test plan

- [x] `pytest` — 333 passed, 1 skipped (baseline 322 + 12 new - 1 unrelated skip).
- [x] importer `dump_signature` matches pre/post for the live `registry/projects.md`.
- [ ] `python tools/check_role_configs.py` — to be confirmed by CI.
- [ ] `python -m tools.state_db.drift_check` — to be confirmed by CI.
- [ ] CI on this PR.

## Note (out of scope)

`tests/test_parsers.py::TestBuildStateLiveWorkers::test_review_workers_stay_visible_and_archived_disappear` is flaky when run in isolation because it patches only `BASE_DIR` and not `STATE_DB_PATH`. This is unrelated to the parser refactor and passes when the full suite is run in order. Tracking separately is advisable but outside this PR's scope.

Closes #286.
Refs #283, PR #288.