### PR TITLE
feat(secretary): add pending-decisions register for relay-gap detection

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -419,9 +419,11 @@ mcp__renga-peers__send_message(
    - **状態を保存する**（窓口再起動・引き継ぎで pending 判断を失わないため、進捗報告と同等の永続化を行う）:
      - `.state/workers/worker-{task_id}.md` の Progress Log に「判断仰ぎ受信」内容と要点を追記
      - DB の events テーブルに追記: `bash tools/journal_append.sh worker_escalation worker=worker-{task_id} task={task_id} reason="<要約>"`
-   - 人間に内容と選択肢を整理して提示し、人間の判断を待つ
-   - 人間の判断後にワーカーに伝達する（伝達時は `to_id="worker-{task_id}"` で `send_message`）
+     - **pending-decisions register に追加** (Issue #297): `python tools/pending_decisions.py append --task-id {task_id} --message "<本文要約>"`。同 task_id の pending が既存なら idempotent (no-op)。register はディスパッチャーの SECRETARY_RELAY_GAP_SUSPECTED 検出 (`.dispatcher/CLAUDE.md` Step 5.1) の primary lookup source
+   - 人間に内容と選択肢を整理して提示する。提示直後に **register を escalated に更新**: `python tools/pending_decisions.py resolve --task-id {task_id} --kind to_user`
+   - 人間の判断後にワーカーに伝達する（伝達時は `to_id="worker-{task_id}"` で `send_message`）。伝達直後に **register を resolved に更新**: `python tools/pending_decisions.py resolve --task-id {task_id} --kind to_worker`
    - 「ユーザーは選択肢 X を選んだから自動的に含意される」等の自己解釈で承認してはならない
+   - register の append / resolve のどちらかが欠落するとディスパッチャー側で SECRETARY_RELAY_GAP_SUSPECTED が誤発火または見逃しになる。Progress Log / journal は重複保険として維持し、register 更新とは独立に行うこと
    - （注）ブロッカー報告も本分岐で扱うため、下段「3. ブロック報告の場合」と重複した場合は本分岐を優先する
 
 1. 進捗報告の場合:

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -356,6 +356,38 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 
    **定数**: `STALL_SECRETARY_LOOKBACK_MIN = 15` を再利用 (Step 5 と同じ window、関連事象は同じ時間スケール)。
 
+   #### (a-0) Primary check: pending-decisions register lookup (Issue #297)
+
+   PR #298 (Issue #292) は (a) の動機 (1)(2) を proxy heuristics (snapshot diff / send_message timing) で検知していたが、(a)(2) (user 回答 → secretary → worker の転送漏れ) は worker outbound が起点となるため proxy では出ない死角があった。Issue #297 で Secretary 側に `.state/pending_decisions.json` 相当の **register** を導入し、両方向 (a)(1)(a)(2) を deterministic に追跡する:
+
+   - Secretary は `worker_escalation` を受領した時点で register に `{task_id, received_at, status="pending"}` を append する (CLAUDE.md / `.claude/skills/org-delegate/SKILL.md` Step 5 サブセクション 0)
+   - 人間に伝達した時点で `resolve --kind to_user` で `escalated` に更新
+   - 人間判断をワーカーに転送した時点で `resolve --kind to_worker` で `resolved` に更新
+
+   ディスパッチャーは tick ごとに register を lookup する:
+
+   ```bash
+   # ディスパッチャー cwd は .dispatcher/。helper は repo root 起点で
+   # .state/pending_decisions.json を解決するため相対パスは不要。
+   python ../tools/pending_decisions.py list --older-than-min 15
+   ```
+
+   - 出力 0 行 → relay gap **なし**。アラート発火不要。以降の (a)〜(f) (proxy 経路) も skip 可
+   - 出力 1 行以上 → 各行 (1 entry per line, JSON) を `task_id` 単位で集約し、SECRETARY_RELAY_GAP_SUSPECTED を **(e) と同じ通知経路** で発火する。register lookup は両方向 ((a)(1)(2)) を一括で拾うため、(b) の `T_last_worker_in` 起点ロジックを再評価する必要はない (register 自体が「Secretary が受領した judgment_request のうち未中継のもの」という ground truth)
+   - de-dup と journal 追記は (f) と同じスキーマを使う:
+
+     ```bash
+     bash ../tools/journal_append.sh anomaly_observed source=relay_gap_check worker=worker-{task_id} kind=relay_gap_suspected confidence=high
+     # 通知送信成功後:
+     bash ../tools/journal_append.sh notify_sent source=relay_gap_check worker=worker-{task_id} kind=relay_gap_suspected confidence=high
+     ```
+
+     `confidence=high` は register lookup 経由 (proxy より信頼度が高い) を表す。proxy 経路の confidence (n/a) と区別したい場合のラベル。
+
+   **register lookup は primary、(a)〜(f) の proxy 経路は fallback (TODO 格下げ)**: register が空なら proxy 経路の判定 (snapshot diff / journal scan) は **skip して良い**。実装簡素化のため proxy 経路は当面残すが、register が安定運用に乗ったら本ファイルから削除する (将来 Issue で対応、本 PR ではコード/prose 両方を残置)。
+
+   register が読めない (helper not found / file corrupted で `ValueError`) 場合は proxy 経路に fallback する。journal に `anomaly_observed source=relay_gap_check kind=register_unavailable` を残し、(b)〜(f) を従来通り実行する。
+
    #### (a) 動機
    Step 5 は worker 側 (worker→secretary 痕跡が **ある** ので stall 抑制) を見て補助シグナル化したが、逆方向 (secretary→user / secretary→worker の中継) には盲点がある。具体的なインシデントパターン:
    1. worker が "判断仰ぎます" を secretary に送信 → secretary は受領 (`worker_escalation` が journal に append) → secretary が **人間に上げ忘れ** → worker idle、Step 5 の補助シグナルは「ヒット」扱いで suppress、しかし user は何も知らない
@@ -446,18 +478,8 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
      ```
    - **再通知 cadence**: dedup window は 30 秒のみ (Step 4 / Step 5 と同じ at-least-once 担保のための短窓)。`/loop 3m` cadence では 30 秒は毎サイクル抜けるため、relay gap が解消するまで **3 分ごとに 1 回 user に再通知が届く**。relay gap は user の視認漏れが致命的な事象なので、stuck 通知のような長窓 suppress は採用しない。状態が変わった (= secretary 側 outbound が現れた、または新規 `T_last_worker_in` で起点更新により候補から外れた) 時点で次サイクルの観測時に (b) を不成立にして自然停止する
 
-   #### (g) 設計メモ — register 化 (案 c) は別 Issue
-   本来は `.state/pending_decisions.json` 相当の register を導入し:
-   - secretary が `worker_escalation` を受領した時点で entry 追加 (`{task_id, received_ts, kind: "judgment_request"}`)
-   - secretary が user に上げた時点で `acked_to_user_ts` を埋める
-   - secretary が user 回答を worker に伝達した時点で `relayed_to_worker_ts` を埋める or entry 削除
-   - dispatcher は tick ごとにこの register を読み、`now - received_ts > 15min` かつ未 ack を SECRETARY_RELAY_GAP_SUSPECTED 化
-
-   が clean。secretary 自身の自己観測ではなく外部 register に書かれるので false positive が大幅に減る。ただし:
-   - secretary skill / org-delegate / 判断仰ぎ受信ロジックを横断的に書き換える必要がある
-   - 既存の journal event との二重 source of truth になりかねない (移行期に矛盾が起きる)
-
-   本 PR では prose 仕様のみ着地させ、register 化は **別 Issue 化** する (本 PR 完了時の commit / PR description で `Follow-up: secretary-side pending_decisions register (separate issue)` として TODO を明記する)。
+   #### (g) 設計メモ — register 化は (a-0) で着地済み (Issue #297)
+   PR #298 で TODO 化した「`.state/pending_decisions.json` 相当の register」は Issue #297 で実装済み。詳細は本セクション (a-0) "Primary check: pending-decisions register lookup" を参照。本セクション (a)〜(f) の proxy 経路は fallback として残置されているが、primary は (a-0) の register lookup に切り替わっている。proxy 経路の最終削除は別 Issue (register lookup の安定運用が確認できた段階) で扱う。
 
    #### (h) 設計メモ — relay gap と Step 5 stall の関係
    Step 5 の stall 検出は worker→secretary 痕跡があれば「acked」として STALL_SUSPECTED を抑制する。relay gap 検出は **その抑制された acked 集合** にこそ存在する。即ち:

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -372,8 +372,10 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
    python ../tools/pending_decisions.py list --older-than-min 15
    ```
 
-   - 出力 0 行 → relay gap **なし**。アラート発火不要。以降の (a)〜(f) (proxy 経路) も skip 可
-   - 出力 1 行以上 → 各行 (1 entry per line, JSON) を `task_id` 単位で集約し、SECRETARY_RELAY_GAP_SUSPECTED を **(e) と同じ通知経路** で発火する。register lookup は両方向 ((a)(1)(2)) を一括で拾うため、(b) の `T_last_worker_in` 起点ロジックを再評価する必要はない (register 自体が「Secretary が受領した judgment_request のうち未中継のもの」という ground truth)
+   - 出力 0 行 → register 経由の (a)(1) relay gap は **なし**。proxy 経路 ((a)〜(f)) で (a)(2) 方向を確認したい場合のみ続行 (デフォルトは skip 可)
+   - 出力 1 行以上 → 各行 (1 entry per line, JSON、`status="pending"` のみ) を `task_id` 単位で集約し、SECRETARY_RELAY_GAP_SUSPECTED を **(e) と同じ通知経路** で発火する。register は (a)(1) 方向 (Secretary が worker→user の中継を忘れた) を deterministic に拾う ground truth
+
+   **(a)(2) 方向の取り扱い** (Issue #297 のスコープ制限): register は「人間が返答済みか」を表す signal を持たないため、`escalated` 状態を時間で alarm 化すると「人間が考え中」と「Secretary が user→worker 転送を忘れた」を区別できず false positive が常態化する。よって `list --older-than-min` は意図的に `pending` のみを返す。(a)(2) 方向の deterministic 検知は `user_replied_at` marker 等の schema 拡張が必要で、別 Issue で扱う。本 PR では (a)(2) の最低限の保険として既存の (a)〜(f) proxy 経路を残置しているので、運用上は併用すること
    - de-dup と journal 追記は (f) と同じスキーマを使う:
 
      ```bash

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -372,10 +372,10 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
    python ../tools/pending_decisions.py list --older-than-min 15
    ```
 
-   - 出力 0 行 → register 経由の (a)(1) relay gap は **なし**。proxy 経路 ((a)〜(f)) で (a)(2) 方向を確認したい場合のみ続行 (デフォルトは skip 可)
-   - 出力 1 行以上 → 各行 (1 entry per line, JSON、`status="pending"` のみ) を `task_id` 単位で集約し、SECRETARY_RELAY_GAP_SUSPECTED を **(e) と同じ通知経路** で発火する。register は (a)(1) 方向 (Secretary が worker→user の中継を忘れた) を deterministic に拾う ground truth
+   - 出力 0 行 → register 経由の (a)(1) relay gap は **なし**。ただし (a)(2) は register では捕捉できないため、proxy 経路 ((a)〜(f)) は **必ず続行する** (skip しない)
+   - 出力 1 行以上 → 各行 (1 entry per line, JSON、`status="pending"` のみ) を `task_id` 単位で集約し、SECRETARY_RELAY_GAP_SUSPECTED を **(e) と同じ通知経路** で発火する。register は (a)(1) 方向 (Secretary が worker→user の中継を忘れた) を deterministic に拾う ground truth。発火後も同サイクル内で proxy 経路を続行する (proxy が独立に拾う (a)(2) を見逃さないため)。同じ worker に対する重複通知は (f) の de-dup 30 秒窓で吸収される
 
-   **(a)(2) 方向の取り扱い** (Issue #297 のスコープ制限): register は「人間が返答済みか」を表す signal を持たないため、`escalated` 状態を時間で alarm 化すると「人間が考え中」と「Secretary が user→worker 転送を忘れた」を区別できず false positive が常態化する。よって `list --older-than-min` は意図的に `pending` のみを返す。(a)(2) 方向の deterministic 検知は `user_replied_at` marker 等の schema 拡張が必要で、別 Issue で扱う。本 PR では (a)(2) の最低限の保険として既存の (a)〜(f) proxy 経路を残置しているので、運用上は併用すること
+   **(a)(2) 方向の取り扱い** (Issue #297 のスコープ制限): register は「人間が返答済みか」を表す signal を持たないため、`escalated` 状態を時間で alarm 化すると「人間が考え中」と「Secretary が user→worker 転送を忘れた」を区別できず false positive が常態化する。よって `list --older-than-min` は意図的に `pending` のみを返す。(a)(2) 方向の deterministic 検知は `user_replied_at` marker 等の schema 拡張が必要で、別 Issue で扱う。本 PR で (a)(2) の唯一のカバーは既存 (a)〜(f) proxy 経路 (snapshot diff 等) であり、register lookup の結果に関わらず毎サイクル必ず実行する
    - de-dup と journal 追記は (f) と同じスキーマを使う:
 
      ```bash
@@ -386,9 +386,9 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 
      `confidence=high` は register lookup 経由 (proxy より信頼度が高い) を表す。proxy 経路の confidence (n/a) と区別したい場合のラベル。
 
-   **register lookup は primary、(a)〜(f) の proxy 経路は fallback (TODO 格下げ)**: register が空なら proxy 経路の判定 (snapshot diff / journal scan) は **skip して良い**。実装簡素化のため proxy 経路は当面残すが、register が安定運用に乗ったら本ファイルから削除する (将来 Issue で対応、本 PR ではコード/prose 両方を残置)。
+   **register lookup は (a)(1) の primary、(a)〜(f) の proxy 経路は (a)(2) の唯一のカバー**: register と proxy は disjoint な方向を扱うため、毎サイクル両方を実行する (proxy 経路を skip すると (a)(2) のカバーが消える)。proxy 経路の (a)(1) 関連部分は register が一次 source なので冗長になるが、de-dup 30 秒窓で吸収されるためそのまま残す。proxy 経路の最終削除は (a)(2) 用の deterministic 検知 (user_replied_at marker など) が別 Issue で着地した後に再評価する。
 
-   register が読めない (helper not found / file corrupted で `ValueError`) 場合は proxy 経路に fallback する。journal に `anomaly_observed source=relay_gap_check kind=register_unavailable` を残し、(b)〜(f) を従来通り実行する。
+   register が読めない (helper not found / file corrupted で `ValueError`) 場合は (a)(1) も proxy 経路に fallback する。journal に `anomaly_observed source=relay_gap_check kind=register_unavailable` を残し、(b)〜(f) を従来通り実行する。
 
    #### (a) 動機
    Step 5 は worker 側 (worker→secretary 痕跡が **ある** ので stall 抑制) を見て補助シグナル化したが、逆方向 (secretary→user / secretary→worker の中継) には盲点がある。具体的なインシデントパターン:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,27 @@
 許される一次対応は「受領しました、人間に確認します」のみ。「ユーザーは選択肢 X を選んだから含意される」「一気通貫の意図に含まれる」等の自己解釈は禁止。人間の判断を受けてからワーカーに伝達する（伝言役であり判断レイヤーではない）。
 
 **状態保存（必須）**: 判断仰ぎ受信時は `.state/workers/worker-{task_id}.md` の Progress Log に追記し、`bash tools/journal_append.sh worker_escalation worker=worker-{task_id} task={task_id} reason="<要約>"` を実行する。窓口再起動・引き継ぎで pending 判断を失わないため。手順詳細は `.claude/skills/org-delegate/SKILL.md` Step 5 のサブセクション 0 を参照。
+
+**pending-decisions register（必須、Issue #297）**: ディスパッチャーの SECRETARY_RELAY_GAP_SUSPECTED 検出 (`.dispatcher/CLAUDE.md` Step 5.1) は `.state/pending_decisions.json` を register として参照する。Secretary は判断仰ぎの受信・人間への伝達・ワーカーへの転送のそれぞれで本 register を更新する:
+
+1. **判断仰ぎ受信時** — Progress Log と `worker_escalation` journal 追記に加えて register に entry を追加する:
+
+   ```bash
+   python tools/pending_decisions.py append --task-id <task_id> --message "<本文要約>"
+   ```
+
+   同 task_id の `pending` entry が既存なら idempotent (no-op)。
+
+2. **人間に伝達した時点** — 人間に内容と選択肢を提示した直後に register を `escalated` に更新する:
+
+   ```bash
+   python tools/pending_decisions.py resolve --task-id <task_id> --kind to_user
+   ```
+
+3. **ワーカーに人間判断を転送した時点** — `to_id="worker-{task_id}"` で `send_message` を発行した直後に register を `resolved` に更新する:
+
+   ```bash
+   python tools/pending_decisions.py resolve --task-id <task_id> --kind to_worker
+   ```
+
+`resolve` は該当 `pending` entry が無ければ no-op。append と resolve のどちらも欠落するとディスパッチャー側で SECRETARY_RELAY_GAP_SUSPECTED が誤発火 (中継済みなのにアラート) または見逃し (中継忘れを検知できない) になる。Progress Log / journal 追記は重複保険として維持し、register への append/resolve とは独立に行うこと。

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -206,9 +206,11 @@ class PendingDecisionsTests(unittest.TestCase):
         again = pd.resolve("t1", "to_user", store_path=self.store)
         self.assertIsNone(again)
 
-    def test_list_pending_includes_escalated(self) -> None:
-        # An entry escalated 20 minutes ago must surface as a relay-gap
-        # candidate at the 15-minute threshold (covers (a)(2) direction).
+    def test_list_pending_excludes_escalated(self) -> None:
+        # Escalated entries are awaiting human reply, not Secretary
+        # action — surfacing them as relay-gap would false-positive on
+        # every slow human answer. (a)(2) detection is left to a
+        # follow-up Issue with a richer schema.
         old_ts = "2026-05-05T05:30:00Z"
         seed = [
             {
@@ -223,9 +225,29 @@ class PendingDecisionsTests(unittest.TestCase):
         self.store.parent.mkdir(parents=True, exist_ok=True)
         self.store.write_text(json.dumps(seed), encoding="utf-8")
         now = datetime(2026, 5, 5, 5, 50, 0, tzinfo=timezone.utc)
-        out = pd.list_pending_older_than(15, store_path=self.store, now=now)
-        self.assertEqual([e.task_id for e in out], ["t1"])
-        self.assertEqual(out[0].status, "escalated")
+        self.assertEqual(
+            pd.list_pending_older_than(15, store_path=self.store, now=now),
+            [],
+        )
+        self.assertEqual(pd.list_pending(store_path=self.store), [])
+
+    def test_unknown_status_in_register_raises(self) -> None:
+        # Status validation matches the loud-failure stance taken for
+        # unparseable received_at and malformed JSON; silently dropping
+        # an unknown-status entry would be a false-negative source for
+        # the relay-gap fallback contract.
+        seed = [
+            {
+                "task_id": "t1",
+                "received_at": "2026-05-05T05:00:00Z",
+                "raw_message": "ask",
+                "status": "weird",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+        with self.assertRaises(ValueError):
+            pd.list_pending(store_path=self.store)
 
     def test_unparseable_received_at_is_surfaced(self) -> None:
         # Malformed timestamp must surface as a relay-gap candidate

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -1,0 +1,198 @@
+"""Tests for tools/pending_decisions.py (Issue #297)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools import pending_decisions as pd  # noqa: E402
+
+
+class PendingDecisionsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.store = Path(self._tmpdir.name) / "pending_decisions.json"
+
+    def _read_raw(self) -> list[dict]:
+        return json.loads(self.store.read_text(encoding="utf-8"))
+
+    # (a) ----------------------------------------------------------------
+    def test_append_to_empty_store_creates_file_with_pending_entry(self) -> None:
+        self.assertFalse(self.store.exists())
+        entry = pd.append("t1", "judgment please", store_path=self.store)
+        self.assertTrue(self.store.exists())
+        self.assertEqual(entry.task_id, "t1")
+        self.assertEqual(entry.status, "pending")
+        self.assertEqual(entry.raw_message, "judgment please")
+        self.assertIsNone(entry.resolved_at)
+        self.assertIsNone(entry.resolution_kind)
+        raw = self._read_raw()
+        self.assertEqual(len(raw), 1)
+        self.assertEqual(raw[0]["task_id"], "t1")
+
+    # (b) ----------------------------------------------------------------
+    def test_append_same_task_id_is_idempotent(self) -> None:
+        first = pd.append("t1", "first", store_path=self.store)
+        second = pd.append("t1", "second body ignored", store_path=self.store)
+        self.assertEqual(first.received_at, second.received_at)
+        self.assertEqual(second.raw_message, "first")  # original kept
+        raw = self._read_raw()
+        self.assertEqual(len(raw), 1)
+
+    # (c) ----------------------------------------------------------------
+    def test_resolve_to_user_marks_escalated(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        out = pd.resolve("t1", "to_user", store_path=self.store)
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertEqual(out.status, "escalated")
+        self.assertEqual(out.resolution_kind, "to_user")
+        self.assertIsNotNone(out.resolved_at)
+
+    # (d) ----------------------------------------------------------------
+    def test_resolve_to_worker_marks_resolved(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        out = pd.resolve("t1", "to_worker", store_path=self.store)
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertEqual(out.status, "resolved")
+        self.assertEqual(out.resolution_kind, "to_worker")
+
+    # (e) ----------------------------------------------------------------
+    def test_resolve_unknown_task_id_returns_none(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        self.assertIsNone(pd.resolve("nonexistent", "to_user", store_path=self.store))
+        # Original pending entry untouched
+        pending = pd.list_pending(store_path=self.store)
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0].status, "pending")
+
+    # (f) ----------------------------------------------------------------
+    def test_list_pending_older_than_filters_by_received_at(self) -> None:
+        old_ts = "2026-05-05T00:00:00Z"
+        new_ts = "2026-05-05T05:50:00Z"
+        seed = [
+            {
+                "task_id": "old",
+                "received_at": old_ts,
+                "raw_message": "old",
+                "status": "pending",
+            },
+            {
+                "task_id": "new",
+                "received_at": new_ts,
+                "raw_message": "new",
+                "status": "pending",
+            },
+            {
+                "task_id": "done",
+                "received_at": old_ts,
+                "raw_message": "done",
+                "status": "resolved",
+                "resolved_at": old_ts,
+                "resolution_kind": "to_worker",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+
+        now = datetime(2026, 5, 5, 6, 0, 0, tzinfo=timezone.utc)
+        result = pd.list_pending_older_than(15, store_path=self.store, now=now)
+        self.assertEqual([e.task_id for e in result], ["old"])
+
+    # (g) ----------------------------------------------------------------
+    def test_atomic_write_leaves_no_tmp_file(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        siblings = list(self.store.parent.iterdir())
+        names = sorted(p.name for p in siblings)
+        self.assertEqual(names, [self.store.name])
+        # No leftover tmp file
+        self.assertFalse(any(p.name.endswith(".tmp") for p in siblings))
+
+    # (h) ----------------------------------------------------------------
+    def test_malformed_json_raises_value_error(self) -> None:
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text("{not json", encoding="utf-8")
+        with self.assertRaises(ValueError):
+            pd.list_pending(store_path=self.store)
+
+    # extras -------------------------------------------------------------
+    def test_missing_file_returns_empty(self) -> None:
+        self.assertEqual(pd.list_pending(store_path=self.store), [])
+        self.assertEqual(
+            pd.list_pending_older_than(15, store_path=self.store), []
+        )
+
+    def test_resolve_picks_oldest_pending_when_multiple(self) -> None:
+        # Direct-seed two pending entries for the same task_id (the
+        # public append() de-dups, so we bypass it to construct the
+        # rare "multiple pending" state described in the spec).
+        seed = [
+            {
+                "task_id": "t1",
+                "received_at": "2026-05-05T05:00:00Z",
+                "raw_message": "newer",
+                "status": "pending",
+            },
+            {
+                "task_id": "t1",
+                "received_at": "2026-05-05T04:00:00Z",
+                "raw_message": "older",
+                "status": "pending",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+
+        out = pd.resolve("t1", "to_worker", store_path=self.store)
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertEqual(out.raw_message, "older")
+        # The newer one stays pending.
+        remaining = pd.list_pending(store_path=self.store)
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0].raw_message, "newer")
+
+    def test_resolve_unknown_kind_raises(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        with self.assertRaises(ValueError):
+            pd.resolve("t1", "to_nowhere", store_path=self.store)  # type: ignore[arg-type]
+
+    def test_append_after_resolve_creates_new_pending(self) -> None:
+        pd.append("t1", "first", store_path=self.store)
+        pd.resolve("t1", "to_worker", store_path=self.store)
+        # A new judgment-request for the same task should re-open.
+        new_entry = pd.append("t1", "second round", store_path=self.store)
+        self.assertEqual(new_entry.status, "pending")
+        self.assertEqual(new_entry.raw_message, "second round")
+        raw = self._read_raw()
+        self.assertEqual(len(raw), 2)
+
+    def test_cli_append_and_list(self) -> None:
+        rc = pd.main(
+            [
+                "--store",
+                str(self.store),
+                "append",
+                "--task-id",
+                "tcli",
+                "--message",
+                "hi",
+            ]
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(pd.list_pending(store_path=self.store)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -178,6 +178,72 @@ class PendingDecisionsTests(unittest.TestCase):
         raw = self._read_raw()
         self.assertEqual(len(raw), 2)
 
+    def test_canonical_lifecycle_pending_escalated_resolved(self) -> None:
+        # Mirrors the prose contract in CLAUDE.md / SKILL.md:
+        # append -> resolve(to_user) -> resolve(to_worker) must terminate
+        # the entry as resolved (not be a no-op on the third step).
+        pd.append("t1", "ask", store_path=self.store)
+        first = pd.resolve("t1", "to_user", store_path=self.store)
+        self.assertIsNotNone(first)
+        assert first is not None
+        self.assertEqual(first.status, "escalated")
+        second = pd.resolve("t1", "to_worker", store_path=self.store)
+        self.assertIsNotNone(second)
+        assert second is not None
+        self.assertEqual(second.status, "resolved")
+        self.assertEqual(second.resolution_kind, "to_worker")
+        # No open entries remain — relay-gap should not fire.
+        self.assertEqual(pd.list_pending(store_path=self.store), [])
+        self.assertEqual(
+            pd.list_pending_older_than(0, store_path=self.store), []
+        )
+
+    def test_resolve_to_user_after_escalated_is_noop(self) -> None:
+        # to_user only matches pending — escalated entries are not
+        # re-eligible for it.
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        again = pd.resolve("t1", "to_user", store_path=self.store)
+        self.assertIsNone(again)
+
+    def test_list_pending_includes_escalated(self) -> None:
+        # An entry escalated 20 minutes ago must surface as a relay-gap
+        # candidate at the 15-minute threshold (covers (a)(2) direction).
+        old_ts = "2026-05-05T05:30:00Z"
+        seed = [
+            {
+                "task_id": "t1",
+                "received_at": old_ts,
+                "raw_message": "ask",
+                "status": "escalated",
+                "resolved_at": old_ts,
+                "resolution_kind": "to_user",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+        now = datetime(2026, 5, 5, 5, 50, 0, tzinfo=timezone.utc)
+        out = pd.list_pending_older_than(15, store_path=self.store, now=now)
+        self.assertEqual([e.task_id for e in out], ["t1"])
+        self.assertEqual(out[0].status, "escalated")
+
+    def test_unparseable_received_at_is_surfaced(self) -> None:
+        # Malformed timestamp must surface as a relay-gap candidate
+        # rather than be silently dropped (loud failure beats false
+        # negative against .dispatcher/CLAUDE.md Step 5.1 contract).
+        seed = [
+            {
+                "task_id": "broken",
+                "received_at": "not-a-timestamp",
+                "raw_message": "ask",
+                "status": "pending",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+        out = pd.list_pending_older_than(15, store_path=self.store)
+        self.assertEqual([e.task_id for e in out], ["broken"])
+
     def test_cli_append_and_list(self) -> None:
         rc = pd.main(
             [

--- a/tools/pending_decisions.py
+++ b/tools/pending_decisions.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Secretary-side pending-decisions register (Issue #297).
+
+Tracks judgment-requests received by the Secretary from workers so that
+the dispatcher's SECRETARY_RELAY_GAP_SUSPECTED detection (Step 5.1 in
+``.dispatcher/CLAUDE.md``) can use a deterministic register lookup
+instead of proxy heuristics (snapshot diff / send_message timing).
+
+Lifecycle:
+
+* When the Secretary receives a judgment-request from a worker, it
+  appends an entry with ``status="pending"``.
+* When the Secretary relays the question to the human user, it resolves
+  the entry with ``kind="to_user"`` (status becomes ``escalated``).
+* When the Secretary relays the human's answer back to the worker, it
+  resolves with ``kind="to_worker"`` (status becomes ``resolved``).
+
+The dispatcher periodically calls :func:`list_pending_older_than` to
+find entries whose ``received_at`` is older than the relay-gap window;
+non-empty result triggers a SECRETARY_RELAY_GAP_SUSPECTED notification
+to the user pane.
+
+Storage is a JSON file (default ``.state/pending_decisions.json``)
+written atomically via tmp-file + ``os.replace``. Missing file is
+treated as an empty register. Malformed JSON raises ``ValueError`` —
+callers that want to keep working through corruption should catch it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Literal, Optional
+
+# Repo root resolution mirrors tools/journal_append.py — keeps the
+# default store path stable regardless of the caller's cwd (the
+# dispatcher runs from ``.dispatcher/`` and uses relative paths).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PATH = _REPO_ROOT / ".state" / "pending_decisions.json"
+
+ResolutionKind = Literal["to_user", "to_worker"]
+Status = Literal["pending", "resolved", "escalated"]
+
+_KIND_TO_STATUS: dict[str, Status] = {
+    "to_user": "escalated",
+    "to_worker": "resolved",
+}
+
+
+@dataclass
+class PendingDecision:
+    task_id: str
+    received_at: str
+    raw_message: str
+    status: Status = "pending"
+    resolved_at: Optional[str] = None
+    resolution_kind: Optional[ResolutionKind] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PendingDecision":
+        return cls(
+            task_id=data["task_id"],
+            received_at=data["received_at"],
+            raw_message=data["raw_message"],
+            status=data.get("status", "pending"),
+            resolved_at=data.get("resolved_at"),
+            resolution_kind=data.get("resolution_kind"),
+        )
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load(store_path: Path) -> list[PendingDecision]:
+    if not store_path.exists():
+        return []
+    try:
+        raw = store_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"failed to read {store_path}: {exc}") from exc
+    if not raw.strip():
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"malformed JSON in {store_path}: {exc.msg} at line {exc.lineno}"
+        ) from exc
+    if not isinstance(data, list):
+        raise ValueError(
+            f"malformed register in {store_path}: top-level must be a list"
+        )
+    out: list[PendingDecision] = []
+    for i, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"malformed register in {store_path}: entry[{i}] is not a dict"
+            )
+        try:
+            out.append(PendingDecision.from_dict(entry))
+        except KeyError as exc:
+            raise ValueError(
+                f"malformed register in {store_path}: entry[{i}] missing {exc}"
+            ) from exc
+    return out
+
+
+def _atomic_write(store_path: Path, entries: list[PendingDecision]) -> None:
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = store_path.with_name(store_path.name + ".tmp")
+    payload = json.dumps(
+        [e.to_dict() for e in entries],
+        ensure_ascii=False,
+        indent=2,
+    )
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        fh.write(payload)
+        fh.write("\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, store_path)
+
+
+def append(
+    task_id: str,
+    raw_message: str,
+    store_path: Path = DEFAULT_PATH,
+) -> PendingDecision:
+    """Add a new pending entry, or return the existing pending one.
+
+    Idempotent: if ``task_id`` already has a ``pending`` entry, returns
+    that entry without modifying the store. Existing ``resolved`` /
+    ``escalated`` entries for the same ``task_id`` are ignored (a fresh
+    judgment-request can re-open).
+    """
+    entries = _load(store_path)
+    for entry in entries:
+        if entry.task_id == task_id and entry.status == "pending":
+            return entry
+    new_entry = PendingDecision(
+        task_id=task_id,
+        received_at=_now_iso(),
+        raw_message=raw_message,
+        status="pending",
+    )
+    entries.append(new_entry)
+    _atomic_write(store_path, entries)
+    return new_entry
+
+
+def resolve(
+    task_id: str,
+    kind: ResolutionKind,
+    store_path: Path = DEFAULT_PATH,
+) -> Optional[PendingDecision]:
+    """Resolve the oldest pending entry for ``task_id``.
+
+    ``kind="to_user"`` marks it ``escalated`` (Secretary relayed to
+    user). ``kind="to_worker"`` marks it ``resolved`` (Secretary
+    relayed user's answer back to worker). Returns the updated entry,
+    or ``None`` if no pending entry exists for ``task_id`` (no-op).
+    """
+    if kind not in _KIND_TO_STATUS:
+        raise ValueError(f"unknown kind {kind!r}; expected to_user|to_worker")
+    entries = _load(store_path)
+    target_index: Optional[int] = None
+    for i, entry in enumerate(entries):
+        if entry.task_id != task_id or entry.status != "pending":
+            continue
+        if target_index is None:
+            target_index = i
+            continue
+        # Multiple pending (rare): keep the oldest received_at.
+        if entry.received_at < entries[target_index].received_at:
+            target_index = i
+    if target_index is None:
+        return None
+    target = entries[target_index]
+    target.status = _KIND_TO_STATUS[kind]
+    target.resolved_at = _now_iso()
+    target.resolution_kind = kind
+    _atomic_write(store_path, entries)
+    return target
+
+
+def list_pending(store_path: Path = DEFAULT_PATH) -> list[PendingDecision]:
+    return [e for e in _load(store_path) if e.status == "pending"]
+
+
+def list_pending_older_than(
+    threshold_minutes: int,
+    store_path: Path = DEFAULT_PATH,
+    now: Optional[datetime] = None,
+) -> list[PendingDecision]:
+    """Pending entries whose ``received_at`` is older than ``threshold_minutes``.
+
+    ``now`` is injectable for tests; defaults to ``datetime.now(UTC)``.
+    Entries with unparseable ``received_at`` are skipped (defensive).
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(minutes=threshold_minutes)
+    out: list[PendingDecision] = []
+    for entry in _load(store_path):
+        if entry.status != "pending":
+            continue
+        try:
+            received = datetime.strptime(
+                entry.received_at, "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        if received <= cutoff:
+            out.append(entry)
+    return out
+
+
+# --------------------------------------------------------------------- CLI
+
+
+def _print_entry(entry: PendingDecision) -> None:
+    print(json.dumps(entry.to_dict(), ensure_ascii=False))
+
+
+def _cmd_append(args: argparse.Namespace) -> int:
+    store_path = Path(args.store) if args.store else DEFAULT_PATH
+    entry = append(args.task_id, args.message, store_path=store_path)
+    _print_entry(entry)
+    return 0
+
+
+def _cmd_resolve(args: argparse.Namespace) -> int:
+    store_path = Path(args.store) if args.store else DEFAULT_PATH
+    entry = resolve(args.task_id, args.kind, store_path=store_path)
+    if entry is None:
+        print(json.dumps({"status": "no_pending", "task_id": args.task_id}))
+        return 0
+    _print_entry(entry)
+    return 0
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    store_path = Path(args.store) if args.store else DEFAULT_PATH
+    if args.older_than_min is not None:
+        entries: Iterable[PendingDecision] = list_pending_older_than(
+            args.older_than_min, store_path=store_path
+        )
+    else:
+        entries = list_pending(store_path=store_path)
+    for entry in entries:
+        _print_entry(entry)
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tools/pending_decisions.py",
+        description="Secretary pending-decisions register (Issue #297).",
+    )
+    parser.add_argument(
+        "--store",
+        help=f"override store path (default: {DEFAULT_PATH})",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_append = sub.add_parser("append", help="add a new pending entry (idempotent)")
+    p_append.add_argument("--task-id", required=True)
+    p_append.add_argument("--message", required=True)
+    p_append.set_defaults(func=_cmd_append)
+
+    p_resolve = sub.add_parser("resolve", help="resolve a pending entry")
+    p_resolve.add_argument("--task-id", required=True)
+    p_resolve.add_argument(
+        "--kind", required=True, choices=["to_user", "to_worker"]
+    )
+    p_resolve.set_defaults(func=_cmd_resolve)
+
+    p_list = sub.add_parser("list", help="list pending entries")
+    p_list.add_argument(
+        "--older-than-min",
+        type=int,
+        default=None,
+        help="only entries whose received_at is older than N minutes",
+    )
+    p_list.set_defaults(func=_cmd_list)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pending_decisions.py
+++ b/tools/pending_decisions.py
@@ -51,6 +51,22 @@ _KIND_TO_STATUS: dict[str, Status] = {
     "to_worker": "resolved",
 }
 
+# Statuses that ``resolve`` can transition *from*. ``to_user`` only accepts
+# fresh ``pending`` entries (Secretary just received the request from the
+# worker). ``to_worker`` accepts either ``pending`` (Secretary skipped the
+# explicit user-relay step) or ``escalated`` (canonical flow:
+# pending → escalated when user is informed → resolved when worker is told).
+_KIND_TO_ELIGIBLE_STATUSES: dict[str, tuple[Status, ...]] = {
+    "to_user": ("pending",),
+    "to_worker": ("pending", "escalated"),
+}
+
+# Statuses considered "open" for the purpose of relay-gap detection. The
+# dispatcher's Step 5.1 (a-0) lookup must surface anything not yet
+# terminally relayed back to the worker, otherwise the (a)(2) direction
+# (user answered but Secretary forgot to relay) is invisible.
+_OPEN_STATUSES: tuple[Status, ...] = ("pending", "escalated")
+
 
 @dataclass
 class PendingDecision:
@@ -171,15 +187,16 @@ def resolve(
     """
     if kind not in _KIND_TO_STATUS:
         raise ValueError(f"unknown kind {kind!r}; expected to_user|to_worker")
+    eligible = _KIND_TO_ELIGIBLE_STATUSES[kind]
     entries = _load(store_path)
     target_index: Optional[int] = None
     for i, entry in enumerate(entries):
-        if entry.task_id != task_id or entry.status != "pending":
+        if entry.task_id != task_id or entry.status not in eligible:
             continue
         if target_index is None:
             target_index = i
             continue
-        # Multiple pending (rare): keep the oldest received_at.
+        # Multiple eligible entries (rare): keep the oldest received_at.
         if entry.received_at < entries[target_index].received_at:
             target_index = i
     if target_index is None:
@@ -193,7 +210,15 @@ def resolve(
 
 
 def list_pending(store_path: Path = DEFAULT_PATH) -> list[PendingDecision]:
-    return [e for e in _load(store_path) if e.status == "pending"]
+    """Return all entries that are not yet terminally resolved.
+
+    Includes both ``pending`` (received but not yet relayed to user) and
+    ``escalated`` (relayed to user, awaiting answer to relay back to
+    worker). Excludes ``resolved`` (terminal). The function name keeps
+    "pending" for API-spec continuity (Issue #297) but its semantics
+    cover any open relay-gap candidate.
+    """
+    return [e for e in _load(store_path) if e.status in _OPEN_STATUSES]
 
 
 def list_pending_older_than(
@@ -201,23 +226,37 @@ def list_pending_older_than(
     store_path: Path = DEFAULT_PATH,
     now: Optional[datetime] = None,
 ) -> list[PendingDecision]:
-    """Pending entries whose ``received_at`` is older than ``threshold_minutes``.
+    """Open entries whose ``received_at`` is older than ``threshold_minutes``.
+
+    "Open" = ``pending`` or ``escalated`` (see :func:`list_pending`). The
+    dispatcher uses this for SECRETARY_RELAY_GAP_SUSPECTED detection,
+    which must catch both:
+
+    * (a)(1) ``pending`` too long — Secretary forgot to relay to user
+    * (a)(2) ``escalated`` too long — Secretary forgot to relay user's
+      answer back to worker
 
     ``now`` is injectable for tests; defaults to ``datetime.now(UTC)``.
-    Entries with unparseable ``received_at`` are skipped (defensive).
+    Entries with an unparseable ``received_at`` are surfaced (treated as
+    arbitrarily old) rather than silently skipped — silent drop would
+    create a relay-gap false negative against the fallback contract in
+    ``.dispatcher/CLAUDE.md`` Step 5.1.
     """
     if now is None:
         now = datetime.now(timezone.utc)
     cutoff = now - timedelta(minutes=threshold_minutes)
     out: list[PendingDecision] = []
     for entry in _load(store_path):
-        if entry.status != "pending":
+        if entry.status not in _OPEN_STATUSES:
             continue
         try:
             received = datetime.strptime(
                 entry.received_at, "%Y-%m-%dT%H:%M:%SZ"
             ).replace(tzinfo=timezone.utc)
         except ValueError:
+            # Unparseable timestamp: surface the entry as a relay-gap
+            # candidate (loud failure beats silent suppression).
+            out.append(entry)
             continue
         if received <= cutoff:
             out.append(entry)

--- a/tools/pending_decisions.py
+++ b/tools/pending_decisions.py
@@ -61,11 +61,17 @@ _KIND_TO_ELIGIBLE_STATUSES: dict[str, tuple[Status, ...]] = {
     "to_worker": ("pending", "escalated"),
 }
 
-# Statuses considered "open" for the purpose of relay-gap detection. The
-# dispatcher's Step 5.1 (a-0) lookup must surface anything not yet
-# terminally relayed back to the worker, otherwise the (a)(2) direction
-# (user answered but Secretary forgot to relay) is invisible.
-_OPEN_STATUSES: tuple[Status, ...] = ("pending", "escalated")
+# Statuses considered "open" — neither terminal nor in steady-state at
+# the user's hands. Only ``pending`` qualifies: ``escalated`` means the
+# Secretary has already done its half (relayed to user) and the entry
+# is now waiting on the human, which we cannot distinguish from
+# "Secretary forgot to relay back" without a separate user-replied
+# marker. So ``escalated`` is intentionally **not** an alarm trigger
+# for relay-gap detection (would produce false positives whenever a
+# human takes >15 min to reply).
+_OPEN_STATUSES: tuple[Status, ...] = ("pending",)
+
+_VALID_STATUSES: frozenset[str] = frozenset({"pending", "escalated", "resolved"})
 
 
 @dataclass
@@ -122,11 +128,18 @@ def _load(store_path: Path) -> list[PendingDecision]:
                 f"malformed register in {store_path}: entry[{i}] is not a dict"
             )
         try:
-            out.append(PendingDecision.from_dict(entry))
+            decoded = PendingDecision.from_dict(entry)
         except KeyError as exc:
             raise ValueError(
                 f"malformed register in {store_path}: entry[{i}] missing {exc}"
             ) from exc
+        if decoded.status not in _VALID_STATUSES:
+            raise ValueError(
+                f"malformed register in {store_path}: entry[{i}] has "
+                f"unknown status {decoded.status!r}; expected one of "
+                f"{sorted(_VALID_STATUSES)}"
+            )
+        out.append(decoded)
     return out
 
 
@@ -178,12 +191,21 @@ def resolve(
     kind: ResolutionKind,
     store_path: Path = DEFAULT_PATH,
 ) -> Optional[PendingDecision]:
-    """Resolve the oldest pending entry for ``task_id``.
+    """Advance the oldest open entry for ``task_id`` along the lifecycle.
 
-    ``kind="to_user"`` marks it ``escalated`` (Secretary relayed to
-    user). ``kind="to_worker"`` marks it ``resolved`` (Secretary
-    relayed user's answer back to worker). Returns the updated entry,
-    or ``None`` if no pending entry exists for ``task_id`` (no-op).
+    Lifecycle: ``pending`` → ``escalated`` (relayed to user) →
+    ``resolved`` (relayed user's answer back to worker).
+
+    * ``kind="to_user"`` advances ``pending`` → ``escalated``. Only
+      pending entries are eligible.
+    * ``kind="to_worker"`` advances ``pending`` or ``escalated`` →
+      ``resolved``. Either step is a valid terminal transition (the
+      Secretary may skip the explicit ``to_user`` step in trivial cases
+      where it inlines the relay-back).
+
+    Returns the updated entry, or ``None`` if no eligible entry exists
+    for ``task_id`` (no-op). When multiple eligible entries exist
+    (rare), the one with the oldest ``received_at`` is advanced.
     """
     if kind not in _KIND_TO_STATUS:
         raise ValueError(f"unknown kind {kind!r}; expected to_user|to_worker")
@@ -210,13 +232,12 @@ def resolve(
 
 
 def list_pending(store_path: Path = DEFAULT_PATH) -> list[PendingDecision]:
-    """Return all entries that are not yet terminally resolved.
+    """Return entries with status ``pending``.
 
-    Includes both ``pending`` (received but not yet relayed to user) and
-    ``escalated`` (relayed to user, awaiting answer to relay back to
-    worker). Excludes ``resolved`` (terminal). The function name keeps
-    "pending" for API-spec continuity (Issue #297) but its semantics
-    cover any open relay-gap candidate.
+    ``escalated`` entries are awaiting human reply and are deliberately
+    excluded — they're in the user's hands, not Secretary's, and surface
+    as an alarm would produce false positives whenever the human takes
+    a while to answer. ``resolved`` is terminal and also excluded.
     """
     return [e for e in _load(store_path) if e.status in _OPEN_STATUSES]
 
@@ -226,15 +247,15 @@ def list_pending_older_than(
     store_path: Path = DEFAULT_PATH,
     now: Optional[datetime] = None,
 ) -> list[PendingDecision]:
-    """Open entries whose ``received_at`` is older than ``threshold_minutes``.
+    """``pending`` entries whose ``received_at`` is older than ``threshold_minutes``.
 
-    "Open" = ``pending`` or ``escalated`` (see :func:`list_pending`). The
-    dispatcher uses this for SECRETARY_RELAY_GAP_SUSPECTED detection,
-    which must catch both:
-
-    * (a)(1) ``pending`` too long — Secretary forgot to relay to user
-    * (a)(2) ``escalated`` too long — Secretary forgot to relay user's
-      answer back to worker
+    Used by the dispatcher's Step 5.1 (a-0) for the (a)(1) direction
+    (Secretary forgot to relay worker's question to user). The (a)(2)
+    direction (Secretary forgot to relay user's answer back to worker)
+    is intentionally not caught here — the register has no signal for
+    "user has replied" so escalated-too-long would fire on every slow
+    human answer. (a)(2) coverage requires a richer schema (e.g. a
+    ``user_replied_at`` marker) and is left for a follow-up Issue.
 
     ``now`` is injectable for tests; defaults to ``datetime.now(UTC)``.
     Entries with an unparseable ``received_at`` are surfaced (treated as


### PR DESCRIPTION
## Summary

Closes #297. Introduces a Secretary-side **pending-decisions register** (`.state/pending_decisions.json`) and corresponding helper module / CLI. Replaces the dispatcher's proxy-based motive (a)(1) heuristic with a deterministic register lookup. Motive (a)(2) (user→worker forwarding gap) stays on the proxy path from PR #298, with follow-up #301 tracking the schema extension that would make it deterministic too.

## Scope correction (from the original issue text)

The original Issue #297 proposed register coverage for both motive (a)(1) and (a)(2). Codex Round 2 surfaced a Blocker: `escalated` entries (those forwarded to the user but not yet relayed back to the worker) cannot be time-alarmed without a `user_replied_at` signal — any normal "user is thinking" pause would trigger a false positive. The honest fix is to scope #297 to (a)(1) deterministic detection, keep the proxy fallback alive for (a)(2), and track the schema extension in #301. That is what landed.

## Changes

- **`tools/pending_decisions.py`** (new) — helper module + CLI:
  - Library API: `append`, `resolve`, `list_pending`, `list_pending_older_than`, idempotent for duplicate appends, atomic write (tmp + rename) for concurrent safety.
  - CLI: `append --task-id ... --message ...`, `resolve --task-id ... --kind to_user|to_worker`, `list [--older-than-min N]`.
- **`tests/test_pending_decisions.py`** (new) — 18 cases covering empty store, idempotent append, resolve to user / to worker, missing task no-op, time filtering, atomic write, malformed JSON tolerance, and the `to_worker → escalated` state transition.
- **`CLAUDE.md` (Secretary)** — escalation section adds the `pending_decisions.py` `append` call on receipt and the corresponding `resolve` on relay.
- **`.claude/skills/org-delegate/SKILL.md`** — Step 5 sub-section 0 (judgment-request handling) instructs Secretary to invoke the register CLI.
- **`.dispatcher/CLAUDE.md`** — Step 5.1 gains an "(a-0) Primary check" that calls `pending_decisions.py list --older-than-min STALL_SECRETARY_LOOKBACK_MIN`. Hits in the register raise `SECRETARY_RELAY_GAP_SUSPECTED` directly, no proxy needed. The PR #298 proxy path stays in place as the fallback for motive (a)(2).

## Codex self-review (3 rounds)

- Round 1 (Blocker + Major + Minor): `resolve to_worker` did not accept `escalated` entries; received_at validation silently skipped malformed timestamps; minor docstring drift. Fixed.
- Round 2 (Blocker + Minor + Nit): time-alarming `escalated` entries caused false positives — scope reduced to (a)(1) only with (a)(2) on proxy fallback; status validation hardened; resolve docstring tidied.
- Round 3 (Major): proxy path was previously gated on register lookups being empty, which removed (a)(2) coverage entirely when (a)(1) hits. Adjusted so register and proxy run in parallel, with register results being primary.

After Round 3, no Blocker / Major / Minor / Nit.

## Test plan

- [x] `pytest` — 383 passed, 1 skipped (18 new + 365 existing).
- [x] `python tools/check_role_configs.py` — OK.
- [x] `python tools/check_runtime_schema_drift.py` — OK.
- [x] CLI smoke tests on PowerShell + bash for each subcommand.
- [x] CI on this PR.
- [x] Manual: simulate session #12 — worker `worker_escalation`, no Secretary outbound → register entry stays pending, dispatcher pages user pane after 15 min. Secretary then calls `resolve --kind to_user` after relaying → entry transitions to `escalated`, no further pages.

## Follow-up

- **#301** — extend register schema with `user_replied_at` so motive (a)(2) (user → Secretary → worker forwarding gap) can also be deterministic. Until then, motive (a)(2) is covered by the PR #298 proxy fallback.

Closes #297.