### PR TITLE
fix(claude): defer balanced-split spec to claude-org-runtime SoT

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -187,10 +187,10 @@ runtime CLI 自体が壊れている場合 (`claude-org-runtime` / `gen_delegate
 balanced split の判定 (target / direction の選択、MIN_PANE / secretary 保険 / role priority によるソート、rect 隣接判定) は **dispatcher が `claude-org-runtime` の `delegate-plan` helper 経由で実行する**。Claude 側で再実装するロジックではない。helper は `mcp__renga-peers__list_panes` の rect スナップショットと task JSON を入力に取り、`spawn` ターゲット名と direction を含む action plan を返す（候補が空なら `split_capacity_exceeded` で escalate を指示）。
 
 仕様詳細・定数値・ソートキー・rect 隣接の正確な定義は **runtime SoT** を参照する:
-- 実装: `claude-org-runtime/src/claude_org_runtime/dispatcher/runner.py` の `choose_split()` / `rect_adjacent()` / `_ROLE_PRIORITY` / `MIN_PANE_*` / `SECRETARY_MIN_*` 定数
-- CLI: `python -m claude_org_runtime.dispatcher.runner delegate-plan --task-json ... --panes-json ...`
+- CLI (運用上の標準呼び出し): `claude-org-runtime dispatcher delegate-plan --task-json ... --panes-json ... --state-dir ... [--template-repo ...] [--locale-json ...]`。`.dispatcher/CLAUDE.md` の delegate-plan helper 節が一次手順
+- ライブラリ: `claude_org_runtime.dispatcher.runner` モジュールの `build_plan()` (action plan 全体: `spawn` / `after_spawn` / `escalate` / `state_writes` / `status`) と、その内部で呼ばれる `choose_split()` (target / direction 選択) / `rect_adjacent()` / `_ROLE_PRIORITY` / `MIN_PANE_*` / `SECRETARY_MIN_*` 定数
 
-本 SKILL から定数値や Step 1-6 の prose を消したのは、runtime と doc が drift する原因になるため (Issue #307 cleanup)。dispatcher が helper を経由しない degraded mode に入った場合、判定再現は `runner.py` を一次参照する。
+本 SKILL から定数値や Step 1-6 の prose を消したのは、runtime と doc が drift する原因になるため (Issue #307 cleanup)。dispatcher が helper を経由しない degraded mode に入った場合、判定再現は `claude_org_runtime.dispatcher.runner` モジュール (インストール先は `python -c "import claude_org_runtime.dispatcher.runner; print(claude_org_runtime.dispatcher.runner.__file__)"` で解決可能) を一次参照する。
 
 #### 3-1c. 候補が空だった場合
 

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -182,44 +182,15 @@ runtime CLI 自体が壊れている場合 (`claude-org-runtime` / `gen_delegate
 - `focused`: bool（出力行に `(focused)` が付くかで判断）
 - `x / y / width / height`: cell 単位の整数
 
-#### 3-1b. balanced split アルゴリズム（Claude が判定ロジックを実行）
+#### 3-1b. balanced split アルゴリズム（runtime helper が判定ロジックを実行）
 
-**定数**:
-- `MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5`: renga 側の分割下限（findings: renga-split-inv）
-- `SECRETARY_MIN_WIDTH = 140` / `SECRETARY_MIN_HEIGHT = 30`: secretary を分割候補にしてよい最小幅・最小高さ（280 cols → 1 回だけ vertical split で 140 まで縮め、以降は自動的に候補から脱落する設計）
-- **role priority**: `secretary = 4`, `curator = 3`, `worker = 2`, `dispatcher = 1`（Step 6 のソート primary key）
+balanced split の判定 (target / direction の選択、MIN_PANE / secretary 保険 / role priority によるソート、rect 隣接判定) は **dispatcher が `claude-org-runtime` の `delegate-plan` helper 経由で実行する**。Claude 側で再実装するロジックではない。helper は `mcp__renga-peers__list_panes` の rect スナップショットと task JSON を入力に取り、`spawn` ターゲット名と direction を含む action plan を返す（候補が空なら `split_capacity_exceeded` で escalate を指示）。
 
-**Step 1. curator を特定**: `role == "curator"` のペインを 1 つ選ぶ（複数あれば先頭）。以降 `$curator` と呼ぶ。存在しなければ `$curator = null`。
+仕様詳細・定数値・ソートキー・rect 隣接の正確な定義は **runtime SoT** を参照する:
+- 実装: `claude-org-runtime/src/claude_org_runtime/dispatcher/runner.py` の `choose_split()` / `rect_adjacent()` / `_ROLE_PRIORITY` / `MIN_PANE_*` / `SECRETARY_MIN_*` 定数
+- CLI: `python -m claude_org_runtime.dispatcher.runner delegate-plan --task-json ... --panes-json ...`
 
-**Step 2. 候補を絞り込む**:
-- `role ∈ {"secretary", "curator", "dispatcher", "worker"}` の 4 役すべてが候補対象
-- `role == "dispatcher"` のペインは、**`$curator` と rect 隣接している場合のみ**残す（`$curator = null` なら dispatcher も除外）。curator 自体には adjacency 制約をかけない
-  - rect 隣接の定義（どちらかを満たす）:
-    - **縦辺共有 + y 区間重なり**: `a.x + a.width == b.x` または `b.x + b.width == a.x`、かつ `max(a.y, b.y) < min(a.y + a.height, b.y + b.height)`
-    - **横辺共有 + x 区間重なり**: `a.y + a.height == b.y` または `b.y + b.height == a.y`、かつ `max(a.x, b.x) < min(a.x + a.width, b.x + b.width)`
-
-**Step 3. 各候補に direction / new_w / new_h / metric を付与**:
-- `direction = (width > height * 2) ? "vertical" : "horizontal"`
-  - ターミナル cell は縦:横 ≈ 2:1（文字が縦長）。`width > height*2` は物理的に横長 → vertical（左右分割）で綺麗に割れる
-  - それ以外は horizontal（上下分割）
-- `new_w = (direction == "vertical") ? floor(width / 2) : width`
-- `new_h = (direction == "horizontal") ? floor(height / 2) : height`
-- `metric = (direction == "vertical") ? new_w : new_h`（分割軸方向の新サイズ）
-
-**Step 4. MIN_PANE 制約**:
-- `new_w >= MIN_PANE_WIDTH` かつ `new_h >= MIN_PANE_HEIGHT` のペインのみ残す
-
-**Step 5. secretary 保険条項**:
-- `role == "secretary"` のペインは `new_w >= SECRETARY_MIN_WIDTH` **かつ** `new_h >= SECRETARY_MIN_HEIGHT` のときだけ残す（width だけ通っても height が足りなければ除外）
-
-**Step 6. ソート & 選択**:
-- 並びは **(role priority desc, metric desc, id asc)**
-  - primary: role priority (secretary=4 > curator=3 > worker=2 > dispatcher=1)
-  - secondary: metric の降順（同 priority 内でのみ効く）
-  - tertiary: id の昇順
-- 先頭要素の `name` を `$target`、`direction` を `$direction` として使用
-
-初回（ワーカー 0 人、典型的な org-start 直後の `secretary 280×43 / dispatcher 140×43 / curator 140×43`、ターミナル ≈ 280×86 を仮定）は **secretary** が priority 4 で選ばれ vertical split される。ターミナル高さが小さく secretary が SECRETARY_MIN_HEIGHT=30 を満たさない場合は最初から脱落し、curator が target になる (role priority 規約は不変)。secretary が SECRETARY_MIN_WIDTH=140 で 1 回しか分割できないため、2 回目以降は **curator** が候補に残る間ずっと curator が選ばれ続ける（role priority が strict primary なので、curator が MIN_PANE を割って脱落して初めて worker 群に流れる）。dispatcher を最後に置くのは「ワーカー監視で active な dispatcher の viewport を頻繁に半減させないため」で、curator (`/loop 30m /org-curate` で大半は idle) を分割吸収先として優先する設計（Issue #307）。
+本 SKILL から定数値や Step 1-6 の prose を消したのは、runtime と doc が drift する原因になるため (Issue #307 cleanup)。dispatcher が helper を経由しない degraded mode に入った場合、判定再現は `runner.py` を一次参照する。
 
 #### 3-1c. 候補が空だった場合
 

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -44,59 +44,26 @@ renga は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 
 
 ### アルゴリズム
 
-新規ワーカーを起動するディスパッチャーは、`spawn_claude_pane` を呼ぶ前に以下を実行する。判定ステップの詳細は `SKILL.md` Step 3-1 を参照（Claude が `list_panes` の結果テキストを解釈してロジックを実行する）。
+balanced split の判定ロジック (target / direction 選択、MIN_PANE 制約、secretary 保険、role priority ソート、rect 隣接判定、`split_capacity_exceeded` 検出) は **`claude-org-runtime` の helper が SoT**。dispatcher は `mcp__renga-peers__list_panes` のスナップショットと task JSON を入力にして以下のいずれかを呼び、返却された action plan に従って `spawn_claude_pane` / escalate を実行する:
 
-1. `mcp__renga-peers__list_panes` で全ペインと属性 (id / name / role / focused / x / y / width / height) を取得する
-2. **候補集合**: `role ∈ {secretary, curator, worker, dispatcher}` のペイン (4 役すべてが候補対象)
-3. **候補の絞り込み**:
-   - **dispatcher-curator 隣接維持**: dispatcher は curator と rect 隣接 (後述) しているときのみ候補に入れる。組織運営上 dispatcher と curator の隣接配置は前提。dispatcher を分割すると隣接が崩れ得るので、既に非隣接な dispatcher は候補から外す。curator 自体には adjacency 制約はかけない (curator が分割されても dispatcher と curator の残部は隣接維持される)
-   - **secretary 保護**: secretary は分割後の新ペイン幅 `new_w >= 140` **かつ** 新ペイン高さ `new_h >= 30` を満たす場合のみ候補化 (保険条項。280 cols → 1 回だけ vertical split で 140 まで縮め、以降は自動的に候補から脱落する設計)。width だけ通っても height が足りなければ却下する
-4. **direction 決定** (各候補の aspect ratio から):
-   - `width > height * 2` → `vertical` (左右分割)
-   - それ以外 → `horizontal` (上下分割)
-   - ターミナルセルは縦長 (縦横比 ≈ 2:1) なので、文字単位で `width = 2 * height` のとき物理的にほぼ正方形。`width > height * 2` は「物理的に横長」判定として妥当
-5. **MIN_PANE 制約**: 分割後の新ペインサイズ `(new_w, new_h)` が `new_w >= 20` かつ `new_h >= 5` を満たさない候補は除外
-   - vertical 分割: `(new_w, new_h) = (floor(width / 2), height)`
-   - horizontal 分割: `(new_w, new_h) = (width, floor(height / 2))`
-6. **target 選出**: 残った候補を **(role priority desc, metric desc, id asc)** で並べ、先頭を target にする。
-   - role priority: `secretary = 4`, `curator = 3`, `worker = 2`, `dispatcher = 1`
-   - metric は分割軸方向の新サイズ (vertical なら `new_w`、horizontal なら `new_h`)
-   - id 昇順は最終 tie-break (スナップショット内で再現可能。セッション跨ぎの安定性までは保証しない)
-   - secretary を最優先にすることで、初期レイアウト (secretary 280 cols 想定) では 1 回目のワーカー split が必ず secretary 側に入り、以降は SECRETARY_MIN_WIDTH=140 ガードで自動的に curator → worker → dispatcher の順に流れる。dispatcher を最後に置くのは「ワーカー監視で active な dispatcher の viewport を頻繁に半減させないため」で、curator (`/loop 30m /org-curate` で大半は idle) を分割吸収先として優先する設計
-7. **候補が空なら escalate**: `SKILL.md` Step 3-1c の `SPLIT_CAPACITY_EXCEEDED` 経路で窓口に escalate (`spawn_claude_pane` は発行せず、該当ワーカー 1 件だけ派遣中止、ディスパッチャー本体は継続)
+- ライブラリ: `claude_org_runtime.dispatcher.runner.choose_split(panes)` / `build_plan(...)`
+- CLI: `python -m claude_org_runtime.dispatcher.runner delegate-plan --task-json ... --panes-json ...`
 
-### rect 隣接判定の定義
+定数値 (MIN_PANE_WIDTH / MIN_PANE_HEIGHT / SECRETARY_MIN_WIDTH / SECRETARY_MIN_HEIGHT / role priority マップ) と判定順序、rect 隣接の厳密な定義は **`claude-org-runtime/src/claude_org_runtime/dispatcher/runner.py` を一次参照** とする。本ドキュメントから定数値の prose を削除したのは、runtime と doc の drift が `[split_refused]` 等の不可解な失敗を生む原因になるため (Issue #307 cleanup)。
 
-rect `A, B` が隣接するとは以下のいずれかを満たすこと:
+候補が空のときは helper が `status="split_capacity_exceeded"` と `escalate.send_message(to_id="secretary", ...)` を返す。dispatcher は `spawn_claude_pane` を発行せず、該当ワーカー 1 件だけ派遣を中止、本体監視ループは継続する (`SKILL.md` Step 3-1c 参照)。
 
-- **左右隣接**: `A.x + A.width == B.x` または `B.x + B.width == A.x`、かつ y 区間が overlap (`max(A.y, B.y) < min(A.y + A.height, B.y + B.height)`)
-- **上下隣接**: `A.y + A.height == B.y` または `B.y + B.height == A.y`、かつ x 区間が overlap (`max(A.x, B.x) < min(A.x + A.width, B.x + B.width)`)
+### Verification trace (Issue #307 シナリオ、参考)
 
-renga の cell 座標は整数なので tolerance なし完全一致で判定する。
+`secretary 280×43 / dispatcher 140×43 / curator 140×43` の直後レイアウト (ターミナル ≈ 280×86、org-start で secretary horizontal split → dispatcher vertical split 直後を想定) を入力にした場合の `choose_split` の挙動を手動 trace した参考表。**正準値は runtime SoT**。doc 上の値と runtime の挙動が食い違ったら runtime を信じる。
 
-### 初期状態と典型的な挙動
+| spawn | 選出 role | direction | 直感的な根拠 |
+|---|---|---|---|
+| 1st | secretary | vertical | secretary が分割可能サイズを満たすうちは role priority で最優先 |
+| 2nd | curator | vertical | secretary が SECRETARY_MIN_WIDTH ガードで脱落、次点 priority の curator が選ばれる |
+| 3rd | curator | horizontal | role priority が strict primary なので curator が MIN_PANE を割るまで curator 連続 |
 
-> **前提条件**: 以下のシナリオは Issue #307 の verification と同じ「ターミナル ≈ 280 cols × 86 rows、org-start で secretary を horizontal split → dispatcher を vertical split した直後」を仮定する。secretary は上半分 (280×43) を占め、SECRETARY_MIN_HEIGHT=30 を満たす。43 行未満の縦に低いターミナル (例: 高さ 43 行で secretary が 21 行になる場合) では secretary は最初から SECRETARY_MIN_HEIGHT で脱落するため、本シナリオは成立しない。その場合 1st spawn は curator → ... の順で進行する (role priority 規約は不変)。
-
-典型的な org-start 直後のレイアウト (secretary 280×43 上半分 / dispatcher 140×43 下半分左 / curator 140×43 下半分右) では、role priority に従って:
-
-- **1st worker spawn**: candidate = {secretary (priority 4, vertical split で 140×43, OK), curator (priority 3), worker は不在, dispatcher (priority 1, curator 隣接 OK)}。secretary が最優先で選ばれる → vertical split。secretary は 280→140 に縮む。
-- **2nd worker spawn**: secretary は今や 140 cols で `new_w = floor(140/2) = 70 < 140` のため SECRETARY_MIN_WIDTH ガードで脱落。残る最高優先度は **curator** (priority 3) → curator が target に。curator は典型 140×43 で横長なので vertical split。
-- **3rd worker spawn**: role priority が strict primary なので、curator が MIN_PANE を満たす限り curator が再度選ばれる (priority 3 > worker priority 2)。curator が MIN_PANE_WIDTH を割って候補から脱落して初めて、priority 2 の worker 群の中で metric desc 比較が効く。
-
-以降は role priority と分割後サイズに応じて自然に交替することで準 balanced な配置になる。固定的な 4 並列 / 8 並列の図は意味を持たないため割愛する (動的で決まるため)。
-
-### Verification trace (Issue #307 シナリオ)
-
-`secretary 280×43 / dispatcher 140×43 / curator 140×43` の直後レイアウトで本アルゴリズムを手動 trace した結果:
-
-| spawn | candidates (Step 5 通過後) | 選出 (priority, metric) | direction | 分割後 |
-|---|---|---|---|---|
-| 1st | secretary (p4, m=140) / curator (p3, m=70) / dispatcher (p1, m=70) | **secretary** (p=4 最高) | vertical | secretary 140×43 / worker-1 140×43 |
-| 2nd | curator (p3, m=70) / worker-1 (p2, m=70) / dispatcher (p1, m=70) — secretary は new_w=70<140 で脱落 | **curator** (p=3 最高) | vertical | curator 70×43 / worker-2 70×43 |
-| 3rd | curator (p3, m=35) / worker-1 (p2, m=70) / worker-2 (p2, m=35) / dispatcher (p1, m=70) | **curator** (p=3 最高、metric が小さくても primary は role priority) | horizontal | curator 70×21 / worker-3 70×22 |
-
-注: 3rd spawn では Issue 本文の "curator or worker-1 (whichever has larger metric)" という記述があるが、本アルゴリズムでは role priority が primary key なので curator が MIN_PANE を通る限り curator が選ばれる。curator が将来 MIN_PANE を割って脱落した時点で、初めて worker-1 が priority 2 の中で metric desc で選ばれる。priority と metric の関係は「priority が strict primary、同 priority 内でのみ metric が効く」。
+curator が MIN_PANE を割って脱落した後は priority 2 の worker 群に流れる。dispatcher を最後に置く設計意図 (active 監視ペインの viewport を頻繁に半減させない、curator の方が `/loop 30m /org-curate` で大半 idle) は runner.py の `_ROLE_PRIORITY` コメントを参照。
 
 ### Edge cases / 運用時の注意
 

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -44,12 +44,12 @@ renga は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 
 
 ### アルゴリズム
 
-balanced split の判定ロジック (target / direction 選択、MIN_PANE 制約、secretary 保険、role priority ソート、rect 隣接判定、`split_capacity_exceeded` 検出) は **`claude-org-runtime` の helper が SoT**。dispatcher は `mcp__renga-peers__list_panes` のスナップショットと task JSON を入力にして以下のいずれかを呼び、返却された action plan に従って `spawn_claude_pane` / escalate を実行する:
+balanced split の判定ロジック (target / direction 選択、MIN_PANE 制約、secretary 保険、role priority ソート、rect 隣接判定、`split_capacity_exceeded` 検出) は **`claude-org-runtime` の helper が SoT**。dispatcher は `mcp__renga-peers__list_panes` のスナップショットと task JSON を入力にして以下のいずれかを呼び、返却された action plan (`spawn` / `after_spawn` / `escalate` / `state_writes` / `status`) に従って `spawn_claude_pane` / escalate を実行する:
 
-- ライブラリ: `claude_org_runtime.dispatcher.runner.choose_split(panes)` / `build_plan(...)`
-- CLI: `python -m claude_org_runtime.dispatcher.runner delegate-plan --task-json ... --panes-json ...`
+- CLI (運用上の標準呼び出し): `claude-org-runtime dispatcher delegate-plan --task-json ... --panes-json ... --state-dir ... [--template-repo ...] [--locale-json ...]`。dispatcher 側の手順は `.dispatcher/CLAUDE.md` の delegate-plan helper 節を一次参照
+- ライブラリ: `claude_org_runtime.dispatcher.runner` モジュールの `build_plan(...)` (action plan 全体) と `choose_split(panes)` (target / direction だけ欲しい場合の low-level helper)
 
-定数値 (MIN_PANE_WIDTH / MIN_PANE_HEIGHT / SECRETARY_MIN_WIDTH / SECRETARY_MIN_HEIGHT / role priority マップ) と判定順序、rect 隣接の厳密な定義は **`claude-org-runtime/src/claude_org_runtime/dispatcher/runner.py` を一次参照** とする。本ドキュメントから定数値の prose を削除したのは、runtime と doc の drift が `[split_refused]` 等の不可解な失敗を生む原因になるため (Issue #307 cleanup)。
+定数値 (MIN_PANE_WIDTH / MIN_PANE_HEIGHT / SECRETARY_MIN_WIDTH / SECRETARY_MIN_HEIGHT / role priority マップ) と判定順序、rect 隣接の厳密な定義は **`claude_org_runtime.dispatcher.runner` モジュール本体** (`_ROLE_PRIORITY` / `MIN_PANE_*` / `SECRETARY_MIN_*` / `choose_split()` / `rect_adjacent()`) を一次参照とする。本ドキュメントから定数値の prose を削除したのは、runtime と doc の drift が `[split_refused]` 等の不可解な失敗を生む原因になるため (Issue #307 cleanup)。
 
 候補が空のときは helper が `status="split_capacity_exceeded"` と `escalate.send_message(to_id="secretary", ...)` を返す。dispatcher は `spawn_claude_pane` を発行せず、該当ワーカー 1 件だけ派遣を中止、本体監視ループは継続する (`SKILL.md` Step 3-1c 参照)。
 


### PR DESCRIPTION
## Summary

Phase 3 follow-up to PR #310 and the matching runtime release ([claude-org-runtime v0.1.2](https://github.com/suisya-systems/claude-org-runtime/releases/tag/v0.1.2)). Now that `dispatcher.runner.choose_split` is the actual source of truth, the duplicated algorithm prose in claude-org-ja was dead documentation that could drift from runtime; this PR collapses it to a short overview that defers to the runtime helper, and repairs the historical state-DB drift left over from session #13.

## Changes

- `.claude/skills/org-delegate/SKILL.md` (Step 3-1b) and `references/pane-layout.md`: removed concrete constants and the Step 1–6 algorithm prose; now references the `claude-org-runtime dispatcher delegate-plan` CLI / `build_plan()` / `choose_split()` as SoT. Verification trace kept (symbolic constant names only — no value to drift).
- State-DB drift repair (via `StateWriter.transaction()`):
  - `runs` id=186 (issue-309-worktree-creation): `queued` → `completed`, PR #311 / commit `daaa8b7` / merged `2026-05-05T18:35:05Z`.
  - `runs` id=187 (issue-313-legacy-externalize): backfilled `pr_url` / `commit_short` / `pr_state='merged'` / `completed_at` from PR #315 / commit `1a7bbbc`.
  - `runs` id=191 (issue-312-ack-approval-gate): created from journal events; PR #314 / commit `598bea5`.
- Worktree cleanup: removed leftover `.worktrees/` entries (`issue-307-pane-priority` / `issue-309-worktree-creation` / `issue-307-run-cleanup` etc.); branches preserved for PR history. `worker_dirs` rows pruned.

## Why this drift happened

Session #13 closed the four merged PRs by sending `CLOSE_PANE` and writing `worker_closed` journal events, but skipped the matching `update_run_status('completed')` and PR-metadata writes required by `org-delegate` Step 5 2b-ii. `/org-suspend` then snapshotted the inconsistent state. The fix here is one-shot — the procedural gap is a separate concern.

## Tests

- `drift_check`: no drift
- `pytest`: 401 passed, 1 skipped (1 pre-existing failure on `tests/test_parsers.py::TestBuildStateLiveWorkers::test_review_workers_stay_visible_and_archived_disappear` is also failing on `main` HEAD and is out of scope here)
- Codex self-review: round 2 clean (round 1 fed back: CLI form corrected to `claude-org-runtime dispatcher delegate-plan`, `build_plan()` added to the SoT list)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>