### PR TITLE
fix(claude): enforce explicit ack to worker + strict user-approval gate

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -422,15 +422,27 @@ worker → Secretary peer message
   5. CI watch / next instruction
 ```
 
-- 1 (ack) は worker dead-lock 防止の必須 step。worker は ack を受け取るまで「次の指示待ち」で idle になり続ける。ack の最低内容と種別ごとの例文は [`references/ack-template.md`](references/ack-template.md) を参照
+- **適用範囲**:
+  - **step 1 (ack) と step 2 (state 更新) は全 message 共通で必須**。完了 / 進捗 / Codex round / 判断仰ぎ いずれを受けても worker 宛 ack を最初に発行する（dead-lock 防止）
+  - **step 3 (user 報告) と step 4 (承認待ち)** は完了報告・判断仰ぎ・ブロッカー・スコープ拡張提案 等 user の判断を要する種別に限る。**純粋な進捗報告（subsection 1）は ack + Progress Log + events 追記で完了**し、user 報告・承認待ちは行わない（worker を不要に止めない）
+  - **step 5 (CI watch / 次の指示)** は push / PR 後または追加指示が必要な種別のみ
+- ack の最低内容と種別ごとの例文は [`references/ack-template.md`](references/ack-template.md) を参照
 - 2 → 3 の順序は「内部状態を先に整合させてから user に報告する」原則。逆にすると user 承認後に DB 不整合が残るリスクがある
-- 4 (user approval gate) は判断仰ぎ・完了報告いずれも対象。`git push` / `gh pr create` / `tools/pr-watch.*` は user の明示的 OK 後にのみ発行する。ack ≠ user 承認
+- step 4 の `git push` / `gh pr create` / `tools/pr-watch.*` は user の明示的 OK 後にのみ発行する。**ack ≠ user 承認** — ack は worker dead-lock 解除のための受領確認で、push/PR 権限を生まない
 
 ワーカーから renga-peers でメッセージを受け取ったら:
 
 0. 判断仰ぎ・スコープ拡張提案・承認要求・ブロッカーの場合（**最優先で識別**）:
    - ワーカーが「承認を仰ぎます」「判断仰ぎます」「続行可否」「スコープ拡張」「提案」「想定外」「runbook 逸脱」「ブロック」「ブロッカー」「block」等を含むメッセージを送ってきた場合
-   - **Secretary は一次承認しない**。「受領しました、人間に確認します」のみ返答してよい
+   - **最初に worker へ ack を返す**（Canonical event flow step 1。状態保存・user 伝達より前に発行する）:
+     ```
+     mcp__renga-peers__send_message(
+       to_id="worker-{task_id}",
+       message="判断仰ぎ受領しました。Secretary では一次承認しません。人間に確認します。返答が来るまでペイン保持で待機してください（自動続行しないこと）。"
+     )
+     ```
+     文面例は [`references/ack-template.md`](references/ack-template.md) の「判断仰ぎ ack」節
+   - **Secretary は一次承認しない**。worker への返答も「受領しました、人間に確認します」のみ
    - **状態を保存する**（窓口再起動・引き継ぎで pending 判断を失わないため、進捗報告と同等の永続化を行う）:
      - `.state/workers/worker-{task_id}.md` の Progress Log に「判断仰ぎ受信」内容と要点を追記
      - DB の events テーブルに追記: `bash tools/journal_append.sh worker_escalation worker=worker-{task_id} task={task_id} reason="<要約>"`
@@ -443,6 +455,14 @@ worker → Secretary peer message
    - （注）ブロッカー報告も本分岐で扱うため、下段「3. ブロック報告の場合」と重複した場合は本分岐を優先する
 
 1. 進捗報告の場合:
+   - **最初に worker へ ack を返す**（Canonical event flow step 1。Progress Log 追記より前）:
+     ```
+     mcp__renga-peers__send_message(
+       to_id="worker-{task_id}",
+       message="進捗受領しました。続行 OK。完了したら同じ to_id=\"secretary\" で報告してください。ペイン保持で。"
+     )
+     ```
+     文面例は [`references/ack-template.md`](references/ack-template.md) の「進捗報告 ack」節。**進捗報告は user に上げない・承認待ちもしない**（Canonical event flow の適用範囲注記参照）
    - `.state/workers/worker-{task_id}.md` の Progress Log に追記
    - DB の events テーブルにイベント追記 (`bash tools/journal_append.sh ...`)
 2a. ワーカーから完了報告を受け取ったら:

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -411,6 +411,21 @@ mcp__renga-peers__send_message(
 
 ### ワーカーからのメッセージ受信時
 
+**Canonical event flow**（ワーカーからの完了 / 進捗 / Codex round / 判断仰ぎ いずれの peer message にも共通する正準順序。途中段階を飛ばしてはならない）:
+
+```
+worker → Secretary peer message
+  1. ack to worker (mcp__renga-peers__send_message, to_id="worker-{task_id}")
+  2. update Progress Log + DB (run.status / events / pending-decisions register)
+  3. report to user
+  4. wait for user approval before push/PR (2b-i)
+  5. CI watch / next instruction
+```
+
+- 1 (ack) は worker dead-lock 防止の必須 step。worker は ack を受け取るまで「次の指示待ち」で idle になり続ける。ack の最低内容と種別ごとの例文は [`references/ack-template.md`](references/ack-template.md) を参照
+- 2 → 3 の順序は「内部状態を先に整合させてから user に報告する」原則。逆にすると user 承認後に DB 不整合が残るリスクがある
+- 4 (user approval gate) は判断仰ぎ・完了報告いずれも対象。`git push` / `gh pr create` / `tools/pr-watch.*` は user の明示的 OK 後にのみ発行する。ack ≠ user 承認
+
 ワーカーから renga-peers でメッセージを受け取ったら:
 
 0. 判断仰ぎ・スコープ拡張提案・承認要求・ブロッカーの場合（**最優先で識別**）:
@@ -431,6 +446,14 @@ mcp__renga-peers__send_message(
    - `.state/workers/worker-{task_id}.md` の Progress Log に追記
    - DB の events テーブルにイベント追記 (`bash tools/journal_append.sh ...`)
 2a. ワーカーから完了報告を受け取ったら:
+   - **最初に worker へ ack を返す**（Canonical event flow の step 1。run.status 更新・user 報告・後続作業より前に発行する）:
+     ```
+     mcp__renga-peers__send_message(
+       to_id="worker-{task_id}",
+       message="<受領確認> + <次の予定: PR 作成は user 承認後 / CI 結果待ち / 追加レビュー要否> + <ペイン状態: 保持 or クローズ予定>"
+     )
+     ```
+     ack 文面の例（種別別）は [`references/ack-template.md`](references/ack-template.md)。worker は ack を受けるまで「次の指示待ち」で idle になり、dead-lock の原因になる
    - **DB 経由で run を REVIEW に遷移する**（markdown 直接編集禁止。post-commit hook が `.state/org-state.md` を再生成）:
      ```bash
      python -c "
