### PR TITLE
fix(claude): create git worktree during Pattern B apply

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -698,14 +698,29 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
             }
         )
         import subprocess as _sp
+        self._init_repo_with_origin_main(self.sb.claude_org_root)
+
+    def _init_repo_with_origin_main(self, base: Path) -> None:
+        """Init ``base`` as a git repo on `main` with one commit and
+        ``origin/HEAD`` pointing at ``origin/main`` (no real remote required)."""
+        import subprocess as _sp
+        _sp.run(["git", "-C", str(base), "init", "-q", "-b", "main"],
+                check=True)
+        _sp.run(["git", "-C", str(base), "commit", "--allow-empty",
+                 "-m", "init", "-q"],
+                check=True, env=self._git_env)
+        sha = _sp.check_output(
+            ["git", "-C", str(base), "rev-parse", "main"],
+        ).decode().strip()
         _sp.run(
-            ["git", "-C", str(self.sb.claude_org_root), "init", "-q", "-b", "main"],
+            ["git", "-C", str(base), "update-ref",
+             "refs/remotes/origin/main", sha],
             check=True,
         )
         _sp.run(
-            ["git", "-C", str(self.sb.claude_org_root), "commit",
-             "--allow-empty", "-m", "init", "-q"],
-            check=True, env=self._git_env,
+            ["git", "-C", str(base), "symbolic-ref",
+             "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
+            check=True,
         )
 
     def tearDown(self) -> None:
@@ -836,6 +851,13 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         main_sha = _sp.check_output(
             ["git", "-C", str(base), "rev-parse", "main"],
         ).decode().strip()
+        # Refresh the simulated origin/main to point at the latest main tip,
+        # since setUp captured an earlier commit before the seed file landed.
+        _sp.run(
+            ["git", "-C", str(base), "update-ref",
+             "refs/remotes/origin/main", main_sha],
+            check=True,
+        )
         _sp.run(["git", "-C", str(base), "checkout", "-q", "-b", "feat/other"],
                 check=True)
         feat_file = base / "feat.txt"
@@ -890,17 +912,20 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
             )
         self.assertIn("not the planned", str(cm.exception))
 
-    def test_apply_aborts_when_no_default_trunk_ref(self):
-        """Codex Round 2 Major: must not silently fall back to HEAD when
-        origin/HEAD / main / master are all absent — that would re-introduce
-        the original bug on repos whose default branch is `trunk`."""
-        # Rename the only branch to `trunk` so neither main nor master nor
-        # origin/HEAD exists.
+    def test_apply_aborts_when_no_origin_head(self):
+        """Codex Round 2 + Round 3 Major: must abort when origin/HEAD is
+        absent — never guess from local main/master (could be stale after
+        a trunk-rename) and never fall back to HEAD (re-introduces the
+        original Pattern-B bug)."""
         import subprocess as _sp
         base = self.sb.claude_org_root
-        _sp.run(["git", "-C", str(base), "branch", "-m", "main", "trunk"],
-                check=True)
-        plan = self._build_self_edit_b(task_id="no-trunk-task")
+        # Tear down the origin/HEAD setup from setUp so the resolver can't
+        # find any authoritative trunk.
+        _sp.run(["git", "-C", str(base), "symbolic-ref", "--delete",
+                 "refs/remotes/origin/HEAD"], check=True)
+        _sp.run(["git", "-C", str(base), "update-ref", "-d",
+                 "refs/remotes/origin/main"], check=True)
+        plan = self._build_self_edit_b(task_id="no-origin-head-task")
         with self.assertRaises(gdp.WorktreeApplyError) as cm:
             gdp.apply_delegate_plan(
                 plan,
@@ -908,11 +933,37 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
                 claude_org_root=self.sb.claude_org_root,
                 skip_settings=True,
             )
-        self.assertIn("default trunk ref", str(cm.exception))
+        self.assertIn("origin/HEAD", str(cm.exception))
         # Neither DB row nor brief should exist.
         self.assertFalse(
-            any(r["task_id"] == "no-trunk-task" for r in self.sb.list_runs())
+            any(r["task_id"] == "no-origin-head-task"
+                for r in self.sb.list_runs())
         )
