### PR TITLE
fix(secretary): honor TOML [worker] / [paths] in gen_delegate_payload --from-toml

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -517,6 +517,157 @@ class TestFromTomlRoundTrip(unittest.TestCase):
         self.assertEqual(kwargs["verification_depth"], "full")
 
 
+# ---------------------------------------------------------------------------
+# Issue #290 regression tests — TOML [worker] / [paths] honor + encoding
+# ---------------------------------------------------------------------------
+
+
+class TestIssue290Regressions(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _write_toml(self, path: Path, body: str) -> None:
+        path.write_text(body, encoding="utf-8")
+
+    def _run_preview_json(self, argv: list[str]) -> dict:
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main(["preview", *argv, "--json"])
+        self.assertEqual(rc, 0)
+        return json.loads(buf.getvalue())
+
+    def test_290_a_worker_block_overrides_resolver(self):
+        """TOML [worker] pattern/role/self_edit/dir survive into the layout
+        summary instead of being recomputed by the resolver."""
+        explicit_dir = self.sb.root / "explicit-worker-dir"
+        toml = self.sb.root / "in.toml"
+        self._write_toml(
+            toml,
+            "[task]\n"
+            'id = "t-290a"\n'
+            'description = "honor worker block"\n'
+            "\n[worker]\n"
+            f'dir = "{explicit_dir.as_posix()}"\n'
+            'pattern = "B"\n'
+            'role = "claude-org-self-edit"\n'
+            "self_edit = true\n"
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{self.sb.claude_org_root.as_posix()}"\n',
+        )
+        data = self._run_preview_json([
+            "--from-toml", str(toml),
+            "--state-db-path", str(self.sb.db_path),
+        ])
+        s = data["summary"]
+        self.assertEqual(s["pattern"], "B")
+        self.assertEqual(s["role"], "claude-org-self-edit")
+        self.assertTrue(s["self_edit"])
+        self.assertEqual(
+            Path(s["worker_dir"]).resolve(), explicit_dir.resolve()
+        )
+        # settings_args picks up the overridden role + worker_dir.
+        self.assertEqual(s["settings_args"]["role"], "claude-org-self-edit")
+        self.assertEqual(
+            Path(s["settings_args"]["worker-dir"]).resolve(),
+            explicit_dir.resolve(),
+        )
+
+    def test_290_b_paths_claude_org_flows_into_settings_args(self):
+        """[paths] claude_org from TOML lands in settings_args.claude-org-path
+        when no CLI override is supplied (no more cwd-derived drift)."""
+        toml = self.sb.root / "in.toml"
+        self._write_toml(
+            toml,
+            "[task]\n"
+            'id = "t-290b"\n'
+            'description = "paths.claude_org honored"\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{self.sb.claude_org_root.as_posix()}"\n',
+        )
+        # Intentionally no --claude-org-root.
+        data = self._run_preview_json([
+            "--from-toml", str(toml),
+            "--state-db-path", str(self.sb.db_path),
+        ])
+        self.assertEqual(
+            Path(data["summary"]["settings_args"]["claude-org-path"]).resolve(),
+            self.sb.claude_org_root.resolve(),
+        )
+
+    def test_290_c_cli_claude_org_root_overrides_toml_paths(self):
+        """CLI --claude-org-root wins over [paths] claude_org."""
+        bogus = self.sb.root / "bogus-elsewhere"
+        toml = self.sb.root / "in.toml"
+        self._write_toml(
+            toml,
+            "[task]\n"
+            'id = "t-290c"\n'
+            'description = "cli wins"\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{bogus.as_posix()}"\n',
+        )
+        data = self._run_preview_json([
+            "--from-toml", str(toml),
+            "--claude-org-root", str(self.sb.claude_org_root),
+            "--state-db-path", str(self.sb.db_path),
+        ])
+        resolved = Path(
+            data["summary"]["settings_args"]["claude-org-path"]
+        ).resolve()
+        self.assertEqual(resolved, self.sb.claude_org_root.resolve())
+        self.assertNotEqual(resolved, bogus.resolve())
+
+    def test_290_d_japanese_preview_does_not_mojibake_under_cp932(self):
+        """preview stdout decodes cleanly even when the underlying console
+        is cp932 — the encoding wrapper rewraps stdout to utf-8."""
+        import io as _io
+
+        toml = self.sb.root / "in.toml"
+        self._write_toml(
+            toml,
+            "[task]\n"
+            'id = "t-290d"\n'
+            'description = "日本語の説明文 — 派遣テスト"\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{self.sb.claude_org_root.as_posix()}"\n',
+        )
+
+        raw = _io.BytesIO()
+        wrapper = _io.TextIOWrapper(
+            raw, encoding="cp932", errors="strict", write_through=True
+        )
+        old_stdout = sys.stdout
+        sys.stdout = wrapper
+        try:
+            rc = gdp.main([
+                "preview",
+                "--from-toml", str(toml),
+                "--state-db-path", str(self.sb.db_path),
+            ])
+        finally:
+            try:
+                wrapper.flush()
+            except Exception:
+                pass
+            sys.stdout = old_stdout
+        self.assertEqual(rc, 0)
+        decoded = raw.getvalue().decode("utf-8")
+        # Japanese phrases from the DELEGATE template + description survive.
+        self.assertIn("以下のワーカーを派遣", decoded)
+        self.assertIn("日本語の説明文", decoded)
+
+
 def _env_update_goldens() -> bool:
     import os
     return os.environ.get("UPDATE_GOLDENS") == "1"

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -630,7 +630,10 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
     if role:
         layout_overrides["role"] = role
     if "self_edit" in worker:
-        layout_overrides["self_edit"] = bool(worker["self_edit"])
+        # Pass through unchanged so resolve()'s strict bool check fires
+        # on malformed input (e.g. self_edit = "false" parsed as a string).
+        # Codex Round 2 Minor.
+        layout_overrides["self_edit"] = worker["self_edit"]
 
     return {
         "task_id": task.get("id"),

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -208,6 +208,7 @@ def build_delegate_plan(
     state_db_path: Optional[Path] = None,
     claude_org_root: Path,
     workers_dir: Optional[Path] = None,
+    layout_overrides: Optional[dict[str, Any]] = None,
 ) -> DelegatePlan:
     """Resolve the layout, assemble the brief config, format the DELEGATE body.
 
@@ -235,6 +236,7 @@ def build_delegate_plan(
         state_db_path=state_db_path,
         claude_org_root=claude_org_root,
         workers_dir=workers_dir,
+        layout_overrides=layout_overrides,
     )
 
     self_edit = bool(config["worker"]["self_edit"])
@@ -555,8 +557,28 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _resolve_claude_org_root(args: argparse.Namespace) -> Path:
+    """Resolve claude-org repo root. Priority (highest first):
+
+    1. ``--claude-org-root`` CLI flag (explicit).
+    2. ``[paths] claude_org`` from ``--from-toml`` (Issue #290 defect 2 —
+       previously ignored, leaving cwd-derived paths to drift).
+    3. cwd-walk fallback (:func:`gwb._detect_claude_org_root`).
+    """
     if args.claude_org_root is not None:
-        return args.claude_org_root
+        return Path(args.claude_org_root).resolve()
+    toml_path = getattr(args, "from_toml", None)
+    if toml_path is not None:
+        try:
+            with Path(toml_path).open("rb") as fh:
+                cfg = tomllib.load(fh)
+        except (OSError, tomllib.TOMLDecodeError):
+            cfg = {}
+        cfg_path = (cfg.get("paths") or {}).get("claude_org")
+        if cfg_path:
+            p = Path(cfg_path)
+            if not p.is_absolute():
+                p = (Path(toml_path).resolve().parent / p)
+            return p.resolve()
     return gwb._detect_claude_org_root()
 
 
@@ -589,6 +611,21 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
     parallel = cfg.get("parallel", {})
     role = (worker.get("role") or "").strip()
     mode_from_toml = "audit" if role == "doc-audit" else "edit"
+
+    # Issue #290 defect 1: surface explicit [worker] fields so the resolver
+    # honors them instead of silently re-deriving pattern/role/dir/self_edit.
+    layout_overrides: dict[str, Any] = {}
+    if worker.get("pattern"):
+        layout_overrides["pattern"] = worker["pattern"]
+    if worker.get("pattern_variant"):
+        layout_overrides["pattern_variant"] = worker["pattern_variant"]
+    if worker.get("dir"):
+        layout_overrides["worker_dir"] = worker["dir"]
+    if role:
+        layout_overrides["role"] = role
+    if "self_edit" in worker:
+        layout_overrides["self_edit"] = bool(worker["self_edit"])
+
     return {
         "task_id": task.get("id"),
         "project_slug": project.get("name"),
@@ -605,6 +642,7 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
         "references_knowledge": refs.get("knowledge"),
         "parallel_notes": parallel.get("notes"),
         "mode": mode_from_toml,
+        "layout_overrides": layout_overrides or None,
     }
 
 
@@ -722,7 +760,19 @@ def _cmd_apply(args: argparse.Namespace) -> int:
     return 0
 
 
+def _reconfigure_stdout() -> None:
+    """Force stdout/stderr to UTF-8 on Windows so the DELEGATE body / Layout
+    summary (which contain Japanese) don't mojibake under cp932 consoles
+    (Issue #290 defect 3). No-op when reconfigure is unavailable."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+
 def main(argv: Optional[list[str]] = None) -> int:
+    _reconfigure_stdout()
     args = _build_parser().parse_args(argv)
     if args.cmd == "preview":
         return _cmd_preview(args)

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -620,7 +620,13 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
     if worker.get("pattern_variant"):
         layout_overrides["pattern_variant"] = worker["pattern_variant"]
     if worker.get("dir"):
-        layout_overrides["worker_dir"] = worker["dir"]
+        # Resolve relative dirs against the TOML file's parent so
+        # [paths].claude_org and [worker].dir share the same base
+        # (Codex Round 1 Minor — previously cwd-relative).
+        wd = Path(worker["dir"])
+        if not wd.is_absolute():
+            wd = (path.resolve().parent / wd)
+        layout_overrides["worker_dir"] = str(wd)
     if role:
         layout_overrides["role"] = role
     if "self_edit" in worker:

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -407,6 +407,11 @@ def build_config_from_task(
             "claude_org": str(Path(claude_org_root).resolve()),
         },
     }
+    # pattern_variant is added only when set so the common case keeps a
+    # minimal [worker] schema; gitignored_repo_root round-trips through
+    # --write-toml cleanly. Codex Round 2 Major.
+    if layout.pattern_variant is not None:
+        config["worker"]["pattern_variant"] = layout.pattern_variant
     if issue_url:
         config["task"]["issue_url"] = issue_url
     if closes_issue is not None:

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -318,6 +318,7 @@ def build_config_from_task(
     state_db_path: Optional[Path] = None,
     claude_org_root: Path,
     workers_dir: Optional[Path] = None,
+    layout_overrides: Optional[dict[str, Any]] = None,
 ) -> tuple[dict[str, Any], "object"]:
     """Resolve layout + assemble a render-ready config.
 
@@ -341,6 +342,7 @@ def build_config_from_task(
         state_db_path=state_db_path,
         claude_org_root=claude_org_root,
         workers_dir=workers_dir,
+        layout_overrides=layout_overrides,
     )
 
     # gitignored_repo_root inherits the .local.md template treatment even

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -364,13 +364,31 @@ def resolve(
     # produced Pattern C without one). Codex Round 1 Major.
     if layout_overrides:
         if "pattern" in layout_overrides and layout_overrides["pattern"]:
-            pattern = layout_overrides["pattern"]
+            pat = layout_overrides["pattern"]
+            if pat not in VALID_PATTERNS:
+                raise ResolveError(
+                    f"layout_overrides['pattern'] must be one of {VALID_PATTERNS}, got {pat!r}"
+                )
+            pattern = pat
             # Pattern explicitly set; reset variant unless TOML also supplied one.
             variant = layout_overrides.get("pattern_variant")
+            if variant is not None and variant not in VALID_VARIANTS:
+                raise ResolveError(
+                    f"layout_overrides['pattern_variant'] must be one of {VALID_VARIANTS} or None, got {variant!r}"
+                )
         if "worker_dir" in layout_overrides and layout_overrides["worker_dir"]:
             worker_dir = Path(layout_overrides["worker_dir"]).resolve()
         if "role" in layout_overrides and layout_overrides["role"]:
-            role = layout_overrides["role"]
+            r = layout_overrides["role"]
+            # Validate before any side effect (e.g. before apply reserves
+            # the DB row): a malformed role used to leak through to
+            # gen_worker_brief.validate() and only fail after the DB
+            # reservation was already persisted (Codex Round 2 Major).
+            if r not in VALID_ROLES:
+                raise ResolveError(
+                    f"layout_overrides['role'] must be one of {VALID_ROLES}, got {r!r}"
+                )
+            role = r
             self_edit = role == "claude-org-self-edit"
         if "self_edit" in layout_overrides:
             se = layout_overrides["self_edit"]

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -286,6 +286,7 @@ def resolve(
     state_db_path: Optional[Path] = None,
     claude_org_root: Path,
     workers_dir: Optional[Path] = None,
+    layout_overrides: Optional[dict[str, Any]] = None,
 ) -> WorkerLayout:
     """Resolve worker layout for one delegation. See module docstring."""
     if not task_id:
@@ -361,6 +362,26 @@ def resolve(
         planned_branch: Optional[str] = None
     else:
         planned_branch = branch_override or infer_branch(task_id, description)
+
+    # --- TOML [worker] block overrides (Issue #290 defect 1) --------------
+    # Honor explicit values from the caller (typically a worker_brief.toml
+    # passed via gen_delegate_payload --from-toml) instead of letting the
+    # auto-derive above override them. Priority order, highest first:
+    #   TOML [worker] field > CLI flag > resolver auto-derive.
+    if layout_overrides:
+        if "pattern" in layout_overrides and layout_overrides["pattern"]:
+            pattern = layout_overrides["pattern"]
+            # Pattern explicitly set; reset variant unless TOML also supplied one.
+            variant = layout_overrides.get("pattern_variant")
+        if "worker_dir" in layout_overrides and layout_overrides["worker_dir"]:
+            worker_dir = Path(layout_overrides["worker_dir"]).resolve()
+        if "role" in layout_overrides and layout_overrides["role"]:
+            role = layout_overrides["role"]
+            self_edit = role == "claude-org-self-edit"
+        if "self_edit" in layout_overrides:
+            self_edit = bool(layout_overrides["self_edit"])
+        if "planned_branch" in layout_overrides:
+            planned_branch = layout_overrides["planned_branch"]
 
     # --- settings_args -----------------------------------------------------
     settings_args = {

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -353,21 +353,15 @@ def resolve(
     role = decide_role(mode=mode, project=project, claude_org_root=claude_org_root)
     self_edit = role == "claude-org-self-edit"
 
-    # --- Branch decision ---------------------------------------------------
-    if pattern == "C":
-        # Pattern C ephemeral has no branch (no git); gitignored sub-mode
-        # runs against the repo root's existing branch and must not invent
-        # a new one (Codex M-2: planned_branch is a *suggestion*, not a
-        # commitment, and for Pattern C the suggestion is "don't").
-        planned_branch: Optional[str] = None
-    else:
-        planned_branch = branch_override or infer_branch(task_id, description)
-
     # --- TOML [worker] block overrides (Issue #290 defect 1) --------------
     # Honor explicit values from the caller (typically a worker_brief.toml
     # passed via gen_delegate_payload --from-toml) instead of letting the
     # auto-derive above override them. Priority order, highest first:
     #   TOML [worker] field > CLI flag > resolver auto-derive.
+    # Applied BEFORE the branch decision so a TOML-supplied pattern flips
+    # planned_branch consistently (e.g. pattern=C must imply planned_branch=None;
+    # pattern=B/A must compute a feat-/fix- branch even if auto-derive
+    # produced Pattern C without one). Codex Round 1 Major.
     if layout_overrides:
         if "pattern" in layout_overrides and layout_overrides["pattern"]:
             pattern = layout_overrides["pattern"]
@@ -379,9 +373,29 @@ def resolve(
             role = layout_overrides["role"]
             self_edit = role == "claude-org-self-edit"
         if "self_edit" in layout_overrides:
-            self_edit = bool(layout_overrides["self_edit"])
-        if "planned_branch" in layout_overrides:
-            planned_branch = layout_overrides["planned_branch"]
+            se = layout_overrides["self_edit"]
+            # Strictly boolean — silently coercing a truthy string like
+            # "false" would let a malformed TOML bypass downstream validate()
+            # contracts (Codex Round 1 Minor).
+            if not isinstance(se, bool):
+                raise ResolveError(
+                    f"layout_overrides['self_edit'] must be bool, got {type(se).__name__}"
+                )
+            self_edit = se
+
+    # --- Branch decision ---------------------------------------------------
+    # Re-derived from the *final* pattern so a TOML-supplied pattern override
+    # flips planned_branch consistently.
+    if pattern == "C":
+        # Pattern C ephemeral has no branch (no git); gitignored sub-mode
+        # runs against the repo root's existing branch and must not invent
+        # a new one (Codex M-2: planned_branch is a *suggestion*, not a
+        # commitment, and for Pattern C the suggestion is "don't").
+        planned_branch: Optional[str] = None
+    else:
+        planned_branch = branch_override or infer_branch(task_id, description)
+    if layout_overrides and "planned_branch" in layout_overrides:
+        planned_branch = layout_overrides["planned_branch"]
 
     # --- settings_args -----------------------------------------------------
     settings_args = {


### PR DESCRIPTION
## Summary

Closes #290. Three defects from the first dogfood of `gen_delegate_payload preview --from-toml` (Issue #283 / PR #288) are addressed in one PR.

## Defects fixed

1. **TOML `[worker]` block was ignored.** When `--from-toml` was used, the resolver re-derived `pattern` / `role` / `self_edit` / `dir` from defaults instead of taking the explicit TOML values. A new `layout_overrides` plumbing carries the TOML values into the resolver, applied before branch derivation. Precedence (high → low): TOML `[worker]` field > CLI flag > resolver auto-derive. This precedence is per the task spec; Codex Round 3 raised "CLI should win", but the spec explicitly chose TOML-wins for the dogfood loop and we preserve that.
2. **`claude-org-path` bled from cwd.** `_resolve_claude_org_root` now reads in this order: CLI `--claude-org-root` > TOML `[paths] claude_org` > cwd repo detection.
3. **CP932 console mojibake.** `main()` reconfigures stdout/stderr to UTF-8 so the preview body and layout summary print readable Japanese on Windows consoles without `PYTHONIOENCODING=utf-8`.

## Tests

`tests/test_gen_delegate_payload.py` adds 4 regression tests:

- (a) TOML `[worker]` block (pattern/role/self_edit/dir/pattern_variant) is honored end-to-end.
- (b) TOML `[paths] claude_org` lands in `settings_args.claude-org-path`.
- (c) CLI `--claude-org-root` override beats the TOML value.
- (d) UTF-8 console output round-trips Japanese characters under simulated CP932 stdout.

All 100 tests pass (96 existing + 4 new). `check_role_configs`, `check_runtime_schema_drift`, `check_renga_compat`: all OK.

## Codex self-review (3 rounds)

- Round 1: 1 Major + 2 Minors → resolved in `6175dc0`.
- Round 2: 2 Majors + 1 Minor → resolved in `19d8275`.
- Round 3: 1 Major ("CLI flag should beat TOML"). Not adopted: the task spec deliberately makes TOML the explicit input for the dogfood path, and CLI flags exist as overrides for one-off tweaks. The worker correctly cited primary source (CLAUDE.local.md / brief) over Codex's intuition. Tracked in this PR's description for transparency.

## Verification with the live `worker_brief.toml`

Re-running the original Issue #286 dispatch through `preview --from-toml`:

- `pattern: "B"` (was `"A"`)
- `role: "claude-org-self-edit"` (was `"default"`)
- `self_edit: true` (was `false`)
- `worker_dir`: matches the explicit TOML value
- `settings_args.claude-org-path`: matches the live claude-org root (was a bleed-in worktree path)

The first dogfood now produces the correct DELEGATE body. Future dispatches can use this path instead of falling back to the legacy `gen_worker_brief.py --config` flow.

## Test plan

- [x] `pytest tests/test_gen_delegate_payload.py` — 100 tests pass.
- [x] `python tools/check_role_configs.py` — OK.
- [x] `python tools/check_runtime_schema_drift.py` — OK.
- [ ] CI on this PR.
- [ ] Manual: dogfood with the next dispatch (e.g. Round 2 of the post-procedure-audit queue).

Closes #290.