@@ -446,6 +469,7 @@ mcp__renga-peers__send_message(
    - JSON snapshot は StateWriter post-commit hook が自動再生成 (Issue #284)
    - 結果を人間に報告する
    - **ペインはまだ閉じない**
+   - **承認待ちで停止する**: 人間から「OK」「確認した」「問題ない」「進めて」等の **明示的承認** を受けるまで、`git push` / `gh pr create` / `tools/pr-watch.ps1` / `tools/pr-watch.sh` を発行してはならない。「報告して即続行」ではなく「報告して承認待ち」が正準フロー。ack（worker 宛）は user 承認とは別物 — ack は worker dead-lock 解除のためで、push/PR 権限を生まない。承認なしで push/PR を発行すると worker / user 双方への protocol 違反
 
 2b. 人間が承認した場合（「OK」「確認した」「問題ない」等）:
 

--- a/.claude/skills/org-delegate/references/ack-template.md
+++ b/.claude/skills/org-delegate/references/ack-template.md
@@ -1,0 +1,66 @@
+# Ack template — Secretary → worker peer message
+
+Secretary が worker からの peer message を受け取ったときの ack（acknowledgement）文面テンプレート。SKILL.md Step 5 の "Canonical event flow" の **step 1** で必ず発行する。
+
+## なぜ ack が必須か
+
+- worker-claude-template は完了 / 進捗報告の末尾に「ペイン保持。次の指示お待ちします」を書くよう指示している
+- Secretary が ack を返さないと worker は「Secretary に届いたか / 次の指示は何か」が判らないまま idle で待ち続ける（dead-lock）
+- session #13 で実際に観測された失敗モード — Secretary は「user に報告した」を「worker への返答」と誤認していた
+- ack ≠ user 承認。ack は dead-lock 解除のための受領確認であり、push/PR 権限を生まない
+
+## ack の最低内容（必須 3 要素）
+
+1. **受領確認**: 「受領」「了解」「確認」等
+2. **次の予定**: PR 作成は user 承認後 / CI 結果待ち / 追加レビュー要否 / 人間判断待ち 等
+3. **ペイン状態**: 保持 / クローズ予定
+
+## 種別ごとの例文
+
+### 進捗報告 ack
+
+```
+mcp__renga-peers__send_message(
+  to_id="worker-{task_id}",
+  message="進捗受領しました。続行 OK。完了したら同じ to_id=\"secretary\" で報告してください。ペイン保持で。"
+)
+```
+
+### 完了報告 ack（PR 未作成時）
+
+```
+mcp__renga-peers__send_message(
+  to_id="worker-{task_id}",
+  message="完了報告受領しました。これから user に報告し、承認を取ってから push / PR 作成を Secretary 側で行います。ペイン保持で待機してください。CI / レビュー指摘が来たら同ペインで対応依頼を送ります。"
+)
+```
+
+### Codex セルフレビュー round 完了 ack
+
+```
+mcp__renga-peers__send_message(
+  to_id="worker-{task_id}",
+  message="Codex round 受領しました。Blocker/Major があれば修正コミット → 次 round へ。3 round 上限まで進めて OK。残りが Minor/Nit のみなら最終完了報告に切り替えてください。ペイン保持で。"
+)
+```
+
+### 判断仰ぎ ack（escalation）
+
+```
+mcp__renga-peers__send_message(
+  to_id="worker-{task_id}",
+  message="判断仰ぎ受領しました。Secretary では一次承認しません。人間に確認します。返答が来るまでペイン保持で待機してください（自動続行しないこと）。"
+)
+```
+
+判断仰ぎの場合は SKILL.md Step 5 の subsection 0 に従い、Progress Log 追記 + `worker_escalation` journal 追記 + `pending_decisions append` も並行して行う。ack はそれらと独立した worker 宛のフィードバック。
+
+### ブロック報告 ack
+
+判断仰ぎ ack と同じ文面で OK。ブロック内容によっては「該当タスクは中断、別 worker に振り直すかも」「ペインクローズ予定」と次の予定を明示する。
+
+## アンチパターン
+
+- ❌ ack を省略して run.status 更新と user 報告だけ行う → worker dead-lock
+- ❌ ack の内容に「OK、push します」と書いて user 承認前に push を発行 → user approval gate 違反（SKILL.md Step 5 (2a→2b) gate）
+- ❌ user 承認後の "進めます" 通知を ack の代わりにする → 完了報告から user 承認までのタイムラグの間 worker は idle で待つことになる。ack は受信直後に即発行する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@
 - 実作業は全てワーカーに委譲する（コード編集、デバッグ、テスト、ビルド、git commit、環境構築等）
 - 問題が報告されたら、自分で調査せずワーカーに投げる
 
+## ワーカー peer message を受けたら必ず ack を返す（Issue #312）
+
+ワーカーから renga-peers で完了 / 進捗 / Codex round / 判断仰ぎ いずれの message を受け取っても、Secretary は **最初に worker 宛 ack** を `mcp__renga-peers__send_message(to_id="worker-{task_id}", ...)` で発行する。ack を返さないと worker は「ペイン保持。次の指示お待ちします」のまま idle で dead-lock する。canonical event flow と ack 文例は [`.claude/skills/org-delegate/SKILL.md` Step 5](./.claude/skills/org-delegate/SKILL.md) と [`references/ack-template.md`](./.claude/skills/org-delegate/references/ack-template.md) を参照。**ack ≠ user 承認**: push / `gh pr create` / `tools/pr-watch.*` は user の明示的 OK を受けてから発行する。
+
 ## ワーカーからの判断仰ぎは人間にエスカレーションする
 
 ワーカーから renga-peers で以下のメッセージが来たら、Secretary は **必ず人間に上げる**。一次承認・自己解釈で返答しない:


### PR DESCRIPTION
## Summary
- Adds a canonical event-flow checklist (ack → state → user → approval → push) at the top of `org-delegate` Step 5 so the Secretary cannot skip ack-to-worker or push prematurely.
- Step 5 (2a) now explicitly requires `mcp__renga-peers__send_message(to_id="worker-{task_id}", ...)` as the first action on every worker peer message (escalation, progress, completion, codex round). Without this, workers idle after writing "ペイン保持" and the Secretary unilaterally drives next steps.
- Step 5 (2a→2b) gate language is tightened: `git push` / `gh pr create` / `tools/pr-watch.*` may not fire until the user explicitly OKs ("OK", "確認した", "問題ない"). ack ≠ approval.
- New `references/ack-template.md` provides four worked ack examples (進捗 / 完了 / Codex round / 判断仰ぎ) plus an anti-pattern section.
- Repo-root `CLAUDE.md` gets a one-line cross-reference so the rule is visible at the Secretary contract layer.

## Test plan
- [x] `python -m pytest tests/` — 147 tests pass (changes are documentation-centric)
- [x] Codex round-1 review: 2 Major addressed (canonical-flow scope ambiguity, ack missing in subsections 0/1) → fixed in 8dec828
- [x] Codex round-2 review: no Blocker/Major; one Minor + one Nit out of scope, intentionally left
- [ ] Live verification: behavior change applies to subsequent worker peer-message handling; observable on next delegation cycle.

Closes #312