### PR TITLE
feat(secretary): add user_replied_at marker for deterministic (a)(2) relay-gap detection

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -421,6 +421,7 @@ mcp__renga-peers__send_message(
      - DB の events テーブルに追記: `bash tools/journal_append.sh worker_escalation worker=worker-{task_id} task={task_id} reason="<要約>"`
      - **pending-decisions register に追加** (Issue #297): `python tools/pending_decisions.py append --task-id {task_id} --message "<本文要約>"`。同 task_id の pending が既存なら idempotent (no-op)。register はディスパッチャーの SECRETARY_RELAY_GAP_SUSPECTED 検出 (`.dispatcher/CLAUDE.md` Step 5.1) の primary lookup source
    - 人間に内容と選択肢を整理して提示する。提示直後に **register を escalated に更新**: `python tools/pending_decisions.py resolve --task-id {task_id} --kind to_user`
+   - **ユーザーから返答（decision／フィードバック／修正指示）を受領した時点** — ワーカーへ転送する **前に** `user_replied_at` marker を register に記録する (Issue #301): `python tools/pending_decisions.py mark-user-replied --task-id {task_id}`。escalated entry が無ければ no-op、既に設定済みでも idempotent。これにより `.dispatcher/CLAUDE.md` Step 5.1 (a-2) で「ユーザー返答済みなのに Secretary が転送忘れ」を deterministic に検知できる
    - 人間の判断後にワーカーに伝達する（伝達時は `to_id="worker-{task_id}"` で `send_message`）。伝達直後に **register を resolved に更新**: `python tools/pending_decisions.py resolve --task-id {task_id} --kind to_worker`
    - 「ユーザーは選択肢 X を選んだから自動的に含意される」等の自己解釈で承認してはならない
    - register の append / resolve のどちらかが欠落するとディスパッチャー側で SECRETARY_RELAY_GAP_SUSPECTED が誤発火または見逃しになる。Progress Log / journal は重複保険として維持し、register 更新とは独立に行うこと

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -375,7 +375,7 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
    - 出力 0 行 → register 経由の (a)(1) relay gap は **なし**。ただし (a)(2) は register では捕捉できないため、proxy 経路 ((a)〜(f)) は **必ず続行する** (skip しない)
    - 出力 1 行以上 → 各行 (1 entry per line, JSON、`status="pending"` のみ) を `task_id` 単位で集約し、SECRETARY_RELAY_GAP_SUSPECTED を **(e) と同じ通知経路** で発火する。register は (a)(1) 方向 (Secretary が worker→user の中継を忘れた) を deterministic に拾う ground truth。発火後も同サイクル内で proxy 経路を続行する (proxy が独立に拾う (a)(2) を見逃さないため)。同じ worker に対する重複通知は (f) の de-dup 30 秒窓で吸収される
 
-   **(a)(2) 方向の取り扱い** (Issue #297 のスコープ制限): register は「人間が返答済みか」を表す signal を持たないため、`escalated` 状態を時間で alarm 化すると「人間が考え中」と「Secretary が user→worker 転送を忘れた」を区別できず false positive が常態化する。よって `list --older-than-min` は意図的に `pending` のみを返す。(a)(2) 方向の deterministic 検知は `user_replied_at` marker 等の schema 拡張が必要で、別 Issue で扱う。本 PR で (a)(2) の唯一のカバーは既存 (a)〜(f) proxy 経路 (snapshot diff 等) であり、register lookup の結果に関わらず毎サイクル必ず実行する
+   **(a)(2) 方向の取り扱い** (Issue #297 のスコープ制限、#301 で deterministic 化): Issue #297 時点では register に「人間が返答済みか」を表す signal が無く、`escalated` 状態を時間で alarm 化すると「人間が考え中」と「Secretary が user→worker 転送を忘れた」を区別できず false positive が常態化していたため、`list --older-than-min` は意図的に `pending` のみを返す設計だった。Issue #301 で `user_replied_at` marker を schema に追加したことで、(a)(2) 方向も deterministic に観測可能になった (下記 (a-2) 経路)。proxy 経路 ((a)〜(f)) は (a-2) を観測する手段が無かった旧 Secretary の既存 entry や Secretary が `mark-user-replied` を呼び忘れたケースの fallback として残置する
    - de-dup と journal 追記は (f) と同じスキーマを使う:
 
      ```bash
@@ -389,6 +389,47 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
    **register lookup は (a)(1) の primary、(a)〜(f) の proxy 経路は (a)(2) の唯一のカバー**: register と proxy は disjoint な方向を扱うため、毎サイクル両方を実行する (proxy 経路を skip すると (a)(2) のカバーが消える)。proxy 経路の (a)(1) 関連部分は register が一次 source なので冗長になるが、de-dup 30 秒窓で吸収されるためそのまま残す。proxy 経路の最終削除は (a)(2) 用の deterministic 検知 (user_replied_at marker など) が別 Issue で着地した後に再評価する。
 
    register が読めない (helper not found / file corrupted で `ValueError`) 場合は (a)(1) も proxy 経路に fallback する。journal に `anomaly_observed source=relay_gap_check kind=register_unavailable` を残し、(b)〜(f) を従来通り実行する。
+
+   #### (a-2) Primary check: user_replied_at lookup (Issue #301)
+
+   Issue #297 で register lookup を導入した際、(a)(2) 方向 (user 回答 → secretary → worker の転送漏れ) は schema に「人間返答済み signal」が無いため deterministic 化できず proxy 経路に依存していた。Issue #301 で `user_replied_at` (ISO timestamp) を `PendingDecision` に追加し、Secretary が user 返答受領時に `mark-user-replied` CLI で marker を記録する運用に変更したことで、(a)(2) 方向も register lookup で deterministic に判定できるようになった。
+
+   Secretary 側のライフサイクル (CLAUDE.md 「ワーカーからの判断仰ぎは人間にエスカレーションする」セクション):
+
+   - 判断仰ぎ受信 → `append` (status=`pending`)
+   - 人間に伝達 → `resolve --kind to_user` (status=`escalated`)
+   - **user 返答受領 → `mark-user-replied` (`user_replied_at` 設定、status=`escalated` のまま)**
+   - worker に転送 → `resolve --kind to_worker` (status=`resolved`)
+
+   ディスパッチャーは tick ごとに (a-0) の `--older-than-min` lookup と並行して、`user_replied_at` lookup を発行する:
+
+   ```bash
+   # ディスパッチャー cwd は .dispatcher/。helper は repo root 起点で
+   # .state/pending_decisions.json を解決するため相対パスは不要。
+   python ../tools/pending_decisions.py list --user-replied-older-than-min 15
+   ```
+
+   - 出力 0 行 → register 経由の (a)(2) relay gap は **なし**
+   - 出力 1 行以上 → 各行 (1 entry per line, JSON、`status="escalated"` かつ `user_replied_at` が 15 分以上前のもの) を `task_id` 単位で集約し、SECRETARY_RELAY_GAP_SUSPECTED を **(e) と同じ通知経路** で発火する。register は (a)(2) 方向 (user 回答済みなのに Secretary が worker へ転送忘れ) を deterministic に拾う ground truth。発火後も同サイクル内で proxy 経路 ((b)〜(f)) を続行する (`mark-user-replied` を呼び忘れた legacy entry を proxy がカバーするため)
+
+   - de-dup と journal 追記は (f) と同じスキーマを使う:
+
+     ```bash
+     bash ../tools/journal_append.sh anomaly_observed source=relay_gap_check worker=worker-{task_id} kind=relay_gap_suspected confidence=high
+     # 通知送信成功後:
+     bash ../tools/journal_append.sh notify_sent source=relay_gap_check worker=worker-{task_id} kind=relay_gap_suspected confidence=high
+     ```
+
+     (a-0) と (a-2) は同じ `kind=relay_gap_suspected` を共有する。同 worker に対する重複通知は 30 秒窓 de-dup で吸収される (両方向の register lookup が同時 hit するケースは Secretary が両方の中継を忘れた時に限られ、相対的に稀)。
+
+   register が読めない場合は (a-0) と同じ fallback (`register_unavailable` を journal に残し proxy 経路に委ねる)。
+
+   **proxy 経路 ((a)〜(f)) は (a-3) Fallback に格下げ**: Issue #297 時点では (a)(2) の唯一のカバーだったが、#301 で (a-2) deterministic 化が完了したことで、proxy 経路は次のケースの fallback としてのみ意味を持つ:
+   - 旧 Secretary 実装で書かれた entry (`user_replied_at` が None のまま) を後方互換でカバー
+   - Secretary が `mark-user-replied` を呼び忘れた運用ミスの保険
+   - register 自体が読めない / corrupted な状況の degraded mode
+
+   proxy 経路の最終削除は (a-2) の安定運用が確認できた段階で別 Issue で扱う。
 
    #### (a) 動機
    Step 5 は worker 側 (worker→secretary 痕跡が **ある** ので stall 抑制) を見て補助シグナル化したが、逆方向 (secretary→user / secretary→worker の中継) には盲点がある。具体的なインシデントパターン:

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -386,9 +386,9 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 
      `confidence=high` は register lookup 経由 (proxy より信頼度が高い) を表す。proxy 経路の confidence (n/a) と区別したい場合のラベル。
 
-   **register lookup は (a)(1) の primary、(a)〜(f) の proxy 経路は (a)(2) の唯一のカバー**: register と proxy は disjoint な方向を扱うため、毎サイクル両方を実行する (proxy 経路を skip すると (a)(2) のカバーが消える)。proxy 経路の (a)(1) 関連部分は register が一次 source なので冗長になるが、de-dup 30 秒窓で吸収されるためそのまま残す。proxy 経路の最終削除は (a)(2) 用の deterministic 検知 (user_replied_at marker など) が別 Issue で着地した後に再評価する。
+   **register lookup は (a)(1) の primary、(a-2) と並列に (a)(2) も deterministic 化済み (Issue #301)、(a)〜(f) の proxy 経路は (a-3) Fallback**: 毎サイクル (a-0) → (a-2) → (b)〜(f) を順に実行する。register lookup は (a)(1)(a)(2) 双方の ground truth を提供し、proxy 経路は legacy entry / 呼び忘れ運用ミス / register 不通の degraded mode をカバーする。重複通知は de-dup 30 秒窓で吸収される。proxy 経路の最終削除は (a-2) 安定運用確認後に別 Issue で扱う。
 
-   register が読めない (helper not found / file corrupted で `ValueError`) 場合は (a)(1) も proxy 経路に fallback する。journal に `anomaly_observed source=relay_gap_check kind=register_unavailable` を残し、(b)〜(f) を従来通り実行する。
+   register が読めない (helper not found / file corrupted で `ValueError`) 場合は (a)(1)(a)(2) 双方とも proxy 経路に fallback する。journal に `anomaly_observed source=relay_gap_check kind=register_unavailable` を残し、(b)〜(f) を従来通り実行する。
 
    #### (a-2) Primary check: user_replied_at lookup (Issue #301)
 

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -438,7 +438,7 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 
    どちらも Step 5 (worker 側監視) と Step 4 (worker pane 画面監視) では検知できない。secretary 側の outbound (secretary→user / secretary→worker) を観測する独立チャネルが必要。Issue #287 (PR #295) の sibling、両側監視で完成。Issue #292。
 
-   **本 PR のスコープ (重要)**: 上記 2 パターンのうち **(1) 「secretary が人間に上げ忘れ」のみ** を検知対象とする。(2) 「user 回答を worker に転送し忘れ」は journal に secretary→worker outbound の ledger が無く ((c) 参照)、prose-only の本 PR では確実な検知手段が組めないため、(g) の register 化 follow-up Issue で恒久対応する。仕様の (b) 以降は (1) を絞り込む条件として読む。
+   **proxy 経路の歴史的スコープ (旧 PR #298)**: 以下 (b)〜(f) は PR #298 当時の proxy-only 実装を記述しており、(1) 「secretary が人間に上げ忘れ」のみを対象としていた。(2) 「user 回答を worker に転送し忘れ」は当時 journal に secretary→worker outbound の ledger が無く検知できなかった。Issue #297 (PR #302) で (a-0) primary lookup により (1) は register 経由で deterministic 化、Issue #301 で (a-2) primary lookup により (2) も `user_replied_at` marker 経由で deterministic 化済み。proxy 経路 (b)〜(f) は legacy entry / Secretary が CLI 呼び忘れ / register 不通の degraded mode の (a-3) Fallback として残置されている。
 
    #### (b) いつ relay gap を疑うか
    起点は **直近の worker→secretary event** に固定する。`.state/journal.jsonl` から `event ∈ {worker_escalation, worker_reported}` かつ `worker == "worker-{task_id}"` を満たすエントリの最新 1 件を取り、その `ts` を `T_last_worker_in` とする。`worker_completed` / `plan_delivered` / `prep_delivered` は **対象外** (これらは「完了 / 中間引き渡し」で、secretary が直ちに user に上げる契約ではない。判断仰ぎ・進捗共有のみが relay gap の対象)。
@@ -461,7 +461,7 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
    1. **journal scan**: 既存 event catalog (`docs/journal-events.md`) に「secretary→worker の send_message 受信時に secretary が書く event」は定義されていない。`worker_escalation` / `worker_reported` / `worker_completed` 等は **worker 起点の inbound** を secretary が記録する ledger であり、逆方向 (secretary→worker outbound) は ledger 化されていない。`user_decision_relayed` のような新 event を捏造して proxy にするのは event 名の確定を要し、本 PR スコープ外 (curator 領域)
    2. **renga-peers `poll_events` 経由**: Step 5 (c) と同じく現状の renga `poll_events` は pane lifecycle のみで `send_message` を流さない。将来 send_message が flow するようになれば、Step 1 の cursor (`.state/dispatcher-event-cursor.txt`) を再利用して `(actor=secretary, recipient=worker-{task_id})` を直接観測できる。プレースホルダ
 
-   従って (b)(2) のうち「secretary→worker 痕跡なし」は、本 PR では **常に true** として扱う (痕跡を観測する手段が無いため、中継が動いているかどうかを判別できない)。これにより relay gap 候補の絞り込みは事実上 (d) の secretary→user proxy だけに依存することになり、結果的に動機 (a)(2) の「user 答えた後に secretary が worker に転送し忘れ」ケースは **(d) の secretary 画面更新で擬陽性的に suppress される** (user 回答に secretary が応答した時点で secretary pane が更新されるため)。本ケースを正しく検知するには (g) の register 化が必須で、本 PR では割り切る (動機 (a)(1) の「人間に上げ忘れ」ケースを優先カバー)。
+   従って (b)(2) のうち「secretary→worker 痕跡なし」は、proxy 経路では **常に true** として扱う (痕跡を観測する手段が無いため、中継が動いているかどうかを判別できない)。これにより proxy 経路の絞り込みは事実上 (d) の secretary→user proxy だけに依存することになり、結果的に動機 (a)(2) の「user 答えた後に secretary が worker に転送し忘れ」ケースは proxy では **(d) の secretary 画面更新で擬陽性的に suppress** される。Issue #301 の (a-2) primary lookup (`user_replied_at` marker) で本ケースは deterministic 化済みであり、proxy 経路は legacy entry / 呼び忘れの (a-3) Fallback としてのみ機能する。
 
    #### (d) secretary→user 観測手段 — `inspect_pane` による画面 diff
    user 向け visible output を直接捉える journal event は無い (user pane に届く文字は renga の terminal レイヤーに流れるだけで journal を経由しない)。代替として **secretary pane の画面差分** を proxy として使う:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,15 @@
    python tools/pending_decisions.py resolve --task-id <task_id> --kind to_user
    ```
 
-3. **ワーカーに人間判断を転送した時点** — `to_id="worker-{task_id}"` で `send_message` を発行した直後に register を `resolved` に更新する:
+3. **ユーザーから当該 task について返答（decision／フィードバック／修正指示等）を受領した時点** — ワーカーへ転送する **前に** `user_replied_at` marker を register に記録する（Issue #301）:
+
+   ```bash
+   python tools/pending_decisions.py mark-user-replied --task-id <task_id>
+   ```
+
+   該当 task の最古 `escalated` entry に user_replied_at を設定する（status は escalated のまま）。escalated entry が無い場合は no-op。既に user_replied_at が設定済みの場合も idempotent。これにより、ディスパッチャーは「ユーザーは答えたのに Secretary がワーカーへ転送し忘れている」帯を `.dispatcher/CLAUDE.md` Step 5.1 (a-2) で deterministic に観測できるようになる。
+
+4. **ワーカーに人間判断を転送した時点** — `to_id="worker-{task_id}"` で `send_message` を発行した直後に register を `resolved` に更新する:
 
    ```bash
    python tools/pending_decisions.py resolve --task-id <task_id> --kind to_worker

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -440,6 +440,47 @@ class MarkUserRepliedTests(unittest.TestCase):
         # only "stale" matches: escalated + user_replied_at older than 15min
         self.assertEqual([e.task_id for e in out], ["stale"])
 
+    def test_mark_user_replied_skips_already_marked_to_reach_new_escalated(self) -> None:
+        # Codex round 1 Major: append() permits re-opening for the same
+        # task_id (e.g. follow-up judgment-request after a prior round
+        # was resolved). If a stale escalated entry already has
+        # user_replied_at set, mark_user_replied() must not stop there
+        # — it must mark the newer escalated entry that actually needs
+        # the marker.
+        pd.append("t1", "round1", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        pd.mark_user_replied("t1", store_path=self.store)
+        pd.resolve("t1", "to_worker", store_path=self.store)
+        # The store now has one resolved entry. Re-open with a new
+        # judgment-request and walk the lifecycle to a second escalated.
+        pd.append("t1", "round2", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+
+        # Direct-seed a third entry that mimics a stale escalated whose
+        # marker was set but whose to_worker resolve was forgotten — the
+        # exact shape Codex flagged. Use _atomic_write to bypass append().
+        entries = pd._load(self.store)
+        entries.append(
+            pd.PendingDecision(
+                task_id="t1",
+                received_at="2026-05-05T03:00:00Z",
+                raw_message="stale-escalated-with-marker",
+                status="escalated",
+                resolved_at="2026-05-05T03:01:00Z",
+                resolution_kind="to_user",
+                user_replied_at="2026-05-05T03:05:00Z",
+            )
+        )
+        pd._atomic_write(self.store, entries)
+
+        out = pd.mark_user_replied("t1", store_path=self.store)
+        self.assertIsNotNone(out)
+        assert out is not None
+        # Must have marked the round2 escalated, not returned the stale
+        # one as a no-op.
+        self.assertEqual(out.raw_message, "round2")
+        self.assertIsNotNone(out.user_replied_at)
+
     def test_resolve_to_worker_after_user_replied_preserves_marker(self) -> None:
         # Canonical lifecycle: pending -> escalated -> user_replied marker
         # -> resolved. user_replied_at must survive the final resolve.

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -282,5 +282,175 @@ class PendingDecisionsTests(unittest.TestCase):
         self.assertEqual(len(pd.list_pending(store_path=self.store)), 1)
 
 
+class MarkUserRepliedTests(unittest.TestCase):
+    """Regression tests for Issue #301 user_replied_at marker."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.store = Path(self._tmpdir.name) / "pending_decisions.json"
+
+    def _read_raw(self) -> list[dict]:
+        return json.loads(self.store.read_text(encoding="utf-8"))
+
+    # (a) ----------------------------------------------------------------
+    def test_mark_user_replied_on_pending_is_noop(self) -> None:
+        # Only escalated entries are eligible — pending means Secretary
+        # has not yet relayed the question to the user, so a "user
+        # replied" marker is meaningless.
+        pd.append("t1", "ask", store_path=self.store)
+        out = pd.mark_user_replied("t1", store_path=self.store)
+        self.assertIsNone(out)
+        raw = self._read_raw()
+        self.assertEqual(len(raw), 1)
+        self.assertIsNone(raw[0].get("user_replied_at"))
+
+    # (b) ----------------------------------------------------------------
+    def test_mark_user_replied_on_escalated_sets_marker(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        out = pd.mark_user_replied("t1", store_path=self.store)
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertEqual(out.status, "escalated")  # status unchanged
+        self.assertIsNotNone(out.user_replied_at)
+        # Persisted to disk
+        raw = self._read_raw()
+        self.assertEqual(raw[0]["status"], "escalated")
+        self.assertIsNotNone(raw[0]["user_replied_at"])
+
+    # (c) ----------------------------------------------------------------
+    def test_mark_user_replied_is_idempotent(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        first = pd.mark_user_replied("t1", store_path=self.store)
+        assert first is not None
+        first_ts = first.user_replied_at
+        second = pd.mark_user_replied("t1", store_path=self.store)
+        assert second is not None
+        # Timestamp not rewritten — original retained
+        self.assertEqual(second.user_replied_at, first_ts)
+
+    # (d) ----------------------------------------------------------------
+    def test_mark_user_replied_unknown_task_id_returns_none(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        out = pd.mark_user_replied("nonexistent", store_path=self.store)
+        self.assertIsNone(out)
+
+    # (e) ----------------------------------------------------------------
+    def test_json_roundtrip_preserves_user_replied_at(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        marked = pd.mark_user_replied("t1", store_path=self.store)
+        assert marked is not None
+        # Reload via list_pending fast-path or direct _load
+        reloaded = pd._load(self.store)
+        self.assertEqual(len(reloaded), 1)
+        self.assertEqual(reloaded[0].user_replied_at, marked.user_replied_at)
+        self.assertEqual(reloaded[0].status, "escalated")
+        self.assertEqual(reloaded[0].resolution_kind, "to_user")
+
+    # (f) ----------------------------------------------------------------
+    def test_cli_mark_user_replied(self) -> None:
+        pd.append("tcli", "ask", store_path=self.store)
+        pd.resolve("tcli", "to_user", store_path=self.store)
+        rc = pd.main(
+            [
+                "--store",
+                str(self.store),
+                "mark-user-replied",
+                "--task-id",
+                "tcli",
+            ]
+        )
+        self.assertEqual(rc, 0)
+        raw = self._read_raw()
+        self.assertEqual(len(raw), 1)
+        self.assertIsNotNone(raw[0]["user_replied_at"])
+
+    # extras -------------------------------------------------------------
+    def test_legacy_entry_without_user_replied_at_loads(self) -> None:
+        # Schema compat: entries written before #301 lack the
+        # user_replied_at field; load must default it to None.
+        seed = [
+            {
+                "task_id": "legacy",
+                "received_at": "2026-05-05T05:00:00Z",
+                "raw_message": "ask",
+                "status": "escalated",
+                "resolved_at": "2026-05-05T05:01:00Z",
+                "resolution_kind": "to_user",
+            }
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+        loaded = pd._load(self.store)
+        self.assertEqual(len(loaded), 1)
+        self.assertIsNone(loaded[0].user_replied_at)
+
+    def test_list_escalated_user_replied_older_than_filters(self) -> None:
+        old_replied = "2026-05-05T05:00:00Z"
+        new_replied = "2026-05-05T05:50:00Z"
+        seed = [
+            {
+                "task_id": "stale",
+                "received_at": "2026-05-05T04:30:00Z",
+                "raw_message": "ask",
+                "status": "escalated",
+                "resolved_at": "2026-05-05T04:35:00Z",
+                "resolution_kind": "to_user",
+                "user_replied_at": old_replied,
+            },
+            {
+                "task_id": "fresh",
+                "received_at": "2026-05-05T05:40:00Z",
+                "raw_message": "ask",
+                "status": "escalated",
+                "resolved_at": "2026-05-05T05:45:00Z",
+                "resolution_kind": "to_user",
+                "user_replied_at": new_replied,
+            },
+            {
+                "task_id": "no-reply",
+                "received_at": "2026-05-05T04:00:00Z",
+                "raw_message": "ask",
+                "status": "escalated",
+                "resolved_at": "2026-05-05T04:05:00Z",
+                "resolution_kind": "to_user",
+            },
+            {
+                "task_id": "done",
+                "received_at": "2026-05-05T03:00:00Z",
+                "raw_message": "ask",
+                "status": "resolved",
+                "resolved_at": "2026-05-05T03:30:00Z",
+                "resolution_kind": "to_worker",
+                "user_replied_at": old_replied,
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+        now = datetime(2026, 5, 5, 6, 0, 0, tzinfo=timezone.utc)
+        out = pd.list_escalated_user_replied_older_than(
+            15, store_path=self.store, now=now
+        )
+        # only "stale" matches: escalated + user_replied_at older than 15min
+        self.assertEqual([e.task_id for e in out], ["stale"])
+
+    def test_resolve_to_worker_after_user_replied_preserves_marker(self) -> None:
+        # Canonical lifecycle: pending -> escalated -> user_replied marker
+        # -> resolved. user_replied_at must survive the final resolve.
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        pd.mark_user_replied("t1", store_path=self.store)
+        final = pd.resolve("t1", "to_worker", store_path=self.store)
+        assert final is not None
+        self.assertEqual(final.status, "resolved")
+        self.assertIsNotNone(final.user_replied_at)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/pending_decisions.py
+++ b/tools/pending_decisions.py
@@ -82,6 +82,13 @@ class PendingDecision:
     status: Status = "pending"
     resolved_at: Optional[str] = None
     resolution_kind: Optional[ResolutionKind] = None
+    # ISO timestamp recorded when the user replies to this escalated
+    # entry (Issue #301). Lets the dispatcher's Step 5.1 (a-2) path
+    # deterministically detect the "Secretary forgot to relay user's
+    # answer back to worker" direction without proxy heuristics. None
+    # for legacy entries written before #301 — those fall back to the
+    # snapshot-diff proxy path (a-3).
+    user_replied_at: Optional[str] = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -95,6 +102,7 @@ class PendingDecision:
             status=data.get("status", "pending"),
             resolved_at=data.get("resolved_at"),
             resolution_kind=data.get("resolution_kind"),
+            user_replied_at=data.get("user_replied_at"),
         )
 
 
@@ -231,6 +239,43 @@ def resolve(
     return target
 
 
+def mark_user_replied(
+    task_id: str,
+    store_path: Path = DEFAULT_PATH,
+) -> Optional[PendingDecision]:
+    """Record that the user has replied to the oldest ``escalated`` entry.
+
+    Issue #301. Sets ``user_replied_at`` on the oldest ``escalated``
+    entry for ``task_id`` (status stays ``escalated``). The dispatcher's
+    Step 5.1 (a-2) path uses this marker to deterministically detect
+    the "Secretary forgot to relay user's answer back to worker"
+    direction without proxy heuristics.
+
+    Idempotent: if the matching entry already has ``user_replied_at``
+    set, returns it unchanged (no rewrite). Returns ``None`` when no
+    ``escalated`` entry exists for ``task_id`` — Secretary should call
+    ``resolve --kind to_user`` first.
+    """
+    entries = _load(store_path)
+    target_index: Optional[int] = None
+    for i, entry in enumerate(entries):
+        if entry.task_id != task_id or entry.status != "escalated":
+            continue
+        if target_index is None:
+            target_index = i
+            continue
+        if entry.received_at < entries[target_index].received_at:
+            target_index = i
+    if target_index is None:
+        return None
+    target = entries[target_index]
+    if target.user_replied_at is not None:
+        return target
+    target.user_replied_at = _now_iso()
+    _atomic_write(store_path, entries)
+    return target
+
+
 def list_pending(store_path: Path = DEFAULT_PATH) -> list[PendingDecision]:
     """Return entries with status ``pending``.
 
@@ -284,6 +329,46 @@ def list_pending_older_than(
     return out
 
 
+def list_escalated_user_replied_older_than(
+    threshold_minutes: int,
+    store_path: Path = DEFAULT_PATH,
+    now: Optional[datetime] = None,
+) -> list[PendingDecision]:
+    """``escalated`` entries with ``user_replied_at`` older than threshold.
+
+    Issue #301. Drives the dispatcher's Step 5.1 (a-2) deterministic
+    path: when a user has replied (user_replied_at is set) but Secretary
+    has not yet forwarded back to the worker (status still ``escalated``,
+    resolved_at unset), the elapsed time since the user reply is the
+    Secretary's relay-gap window.
+
+    Entries with a malformed ``user_replied_at`` are surfaced (treated
+    as arbitrarily old) — same loud-failure stance as
+    :func:`list_pending_older_than`.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(minutes=threshold_minutes)
+    out: list[PendingDecision] = []
+    for entry in _load(store_path):
+        if entry.status != "escalated":
+            # status=="resolved" means Secretary already forwarded the
+            # answer back to the worker — terminal, no relay-gap.
+            continue
+        if entry.user_replied_at is None:
+            continue
+        try:
+            replied = datetime.strptime(
+                entry.user_replied_at, "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=timezone.utc)
+        except ValueError:
+            out.append(entry)
+            continue
+        if replied <= cutoff:
+            out.append(entry)
+    return out
+
+
 # --------------------------------------------------------------------- CLI
 
 
@@ -310,14 +395,28 @@ def _cmd_resolve(args: argparse.Namespace) -> int:
 
 def _cmd_list(args: argparse.Namespace) -> int:
     store_path = Path(args.store) if args.store else DEFAULT_PATH
-    if args.older_than_min is not None:
-        entries: Iterable[PendingDecision] = list_pending_older_than(
+    if args.user_replied_older_than_min is not None:
+        entries: Iterable[PendingDecision] = list_escalated_user_replied_older_than(
+            args.user_replied_older_than_min, store_path=store_path
+        )
+    elif args.older_than_min is not None:
+        entries = list_pending_older_than(
             args.older_than_min, store_path=store_path
         )
     else:
         entries = list_pending(store_path=store_path)
     for entry in entries:
         _print_entry(entry)
+    return 0
+
+
+def _cmd_mark_user_replied(args: argparse.Namespace) -> int:
+    store_path = Path(args.store) if args.store else DEFAULT_PATH
+    entry = mark_user_replied(args.task_id, store_path=store_path)
+    if entry is None:
+        print(json.dumps({"status": "no_escalated", "task_id": args.task_id}))
+        return 0
+    _print_entry(entry)
     return 0
 
 
@@ -349,9 +448,25 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--older-than-min",
         type=int,
         default=None,
-        help="only entries whose received_at is older than N minutes",
+        help="only pending entries whose received_at is older than N minutes",
+    )
+    p_list.add_argument(
+        "--user-replied-older-than-min",
+        type=int,
+        default=None,
+        help=(
+            "only escalated entries whose user_replied_at is older than N "
+            "minutes (Issue #301, dispatcher Step 5.1 (a-2) deterministic path)"
+        ),
     )
     p_list.set_defaults(func=_cmd_list)
+
+    p_mark = sub.add_parser(
+        "mark-user-replied",
+        help="record that the user has replied to an escalated entry (Issue #301)",
+    )
+    p_mark.add_argument("--task-id", required=True)
+    p_mark.set_defaults(func=_cmd_mark_user_replied)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/tools/pending_decisions.py
+++ b/tools/pending_decisions.py
@@ -257,23 +257,32 @@ def mark_user_replied(
     ``resolve --kind to_user`` first.
     """
     entries = _load(store_path)
+    # Prefer the oldest escalated entry whose user_replied_at is still
+    # unset. If all are already set, fall back to the oldest escalated
+    # so callers see an idempotent no-op (Codex round 1 Major: a stale
+    # escalated entry with marker set must not shadow a newer one that
+    # actually needs marking after a re-open via append()).
     target_index: Optional[int] = None
+    fallback_index: Optional[int] = None
     for i, entry in enumerate(entries):
         if entry.task_id != task_id or entry.status != "escalated":
             continue
-        if target_index is None:
-            target_index = i
-            continue
-        if entry.received_at < entries[target_index].received_at:
-            target_index = i
-    if target_index is None:
-        return None
-    target = entries[target_index]
-    if target.user_replied_at is not None:
+        if entry.user_replied_at is None:
+            if target_index is None or entry.received_at < entries[target_index].received_at:
+                target_index = i
+        else:
+            if fallback_index is None or entry.received_at < entries[fallback_index].received_at:
+                fallback_index = i
+    if target_index is not None:
+        target = entries[target_index]
+        target.user_replied_at = _now_iso()
+        _atomic_write(store_path, entries)
         return target
-    target.user_replied_at = _now_iso()
-    _atomic_write(store_path, entries)
-    return target
+    if fallback_index is not None:
+        # All escalated entries already marked — idempotent no-op,
+        # return the oldest so callers can observe the prior marker.
+        return entries[fallback_index]
+    return None
 
 
 def list_pending(store_path: Path = DEFAULT_PATH) -> list[PendingDecision]:


### PR DESCRIPTION
## Summary

Closes #301. Extends the pending-decisions register schema with a `user_replied_at` marker so that motive (a)(2) — user → Secretary → worker forwarding gap — can be detected deterministically by the dispatcher, removing the proxy-based fallback's false-positive surface area.

PR #302 (Issue #297) intentionally scoped the register to motive (a)(1) only because there was no signal recording that the human had actually replied to a Secretary-surfaced question. This PR adds that signal and switches the dispatcher's Step 5.1 (a)(2) check from proxy-only to register-primary with proxy as fallback.

## Changes

- **`tools/pending_decisions.py`** — adds `user_replied_at: Optional[str]` to the `PendingDecision` schema; new library API `mark_user_replied(task_id)` and `list_escalated_user_replied_older_than(threshold_minutes)`. New CLI subcommands: `mark-user-replied --task-id <id>` and `list --user-replied-older-than-min N`. Existing entries persist with `user_replied_at=None` and load forward-compatibly.
- **`tests/test_pending_decisions.py`** — 7 new regression tests covering the 6 acceptance scenarios plus a Codex Round 1 reproducer.
- **`CLAUDE.md` (Secretary)** — register lifecycle gains Step 3: when the user replies to a Secretary-surfaced question for a given task, run `python tools/pending_decisions.py mark-user-replied --task-id <id>` before forwarding to the worker.
- **`.dispatcher/CLAUDE.md`** — Step 5.1 splits:
  - `(a-0)` Primary register check (existing, from PR #302) — covers (a)(1).
  - `(a-2)` Primary register check (new) — covers (a)(2): `escalated` AND `user_replied_at` set AND `resolved_at` unset AND `now - user_replied_at > STALL_SECRETARY_LOOKBACK_MIN`.
  - `(a-3)` Fallback proxy (formerly the primary path from PR #298) — covers entries written before this schema landed and the case where Secretary forgot to call `mark-user-replied`.
- **`.claude/skills/org-delegate/SKILL.md`** — Step 5 sub-section 0 documents the `mark-user-replied` step.

## Codex self-review (3 rounds)

- Round 1: Major (mark_user_replied selection logic chose wrong entry when multiple escalated) + Minor. Fixed in `68fc2cc`.
- Round 2: Major (org-delegate SKILL still referenced the old lifecycle without the new step) + Minor (dispatcher prose carried obsolete framing). Fixed in `bbd5673`.
- Round 3: no Blocker / Major. 1 Minor + 1 Nit (a-0 docstring residue, pending_decisions test residue) intentionally left per "Minor/Nit retainable" policy in CLAUDE.local.md.

## Test plan

- [x] `pytest` — 393 passed, 1 skipped (7 new + 386 existing).
- [x] `python tools/check_role_configs.py` — OK.
- [x] `python tools/check_runtime_schema_drift.py` — OK against runtime 0.1.1.
- [x] CLI smoke: `mark-user-replied --help`, `list --user-replied-older-than-min 15`.
- [ ] CI on this PR.
- [ ] Manual: simulate full session #12 cycle — worker `worker_escalation`, Secretary `append`, Secretary forwards to user (`resolve --kind to_user`), user replies (`mark-user-replied`), Secretary forgets to forward → dispatcher pages user pane after 15 min via the new (a-2) primary path.

## Closes the dual deterministic detection promised by #297

With this PR landed:
- (a)(1) worker → Secretary → user gap: register-primary detection from #297.
- (a)(2) user → Secretary → worker gap: register-primary detection from this PR.
- Proxy fallback continues to handle the "Secretary forgot to call register CLI" edge case.

Closes #301.