### PR TITLE
fix(claude): hardcode permission_mode literal 'auto' across skills/docs

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -215,7 +215,7 @@ mcp__renga-peers__spawn_claude_pane(
   role="worker",
   name="worker-{task_id}",                # 後続操作で参照する安定名。英字含む前提
   cwd="{workers_dir}/{task_id}",          # 絶対パス推奨。相対は caller pane の cwd 基点
-  permission_mode="{default_permission_mode}",
+  permission_mode="auto",
   model="opus"                            # 必須。sonnet 禁止（auto classifier が不安定）
 )
 ```

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -27,8 +27,8 @@ Tab 1: ops (ワーカー 0 人)
 | 対象 | 操作 | 備考 |
 |---|---|---|
 | ディスパッチャー | 窓口ペインを水平分割して下半分 | `mcp__renga-peers__spawn_claude_pane(target="focused", direction="horizontal", role="dispatcher", name="dispatcher", cwd=".dispatcher", permission_mode="bypassPermissions", model="sonnet")` (org-start Step 2) |
-| キュレーター | ディスパッチャーペインを垂直分割して右半分 | `mcp__renga-peers__spawn_claude_pane(target="dispatcher", direction="vertical", role="curator", name="curator", cwd=".curator", permission_mode="{default_permission_mode}")` (org-start Step 3) |
-| 各ワーカー | **balanced split**: `list_panes` が返す現在の rect から target と direction を動的に選び、同一タブ内に積む | 詳細は下記「ワーカーの balanced split 戦略」セクション。`mcp__renga-peers__spawn_claude_pane(target={target}, direction={direction}, role="worker", name="worker-{task_id}", cwd="{workers_dir}/{task_id}", permission_mode="{default_permission_mode}")` (org-delegate Step 3) |
+| キュレーター | ディスパッチャーペインを垂直分割して右半分 | `mcp__renga-peers__spawn_claude_pane(target="dispatcher", direction="vertical", role="curator", name="curator", cwd=".curator", permission_mode="auto")` (org-start Step 3) |
+| 各ワーカー | **balanced split**: `list_panes` が返す現在の rect から target と direction を動的に選び、同一タブ内に積む | 詳細は下記「ワーカーの balanced split 戦略」セクション。`mcp__renga-peers__spawn_claude_pane(target={target}, direction={direction}, role="worker", name="worker-{task_id}", cwd="{workers_dir}/{task_id}", permission_mode="auto")` (org-delegate Step 3) |
 
 > **`spawn_claude_pane` を使う理由**: renga 0.18.0+ で追加された構造化 launch ツール。`cwd` / `permission_mode` / `model` / `args[]` を構造化フィールドで渡すと、renga が内部で `claude --permission-mode {mode} --dangerously-load-development-channels server:renga-peers ...` を合成する。旧方式（`cd`-プレフィックス付き command 文字列を `spawn_pane` に流し込む）は **禁止**（cwd 変更プレフィックスがあると renga の bare-`claude` auto-upgrade が発動せず、`send_message` の channel push が届かなくなる。窓口→ディスパッチャー / ディスパッチャー→ワーカーの指示が一切通らなくなる）。Secretary のみ `ops.toml` から bare `claude` で起動され auto-upgrade に任せる。
 

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -93,7 +93,7 @@ renga 0.18.0+ では `mcp__renga-peers__spawn_claude_pane` が役割別の構造
 ### キュレーター
 
 - `cwd=".curator"`
-- `permission_mode={default_permission_mode}`
+- `permission_mode=auto`
 - `model="opus"`
 
 ### ワーカー（org-delegate の Step 3 で使用）
@@ -103,7 +103,7 @@ renga 0.18.0+ では `mcp__renga-peers__spawn_claude_pane` が役割別の構造
 
 通常:
 - `cwd="{workers_dir}/{task_id}"`（絶対パス推奨）
-- `permission_mode={default_permission_mode}`
+- `permission_mode=auto`
 - `model="opus"`
 
 ## Step 1.5: ダッシュボードサーバー起動
@@ -178,7 +178,7 @@ renga 0.18.0+ では `mcp__renga-peers__spawn_claude_pane` が役割別の構造
      role="curator",
      name="curator",
      cwd=".curator",
-     permission_mode="{default_permission_mode}",
+     permission_mode="auto",
      model="opus"
    )
    ```

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -77,7 +77,7 @@ read 経路は **DB only**（Issue #267 / M4）。
 renga 0.18.0+ では `mcp__renga-peers__spawn_claude_pane` が役割別の構造化フィールド（`cwd` / `permission_mode` / `model` / `args[]`）を受け取り、`--dangerously-load-development-channels server:renga-peers` を自動付与する。旧方式の `cd X && claude ...` を `spawn_pane` に流し込むパターンは **禁止**（renga の bare-`claude` auto-upgrade が発動せず channel push が届かなくなる落とし穴を再導入するため）。
 
 共通引数:
