### PR TITLE
feat(dispatcher): extract retro completion-report polling into dispatcher_retro_gate.py

### DIFF
--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -308,12 +308,14 @@ python ../tools/dispatcher_retro_gate.py --task-id <task_id>
 - スクリプトは stdout に行区切り JSON で `{"action": "send_initial", ...}` → `{"action": "check_messages", "attempt": N}` の順にプロンプトを出す。
 - ディスパッチャー Claude は `send_initial` を見たら `mcp__renga-peers__send_message(to_id=<secretary>, message=<同梱の message>)` を 1 度だけ送る。
 - 各 `check_messages` プロンプトに対して `mcp__renga-peers__check_messages` の戻り（`from_id` 等を含むメッセージ配列）を `{"messages": [...]}` という JSON 1 行として stdin に書き戻す。
-- スクリプト側が cadence（30 秒×最大 10 回 = 5 分上限）と ack regex 判定を行い、最終行に `{"status": "acked"|"timeout"|"error", "received_at": ..., "raw": ..., "attempts": N}` を出力して exit する（exit code: 0=acked, 1=timeout, 2=error）。
+- スクリプト側が cadence（30 秒×最大 10 回 = 5 分上限）と ack regex 判定を行い、最終行に `{"status": "acked"|"replied_no_ack"|"timeout"|"error", "received_at": ..., "raw": ..., "attempts": N}` を出力して exit する（exit code: 0=acked, 1=timeout, 2=error, 3=replied_no_ack）。
 
 この最終 JSON の `status` で switch する:
 
 - `acked` → そのまま retro を続行する。
-- `timeout` / `error` → 下の「secretary unreachable 時の fallback」フローに入る（retro に「未着」と書かない）。
+- `replied_no_ack` → secretary は到達しているが本文が ack regex に一致しなかった（例: 「見当たりません」「確認します」）。`raw` を読んで内容に応じて判断する。「届いていない」旨の返信なら retro に未着を確定的に書いてよい。曖昧なら secretary に追問する。`secretary_unreachable` フローには入らない。
+- `timeout` → secretary から 5 分間まったく返信が無い。下の「secretary unreachable 時の fallback」フローに入る（retro に「未着」と書かない）。
+- `error` → CLI 側のスキーマ不整合 / regex compile 失敗。`reason` を確認して呼び出し側を修正する。retro は保留扱い。
 
 **理由**: ワーカーのレポートチャネルは secretary 直送である。dispatcher のメッセージキュー（`check_messages` の戻り）に完了報告が無いことは、「システム上に存在しない」ことを意味しない。secretary 側に既に届いていることがしばしばあり、確認を怠ると「完了報告未着」と誤った結論を retro に残してしまう（実インシデント: `knowledge/raw/2026-05-03-delegation-smoke-completion-report.md`）。
 

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -296,13 +296,24 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 
 #### ⚠️ 完了報告ゲート（結論を書く前に必ず実行）
 
-「完了報告未着」「報告が届かなかった」「ワーカーが報告しなかった」等の結論を retro に書く **前に**、必ず以下を実行すること:
+「完了報告未着」「報告が届かなかった」「ワーカーが報告しなかった」等の結論を retro に書く **前に**、必ず `tools/dispatcher_retro_gate.py` を起動して secretary の ack を待つこと。
 
-```
-mcp__renga-peers__send_message(to_id="secretary", message="<task_id> の完了報告は届いていますか？")
+```bash
+# ディスパッチャー cwd は .dispatcher/ なので 1 段上がリポジトリルート。
+python ../tools/dispatcher_retro_gate.py --task-id <task_id>
 ```
 
-そのうえで secretary の応答を待ってから retro を続行する。応答待ちは `mcp__renga-peers__check_messages` を 30 秒間隔で最大 10 回（合計 5 分上限）ポーリングし、`from_id == "secretary"` のメッセージが届いた時点で打ち切る。5 分経過しても応答が無い場合は下の「secretary unreachable」フローに入る。
+挙動（決定論的、Issue #285 で切り出し済み）:
+
+- スクリプトは stdout に行区切り JSON で `{"action": "send_initial", ...}` → `{"action": "check_messages", "attempt": N}` の順にプロンプトを出す。
+- ディスパッチャー Claude は `send_initial` を見たら `mcp__renga-peers__send_message(to_id=<secretary>, message=<同梱の message>)` を 1 度だけ送る。
+- 各 `check_messages` プロンプトに対して `mcp__renga-peers__check_messages` の戻り（`from_id` 等を含むメッセージ配列）を `{"messages": [...]}` という JSON 1 行として stdin に書き戻す。
+- スクリプト側が cadence（30 秒×最大 10 回 = 5 分上限）と ack regex 判定を行い、最終行に `{"status": "acked"|"timeout"|"error", "received_at": ..., "raw": ..., "attempts": N}` を出力して exit する（exit code: 0=acked, 1=timeout, 2=error）。
+
+この最終 JSON の `status` で switch する:
+
+- `acked` → そのまま retro を続行する。
+- `timeout` / `error` → 下の「secretary unreachable 時の fallback」フローに入る（retro に「未着」と書かない）。
 
 **理由**: ワーカーのレポートチャネルは secretary 直送である。dispatcher のメッセージキュー（`check_messages` の戻り）に完了報告が無いことは、「システム上に存在しない」ことを意味しない。secretary 側に既に届いていることがしばしばあり、確認を怠ると「完了報告未着」と誤った結論を retro に残してしまう（実インシデント: `knowledge/raw/2026-05-03-delegation-smoke-completion-report.md`）。
 

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -296,26 +296,43 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 
 #### ⚠️ 完了報告ゲート（結論を書く前に必ず実行）
 
-「完了報告未着」「報告が届かなかった」「ワーカーが報告しなかった」等の結論を retro に書く **前に**、必ず `tools/dispatcher_retro_gate.py` を起動して secretary の ack を待つこと。
+「完了報告未着」「報告が届かなかった」「ワーカーが報告しなかった」等の結論を retro に書く **前に**、必ず `tools/dispatcher_retro_gate.py` を使って secretary の ack を待つこと。
+
+CLI は **1 attempt あたり 1 回起動する単発判定**（Issue #285、Claude Code の Bash tool が一往復であるため、長寿命の双方向プロセスは想定しない）。各 attempt の cadence（30 秒スリープ）はディスパッチャー側が `Bash sleep 30` で挟む。
+
+#### 1. 初回送信（attempt=1 の前に 1 度だけ）
+
+`--print-initial-prompt` で task_id 込みの定型文を取り出し、`mcp__renga-peers__send_message` で secretary に送る:
 
 ```bash
 # ディスパッチャー cwd は .dispatcher/ なので 1 段上がリポジトリルート。