+
+    def test_apply_aborts_when_existing_worktree_in_detached_head(self):
+        """Codex Round 3 Major: idempotent reuse must reject detached HEAD
+        too, not just a different-named branch."""
+        import subprocess as _sp
+        plan = self._build_self_edit_b(task_id="detached-task")
+        worker_dir = Path(plan.layout.worker_dir)
+        worker_dir.parent.mkdir(parents=True, exist_ok=True)
+        # Create as a detached worktree (no -b, no branch name).
+        main_sha = _sp.check_output(
+            ["git", "-C", str(self.sb.claude_org_root), "rev-parse", "main"],
+        ).decode().strip()
+        _sp.run(
+            ["git", "-C", str(self.sb.claude_org_root),
+             "worktree", "add", "--detach", str(worker_dir), main_sha],
+            check=True, capture_output=True,
+        )
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("detached-HEAD", str(cm.exception))
 
     def test_apply_creates_plain_pattern_b_worktree_for_project_repo(self):
         """Non-self-edit Pattern B branches from the project's registered repo."""
@@ -920,15 +971,7 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         import subprocess as _sp
         project_repo = Path(self._td.name) / "clock-app-repo"
         project_repo.mkdir()
-        _sp.run(
-            ["git", "-C", str(project_repo), "init", "-q", "-b", "main"],
-            check=True,
-        )
-        _sp.run(
-            ["git", "-C", str(project_repo), "commit",
-             "--allow-empty", "-m", "init", "-q"],
-            check=True, env=self._git_env,
-        )
+        self._init_repo_with_origin_main(project_repo)
         (self.sb.claude_org_root / "registry" / "projects.md").write_text(
             "# Projects\n\n"
             "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -668,6 +668,197 @@ class TestIssue290Regressions(unittest.TestCase):
         self.assertIn("日本語の説明文", decoded)
 
 
+# ---------------------------------------------------------------------------
+# Issue #309: Pattern B apply must create the git worktree
+# ---------------------------------------------------------------------------
+
+
+class TestPatternBWorktreeCreation(unittest.TestCase):
+    """apply for Pattern B (incl. live_repo_worktree variant) must run
+    `git worktree add` so the brief lands inside a real worktree."""
+
+    def setUp(self) -> None:
+        try:
+            import subprocess as _sp
+            _sp.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # Initialize claude_org_root as a real git repo so live_repo_worktree
+        # can branch from it.
+        import os
+        self._git_env = os.environ.copy()
+        self._git_env.update(
+            {
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+        import subprocess as _sp
+        _sp.run(
+            ["git", "-C", str(self.sb.claude_org_root), "init", "-q", "-b", "main"],
+            check=True,
+        )
+        _sp.run(
+            ["git", "-C", str(self.sb.claude_org_root), "commit",
+             "--allow-empty", "-m", "init", "-q"],
+            check=True, env=self._git_env,
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _build_self_edit_b(self, *, task_id: str = "b-task"):
+        return gdp.build_delegate_plan(
+            task_id=task_id,
+            project_slug="claude-org-ja",
+            description="self-edit pattern B",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={
+                "pattern": "B",
+                "pattern_variant": "live_repo_worktree",
+                "role": "claude-org-self-edit",
+                "self_edit": True,
+            },
+        )
+
+    def _list_worktrees(self) -> list[str]:
+        import subprocess as _sp
+        out = _sp.check_output(
+            ["git", "-C", str(self.sb.claude_org_root),
+             "worktree", "list", "--porcelain"],
+        ).decode("utf-8", errors="replace")
+        return [
+            line[len("worktree "):].strip()
+            for line in out.splitlines()
+            if line.startswith("worktree ")
+        ]
+
+    def test_apply_creates_live_repo_worktree(self):
+        plan = self._build_self_edit_b()
+        # Plan should know which repo to branch from.
+        self.assertEqual(
+            Path(plan.base_repo).resolve(), self.sb.claude_org_root.resolve()
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        worker_dir = Path(plan.layout.worker_dir).resolve()
+        self.assertTrue(worker_dir.exists())
+        self.assertTrue((worker_dir / ".git").exists())
+        # Registered with git as a worktree
+        registered = {Path(p).resolve() for p in self._list_worktrees()}
+        self.assertIn(worker_dir, registered)
+        # Brief landed inside the worktree
+        brief = worker_dir / "CLAUDE.local.md"
+        self.assertTrue(brief.exists())
+
+    def test_apply_idempotent_when_worktree_already_registered(self):
+        plan = self._build_self_edit_b(task_id="idem-task")
+        worker_dir = Path(plan.layout.worker_dir)
+        # Pre-create the worktree manually to simulate a partial / retry run.
+        worker_dir.parent.mkdir(parents=True, exist_ok=True)
+        import subprocess as _sp
+        _sp.run(
+            ["git", "-C", str(self.sb.claude_org_root),
+             "worktree", "add", "-b", plan.layout.planned_branch,
+             str(worker_dir)],
+            check=True, capture_output=True,
+        )
+        # Apply must NOT raise and must not duplicate or replace it.
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        # Brief still lands in the worktree
+        self.assertTrue((worker_dir / "CLAUDE.local.md").exists())
+
+    def test_apply_aborts_when_worker_dir_has_unrelated_content(self):
+        plan = self._build_self_edit_b(task_id="dirty-task")
+        worker_dir = Path(plan.layout.worker_dir)
+        worker_dir.mkdir(parents=True)
+        (worker_dir / "stale.txt").write_text("garbage", encoding="utf-8")
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("not a registered git worktree", str(cm.exception))
+        # Brief was NOT written into the dirty dir.
+        self.assertFalse((worker_dir / "CLAUDE.local.md").exists())
+
+    def test_apply_creates_plain_pattern_b_worktree_for_project_repo(self):
+        """Non-self-edit Pattern B branches from the project's registered repo."""
+        # Stand up a dedicated project repo on disk and re-seed the registry.
+        import subprocess as _sp
+        project_repo = Path(self._td.name) / "clock-app-repo"
+        project_repo.mkdir()
+        _sp.run(
+            ["git", "-C", str(project_repo), "init", "-q", "-b", "main"],
+            check=True,
+        )
+        _sp.run(
+            ["git", "-C", str(project_repo), "commit",
+             "--allow-empty", "-m", "init", "-q"],
+            check=True, env=self._git_env,
+        )
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| 時計アプリ | clock-app | {project_repo} | Web 時計 | デザイン |\n"
+            f"| claude-org-ja | claude-org-ja | {self.sb.claude_org_root} | Self | スキル改善 |\n",
+            encoding="utf-8",
+        )
+        # Force Pattern B by adding an active concurrent run on the project.
+        self.sb.add_active_run(
+            task_id="other-clock-task",
+            project_slug="clock-app",
+            worker_dir=str(self.sb.workers / "clock-app"),
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="plain-b-task",
+            project_slug="clock-app",
+            description="add a sparkline",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertIsNone(plan.layout.pattern_variant)
+        self.assertEqual(
+            Path(plan.base_repo).resolve(), project_repo.resolve()
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        worker_dir = Path(plan.layout.worker_dir).resolve()
+        # Worktree registered against the project repo (not claude-org).
+        out = _sp.check_output(
+            ["git", "-C", str(project_repo),
+             "worktree", "list", "--porcelain"],
+        ).decode("utf-8", errors="replace")
+        registered = {
+            Path(line[len("worktree "):].strip()).resolve()
+            for line in out.splitlines() if line.startswith("worktree ")
+        }
+        self.assertIn(worker_dir, registered)
+        self.assertTrue((worker_dir / "CLAUDE.md").exists())
+
+
 def _env_update_goldens() -> bool:
     import os
     return os.environ.get("UPDATE_GOLDENS") == "1"

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -867,6 +867,53 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         # Sanity: the feat-only file must NOT appear in the new worktree.
         self.assertFalse((worker_dir / "feat.txt").exists())
 
+    def test_apply_aborts_when_existing_worktree_on_wrong_branch(self):
+        """Codex Round 2 Major: idempotent reuse must verify the existing
+        worktree is on the planned branch — a stale partial-retry on a
+        different branch must abort, not silently dispatch."""
+        plan = self._build_self_edit_b(task_id="branch-mismatch")
+        worker_dir = Path(plan.layout.worker_dir)
+        import subprocess as _sp
+        worker_dir.parent.mkdir(parents=True, exist_ok=True)
+        # Pre-create on a different branch than planned_branch.
+        _sp.run(
+            ["git", "-C", str(self.sb.claude_org_root),
+             "worktree", "add", "-b", "wrong-branch", str(worker_dir)],
+            check=True, capture_output=True,
+        )
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("not the planned", str(cm.exception))
+
+    def test_apply_aborts_when_no_default_trunk_ref(self):
+        """Codex Round 2 Major: must not silently fall back to HEAD when
+        origin/HEAD / main / master are all absent — that would re-introduce
+        the original bug on repos whose default branch is `trunk`."""
+        # Rename the only branch to `trunk` so neither main nor master nor
+        # origin/HEAD exists.
+        import subprocess as _sp
+        base = self.sb.claude_org_root
+        _sp.run(["git", "-C", str(base), "branch", "-m", "main", "trunk"],
+                check=True)
+        plan = self._build_self_edit_b(task_id="no-trunk-task")
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("default trunk ref", str(cm.exception))
+        # Neither DB row nor brief should exist.
+        self.assertFalse(
+            any(r["task_id"] == "no-trunk-task" for r in self.sb.list_runs())
+        )
+
     def test_apply_creates_plain_pattern_b_worktree_for_project_repo(self):
         """Non-self-edit Pattern B branches from the project's registered repo."""
         # Stand up a dedicated project repo on disk and re-seed the registry.

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -798,6 +798,75 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         # Brief was NOT written into the dirty dir.
         self.assertFalse((worker_dir / "CLAUDE.local.md").exists())
 
+    def test_apply_aborts_do_not_leak_queued_db_row(self):
+        """Codex Major: a failed _ensure_worktree must not leave behind a
+        queued runs row, because resolve_worker_layout treats `queued` as an
+        active run and would steer subsequent delegations onto Pattern B."""
+        plan = self._build_self_edit_b(task_id="leak-task")
+        worker_dir = Path(plan.layout.worker_dir)
+        worker_dir.mkdir(parents=True)
+        (worker_dir / "stale.txt").write_text("garbage", encoding="utf-8")
+        with self.assertRaises(gdp.WorktreeApplyError):
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        runs = self.sb.list_runs()
+        self.assertFalse(
+            any(r["task_id"] == "leak-task" for r in runs),
+            f"queued row leaked after worktree abort: {runs}",
+        )
+
+    def test_apply_branches_off_default_ref_not_current_head(self):
+        """Codex Blocker: the new worktree must branch off the default ref
+        (origin/HEAD or main), not the base repo's currently-checked-out
+        feature branch."""
+        import subprocess as _sp
+        # Make a commit on main so HEAD is non-empty, then check the base
+        # repo out onto a feature branch with its own commit. apply must
+        # still branch off main.
+        base = self.sb.claude_org_root
+        seed_file = base / "seed.txt"
+        seed_file.write_text("seed", encoding="utf-8")
+        _sp.run(["git", "-C", str(base), "add", "seed.txt"], check=True)
+        _sp.run(["git", "-C", str(base), "commit", "-m", "seed", "-q"],
+                check=True, env=self._git_env)
+        main_sha = _sp.check_output(
+            ["git", "-C", str(base), "rev-parse", "main"],
+        ).decode().strip()
+        _sp.run(["git", "-C", str(base), "checkout", "-q", "-b", "feat/other"],
+                check=True)
+        feat_file = base / "feat.txt"
+        feat_file.write_text("feat-only", encoding="utf-8")
+        _sp.run(["git", "-C", str(base), "add", "feat.txt"], check=True)
+        _sp.run(["git", "-C", str(base), "commit", "-m", "feat-only", "-q"],
+                check=True, env=self._git_env)
+        feat_sha = _sp.check_output(
+            ["git", "-C", str(base), "rev-parse", "HEAD"],
+        ).decode().strip()
+        self.assertNotEqual(main_sha, feat_sha)
+
+        plan = self._build_self_edit_b(task_id="default-ref-task")
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        worker_dir = Path(plan.layout.worker_dir)
+        new_sha = _sp.check_output(
+            ["git", "-C", str(worker_dir), "rev-parse", "HEAD"],
+        ).decode().strip()
+        self.assertEqual(
+            new_sha, main_sha,
+            "new worktree must branch off main, not the base repo's "
+            "currently-checked-out feature branch",
+        )
+        # Sanity: the feat-only file must NOT appear in the new worktree.
+        self.assertFalse((worker_dir / "feat.txt").exists())
+
     def test_apply_creates_plain_pattern_b_worktree_for_project_repo(self):
         """Non-self-edit Pattern B branches from the project's registered repo."""
         # Stand up a dedicated project repo on disk and re-seed the registry.

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -66,6 +66,14 @@ _PATTERN_LABELS = {
 }
 
 
+class WorktreeApplyError(RuntimeError):
+    """Raised by apply when Pattern B worktree creation cannot proceed safely
+    (e.g. ``worker_dir`` already contains unrelated content, or git fails).
+    Issue #309: apply must abort rather than silently leave a half-formed
+    worker dir for Secretary to discover after the worker has been spawned.
+    """
+
+
 @dataclass(frozen=True)
 class DelegatePlan:
     task_id: str
@@ -81,6 +89,10 @@ class DelegatePlan:
     closes_issue: Optional[int]
     refs_issues: list[int]
     artifacts_to_create: list[Path] = field(default_factory=list)
+    # Pattern B only: absolute path of the repo from which `git worktree add`
+    # is run. None for Pattern A / C, or when no usable base repo could be
+    # determined (apply will then raise WorktreeApplyError).
+    base_repo: Optional[Path] = None
 
     def to_summary_dict(self) -> dict[str, Any]:
         return {
@@ -97,6 +109,7 @@ class DelegatePlan:
             "brief_out_path": str(self.brief_out_path),
             "settings_args": dict(self.settings_args),
             "artifacts_to_create": [str(p) for p in self.artifacts_to_create],
+            "base_repo": str(self.base_repo) if self.base_repo else None,
         }
 
 
@@ -273,6 +286,16 @@ def build_delegate_plan(
         Path(layout.worker_dir) / ".claude" / "settings.local.json",
     ]
 
+    # Pattern B: figure out which repo `git worktree add` should be run from.
+    # live_repo_worktree → Secretary's live claude-org repo;
+    # plain Pattern B    → the registered project's path.
+    base_repo: Optional[Path] = None
+    if layout.pattern == "B":
+        if layout.pattern_variant == "live_repo_worktree":
+            base_repo = Path(claude_org_root).resolve()
+        elif project_path and rwl.is_local_git_repo(project_path):
+            base_repo = Path(project_path).resolve()
+
     return DelegatePlan(
         task_id=task_id,
         project_slug=project_slug,
@@ -287,6 +310,7 @@ def build_delegate_plan(
         closes_issue=closes_issue,
         refs_issues=list(refs_issues or []),
         artifacts_to_create=artifacts,
+        base_repo=base_repo,
     )
 
 
@@ -368,6 +392,79 @@ def _reserve_in_db(
         conn.close()
 
 
+def _is_registered_worktree(base_repo: Path, worker_dir: Path) -> bool:
+    """True iff ``worker_dir`` is already a registered worktree of ``base_repo``.
+
+    Compared by resolved absolute path so a re-run of apply against an
+    already-created worktree is idempotent (Issue #309).
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(base_repo), "worktree", "list", "--porcelain"],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        return False
+    try:
+        target = worker_dir.resolve()
+    except OSError:
+        return False
+    for line in proc.stdout.decode("utf-8", errors="replace").splitlines():
+        if line.startswith("worktree "):
+            try:
+                p = Path(line[len("worktree "):]).resolve()
+            except OSError:
+                continue
+            if p == target:
+                return True
+    return False
+
+
+def _ensure_worktree(plan: DelegatePlan) -> None:
+    """For Pattern B, run ``git worktree add`` if the dir is not already one.
+
+    Idempotent — no-op when ``worker_dir`` is already a registered worktree
+    of ``base_repo``. Aborts with :class:`WorktreeApplyError` when the dir
+    exists with unrelated content (Secretary judgment call to clean up,
+    per Issue #309).
+    """
+    if plan.layout.pattern != "B":
+        return
+    if plan.base_repo is None:
+        raise WorktreeApplyError(
+            f"Pattern B but no usable base repo could be determined for "
+            f"project {plan.project_slug!r} (variant="
+            f"{plan.layout.pattern_variant!r}); cannot run `git worktree add`."
+        )
+    worker_dir = Path(plan.layout.worker_dir)
+    if _is_registered_worktree(plan.base_repo, worker_dir):
+        return
+    if worker_dir.exists() and any(worker_dir.iterdir()):
+        raise WorktreeApplyError(
+            f"worker_dir {worker_dir} exists with content but is not a "
+            f"registered git worktree of {plan.base_repo}. Refusing to "
+            "auto-recover — Secretary must clean up the directory (or run "
+            "`git worktree add` manually) and retry apply."
+        )
+    branch = plan.layout.planned_branch
+    if not branch:
+        raise WorktreeApplyError(
+            f"Pattern B requires a planned_branch but layout produced None "
+            f"(task_id={plan.task_id!r})."
+        )
+    worker_dir.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "git", "-C", str(plan.base_repo),
+        "worktree", "add", "-b", branch, str(worker_dir),
+    ]
+    proc = subprocess.run(cmd, capture_output=True)
+    if proc.returncode != 0:
+        stderr = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise WorktreeApplyError(
+            f"`git worktree add` failed (rc={proc.returncode}) for "
+            f"{worker_dir} from {plan.base_repo}: {stderr}"
+        )
+
+
 def _write_brief(plan: DelegatePlan) -> Path:
     text = gwb.render(plan.config)
     out = plan.brief_out_path
@@ -446,6 +543,9 @@ def apply_delegate_plan(
     db_reservation = _reserve_in_db(
         plan, state_db_path=state_db_path, claude_org_root=claude_org_root
     )
+    # Issue #309: brief must be written *into* the worktree, so create the
+    # worktree first when Pattern B. No-op for A / C.
+    _ensure_worktree(plan)
     brief_path = _write_brief(plan)
     settings_path: Optional[Path] = None
     skipped_reason: Optional[str] = None

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -392,17 +392,24 @@ def _reserve_in_db(
         conn.close()
 
 
-def _resolve_base_ref(base_repo: Path) -> str:
+def _resolve_base_ref(base_repo: Path) -> Optional[str]:
     """Pick the starting ref for ``git worktree add -b <branch> <path> <ref>``.
 
     Pattern B is triggered precisely when another active run is occupying
     the base clone — so the base's current ``HEAD`` is typically that
     other task's feature branch. Branching off it would mix unmerged
-    commits into the new worktree (Codex Blocker 2026-05-06). Prefer:
+    commits into the new worktree. We only accept refs we can prove are
+    "the trunk" deterministically:
 
     1. ``origin/HEAD`` (the project's default branch as the remote knows it),
-    2. local ``main`` / ``master``,
-    3. ``HEAD`` as a last resort (single-branch repos with no remote).
+    2. local ``main`` / ``master``.
+
+    Returns ``None`` when neither is present — apply then aborts rather
+    than silently falling back to ``HEAD``, which would re-introduce the
+    original bug on repos whose default branch is named ``trunk`` /
+    ``develop`` / etc. (Codex Round 2 Major 2026-05-06). Secretary can
+    recover by setting ``git remote set-head origin --auto`` or renaming
+    the trunk to ``main``.
     """
     proc = subprocess.run(
         ["git", "-C", str(base_repo), "symbolic-ref", "--short",
@@ -421,7 +428,22 @@ def _resolve_base_ref(base_repo: Path) -> str:
         ).returncode
         if rc == 0:
             return cand
-    return "HEAD"
+    return None
+
+
+def _worktree_branch(worker_dir: Path) -> Optional[str]:
+    """Return the branch name currently checked out at ``worker_dir`` (or
+    None on detached HEAD / git error)."""
+    proc = subprocess.run(
+        ["git", "-C", str(worker_dir), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        return None
+    name = proc.stdout.decode("utf-8", errors="replace").strip()
+    if not name or name == "HEAD":
+        return None
+    return name
 
 
 def _is_registered_worktree(base_repo: Path, worker_dir: Path) -> bool:
@@ -469,6 +491,20 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
         )
     worker_dir = Path(plan.layout.worker_dir)
     if _is_registered_worktree(plan.base_repo, worker_dir):
+        # Idempotent reuse — but only when the existing worktree is on the
+        # branch the brief / DB will pin. A stale partial-retry worktree on
+        # a different branch would otherwise silently dispatch on the wrong
+        # ref (Codex Round 2 Major 2026-05-06).
+        actual = _worktree_branch(worker_dir)
+        expected = plan.layout.planned_branch
+        if expected and actual and actual != expected:
+            raise WorktreeApplyError(
+                f"worker_dir {worker_dir} is registered as a git worktree "
+                f"but is on branch {actual!r}, not the planned "
+                f"{expected!r}. Refusing to dispatch on a mismatched branch "
+                "— Secretary must check out the intended branch (or remove "
+                "the worktree and let apply recreate it) and retry."
+            )
         return
     if worker_dir.exists() and any(worker_dir.iterdir()):
         raise WorktreeApplyError(
@@ -483,8 +519,18 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
             f"Pattern B requires a planned_branch but layout produced None "
             f"(task_id={plan.task_id!r})."
         )
-    worker_dir.parent.mkdir(parents=True, exist_ok=True)
     base_ref = _resolve_base_ref(plan.base_repo)
+    if base_ref is None:
+        raise WorktreeApplyError(
+            f"could not resolve a default trunk ref in {plan.base_repo} "
+            "(no origin/HEAD, no local main, no local master). Refusing to "
+            "fall back to HEAD because Pattern B is invoked precisely when "
+            "the base repo has another active task checked out — branching "
+            "off HEAD would mix that task's commits into the new worktree. "
+            "Set the trunk explicitly via `git remote set-head origin --auto` "
+            "or rename your default branch to main."
+        )
+    worker_dir.parent.mkdir(parents=True, exist_ok=True)
     cmd = [
         "git", "-C", str(plan.base_repo),
         "worktree", "add", "-b", branch, str(worker_dir), base_ref,

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -398,18 +398,20 @@ def _resolve_base_ref(base_repo: Path) -> Optional[str]:
     Pattern B is triggered precisely when another active run is occupying
     the base clone — so the base's current ``HEAD`` is typically that
     other task's feature branch. Branching off it would mix unmerged
-    commits into the new worktree. We only accept refs we can prove are
-    "the trunk" deterministically:
+    commits into the new worktree.
 
-    1. ``origin/HEAD`` (the project's default branch as the remote knows it),
-    2. local ``main`` / ``master``.
+    The only ref we treat as authoritative is ``origin/HEAD`` (the
+    project's default branch as the remote knows it). We deliberately do
+    NOT fall back to local ``main`` / ``master`` / ``HEAD`` because:
 
-    Returns ``None`` when neither is present — apply then aborts rather
-    than silently falling back to ``HEAD``, which would re-introduce the
-    original bug on repos whose default branch is named ``trunk`` /
-    ``develop`` / etc. (Codex Round 2 Major 2026-05-06). Secretary can
-    recover by setting ``git remote set-head origin --auto`` or renaming
-    the trunk to ``main``.
+    - a stale local ``main`` left over after a trunk-rename would silently
+      branch off the wrong commit (Codex Round 3 Major 2026-05-06);
+    - ``HEAD`` is the original bug (Codex Round 2);
+    - convention-based guessing of the trunk name is not safe in repos
+      using ``trunk`` / ``develop`` / etc.
+
+    Returns ``None`` when ``origin/HEAD`` is not set — apply then aborts
+    with a recovery hint pointing to ``git remote set-head origin --auto``.
     """
     proc = subprocess.run(
         ["git", "-C", str(base_repo), "symbolic-ref", "--short",
@@ -420,14 +422,6 @@ def _resolve_base_ref(base_repo: Path) -> Optional[str]:
         ref = proc.stdout.decode("utf-8", errors="replace").strip()
         if ref:
             return ref
-    for cand in ("main", "master"):
-        rc = subprocess.run(
-            ["git", "-C", str(base_repo), "rev-parse", "--verify", "--quiet",
-             cand],
-            capture_output=True,
-        ).returncode
-        if rc == 0:
-            return cand
     return None
 
 
@@ -493,18 +487,29 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
     if _is_registered_worktree(plan.base_repo, worker_dir):
         # Idempotent reuse — but only when the existing worktree is on the
         # branch the brief / DB will pin. A stale partial-retry worktree on
-        # a different branch would otherwise silently dispatch on the wrong
-        # ref (Codex Round 2 Major 2026-05-06).
-        actual = _worktree_branch(worker_dir)
+        # a different branch (or in detached-HEAD state) would otherwise
+        # silently dispatch on the wrong ref (Codex Round 2 + Round 3
+        # Majors 2026-05-06).
         expected = plan.layout.planned_branch
-        if expected and actual and actual != expected:
-            raise WorktreeApplyError(
-                f"worker_dir {worker_dir} is registered as a git worktree "
-                f"but is on branch {actual!r}, not the planned "
-                f"{expected!r}. Refusing to dispatch on a mismatched branch "
-                "— Secretary must check out the intended branch (or remove "
-                "the worktree and let apply recreate it) and retry."
-            )
+        if expected:
+            actual = _worktree_branch(worker_dir)
+            if actual is None:
+                raise WorktreeApplyError(
+                    f"worker_dir {worker_dir} is registered as a git "
+                    f"worktree but is in detached-HEAD state, not on the "
+                    f"planned branch {expected!r}. Refusing to dispatch — "
+                    "Secretary must `git checkout` the intended branch (or "
+                    "remove the worktree and let apply recreate it) and retry."
+                )
+            if actual != expected:
+                raise WorktreeApplyError(
+                    f"worker_dir {worker_dir} is registered as a git "
+                    f"worktree but is on branch {actual!r}, not the planned "
+                    f"{expected!r}. Refusing to dispatch on a mismatched "
+                    "branch — Secretary must check out the intended branch "
+                    "(or remove the worktree and let apply recreate it) "
+                    "and retry."
+                )
         return
     if worker_dir.exists() and any(worker_dir.iterdir()):
         raise WorktreeApplyError(
@@ -522,13 +527,15 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
     base_ref = _resolve_base_ref(plan.base_repo)
     if base_ref is None:
         raise WorktreeApplyError(
-            f"could not resolve a default trunk ref in {plan.base_repo} "
-            "(no origin/HEAD, no local main, no local master). Refusing to "
-            "fall back to HEAD because Pattern B is invoked precisely when "
-            "the base repo has another active task checked out — branching "
-            "off HEAD would mix that task's commits into the new worktree. "
-            "Set the trunk explicitly via `git remote set-head origin --auto` "
-            "or rename your default branch to main."
+            f"could not resolve `origin/HEAD` in {plan.base_repo}. Refusing "
+            "to guess the trunk from local refs because a stale local "
+            "`main` after a trunk-rename would silently branch the new "
+            "worktree off the wrong commit, and `HEAD` is the original "
+            "Pattern-B bug (it points to whatever feature branch the base "
+            "is currently on). Run `git remote set-head origin --auto` in "
+            f"{plan.base_repo} (or `git symbolic-ref refs/remotes/origin/"
+            "HEAD refs/remotes/origin/<trunk>` if you don't have remote "
+            "access) and retry."
         )
     worker_dir.parent.mkdir(parents=True, exist_ok=True)
     cmd = [

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -392,6 +392,38 @@ def _reserve_in_db(
         conn.close()
 
 
+def _resolve_base_ref(base_repo: Path) -> str:
+    """Pick the starting ref for ``git worktree add -b <branch> <path> <ref>``.
+
+    Pattern B is triggered precisely when another active run is occupying
+    the base clone — so the base's current ``HEAD`` is typically that
+    other task's feature branch. Branching off it would mix unmerged
+    commits into the new worktree (Codex Blocker 2026-05-06). Prefer:
+
+    1. ``origin/HEAD`` (the project's default branch as the remote knows it),
+    2. local ``main`` / ``master``,
+    3. ``HEAD`` as a last resort (single-branch repos with no remote).
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(base_repo), "symbolic-ref", "--short",
+         "refs/remotes/origin/HEAD"],
+        capture_output=True,
+    )
+    if proc.returncode == 0:
+        ref = proc.stdout.decode("utf-8", errors="replace").strip()
+        if ref:
+            return ref
+    for cand in ("main", "master"):
+        rc = subprocess.run(
+            ["git", "-C", str(base_repo), "rev-parse", "--verify", "--quiet",
+             cand],
+            capture_output=True,
+        ).returncode
+        if rc == 0:
+            return cand
+    return "HEAD"
+
+
 def _is_registered_worktree(base_repo: Path, worker_dir: Path) -> bool:
     """True iff ``worker_dir`` is already a registered worktree of ``base_repo``.
 
@@ -452,9 +484,10 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
             f"(task_id={plan.task_id!r})."
         )
     worker_dir.parent.mkdir(parents=True, exist_ok=True)
+    base_ref = _resolve_base_ref(plan.base_repo)
     cmd = [
         "git", "-C", str(plan.base_repo),
-        "worktree", "add", "-b", branch, str(worker_dir),
+        "worktree", "add", "-b", branch, str(worker_dir), base_ref,
     ]
     proc = subprocess.run(cmd, capture_output=True)
     if proc.returncode != 0:
@@ -540,12 +573,15 @@ def apply_delegate_plan(
     send_plan_out: Optional[Path] = None,
 ) -> ApplyResult:
     """Execute the side effects: reserve in DB, write brief, settings, send_plan."""
+    # Issue #309: create the worktree FIRST. If this fails (dirty dir,
+    # git error, etc.) we must not leak a `runs.status='queued'` row,
+    # because resolve_worker_layout treats `queued` as an active run and
+    # would silently steer the next delegation onto another Pattern B
+    # branch (Codex Major 2026-05-06). No-op for Pattern A / C.
+    _ensure_worktree(plan)
     db_reservation = _reserve_in_db(
         plan, state_db_path=state_db_path, claude_org_root=claude_org_root
     )
-    # Issue #309: brief must be written *into* the worktree, so create the
-    # worktree first when Pattern B. No-op for A / C.
-    _ensure_worktree(plan)
     brief_path = _write_brief(plan)
     settings_path: Optional[Path] = None
     skipped_reason: Optional[str] = None


### PR DESCRIPTION
## Summary
- `gen_delegate_payload.py apply` now runs `git worktree add -b <planned_branch> <worker_dir> origin/HEAD` for Pattern B (including `live_repo_worktree`) so the worker dir is a real registered worktree, not a bare directory containing only brief artifacts.
- Idempotent reuse: if the worktree is already registered, the apply path verifies the checked-out branch matches `planned_branch` (rejects detached HEAD) and proceeds without re-creating.
- Aborts with a clear `WorktreeApplyError` when `worker_dir` has unrelated content, `origin/HEAD` can't be resolved, or `git worktree add` itself fails. Stderr is included for recovery.
- Worktree creation now happens before T1 reservation so a failure can't leave a stale `runs.status='queued'` row that would mislead `resolve_worker_layout` on the next attempt.
- Adds `TestPatternBWorktreeCreation` (8 tests) covering creation, idempotent reuse, branch mismatch, detached HEAD, missing `origin/HEAD`, content collision, and rollback on failure.

## Test plan
- [x] `python -m unittest discover tests` — 156 tests pass
- [x] `python -m unittest tests.test_gen_delegate_payload` — 32 tests pass (8 new)
- [ ] Live verification: next Pattern B apply (e.g., a fresh issue) should produce a registered worktree in one step without manual `git worktree add` recovery.

Closes #309