-- `permission_mode`: registry/org-config.md の default_permission_mode の値を使用（ディスパッチャー除く）
+- `permission_mode`: `auto` リテラル直書き（ディスパッチャー除く）。CLAUDE.md には変数展開機構がないため `registry/org-config.md` の値を実行時に代入することはできない。値を変更する場合は `registry/org-config.md` 冒頭の同期注意セクションを参照
 - `cwd`: 各ロール専用ディレクトリへの相対パス（caller pane の cwd 基準で解決される）
 
 > **注**: Secretary は `renga --layout ops` で起動され、`--permission-mode` 未指定のまま動作する（人間判断窓口のため）。`registry/org-config.md` の「Role別の適用範囲」節を参照。

--- a/docs/contracts/role-contract.md
+++ b/docs/contracts/role-contract.md
@@ -174,7 +174,7 @@
 
 ### Constraints
 
-- **Permission mode**: Inherits `default_permission_mode` from `registry/org-config.md` (currently `auto`). Model: `opus`.
+- **Permission mode**: `auto` (hardcoded literal at spawn sites; `registry/org-config.md` value is reference-only — see its sync-warning). Model: `opus`.
 - **Path discipline** — curator's cwd is `.curator/`, but knowledge directories live in the parent repo. Must use parent-repo-relative or absolute paths; using cwd-relative `knowledge/raw/` would target a non-existent directory.
 - **Glob fallback** — when `Glob` returns 0 results, must verify with `Bash ls` to detect missing-directory vs. genuinely empty.
 - **No human dialogue** — `.curator/CLAUDE.md` "人間と直接対話することはない". Communication only via secretary.
@@ -231,7 +231,7 @@
 
 ### Constraints
 
-- **Permission mode**: `default_permission_mode` from `registry/org-config.md` (currently `auto`). Model: **`opus` mandatory** — `sonnet` is forbidden because `auto` mode's safety classifier is only stable on Opus.
+- **Permission mode**: `auto` (hardcoded literal at spawn sites; `registry/org-config.md` value is reference-only — see its sync-warning). Model: **`opus` mandatory** — `sonnet` is forbidden because `auto` mode's safety classifier is only stable on Opus.
 - **Working directory is enforced**: First action on launch is `pwd` to verify `worker_dir`. Mismatch → halt and report to secretary.
 - **Hard-blocked operations** (via `permissions.deny` + PreToolUse hooks):
   - Cannot reproduce claude-org structure (`.claude/`, `.dispatcher/`, `.curator/`, `.state/`, `registry/`, `dashboard/`, `knowledge/`) inside `worker_dir`.

--- a/docs/contracts/role-contract.md
+++ b/docs/contracts/role-contract.md
@@ -104,7 +104,7 @@
 
 ### Outputs
 
-- **MCP calls** — `spawn_claude_pane` (workers, `model="opus"` mandatory, `permission_mode={default_permission_mode}`), `send_keys(enter=true)` for the dev-channel prompt, `list_peers` polling, `send_message` for the instruction, `inspect_pane` for the watch loop, `close_pane` for teardown.
+- **MCP calls** — `spawn_claude_pane` (workers, `model="opus"` mandatory, `permission_mode=auto`), `send_keys(enter=true)` for the dev-channel prompt, `list_peers` polling, `send_message` for the instruction, `inspect_pane` for the watch loop, `close_pane` for teardown.
 - **`DELEGATE_COMPLETE`** to secretary (one per worker spawned).
 - **`WORKER_PANE_EXITED`** to secretary (lifecycle event; not a completion claim).
 - **`APPROVAL_BLOCKED`** / **`ERROR_DETECTED`** to secretary, tagged with `source=inspect|self_report` and `confidence=high|n/a`.
@@ -185,7 +185,7 @@
 
 ### Lifecycle / boundaries
 
-- **Spawn**: By the secretary during `/org-start` Step 3. `cwd=".curator"`, `permission_mode={default_permission_mode}`, `model="opus"`. Stable name `curator`, role `curator`.
+- **Spawn**: By the secretary during `/org-start` Step 3. `cwd=".curator"`, `permission_mode=auto`, `model="opus"`. Stable name `curator`, role `curator`.
 - **Activation**: Receives an initial `send_message` from secretary telling it to start the `/loop 30m /org-curate` schedule.
 - **Steady state**: Wakes on the loop, runs `org-curate`, sleeps. Also processes ad-hoc messages from secretary.
 - **Termination**: Pane closed by secretary or by org shutdown.
@@ -255,7 +255,7 @@
 
 ### Lifecycle / boundaries
 