-python ../tools/dispatcher_retro_gate.py --task-id <task_id>
+python ../tools/dispatcher_retro_gate.py --task-id <task_id> --print-initial-prompt
+# stdout: <task_id> の完了報告は届いていますか？
 ```
 
-挙動（決定論的、Issue #285 で切り出し済み）:
+```
+mcp__renga-peers__send_message(to_id="secretary", message="<上記 stdout>")
+```
 
-- スクリプトは stdout に行区切り JSON で `{"action": "send_initial", ...}` → `{"action": "check_messages", "attempt": N}` の順にプロンプトを出す。
-- ディスパッチャー Claude は `send_initial` を見たら `mcp__renga-peers__send_message(to_id=<secretary>, message=<同梱の message>)` を 1 度だけ送る。
-- 各 `check_messages` プロンプトに対して `mcp__renga-peers__check_messages` の戻り（`from_id` 等を含むメッセージ配列）を `{"messages": [...]}` という JSON 1 行として stdin に書き戻す。
-- スクリプト側が cadence（30 秒×最大 10 回 = 5 分上限）と ack regex 判定を行い、最終行に `{"status": "acked"|"replied_no_ack"|"timeout"|"error", "received_at": ..., "raw": ..., "attempts": N}` を出力して exit する（exit code: 0=acked, 1=timeout, 2=error, 3=replied_no_ack）。
+#### 2. polling ループ（attempt=1..10、合計 5 分上限）
 
-この最終 JSON の `status` で switch する:
+各 attempt で:
 
-- `acked` → そのまま retro を続行する。
-- `replied_no_ack` → secretary は到達しているが本文が ack regex に一致しなかった（例: 「見当たりません」「確認します」）。`raw` を読んで内容に応じて判断する。「届いていない」旨の返信なら retro に未着を確定的に書いてよい。曖昧なら secretary に追問する。`secretary_unreachable` フローには入らない。
-- `timeout` → secretary から 5 分間まったく返信が無い。下の「secretary unreachable 時の fallback」フローに入る（retro に「未着」と書かない）。
-- `error` → CLI 側のスキーマ不整合 / regex compile 失敗。`reason` を確認して呼び出し側を修正する。retro は保留扱い。
+1. `mcp__renga-peers__check_messages` で受信を取得し、戻り値を `{"messages": [...]}` の形に整える（`state` は前 attempt の `polling` 出力から引き継ぐ。attempt=1 では省略可）。
+2. CLI を起動して stdin に渡す:
+
+   ```bash
+   echo '<json>' | python ../tools/dispatcher_retro_gate.py \
+       --task-id <task_id> --attempt <n> --max-attempts 10
+   ```
+
+3. stdout は単一 JSON。exit code で switch:
+
+   - `0 / status=acked` → retro を続行する。
+   - `1 / status=timeout` → secretary から 1 度も返信が無く打ち切り。下の「secretary unreachable 時の fallback」フローに入る（retro に「未着」と書かない）。
+   - `2 / status=error` → CLI スキーマ不整合 / regex compile 失敗。`reason` を確認して呼び出し側を修正する。retro は保留扱い。
+   - `3 / status=replied_no_ack` → secretary は到達したが本文が ack regex に一致せず最終 attempt まで進んだ。`raw` を読んで内容に応じて判断する（「届いていない」旨の確定返信なら retro に未着を確定的に書いてよい。曖昧なら secretary に追問する）。`secretary_unreachable` フローには入らない。
+   - `4 / status=polling` → まだ attempt が残っている。`Bash sleep 30` を挟み、`state` フィールドを次回呼び出しに渡して continue する。
 
 **理由**: ワーカーのレポートチャネルは secretary 直送である。dispatcher のメッセージキュー（`check_messages` の戻り）に完了報告が無いことは、「システム上に存在しない」ことを意味しない。secretary 側に既に届いていることがしばしばあり、確認を怠ると「完了報告未着」と誤った結論を retro に残してしまう（実インシデント: `knowledge/raw/2026-05-03-delegation-smoke-completion-report.md`）。
 

--- a/tests/test_dispatcher_retro_gate.py
+++ b/tests/test_dispatcher_retro_gate.py
@@ -97,6 +97,41 @@ class DispatcherRetroGateTests(unittest.TestCase):
         events = _parse(proc.stdout)
         self.assertEqual(events[-1]["status"], "timeout")
 
+    def test_invalid_ack_pattern_returns_error(self) -> None:
+        # No stdin needed — the failure happens before the first poll.
+        proc = _run([], extra_args=["--ack-pattern", "("])
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        self.assertEqual(events[-1]["status"], "error")
+        self.assertIn("invalid_ack_pattern", events[-1]["reason"])
+
+    def test_malformed_messages_payload_returns_error(self) -> None:
+        # 'messages' is a string instead of a list.
+        proc = _run([{"messages": "oops"}])
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        self.assertEqual(events[-1]["status"], "error")
+        self.assertIn("invalid_schema", events[-1]["reason"])
+
+    def test_non_dict_message_entries_are_skipped(self) -> None:
+        # Mixed list: a stray int followed by a real secretary ack must
+        # neither crash nor mask the ack.
+        stdin = [{"messages": [42, {"from_id": "secretary",
+                                    "message": "届きました"}]}]
+        proc = _run(stdin)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        self.assertEqual(events[-1]["status"], "acked")
+
+    def test_anonymous_message_does_not_ack(self) -> None:
+        # Body matches the ack regex but no sender attribution.
+        stdin = [{"messages": [{"message": "届いてます"}]}] + \
+                [{"messages": []} for _ in range(9)]
+        proc = _run(stdin)
+        self.assertEqual(proc.returncode, 1, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        self.assertEqual(events[-1]["status"], "timeout")
+
     def test_custom_ack_pattern(self) -> None:
         stdin = [{"messages": [
             {"from_id": "secretary", "message": "CONFIRMED-285"},

--- a/tests/test_dispatcher_retro_gate.py
+++ b/tests/test_dispatcher_retro_gate.py
@@ -1,0 +1,112 @@
+"""Tests for tools/dispatcher_retro_gate.py (Issue #285).
+
+The CLI is a stdin/stdout JSON co-routine: it emits "action" prompts on
+stdout, the dispatcher pipes ``check_messages`` results back on stdin,
+and the final "status" line on stdout decides retro continuation.
+
+These tests exercise the script end-to-end via subprocess with
+``--interval-seconds 0`` so the polling cadence does not slow CI.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "dispatcher_retro_gate.py"
+
+
+def _run(stdin_payloads: list[dict], extra_args: list[str] | None = None,
+         task_id: str = "issue-285-test") -> subprocess.CompletedProcess:
+    args = [
+        sys.executable, str(SCRIPT),
+        "--task-id", task_id,
+        "--interval-seconds", "0",
+        "--timeout-attempts", "10",
+    ]
+    if extra_args:
+        args.extend(extra_args)
+    stdin_text = "".join(json.dumps(p, ensure_ascii=False) + "\n"
+                         for p in stdin_payloads)
+    return subprocess.run(
+        args, input=stdin_text, capture_output=True, text=True,
+        timeout=15, encoding="utf-8",
+    )
+
+
+def _parse(stdout: str) -> list[dict]:
+    return [json.loads(line) for line in stdout.splitlines() if line.strip()]
+
+
+class DispatcherRetroGateTests(unittest.TestCase):
+
+    def test_ack_on_first_poll(self) -> None:
+        stdin = [{"messages": [
+            {"from_id": "secretary", "message": "完了報告は届いています"},
+        ]}]
+        proc = _run(stdin)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        # Order: send_initial, check_messages(attempt=1), status=acked.
+        self.assertEqual(events[0]["action"], "send_initial")
+        self.assertEqual(events[0]["to_id"], "secretary")
+        self.assertIn("issue-285-test", events[0]["message"])
+        self.assertEqual(events[1], {"action": "check_messages", "attempt": 1})
+        self.assertEqual(events[-1]["status"], "acked")
+        self.assertEqual(events[-1]["attempts"], 1)
+        self.assertIn("届いて", events[-1]["raw"])
+        self.assertIsNotNone(events[-1]["received_at"])
+
+    def test_ack_on_third_poll(self) -> None:
+        stdin = [
+            {"messages": []},
+            {"messages": [{"from_id": "other", "message": "noise"}]},
+            {"messages": [{"from_id": "secretary", "message": "ack received"}]},
+        ]
+        proc = _run(stdin)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        check_msgs = [e for e in events if e.get("action") == "check_messages"]
+        self.assertEqual([e["attempt"] for e in check_msgs], [1, 2, 3])
+        self.assertEqual(events[-1]["status"], "acked")
+        self.assertEqual(events[-1]["attempts"], 3)
+        self.assertEqual(events[-1]["raw"], "ack received")
+
+    def test_timeout_after_max_attempts(self) -> None:
+        stdin = [{"messages": []} for _ in range(10)]
+        proc = _run(stdin)
+        self.assertEqual(proc.returncode, 1, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        check_msgs = [e for e in events if e.get("action") == "check_messages"]
+        self.assertEqual(len(check_msgs), 10)
+        self.assertEqual(events[-1]["status"], "timeout")
+        self.assertEqual(events[-1]["attempts"], 10)
+        self.assertIsNone(events[-1]["received_at"])
+        self.assertIsNone(events[-1]["raw"])
+
+    def test_non_secretary_messages_do_not_ack(self) -> None:
+        # Secretary-pattern body but from a different sender — must not ack.
+        stdin = [
+            {"messages": [{"from_id": "worker-x", "message": "届いてます"}]},
+        ] + [{"messages": []} for _ in range(9)]
+        proc = _run(stdin)
+        self.assertEqual(proc.returncode, 1, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        self.assertEqual(events[-1]["status"], "timeout")
+
+    def test_custom_ack_pattern(self) -> None:
+        stdin = [{"messages": [
+            {"from_id": "secretary", "message": "CONFIRMED-285"},
+        ]}]
+        proc = _run(stdin, extra_args=["--ack-pattern", r"CONFIRMED-\d+"])
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        self.assertEqual(events[-1]["status"], "acked")
+        self.assertEqual(events[-1]["raw"], "CONFIRMED-285")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dispatcher_retro_gate.py
+++ b/tests/test_dispatcher_retro_gate.py
@@ -1,11 +1,11 @@
 """Tests for tools/dispatcher_retro_gate.py (Issue #285).
 
-The CLI is a stdin/stdout JSON co-routine: it emits "action" prompts on
-stdout, the dispatcher pipes ``check_messages`` results back on stdin,
-and the final "status" line on stdout decides retro continuation.
-
-These tests exercise the script end-to-end via subprocess with
-``--interval-seconds 0`` so the polling cadence does not slow CI.
+The CLI is a one-shot per-attempt ack judge: it reads
+``{"messages": [...], "state": {...}}`` from stdin, applies the ack
+regex, and prints either a terminal verdict (acked / replied_no_ack /
+timeout / error) or a ``polling`` verdict carrying state for the next
+invocation. Tests drive it via ``subprocess.run`` so the CLI contract
+is exercised end-to-end.
 """
 from __future__ import annotations
 
@@ -19,161 +19,199 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "tools" / "dispatcher_retro_gate.py"
 
 
-def _run(stdin_payloads: list[dict], extra_args: list[str] | None = None,
+def _run(stdin_payload: dict | None, *, attempt: int = 1, max_attempts: int = 10,
+         extra_args: list[str] | None = None,
          task_id: str = "issue-285-test") -> subprocess.CompletedProcess:
     args = [
         sys.executable, str(SCRIPT),
         "--task-id", task_id,
-        "--interval-seconds", "0",
-        "--timeout-attempts", "10",
+        "--attempt", str(attempt),
+        "--max-attempts", str(max_attempts),
     ]
     if extra_args:
         args.extend(extra_args)
-    stdin_text = "".join(json.dumps(p, ensure_ascii=False) + "\n"
-                         for p in stdin_payloads)
+    stdin_text = ""
+    if stdin_payload is not None:
+        stdin_text = json.dumps(stdin_payload, ensure_ascii=False) + "\n"
     return subprocess.run(
         args, input=stdin_text, capture_output=True, text=True,
         timeout=15, encoding="utf-8",
     )
 
 
-def _parse(stdout: str) -> list[dict]:
-    return [json.loads(line) for line in stdout.splitlines() if line.strip()]
+def _final(proc: subprocess.CompletedProcess) -> dict:
+    lines = [line for line in proc.stdout.splitlines() if line.strip()]
+    assert lines, f"no stdout from CLI; stderr={proc.stderr!r}"
+    return json.loads(lines[-1])
 
 
 class DispatcherRetroGateTests(unittest.TestCase):
 
+    # --- Stage 2 baseline cases mandated by the issue brief ------------
+
     def test_ack_on_first_poll(self) -> None:
-        stdin = [{"messages": [
-            {"from_id": "secretary", "message": "完了報告は届いています"},
-        ]}]
-        proc = _run(stdin)
+        proc = _run(
+            {"messages": [
+                {"from_id": "secretary", "message": "完了報告は届いています"},
+            ]},
+            attempt=1,
+        )
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        # Order: send_initial, check_messages(attempt=1), status=acked.
-        self.assertEqual(events[0]["action"], "send_initial")
-        self.assertEqual(events[0]["to_id"], "secretary")
-        self.assertIn("issue-285-test", events[0]["message"])
-        self.assertEqual(events[1], {"action": "check_messages", "attempt": 1})
-        self.assertEqual(events[-1]["status"], "acked")
-        self.assertEqual(events[-1]["attempts"], 1)
-        self.assertIn("届いて", events[-1]["raw"])
-        self.assertIsNotNone(events[-1]["received_at"])
+        final = _final(proc)
+        self.assertEqual(final["status"], "acked")
+        self.assertEqual(final["attempts"], 1)
+        self.assertIn("届い", final["raw"])
 
     def test_ack_on_third_poll(self) -> None:
-        stdin = [
-            {"messages": []},
-            {"messages": [{"from_id": "other", "message": "noise"}]},
-            {"messages": [{"from_id": "secretary", "message": "ack received"}]},
-        ]
-        proc = _run(stdin)
+        # Driver loops three invocations, threading state through.
+        state = None
+
+        # Attempt 1: empty.
+        proc = _run({"messages": [], "state": state}, attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        f1 = _final(proc)
+        self.assertEqual(f1["status"], "polling")
+        state = f1["state"]
+
+        # Attempt 2: noise from non-secretary.
+        proc = _run({"messages": [{"from_id": "other", "message": "noise"}],
+                      "state": state}, attempt=2)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        state = _final(proc)["state"]
+
+        # Attempt 3: real ack.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                   "message": "ack received"}],
+                     "state": state}, attempt=3)
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        check_msgs = [e for e in events if e.get("action") == "check_messages"]
-        self.assertEqual([e["attempt"] for e in check_msgs], [1, 2, 3])
-        self.assertEqual(events[-1]["status"], "acked")
-        self.assertEqual(events[-1]["attempts"], 3)
-        self.assertEqual(events[-1]["raw"], "ack received")
+        final = _final(proc)
+        self.assertEqual(final["status"], "acked")
+        self.assertEqual(final["attempts"], 3)
+        self.assertEqual(final["raw"], "ack received")
 
     def test_timeout_after_max_attempts(self) -> None:
-        stdin = [{"messages": []} for _ in range(10)]
-        proc = _run(stdin)
+        # All 10 attempts return empty messages and no secretary reply.
+        state = None
+        for n in range(1, 10):
+            proc = _run({"messages": [], "state": state}, attempt=n)
+            self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+            state = _final(proc)["state"]
+        proc = _run({"messages": [], "state": state}, attempt=10)
         self.assertEqual(proc.returncode, 1, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        check_msgs = [e for e in events if e.get("action") == "check_messages"]
-        self.assertEqual(len(check_msgs), 10)
-        self.assertEqual(events[-1]["status"], "timeout")
-        self.assertEqual(events[-1]["attempts"], 10)
-        self.assertIsNone(events[-1]["received_at"])
-        self.assertIsNone(events[-1]["raw"])
+        final = _final(proc)
+        self.assertEqual(final["status"], "timeout")
+        self.assertEqual(final["attempts"], 10)
+        self.assertIsNone(final["received_at"])
+        self.assertIsNone(final["raw"])
 
-    def test_non_secretary_messages_do_not_ack(self) -> None:
-        # Secretary-pattern body but from a different sender — must not ack.
-        stdin = [
-            {"messages": [{"from_id": "worker-x", "message": "届いてます"}]},
-        ] + [{"messages": []} for _ in range(9)]
-        proc = _run(stdin)
-        self.assertEqual(proc.returncode, 1, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        self.assertEqual(events[-1]["status"], "timeout")
-
-    def test_invalid_ack_pattern_returns_error(self) -> None:
-        # No stdin needed — the failure happens before the first poll.
-        proc = _run([], extra_args=["--ack-pattern", "("])
-        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        self.assertEqual(events[-1]["status"], "error")
-        self.assertIn("invalid_ack_pattern", events[-1]["reason"])
-
-    def test_malformed_messages_payload_returns_error(self) -> None:
-        # 'messages' is a string instead of a list.
-        proc = _run([{"messages": "oops"}])
-        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        self.assertEqual(events[-1]["status"], "error")
-        self.assertIn("invalid_schema", events[-1]["reason"])
-
-    def test_non_dict_message_entries_are_skipped(self) -> None:
-        # Mixed list: a stray int followed by a real secretary ack must
-        # neither crash nor mask the ack.
-        stdin = [{"messages": [42, {"from_id": "secretary",
-                                    "message": "届きました"}]}]
-        proc = _run(stdin)
-        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        self.assertEqual(events[-1]["status"], "acked")
+    # --- Hardening cases from Codex review rounds ----------------------
 
     def test_anonymous_message_does_not_ack(self) -> None:
-        # Body matches the ack regex but no sender attribution.
-        stdin = [{"messages": [{"message": "届いてます"}]}] + \
-                [{"messages": []} for _ in range(9)]
-        proc = _run(stdin)
-        self.assertEqual(proc.returncode, 1, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        self.assertEqual(events[-1]["status"], "timeout")
+        # Body matches the regex but no sender attribution → not ack.
+        proc = _run({"messages": [{"message": "届いてます"}]}, attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_non_secretary_messages_do_not_ack(self) -> None:
+        proc = _run({"messages": [{"from_id": "worker-x",
+                                    "message": "届いてます"}]}, attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+
+    def test_invalid_ack_pattern_returns_error(self) -> None:
+        proc = _run(None, extra_args=["--ack-pattern", "("])
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "error")
+        self.assertIn("invalid_ack_pattern", final["reason"])
+
+    def test_malformed_messages_payload_returns_error(self) -> None:
+        proc = _run({"messages": "oops"}, attempt=1)
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "error")
+        self.assertIn("invalid_schema", final["reason"])
+
+    def test_payload_must_be_object(self) -> None:
+        # JSON list at top level instead of object.
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--task-id", "x",
+             "--attempt", "1", "--max-attempts", "10"],
+            input="[1,2,3]\n", capture_output=True, text=True,
+            timeout=15, encoding="utf-8",
+        )
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        self.assertIn("invalid_schema", _final(proc)["reason"])
+
+    def test_non_dict_message_entries_are_skipped(self) -> None:
+        # Mixed list: stray int, then real secretary ack.
+        proc = _run({"messages": [42, {"from_id": "secretary",
+                                        "message": "届きました"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "acked")
+
+    def test_non_string_body_does_not_crash(self) -> None:
+        proc = _run({"messages": [
+            {"from_id": "secretary", "message": 42},
+            {"from_id": "secretary", "message": "ack"},
+        ]}, attempt=1)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_final(proc)["raw"], "ack")
 
     def test_secretary_replies_without_ack_regex(self) -> None:
-        # Secretary replied across attempts, but no body matched the ack
-        # regex — must surface as replied_no_ack (exit 3), not timeout, so
-        # the dispatcher does not jump to the secretary_unreachable fallback.
-        stdin = [
-            {"messages": [{"from_id": "secretary", "message": "確認します"}]},
-            {"messages": []},
-            {"messages": [{"from_id": "secretary",
-                            "message": "見当たりません"}]},
-        ] + [{"messages": []} for _ in range(7)]
-        proc = _run(stdin)
+        # Secretary replies but bodies never match — at the final
+        # attempt the verdict must be replied_no_ack (exit 3), not
+        # timeout, so the dispatcher does not jump to the
+        # secretary_unreachable fallback.
+        state = None
+        # Attempt 1: secretary says "確認します"
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "確認します"}],
+                     "state": state}, attempt=1, max_attempts=3)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        state = _final(proc)["state"]
+        self.assertEqual(state["last_secretary_body"], "確認します")
+        self.assertEqual(state["last_secretary_attempt"], 1)
+
+        # Attempt 2: empty.
+        proc = _run({"messages": [], "state": state},
+                    attempt=2, max_attempts=3)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        state = _final(proc)["state"]
+
+        # Attempt 3 (final): secretary says "見当たりません"
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "見当たりません"}],
+                     "state": state}, attempt=3, max_attempts=3)
         self.assertEqual(proc.returncode, 3, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        final = events[-1]
+        final = _final(proc)
         self.assertEqual(final["status"], "replied_no_ack")
-        # Reports the LAST secretary body seen + the attempt it arrived on.
         self.assertEqual(final["raw"], "見当たりません")
         self.assertEqual(final["attempts"], 3)
 
-    def test_non_string_body_does_not_crash(self) -> None:
-        # message field is an int; pattern.search would TypeError if the
-        # body wasn't coerced. The script must skip the bad body and
-        # continue to the next message rather than die with a traceback.
-        stdin = [{"messages": [
-            {"from_id": "secretary", "message": 42},
-            {"from_id": "secretary", "message": "ack"},
-        ]}]
-        proc = _run(stdin)
-        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        self.assertEqual(events[-1]["status"], "acked")
-        self.assertEqual(events[-1]["raw"], "ack")
-
     def test_custom_ack_pattern(self) -> None:
-        stdin = [{"messages": [
+        proc = _run({"messages": [
             {"from_id": "secretary", "message": "CONFIRMED-285"},
-        ]}]
-        proc = _run(stdin, extra_args=["--ack-pattern", r"CONFIRMED-\d+"])
+        ]}, attempt=1, extra_args=["--ack-pattern", r"CONFIRMED-\d+"])
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-        events = _parse(proc.stdout)
-        self.assertEqual(events[-1]["status"], "acked")
-        self.assertEqual(events[-1]["raw"], "CONFIRMED-285")
+        self.assertEqual(_final(proc)["raw"], "CONFIRMED-285")
+
+    def test_attempt_out_of_range_returns_error(self) -> None:
+        proc = _run({"messages": []}, attempt=11, max_attempts=10)
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        self.assertIn("out of range", _final(proc)["reason"])
+
+    # --- --print-initial-prompt mode -----------------------------------
+
+    def test_print_initial_prompt(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--task-id", "issue-285-test",
+             "--print-initial-prompt"],
+            capture_output=True, text=True, timeout=15, encoding="utf-8",
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertIn("issue-285-test", proc.stdout)
+        self.assertIn("完了報告", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_dispatcher_retro_gate.py
+++ b/tests/test_dispatcher_retro_gate.py
@@ -132,6 +132,39 @@ class DispatcherRetroGateTests(unittest.TestCase):
         events = _parse(proc.stdout)
         self.assertEqual(events[-1]["status"], "timeout")
 
+    def test_secretary_replies_without_ack_regex(self) -> None:
+        # Secretary replied across attempts, but no body matched the ack
+        # regex — must surface as replied_no_ack (exit 3), not timeout, so
+        # the dispatcher does not jump to the secretary_unreachable fallback.
+        stdin = [
+            {"messages": [{"from_id": "secretary", "message": "確認します"}]},
+            {"messages": []},
+            {"messages": [{"from_id": "secretary",
+                            "message": "見当たりません"}]},
+        ] + [{"messages": []} for _ in range(7)]
+        proc = _run(stdin)
+        self.assertEqual(proc.returncode, 3, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        final = events[-1]
+        self.assertEqual(final["status"], "replied_no_ack")
+        # Reports the LAST secretary body seen + the attempt it arrived on.
+        self.assertEqual(final["raw"], "見当たりません")
+        self.assertEqual(final["attempts"], 3)
+
+    def test_non_string_body_does_not_crash(self) -> None:
+        # message field is an int; pattern.search would TypeError if the
+        # body wasn't coerced. The script must skip the bad body and
+        # continue to the next message rather than die with a traceback.
+        stdin = [{"messages": [
+            {"from_id": "secretary", "message": 42},
+            {"from_id": "secretary", "message": "ack"},
+        ]}]
+        proc = _run(stdin)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        events = _parse(proc.stdout)
+        self.assertEqual(events[-1]["status"], "acked")
+        self.assertEqual(events[-1]["raw"], "ack")
+
     def test_custom_ack_pattern(self) -> None:
         stdin = [{"messages": [
             {"from_id": "secretary", "message": "CONFIRMED-285"},

--- a/tools/dispatcher_retro_gate.py
+++ b/tools/dispatcher_retro_gate.py
@@ -51,7 +51,7 @@ if getattr(sys.stdin, "encoding", "").lower() != "utf-8":
     except (AttributeError, io.UnsupportedOperation):
         pass
 
-DEFAULT_ACK_PATTERN = r"(届い|受領|受け取|ack|received|got it)"
+DEFAULT_ACK_PATTERN = r"(届[いきけくこ]|受領|受け取|ack|received|got it)"
 
 
 def _now_iso() -> str:
@@ -65,16 +65,11 @@ def _emit(obj: dict, stream=None) -> None:
 
 
 def _is_secretary_message(msg: dict, secretary: str) -> bool:
-    """Return True if the message looks like it came from the secretary pane.
-
-    renga-peers shapes vary across SDK versions, so accept either id or name
-    matching, and treat messages with no sender attribution as candidates
-    (the dispatcher already filters by recipient = self)."""
-    from_id = msg.get("from_id")
-    from_name = msg.get("from_name")
-    if from_id is None and from_name is None:
-        return True
-    return from_id == secretary or from_name == secretary
+    """Return True only if the message explicitly identifies the secretary
+    as sender. Messages with no sender attribution are NOT treated as
+    secretary-origin — accepting them would let an unrelated message whose
+    body happens to contain "届い" trigger a false ack."""
+    return msg.get("from_id") == secretary or msg.get("from_name") == secretary
 
 
 def _extract_body(msg: dict) -> str:
@@ -87,7 +82,17 @@ def run_gate(args: argparse.Namespace, *, sleep=time.sleep,
     stdout = stdout or sys.stdout
     stderr = stderr or sys.stderr
 
-    pattern = re.compile(args.ack_pattern)
+    try:
+        pattern = re.compile(args.ack_pattern)
+    except re.error as exc:
+        _emit({
+            "status": "error",
+            "reason": f"invalid_ack_pattern: {exc}",
+            "attempts": 0,
+            "received_at": None,
+            "raw": None,
+        }, stdout)
+        return 2
 
     _emit({
         "action": "send_initial",
@@ -124,8 +129,32 @@ def run_gate(args: argparse.Namespace, *, sleep=time.sleep,
             }, stdout)
             return 2
 
-        messages = payload.get("messages") or []
+        if not isinstance(payload, dict):
+            _emit({
+                "status": "error",
+                "reason": "invalid_schema: payload must be a JSON object",
+                "attempts": attempt,
+                "received_at": None,
+                "raw": None,
+            }, stdout)
+            return 2
+
+        messages = payload.get("messages", [])
+        if not isinstance(messages, list):
+            _emit({
+                "status": "error",
+                "reason": "invalid_schema: 'messages' must be a list",
+                "attempts": attempt,
+                "received_at": None,
+                "raw": None,
+            }, stdout)
+            return 2
+
         for msg in messages:
+            if not isinstance(msg, dict):
+                # Skip non-object entries rather than crash; the dispatcher
+                # may surface a future schema variant we don't recognise.
+                continue
             if not _is_secretary_message(msg, args.secretary):
                 continue
             body = _extract_body(msg)

--- a/tools/dispatcher_retro_gate.py
+++ b/tools/dispatcher_retro_gate.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Polling gate for the dispatcher's retro completion-report ack.
+
+Issue #285. Replaces the natural-language polling prose in
+``.dispatcher/CLAUDE.md`` (around the "完了報告ゲート" section) with a
+deterministic CLI so the dispatcher Claude no longer has to re-derive
+cadence and ack-judgement on every retro.
+
+Design (option B from the issue brief): this CLI never calls renga-peers
+itself. The dispatcher Claude stays the MCP boundary — it issues
+``mcp__renga-peers__send_message`` once up front and then
+``mcp__renga-peers__check_messages`` per poll, piping each result into
+this script's stdin. The script owns:
+
+  * cadence (sleep between attempts, max attempt count)
+  * ack judgement (regex against secretary-origin messages)
+  * structured JSON output for the dispatcher to switch on
+
+Wire protocol on stdout / stdin (newline-delimited JSON):
+
+  CLI -> stdout: {"action": "send_initial", "to_id": "<secretary>",
+                  "message": "<task_id> の完了報告は届いていますか？"}
+  CLI -> stdout: {"action": "check_messages", "attempt": <n>}
+  stdin -> CLI:  {"messages": [<msg>, ...]}
+  ... (repeats up to --timeout-attempts)
+  CLI -> stdout: {"status": "acked"|"timeout"|"error", ...}
+
+Exit codes: 0=acked, 1=timeout, 2=error.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import sys
+import time
+from datetime import datetime, timezone
+
+# Ensure UTF-8 stdio on Windows (default cp932 mangles JP prompts).
+for _stream_name in ("stdout", "stderr"):
+    _stream = getattr(sys, _stream_name, None)
+    if _stream is not None and getattr(_stream, "encoding", "").lower() != "utf-8":
+        try:
+            _stream.reconfigure(encoding="utf-8")  # py>=3.7
+        except (AttributeError, io.UnsupportedOperation):
+            pass
+if getattr(sys.stdin, "encoding", "").lower() != "utf-8":
+    try:
+        sys.stdin.reconfigure(encoding="utf-8")
+    except (AttributeError, io.UnsupportedOperation):
+        pass
+
+DEFAULT_ACK_PATTERN = r"(届い|受領|受け取|ack|received|got it)"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _emit(obj: dict, stream=None) -> None:
+    stream = stream or sys.stdout
+    stream.write(json.dumps(obj, ensure_ascii=False) + "\n")
+    stream.flush()
+
+
+def _is_secretary_message(msg: dict, secretary: str) -> bool:
+    """Return True if the message looks like it came from the secretary pane.
+
+    renga-peers shapes vary across SDK versions, so accept either id or name
+    matching, and treat messages with no sender attribution as candidates
+    (the dispatcher already filters by recipient = self)."""
+    from_id = msg.get("from_id")
+    from_name = msg.get("from_name")
+    if from_id is None and from_name is None:
+        return True
+    return from_id == secretary or from_name == secretary
+
+
+def _extract_body(msg: dict) -> str:
+    return msg.get("message") or msg.get("text") or msg.get("body") or ""
+
+
+def run_gate(args: argparse.Namespace, *, sleep=time.sleep,
+             stdin=None, stdout=None, stderr=None) -> int:
+    stdin = stdin or sys.stdin
+    stdout = stdout or sys.stdout
+    stderr = stderr or sys.stderr
+
+    pattern = re.compile(args.ack_pattern)
+
+    _emit({
+        "action": "send_initial",
+        "to_id": args.secretary,
+        "message": f"{args.task_id} の完了報告は届いていますか？",
+    }, stdout)
+
+    for attempt in range(1, args.timeout_attempts + 1):
+        if attempt > 1 and args.interval_seconds > 0:
+            sleep(args.interval_seconds)
+
+        _emit({"action": "check_messages", "attempt": attempt}, stdout)
+
+        line = stdin.readline()
+        if not line:
+            _emit({
+                "status": "error",
+                "reason": "stdin_closed",
+                "attempts": attempt,
+                "received_at": None,
+                "raw": None,
+            }, stdout)
+            return 2
+
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            _emit({
+                "status": "error",
+                "reason": f"invalid_json: {exc}",
+                "attempts": attempt,
+                "received_at": None,
+                "raw": None,
+            }, stdout)
+            return 2
+
+        messages = payload.get("messages") or []
+        for msg in messages:
+            if not _is_secretary_message(msg, args.secretary):
+                continue
+            body = _extract_body(msg)
+            if pattern.search(body):
+                _emit({
+                    "status": "acked",
+                    "received_at": _now_iso(),
+                    "raw": body,
+                    "attempts": attempt,
+                }, stdout)
+                return 0
+
+    _emit({
+        "status": "timeout",
+        "received_at": None,
+        "raw": None,
+        "attempts": args.timeout_attempts,
+    }, stdout)
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Poll for the secretary's completion-report ack before "
+                    "running the dispatcher retro (Issue #285).",
+    )
+    p.add_argument("--task-id", required=True,
+                   help="Task id used in the prompt sent to the secretary.")
+    p.add_argument("--secretary", default="secretary",
+                   help="Secretary pane name / id (default: secretary).")
+    p.add_argument("--timeout-attempts", type=int, default=10,
+                   help="Maximum number of check_messages polls (default: 10).")
+    p.add_argument("--interval-seconds", type=float, default=30.0,
+                   help="Seconds to sleep between polls (default: 30).")
+    p.add_argument("--ack-pattern", default=DEFAULT_ACK_PATTERN,
+                   help="Regex applied to incoming message bodies to decide ack.")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return run_gate(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/dispatcher_retro_gate.py
+++ b/tools/dispatcher_retro_gate.py
@@ -23,9 +23,13 @@ Wire protocol on stdout / stdin (newline-delimited JSON):
   CLI -> stdout: {"action": "check_messages", "attempt": <n>}
   stdin -> CLI:  {"messages": [<msg>, ...]}
   ... (repeats up to --timeout-attempts)
-  CLI -> stdout: {"status": "acked"|"timeout"|"error", ...}
+  CLI -> stdout: {"status": "acked"|"replied_no_ack"|"timeout"|"error", ...}
 
-Exit codes: 0=acked, 1=timeout, 2=error.
+Exit codes: 0=acked, 1=timeout, 2=error, 3=replied_no_ack
+(secretary replied but the body did not match the ack regex — distinct
+from "no reply at all" so the dispatcher can avoid the
+`secretary_unreachable` fallback when the secretary IS reachable but
+the answer was "見当たりません" / "確認します" etc.).
 """
 from __future__ import annotations
 
@@ -73,7 +77,14 @@ def _is_secretary_message(msg: dict, secretary: str) -> bool:
 
 
 def _extract_body(msg: dict) -> str:
-    return msg.get("message") or msg.get("text") or msg.get("body") or ""
+    """Pull the body text out of a renga-peers message dict. Non-string
+    values in any of the candidate fields are coerced to empty so the
+    caller's regex never sees a non-str (which would TypeError)."""
+    for key in ("message", "text", "body"):
+        value = msg.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
 
 
 def run_gate(args: argparse.Namespace, *, sleep=time.sleep,
@@ -99,6 +110,9 @@ def run_gate(args: argparse.Namespace, *, sleep=time.sleep,
         "to_id": args.secretary,
         "message": f"{args.task_id} の完了報告は届いていますか？",
     }, stdout)
+
+    last_secretary_body: str | None = None
+    last_secretary_attempt: int = 0
 
     for attempt in range(1, args.timeout_attempts + 1):
         if attempt > 1 and args.interval_seconds > 0:
@@ -158,6 +172,8 @@ def run_gate(args: argparse.Namespace, *, sleep=time.sleep,
             if not _is_secretary_message(msg, args.secretary):
                 continue
             body = _extract_body(msg)
+            last_secretary_body = body
+            last_secretary_attempt = attempt
             if pattern.search(body):
                 _emit({
                     "status": "acked",
@@ -166,6 +182,15 @@ def run_gate(args: argparse.Namespace, *, sleep=time.sleep,
                     "attempts": attempt,
                 }, stdout)
                 return 0
+
+    if last_secretary_body is not None:
+        _emit({
+            "status": "replied_no_ack",
+            "received_at": _now_iso(),
+            "raw": last_secretary_body,
+            "attempts": last_secretary_attempt,
+        }, stdout)
+        return 3
 
     _emit({
         "status": "timeout",

--- a/tools/dispatcher_retro_gate.py
+++ b/tools/dispatcher_retro_gate.py
@@ -1,35 +1,55 @@
 #!/usr/bin/env python3
-"""Polling gate for the dispatcher's retro completion-report ack.
+"""Per-attempt ack judge for the dispatcher's retro completion-report gate.
 
 Issue #285. Replaces the natural-language polling prose in
 ``.dispatcher/CLAUDE.md`` (around the "完了報告ゲート" section) with a
 deterministic CLI so the dispatcher Claude no longer has to re-derive
-cadence and ack-judgement on every retro.
+ack-judgement on every retro.
 
-Design (option B from the issue brief): this CLI never calls renga-peers
-itself. The dispatcher Claude stays the MCP boundary — it issues
-``mcp__renga-peers__send_message`` once up front and then
-``mcp__renga-peers__check_messages`` per poll, piping each result into
-this script's stdin. The script owns:
+Design: this CLI never calls renga-peers itself, and it does not run a
+long-lived polling loop — Claude Code's Bash tool is one-shot, so a
+co-routine that demands interactive stdin/stdout would not be runnable
+in practice. Instead, the dispatcher Claude runs this script ONCE per
+poll attempt, piping the latest ``check_messages`` result into stdin
+along with the gate state from the previous attempt. The script returns
+either a terminal verdict (``acked`` / ``replied_no_ack`` / ``timeout``
+/ ``error``) or a ``polling`` verdict that carries the updated state
+back so the dispatcher can sleep, fetch again, and re-invoke.
 
-  * cadence (sleep between attempts, max attempt count)
-  * ack judgement (regex against secretary-origin messages)
-  * structured JSON output for the dispatcher to switch on
+Invocation per attempt::
 
-Wire protocol on stdout / stdin (newline-delimited JSON):
+    python tools/dispatcher_retro_gate.py \
+        --task-id <id> --secretary secretary \
+        --attempt <n> --max-attempts 10 [--ack-pattern <regex>]
 
-  CLI -> stdout: {"action": "send_initial", "to_id": "<secretary>",
-                  "message": "<task_id> の完了報告は届いていますか？"}
-  CLI -> stdout: {"action": "check_messages", "attempt": <n>}
-  stdin -> CLI:  {"messages": [<msg>, ...]}
-  ... (repeats up to --timeout-attempts)
-  CLI -> stdout: {"status": "acked"|"replied_no_ack"|"timeout"|"error", ...}
+stdin (single JSON object on one or more lines)::
 
-Exit codes: 0=acked, 1=timeout, 2=error, 3=replied_no_ack
-(secretary replied but the body did not match the ack regex — distinct
-from "no reply at all" so the dispatcher can avoid the
-`secretary_unreachable` fallback when the secretary IS reachable but
-the answer was "見当たりません" / "確認します" etc.).
+    {
+      "messages": [<renga-peers message dict>, ...],
+      "state":    {"last_secretary_attempt": <int>,
+                   "last_secretary_body":    <str|null>}   // optional
+    }
+
+stdout (single JSON object — terminal or progress)::
+
+    {"status": "acked",          "received_at": ..., "raw": ..., "attempts": <n>}
+    {"status": "replied_no_ack", "received_at": ..., "raw": ..., "attempts": <n>}
+    {"status": "timeout",        "received_at": null, "raw": null, "attempts": <max>}
+    {"status": "polling",        "attempts": <n>,  "state": {...}}
+    {"status": "error",          "reason":   ..., "attempts": <n>, ...}
+
+Exit codes::
+
+    0 = acked
+    1 = timeout
+    2 = error
+    3 = replied_no_ack
+    4 = polling (caller should sleep and re-invoke)
+
+The ``--print-initial-prompt`` mode prints the task-templated initial
+question (no stdin needed, no exit code semantics) so the dispatcher
+can pipe it into ``mcp__renga-peers__send_message`` once before the
+first attempt.
 """
 from __future__ import annotations
 
@@ -38,20 +58,20 @@ import io
 import json
 import re
 import sys
-import time
 from datetime import datetime, timezone
+from typing import Any
 
-# Ensure UTF-8 stdio on Windows (default cp932 mangles JP prompts).
-for _stream_name in ("stdout", "stderr"):
+# Ensure UTF-8 stdio on Windows (default cp932 mangles JP prompts/ack
+# bodies). Reconfigure is best-effort — on streams that don't support
+# it we leave the default in place.
+for _stream_name in ("stdout", "stderr", "stdin"):
     _stream = getattr(sys, _stream_name, None)
-    if _stream is not None and getattr(_stream, "encoding", "").lower() != "utf-8":
-        try:
-            _stream.reconfigure(encoding="utf-8")  # py>=3.7
-        except (AttributeError, io.UnsupportedOperation):
-            pass
-if getattr(sys.stdin, "encoding", "").lower() != "utf-8":
+    if _stream is None:
+        continue
+    if getattr(_stream, "encoding", "").lower() == "utf-8":
+        continue
     try:
-        sys.stdin.reconfigure(encoding="utf-8")
+        _stream.reconfigure(encoding="utf-8")  # py>=3.7
     except (AttributeError, io.UnsupportedOperation):
         pass
 
@@ -62,8 +82,7 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _emit(obj: dict, stream=None) -> None:
-    stream = stream or sys.stdout
+def _emit(obj: dict, stream) -> None:
     stream.write(json.dumps(obj, ensure_ascii=False) + "\n")
     stream.flush()
 
@@ -71,8 +90,8 @@ def _emit(obj: dict, stream=None) -> None:
 def _is_secretary_message(msg: dict, secretary: str) -> bool:
     """Return True only if the message explicitly identifies the secretary
     as sender. Messages with no sender attribution are NOT treated as
-    secretary-origin — accepting them would let an unrelated message whose
-    body happens to contain "届い" trigger a false ack."""
+    secretary-origin — accepting them would let an unrelated message
+    whose body happens to contain "届い" trigger a false ack."""
     return msg.get("from_id") == secretary or msg.get("from_name") == secretary
 
 
@@ -87,11 +106,34 @@ def _extract_body(msg: dict) -> str:
     return ""
 
 
-def run_gate(args: argparse.Namespace, *, sleep=time.sleep,
-             stdin=None, stdout=None, stderr=None) -> int:
+def _read_stdin_payload(stdin) -> dict[str, Any]:
+    raw = stdin.read()
+    if not raw or not raw.strip():
+        return {}
+    return json.loads(raw)
+
+
+def run_gate(args: argparse.Namespace, *, stdin=None, stdout=None) -> int:
     stdin = stdin or sys.stdin
     stdout = stdout or sys.stdout
-    stderr = stderr or sys.stderr
+
+    if args.print_initial_prompt:
+        # Plain text on stdout — the dispatcher pipes this into
+        # mcp__renga-peers__send_message before the first attempt.
+        stdout.write(f"{args.task_id} の完了報告は届いていますか？\n")
+        stdout.flush()
+        return 0
+
+    if args.attempt < 1 or args.attempt > args.max_attempts:
+        _emit({
+            "status": "error",
+            "reason": (f"attempt {args.attempt} out of range "
+                       f"[1, {args.max_attempts}]"),
+            "attempts": args.attempt,
+            "received_at": None,
+            "raw": None,
+        }, stdout)
+        return 2
 
     try:
         pattern = re.compile(args.ack_pattern)
@@ -99,123 +141,120 @@ def run_gate(args: argparse.Namespace, *, sleep=time.sleep,
         _emit({
             "status": "error",
             "reason": f"invalid_ack_pattern: {exc}",
-            "attempts": 0,
+            "attempts": args.attempt,
             "received_at": None,
             "raw": None,
         }, stdout)
         return 2
 
-    _emit({
-        "action": "send_initial",
-        "to_id": args.secretary,
-        "message": f"{args.task_id} の完了報告は届いていますか？",
-    }, stdout)
-
-    last_secretary_body: str | None = None
-    last_secretary_attempt: int = 0
-
-    for attempt in range(1, args.timeout_attempts + 1):
-        if attempt > 1 and args.interval_seconds > 0:
-            sleep(args.interval_seconds)
-
-        _emit({"action": "check_messages", "attempt": attempt}, stdout)
-
-        line = stdin.readline()
-        if not line:
-            _emit({
-                "status": "error",
-                "reason": "stdin_closed",
-                "attempts": attempt,
-                "received_at": None,
-                "raw": None,
-            }, stdout)
-            return 2
-
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError as exc:
-            _emit({
-                "status": "error",
-                "reason": f"invalid_json: {exc}",
-                "attempts": attempt,
-                "received_at": None,
-                "raw": None,
-            }, stdout)
-            return 2
-
-        if not isinstance(payload, dict):
-            _emit({
-                "status": "error",
-                "reason": "invalid_schema: payload must be a JSON object",
-                "attempts": attempt,
-                "received_at": None,
-                "raw": None,
-            }, stdout)
-            return 2
-
-        messages = payload.get("messages", [])
-        if not isinstance(messages, list):
-            _emit({
-                "status": "error",
-                "reason": "invalid_schema: 'messages' must be a list",
-                "attempts": attempt,
-                "received_at": None,
-                "raw": None,
-            }, stdout)
-            return 2
-
-        for msg in messages:
-            if not isinstance(msg, dict):
-                # Skip non-object entries rather than crash; the dispatcher
-                # may surface a future schema variant we don't recognise.
-                continue
-            if not _is_secretary_message(msg, args.secretary):
-                continue
-            body = _extract_body(msg)
-            last_secretary_body = body
-            last_secretary_attempt = attempt
-            if pattern.search(body):
-                _emit({
-                    "status": "acked",
-                    "received_at": _now_iso(),
-                    "raw": body,
-                    "attempts": attempt,
-                }, stdout)
-                return 0
-
-    if last_secretary_body is not None:
+    try:
+        payload = _read_stdin_payload(stdin)
+    except json.JSONDecodeError as exc:
         _emit({
-            "status": "replied_no_ack",
-            "received_at": _now_iso(),
-            "raw": last_secretary_body,
-            "attempts": last_secretary_attempt,
+            "status": "error",
+            "reason": f"invalid_json: {exc}",
+            "attempts": args.attempt,
+            "received_at": None,
+            "raw": None,
         }, stdout)
-        return 3
+        return 2
 
+    if not isinstance(payload, dict):
+        _emit({
+            "status": "error",
+            "reason": "invalid_schema: payload must be a JSON object",
+            "attempts": args.attempt,
+            "received_at": None,
+            "raw": None,
+        }, stdout)
+        return 2
+
+    messages = payload.get("messages", [])
+    if not isinstance(messages, list):
+        _emit({
+            "status": "error",
+            "reason": "invalid_schema: 'messages' must be a list",
+            "attempts": args.attempt,
+            "received_at": None,
+            "raw": None,
+        }, stdout)
+        return 2
+
+    state = payload.get("state") or {}
+    if not isinstance(state, dict):
+        state = {}
+    last_secretary_body = state.get("last_secretary_body")
+    last_secretary_attempt = state.get("last_secretary_attempt") or 0
+    if not isinstance(last_secretary_attempt, int):
+        last_secretary_attempt = 0
+    if last_secretary_body is not None and not isinstance(last_secretary_body, str):
+        last_secretary_body = None
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        if not _is_secretary_message(msg, args.secretary):
+            continue
+        body = _extract_body(msg)
+        last_secretary_body = body
+        last_secretary_attempt = args.attempt
+        if pattern.search(body):
+            _emit({
+                "status": "acked",
+                "received_at": _now_iso(),
+                "raw": body,
+                "attempts": args.attempt,
+            }, stdout)
+            return 0
+
+    if args.attempt >= args.max_attempts:
+        if last_secretary_body is not None:
+            _emit({
+                "status": "replied_no_ack",
+                "received_at": _now_iso(),
+                "raw": last_secretary_body,
+                "attempts": last_secretary_attempt,
+            }, stdout)
+            return 3
+        _emit({
+            "status": "timeout",
+            "received_at": None,
+            "raw": None,
+            "attempts": args.max_attempts,
+        }, stdout)
+        return 1
+
+    # More attempts to go — return updated state for the next invocation.
     _emit({
-        "status": "timeout",
-        "received_at": None,
-        "raw": None,
-        "attempts": args.timeout_attempts,
+        "status": "polling",
+        "attempts": args.attempt,
+        "state": {
+            "last_secretary_attempt": last_secretary_attempt,
+            "last_secretary_body": last_secretary_body,
+        },
     }, stdout)
-    return 1
+    return 4
 
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        description="Poll for the secretary's completion-report ack before "
-                    "running the dispatcher retro (Issue #285).",
+        description="Per-attempt ack judge for the dispatcher's retro "
+                    "completion-report gate (Issue #285).",
     )
     p.add_argument("--task-id", required=True,
                    help="Task id used in the prompt sent to the secretary.")
     p.add_argument("--secretary", default="secretary",
                    help="Secretary pane name / id (default: secretary).")
-    p.add_argument("--timeout-attempts", type=int, default=10,
-                   help="Maximum number of check_messages polls (default: 10).")
-    p.add_argument("--interval-seconds", type=float, default=30.0,
-                   help="Seconds to sleep between polls (default: 30).")
+    p.add_argument("--attempt", type=int, default=1,
+                   help="Current poll attempt number, 1-indexed.")
+    p.add_argument("--max-attempts", type=int, default=10,
+                   help="Total number of poll attempts (default: 10).")
     p.add_argument("--ack-pattern", default=DEFAULT_ACK_PATTERN,
                    help="Regex applied to incoming message bodies to decide ack.")
+    p.add_argument("--print-initial-prompt", action="store_true",
+                   help="Print the templated initial prompt and exit. "
+                        "Use this once before --attempt 1 to feed the "
+                        "secretary message via mcp__renga-peers__send_message.")
     return p
 
 


### PR DESCRIPTION
## Summary

Closes #285. Extracts the dispatcher's retro completion-report polling loop from `.dispatcher/CLAUDE.md` prose into a deterministic CLI (`tools/dispatcher_retro_gate.py`), eliminating the LLM-driven polling cadence drift that caused the `2026-05-03-delegation-smoke-completion-report.md` incident.

## Design

The dispatcher runs inside Claude Code's Bash tool, which is one-shot per call. A long-lived polling daemon would never run cleanly under that model. Instead the CLI is **one attempt per invocation**:

- The dispatcher Claude orchestrates cadence with `Bash sleep 30` between attempts.
- Each attempt calls the CLI with the latest `check_messages` result on stdin and the previous attempt's state.
- The CLI returns a single JSON line on stdout and an exit code that drives the dispatcher's branching.

Exit codes:

- `0` — acked (a recognized completion report arrived)
- `1` — timeout (attempts exhausted)
- `2` — error (invalid input, regex compile failure, etc.)
- `3` — replied_no_ack (Secretary replied but the message did not match the ack pattern; distinct from timeout because the human is engaged)
- `4` — polling (more attempts remain, dispatcher should sleep then retry)

Plus a `--print-initial-prompt` mode for emitting the opening "<task_id> の完了報告は届いていますか？" message separately, so the dispatcher can issue it via `mcp__renga-peers__send_message` before the polling loop begins.

## Changes

- **New**: `tools/dispatcher_retro_gate.py` (~250 lines). Pure stdlib, Windows UTF-8 stdio reconfig.
- **New**: `tests/test_dispatcher_retro_gate.py`. 14 tests covering ack-on-first, ack-on-third, timeout, replied_no_ack, anonymous sender, malformed regex, schema-invalid stdin, non-string body guards.
- **Modified**: `.dispatcher/CLAUDE.md` retro gate section — replaces prose polling with the new CLI's invocation contract. The escalation triggers (timeout → notify Secretary) remain natural-language.

## Codex self-review (3 rounds)

- Round 1: 2 Majors + 1 Minor — regex compile exception, stdin schema validation, anonymous sender. Fixed.
- Round 2: 1 Major + 1 Minor — replied_no_ack split out from timeout, non-string body guards. Fixed.
- Round 3 (Blocker): an earlier draft assumed bidirectional stdio inside one Claude Code Bash tool call, which is not actually possible. Redesigned to one-shot per attempt as described above. After redesign no further Blocker / Major / Minor / Nit.

## Test plan

- [x] `pytest tests/test_dispatcher_retro_gate.py` — 14 pass.
- [ ] CI on this PR.
- [ ] Manual: next time a completion report is expected, dispatcher's retro gate should run via this CLI without the LLM re-deriving the polling cadence.

## Parallel coordination

PR #295 (Issue #287) is also editing `.dispatcher/CLAUDE.md` (Step 5 STALL_SUSPECTED, new section). This PR only edits the existing retro-gate section. Conflict at squash time is unlikely but resolve by hand if it appears.

Closes #285.