-- **Spawn**: By the dispatcher in `org-delegate` Step 3, via `mcp__renga-peers__spawn_claude_pane(role="worker", name="worker-{task_id}", cwd={worker_dir}, permission_mode={default_permission_mode}, model="opus")` after balanced-split target/direction selection. CLAUDE.md and `settings.local.json` are placed by the secretary in Step 1.5 *before* spawn.
+- **Spawn**: By the dispatcher in `org-delegate` Step 3, via `mcp__renga-peers__spawn_claude_pane(role="worker", name="worker-{task_id}", cwd={worker_dir}, permission_mode=auto, model="opus")` after balanced-split target/direction selection. CLAUDE.md and `settings.local.json` are placed by the secretary in Step 1.5 *before* spawn.
 - **Activation**: After spawn, the dispatcher approves the "Load development channel?" prompt on the worker's pane via `send_keys(enter=true)`; the worker is then detected via `list_peers` and receives its instruction message. It greets back when secretary sends the `DELEGATE_COMPLETE` follow-up.
 - **Steady state**: Executes the task; reports progress to secretary; if blocked on approval, halts (dispatcher detects via inspect or self-report and notifies secretary).
 - **Completion handoff**:

--- a/registry/org-config.md
+++ b/registry/org-config.md
@@ -1,6 +1,6 @@
 # Organization Config
 
-> **同期注意**: CLAUDE.md には変数展開機構がないため、`.claude/skills/**` および `docs/contracts/role-contract.md` 内の `permission_mode` は `auto` リテラル直書きでハードコードされている（session #15 で Secretary が `acceptEdits` を誤代入した回帰を機に固定化）。このファイルの値を変更しただけでは skill / docs 側に反映されない。`default_permission_mode` を変更する場合は、以下も併せて grep で洗い出して手で書き換えること:
+> **同期注意**: CLAUDE.md には変数展開機構がないため、`.claude/skills/**` および `docs/contracts/role-contract.md` 内の `permission_mode` は `auto` リテラル直書きでハードコードされている（session #15 で Secretary が `acceptEdits` を誤代入した回帰を機に固定化）。このファイルの値を変更しただけでは skill / docs 側に反映されない。`default_permission_mode` を変更する場合は、以下も併せて手で書き換えること（`tools/gen_delegate_payload.py` だけはこのファイルを実行時に読むので追従する。`grep -rn '"auto"' .claude/skills docs/contracts` で取りこぼし確認）:
 >
 > - `.claude/skills/org-start/SKILL.md`
 > - `.claude/skills/org-delegate/SKILL.md`

--- a/registry/org-config.md
+++ b/registry/org-config.md
@@ -1,5 +1,12 @@
 # Organization Config
 
+> **同期注意**: CLAUDE.md には変数展開機構がないため、`.claude/skills/**` および `docs/contracts/role-contract.md` 内の `permission_mode` は `auto` リテラル直書きでハードコードされている（session #15 で Secretary が `acceptEdits` を誤代入した回帰を機に固定化）。このファイルの値を変更しただけでは skill / docs 側に反映されない。`default_permission_mode` を変更する場合は、以下も併せて grep で洗い出して手で書き換えること:
+>
+> - `.claude/skills/org-start/SKILL.md`
+> - `.claude/skills/org-delegate/SKILL.md`
+> - `.claude/skills/org-delegate/references/pane-layout.md`
+> - `docs/contracts/role-contract.md`
+
 ## Permission Mode
 default_permission_mode: auto
 


### PR DESCRIPTION
## Summary
- Replace the `{default_permission_mode}` placeholder with the literal `"auto"` in all skills and reference docs. CLAUDE.md has no built-in variable-expansion mechanism, so the placeholder relied on Secretary substituting the value from `registry/org-config.md` at runtime — and session #15 hit a regression where the Secretary substituted `acceptEdits` instead of `auto`, requiring manual recovery.
- Add a sync-warning note to `registry/org-config.md` so that future changes to `default_permission_mode` are applied to both the registry and the hardcoded skill literals.
- Mirrors the existing literal pattern for worker spawn `model="opus"` (already hardcoded for the same reason: variable expansion is not a CLAUDE.md primitive).

## Files
- `.claude/skills/org-start/SKILL.md` — curator spawn block
- `.claude/skills/org-delegate/SKILL.md` — worker spawn block
- `.claude/skills/org-delegate/references/pane-layout.md`
- `docs/contracts/role-contract.md`
- `registry/org-config.md` — sync-warning section added

## Verification
- `grep -rn '{default_permission_mode}'` returns 0 hits across tracked files.
- Codex self-review (depth: full): 2 rounds, approved on Round 2 after addressing 3 Major findings (duplicated common args in org-start, missing inheritance note in role-contract Constraints, missing sync warning in registry).

## Test plan
- [ ] CI green
- [ ] Manual: next curator spawn launches in `auto` mode without manual override