### PR TITLE
feat(claude): auto-complete run on PR merge (Closes #317)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -497,7 +497,9 @@ worker → Secretary peer message
      ```bash
      python tools/run_complete_on_merge.py --pr <PR>
      ```
-     これは `gh pr view <PR> --json url,state,mergedAt,mergeCommit,headRefName` を一度引いて、PR が merged なら `StateWriter.transaction()` 経由で `runs.status='completed'` / `pr_state='merged'` / `commit_short` / `pr_url` / `completed_at` を更新し、`pr_merged` イベントを 1 行追記する。再呼び出しは idempotent（二重イベントを書かない）。task_id は `runs.pr_url` / `runs.branch` から自動解決され、解決失敗時は `--task-id` を明示する
+     これは `gh pr view <PR> --json url,state,mergedAt,mergeCommit,headRefName` を一度引いて、PR が merged なら `StateWriter.transaction()` 経由で `pr_state='merged'` / `commit_short` / `pr_url` / `completed_at` を更新し、`pr_merged` イベント (payload に `task` / `pattern` / `auto_completed` 含む) を 1 行追記する。再呼び出しは idempotent（二重イベントを書かない）。task_id は `runs.pr_url` / `runs.branch`（active な runs 限定）から自動解決され、解決失敗時は `--task-id` を明示する。
+     - **Pattern A** (worktree なし): `runs.status='completed'` まで自動遷移 (post-commit hook が worker 状態ファイルを archive)
+     - **Pattern B / C / D** (worktree / ephemeral / live-repo): helper は `runs.status` を **触らず** `review` のまま残す。worktree remove / `CLOSE_PANE` / `remove_worker_dir` は窓口が手動で行ってから別途 `update_run_status('<task>', 'completed')` を呼ぶ (state-schema-contract §3.1)
    - **パターン B / C のレジストリエントリ削除や手動 close は別途 StateWriter を呼ぶ**（markdown 直接編集禁止）:
      ```bash
      python -c "

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -469,7 +469,7 @@ worker → Secretary peer message
    2b-i. **PR 作成段階（即時実行）**:
    - 必要に応じて窓口がプッシュ・PR作成を行う（ワーカーには権限がないため）
    - DB の events テーブルにイベント追記 (push / PR open など)
-   - PR 番号が確定したら `tools/pr-watch.ps1 <PR>` (Windows) / `tools/pr-watch.sh <PR>` (POSIX) で CI を監視する。完了時に `ci_completed` が自動で journal に記録される
+   - PR 番号が確定したら `tools/pr-watch.ps1 <PR>` (Windows) / `tools/pr-watch.sh <PR>` (POSIX) で CI を監視する。完了時に `ci_completed` が自動で journal に記録される。CI が `passed` の場合、pr-watch はそのまま `gh pr view --json mergedAt` を 24h ポーリングし続け、初回の merge を観測した時点で `tools/run_complete_on_merge.py` を呼んで run を terminal に駆動する (Issue #317)。merge-watch を切りたい場合は `-NoMergeWatch` / `--no-merge-watch` を付ける
    - run.status は **REVIEW のまま据え置く**（GitHub 側 PR レビュー指摘が来たら同ペインで対応するため。COMPLETED への遷移は 2b-ii で `update_run_status('<task_id>', 'completed')` を呼ぶ）。markdown 直接編集はしない
    - **ペインはまだ閉じない**: PR 作成直後に `CLOSE_PANE` を送らない。worktree 除去・Worker Directory Registry 更新も 2b-ii まで遅延する
    - PR レビューで指摘が来た場合は 2c のフローで同ワーカーに `send_message` 追指示を送り、同ペインで修正コミットを積ませる（新ワーカー再派遣は避ける — Issue / diff / 判断境界の再構築コストを払うことになる）
@@ -493,18 +493,24 @@ worker → Secretary peer message
      - パターン B（worktree）: `git -C {workers_dir}/{project_slug}/ worktree remove .worktrees/{task_id}` を実行。ブランチは残す（マージ済みでもブランチ削除はしない、PR 履歴用）
        - **self-edit (`pattern_variant='live_repo_worktree'`) の場合**: worktree base が `{claude_org_path}` なので `git -C {claude_org_path} worktree remove .worktrees/{task_id}` を実行する（Issue #289）。ブランチは同様に残す
      - パターン C（エフェメラル）: ディレクトリは保持する（容量が問題になった場合のみ手動削除を検討）
-   - **DB 経由で Worker Directory Registry を更新する**（`StateWriter.transaction()` 経由、markdown 直接編集禁止）:
+   - **PR 起点のクローズの場合は `tools/run_complete_on_merge.py` を呼ぶ** (Issue #317。`pr-watch` の merge-watch ループが自動で起動するので通常は手動実行不要だが、merge-watch を skip した場合や手動でマージを観測した場合のみ明示的に呼ぶ):
+     ```bash
+     python tools/run_complete_on_merge.py --pr <PR>
+     ```
+     これは `gh pr view <PR> --json url,state,mergedAt,mergeCommit,headRefName` を一度引いて、PR が merged なら `StateWriter.transaction()` 経由で `runs.status='completed'` / `pr_state='merged'` / `commit_short` / `pr_url` / `completed_at` を更新し、`pr_merged` イベントを 1 行追記する。再呼び出しは idempotent（二重イベントを書かない）。task_id は `runs.pr_url` / `runs.branch` から自動解決され、解決失敗時は `--task-id` を明示する
+   - **パターン B / C のレジストリエントリ削除や手動 close は別途 StateWriter を呼ぶ**（markdown 直接編集禁止）:
      ```bash
      python -c "
-     from pathlib import Path
      from tools.state_db import connect
      from tools.state_db.writer import StateWriter
      conn = connect('.state/state.db')
-     with StateWriter(conn, claude_org_root=Path('.')).transaction() as w:
-         w.update_run_status('<task_id>', 'completed')
-         # パターン B / C のエントリ削除はここで w.remove_worker_dir('<abs>') を追加
+     with StateWriter(conn).transaction() as w:
+         # PR が無い手動クローズ時のみ:
+         #   w.update_run_status('<task_id>', 'completed')
+         w.remove_worker_dir('<abs>')  # パターン B / C
      "
      ```
+     legacy のハンドロール完了スクリプトは `docs/legacy/pr-merge-completion-manual.md` に保管されている。標準経路は上記 `tools/run_complete_on_merge.py` であり、museum copy へ reach するのは Issue を切ってユーザー判断を仰いだ後に限る (PR #315 と同じ pattern)
      - パターン A: lifecycle='active' のまま、run.status='completed' で snapshotter が available 相当の表示にする
      - パターン B / C: 物理 dir は別途処理（worktree remove / dir 保持）。レジストリエントリ削除は上記 with ブロック内に `w.remove_worker_dir('<abs>')` を追加
    - JSON snapshot は StateWriter post-commit hook が自動再生成 (Issue #284)

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -500,16 +500,15 @@ worker → Secretary peer message
      これは `gh pr view <PR> --json url,state,mergedAt,mergeCommit,headRefName` を一度引いて、PR が merged なら `StateWriter.transaction()` 経由で `pr_state='merged'` / `commit_short` / `pr_url` / `completed_at` を更新し、`pr_merged` イベント (payload に `task` / `pattern` / `auto_completed` 含む) を 1 行追記する。再呼び出しは idempotent（二重イベントを書かない）。task_id は `runs.pr_url` / `runs.branch`（active な runs 限定）から自動解決され、解決失敗時は `--task-id` を明示する。
      - **Pattern A** (worktree なし): `runs.status='completed'` まで自動遷移 (post-commit hook が worker 状態ファイルを archive)
      - **Pattern B / C / D** (worktree / ephemeral / live-repo): helper は `runs.status` を **触らず** `review` のまま残す。worktree remove / `CLOSE_PANE` / `remove_worker_dir` は窓口が手動で行ってから別途 `update_run_status('<task>', 'completed')` を呼ぶ (state-schema-contract §3.1)
-   - **パターン B / C のレジストリエントリ削除や手動 close は別途 StateWriter を呼ぶ**（markdown 直接編集禁止）:
+   - **パターン B / C のレジストリエントリ削除と最終 close は別途 StateWriter を呼ぶ**（markdown 直接編集禁止。run_complete_on_merge が `pr_state='merged'` と `completed_at` を既に書いているので、ここでは status flip と worker_dir 削除のみ行う）:
      ```bash
      python -c "
      from tools.state_db import connect
      from tools.state_db.writer import StateWriter
      conn = connect('.state/state.db')
      with StateWriter(conn).transaction() as w:
-         # PR が無い手動クローズ時のみ:
-         #   w.update_run_status('<task_id>', 'completed')
-         w.remove_worker_dir('<abs>')  # パターン B / C
+         w.update_run_status('<task_id>', 'completed')  # post-commit hook が worker-{task}.md を archive
+         w.remove_worker_dir('<abs>')  # パターン B / C のみ
      "
      ```
      legacy のハンドロール完了スクリプトは `docs/legacy/pr-merge-completion-manual.md` に保管されている。標準経路は上記 `tools/run_complete_on_merge.py` であり、museum copy へ reach するのは Issue を切ってユーザー判断を仰いだ後に限る (PR #315 と同じ pattern)

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -469,7 +469,7 @@ worker → Secretary peer message
    2b-i. **PR 作成段階（即時実行）**:
    - 必要に応じて窓口がプッシュ・PR作成を行う（ワーカーには権限がないため）
    - DB の events テーブルにイベント追記 (push / PR open など)
-   - PR 番号が確定したら `tools/pr-watch.ps1 <PR>` (Windows) / `tools/pr-watch.sh <PR>` (POSIX) で CI を監視する。完了時に `ci_completed` が自動で journal に記録される。CI が `passed` の場合、pr-watch はそのまま `gh pr view --json mergedAt` を 24h ポーリングし続け、初回の merge を観測した時点で `tools/run_complete_on_merge.py` を呼んで run を terminal に駆動する (Issue #317)。merge-watch を切りたい場合は `-NoMergeWatch` / `--no-merge-watch` を付ける
+   - PR 番号が確定したら `tools/pr-watch.ps1 <PR>` (Windows) / `tools/pr-watch.sh <PR>` (POSIX) で CI を監視する。完了時に `ci_completed` が自動で journal に記録される。CI 完了で pr-watch は **return** する（review feedback loop 2c や手動 close 2b-ii に進めるよう同期占有しない）。merge を待ち合わせたい時のみ `-MergeWatch` / `--merge-watch` を付けると CI 通過後に `gh pr view --json mergedAt` を 24h ポーリングし、初回の merge で `tools/run_complete_on_merge.py` を呼ぶ (Issue #317)
    - run.status は **REVIEW のまま据え置く**（GitHub 側 PR レビュー指摘が来たら同ペインで対応するため。COMPLETED への遷移は 2b-ii で `update_run_status('<task_id>', 'completed')` を呼ぶ）。markdown 直接編集はしない
    - **ペインはまだ閉じない**: PR 作成直後に `CLOSE_PANE` を送らない。worktree 除去・Worker Directory Registry 更新も 2b-ii まで遅延する
    - PR レビューで指摘が来た場合は 2c のフローで同ワーカーに `send_message` 追指示を送り、同ペインで修正コミットを積ませる（新ワーカー再派遣は避ける — Issue / diff / 判断境界の再構築コストを払うことになる）
@@ -497,9 +497,9 @@ worker → Secretary peer message
      ```bash
      python tools/run_complete_on_merge.py --pr <PR>
      ```
-     これは `gh pr view <PR> --json url,state,mergedAt,mergeCommit,headRefName` を一度引いて、PR が merged なら `StateWriter.transaction()` 経由で `pr_state='merged'` / `commit_short` / `pr_url` / `completed_at` を更新し、`pr_merged` イベント (payload に `task` / `pattern` / `auto_completed` 含む) を 1 行追記する。再呼び出しは idempotent（二重イベントを書かない）。task_id は `runs.pr_url` / `runs.branch`（active な runs 限定）から自動解決され、解決失敗時は `--task-id` を明示する。
-     - **Pattern A** (worktree なし): `runs.status='completed'` まで自動遷移 (post-commit hook が worker 状態ファイルを archive)
-     - **Pattern B / C / D** (worktree / ephemeral / live-repo): helper は `runs.status` を **触らず** `review` のまま残す。worktree remove / `CLOSE_PANE` / `remove_worker_dir` は窓口が手動で行ってから別途 `update_run_status('<task>', 'completed')` を呼ぶ (state-schema-contract §3.1)
+     これは `gh pr view <PR> --json url,state,mergedAt,mergeCommit,headRefName` を一度引いて、PR が merged なら `StateWriter.transaction()` 経由で `pr_state='merged'` / `commit_short` / `pr_url` / `completed_at` を更新し、`pr_merged` イベント (payload: `task` / `pattern` / `auto_completed`) を 1 行追記する。再呼び出しは idempotent（二重イベントを書かない）。task_id は `runs.pr_url` / `runs.branch`（active な runs 限定）から自動解決され、解決失敗時は `--task-id` を明示する。
+     - **helper は runs.status を触らない**: dispatcher 側 pane close / worker_closed / worker-state final update が必要 (delegation-lifecycle-contract §T5)。helper は merge 事実のみ記録し、status flip と worker_dir 削除は窓口が下記の StateWriter で行う
+     - **CLI 終了コード**: `merged` / `already` / `not_yet` は exit 0、`no_run`（runs に該当行なし）は exit 3 で失敗扱いになる。手動運用時は exit code を確認
    - **パターン B / C のレジストリエントリ削除と最終 close は別途 StateWriter を呼ぶ**（markdown 直接編集禁止。run_complete_on_merge が `pr_state='merged'` と `completed_at` を既に書いているので、ここでは status flip と worker_dir 削除のみ行う）:
      ```bash
      python -c "

--- a/docs/legacy/pr-merge-completion-manual.md
+++ b/docs/legacy/pr-merge-completion-manual.md
@@ -1,4 +1,4 @@
-> **このドキュメントは歴史的参考資料です。** Secretary / worker / dispatcher の標準オペレーションでは参照しないでください。標準経路は `python tools/pr-watch.ps1 <PR>` / `python tools/pr-watch.sh <PR>` の merge-watch ループ、もしくは `python tools/run_complete_on_merge.py --pr <PR>` です (Issue #317)。`tools/run_complete_on_merge.py` が想定外の挙動をする場合は手動再現せず Issue を切り、resolver / helper 側のバグが直るまで該当クローズを pause してください。例外的に手作業を行うかどうかはユーザーの明示判断に委ね、Secretary が自走で本ドキュメントに reach した場合は protocol 違反です。
+> **このドキュメントは歴史的参考資料です。** Secretary / worker / dispatcher の標準オペレーションでは参照しないでください。標準経路は `tools/pr-watch.ps1 -PR <PR>` (Windows) / `tools/pr-watch.sh --pr <PR>` (POSIX) の merge-watch ループ、もしくは `python tools/run_complete_on_merge.py --pr <PR>` です (Issue #317)。`tools/run_complete_on_merge.py` が想定外の挙動をする場合は手動再現せず Issue を切り、resolver / helper 側のバグが直るまで該当クローズを pause してください。例外的に手作業を行うかどうかはユーザーの明示判断に委ね、Secretary が自走で本ドキュメントに reach した場合は protocol 違反です。
 
 # Legacy hand-rolled PR-merge completion (museum copy)
 

--- a/docs/legacy/pr-merge-completion-manual.md
+++ b/docs/legacy/pr-merge-completion-manual.md
@@ -1,0 +1,39 @@
+> **このドキュメントは歴史的参考資料です。** Secretary / worker / dispatcher の標準オペレーションでは参照しないでください。標準経路は `python tools/pr-watch.ps1 <PR>` / `python tools/pr-watch.sh <PR>` の merge-watch ループ、もしくは `python tools/run_complete_on_merge.py --pr <PR>` です (Issue #317)。`tools/run_complete_on_merge.py` が想定外の挙動をする場合は手動再現せず Issue を切り、resolver / helper 側のバグが直るまで該当クローズを pause してください。例外的に手作業を行うかどうかはユーザーの明示判断に委ね、Secretary が自走で本ドキュメントに reach した場合は protocol 違反です。
+
+# Legacy hand-rolled PR-merge completion (museum copy)
+
+This file preserves the pre-Issue-317 manual completion snippet for archaeological reference. It was extracted from `.claude/skills/org-delegate/SKILL.md` Step 5 2b-ii (PR #315 と同じ externalization pattern)。
+
+## Why this is no longer in the active skill
+
+Documenting a hand-rolled `python -c` block inside the active skill behaved like an "easy button": when the secretary observed a PR merge, they would copy the snippet and run it ad-hoc, which had several historical failure modes:
+
+- **Forgotten `pr_state='merged'`** — the legacy snippet only called `update_run_status('<task_id>', 'completed')`. `runs.pr_state` stayed at `'open'`, so dashboard / queries that filter on `pr_state` showed inconsistent state. `tools/run_complete_on_merge.py` writes `pr_state='merged'`, `commit_short`, `pr_url`, and `completed_at` from the `gh pr view` payload in one transaction.
+- **Missing `pr_merged` event** — the snippet did not append an event row, so the journal had no record of *why* the run transitioned to completed. The helper appends a single `pr_merged` event with PR / repo / merge_commit / merged_at in the payload, and is idempotent (a second invocation does not double-write).
+- **Manual `mergedAt` confirmation** — the secretary had to call `gh pr view --json mergedAt` themselves and decide whether the PR was actually merged. The merge-watch loop in `tools/pr_watch.py` handles this end-to-end.
+- **No completed_at** — the snippet did not pass `completed_at`, so `runs.completed_at` stayed NULL and downstream "time-to-merge" queries lost data. The helper threads the PR's `mergedAt` directly into `update_run_status(..., completed_at=...)`.
+
+Today, if `tools/run_complete_on_merge.py` errors or produces a wrong row, the canonical response is to **file an Issue against the helper and pause the affected close until the underlying bug is fixed**. Whether to invoke any manual workaround at all is a user judgment call — Secretary must not self-grant the exception.
+
+## Legacy procedure (verbatim, do not use)
+
+```bash
+python -c "
+from pathlib import Path
+from tools.state_db import connect
+from tools.state_db.writer import StateWriter
+conn = connect('.state/state.db')
+with StateWriter(conn, claude_org_root=Path('.')).transaction() as w:
+    w.update_run_status('<task_id>', 'completed')
+    # パターン B / C のエントリ削除はここで w.remove_worker_dir('<abs>') を追加
+"
+```
+
+Operationally that meant:
+
+- 窓口 が `gh pr view <PR> --json mergedAt` 等で merge を確認
+- 上記 inline Python を `<task_id>` 置換して実行
+- 必要なら `bash tools/journal_append.sh pr_merged ...` を別途叩いて event 行を残す（実際にはしばしば忘れられた）
+- パターン B では同じスクリプト内で `w.remove_worker_dir('<abs>')` を追記
+
+The legacy block did **not** set `pr_url` / `pr_state` / `commit_short` / `completed_at`, did **not** append a `pr_merged` event, and did **not** verify mergedAt against `gh pr view`; all four are now done in one transaction by `tools/run_complete_on_merge.py`.

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 # Thin PowerShell wrapper around tools/pr_watch.py.
-# Usage: tools/pr-watch.ps1 -PR <PR> [-Repo OWNER/REPO] [-Interval SEC] [-NoMergeWatch]
+# Usage: tools/pr-watch.ps1 -PR <PR> [-Repo OWNER/REPO] [-Interval SEC] [-MergeWatch] [-NoMergeWatch]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true, Position = 0)]
@@ -11,6 +11,9 @@ param(
 
     [Parameter(Mandatory = $false)]
     [int]$Interval = 30,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$MergeWatch,
 
     [Parameter(Mandatory = $false)]
     [switch]$NoMergeWatch
@@ -72,6 +75,9 @@ if (-not $pyExec) {
 $forwardArgs = $pyArgsPrefix + @($ScriptPath, '--pr', $PR, '--interval', $Interval)
 if ($PSBoundParameters.ContainsKey('Repo') -and $Repo) {
     $forwardArgs += @('--repo', $Repo)
+}
+if ($MergeWatch) {
+    $forwardArgs += @('--merge-watch')
 }
 if ($NoMergeWatch) {
     $forwardArgs += @('--no-merge-watch')

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 # Thin PowerShell wrapper around tools/pr_watch.py.
-# Usage: tools/pr-watch.ps1 -PR <PR> [-Repo OWNER/REPO] [-Interval SEC]
+# Usage: tools/pr-watch.ps1 -PR <PR> [-Repo OWNER/REPO] [-Interval SEC] [-NoMergeWatch]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true, Position = 0)]
@@ -10,7 +10,10 @@ param(
     [string]$Repo,
 
     [Parameter(Mandatory = $false)]
-    [int]$Interval = 30
+    [int]$Interval = 30,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoMergeWatch
 )
 
 $ErrorActionPreference = 'Stop'
@@ -69,6 +72,9 @@ if (-not $pyExec) {
 $forwardArgs = $pyArgsPrefix + @($ScriptPath, '--pr', $PR, '--interval', $Interval)
 if ($PSBoundParameters.ContainsKey('Repo') -and $Repo) {
     $forwardArgs += @('--repo', $Repo)
+}
+if ($NoMergeWatch) {
+    $forwardArgs += @('--no-merge-watch')
 }
 
 & $pyExec @forwardArgs

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -388,14 +388,24 @@ def main(argv: "list[str] | None" = None) -> int:
         help="poll interval in seconds (default: 30)",
     )
     parser.add_argument(
-        "--no-merge-watch",
+        "--merge-watch",
         action="store_true",
         help=(
-            "skip the post-CI merge-watch loop (Issue #317). When unset, "
-            "after CI passes pr_watch keeps polling `gh pr view --json "
-            "mergedAt` for up to 24h and invokes "
-            "tools/run_complete_on_merge.py on the first mergedAt."
+            "After CI passes, keep polling `gh pr view --json mergedAt` "
+            "for up to 24h and invoke tools/run_complete_on_merge.py on "
+            "the first mergedAt (Issue #317). Off by default — pr_watch "
+            "is otherwise a CI-only blocking call, and a 24h wall is "
+            "incompatible with the secretary's 2c/T6 review-feedback "
+            "loop. Opt in only when secretary actually wants to wait."
         ),
+    )
+    # --no-merge-watch is kept as a no-op alias for back-compat with
+    # callers / tests that already opted out. The default is off either
+    # way; this keeps argv compatible with the prior turn's commits.
+    parser.add_argument(
+        "--no-merge-watch",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
     args = parser.parse_args(argv)
 
@@ -468,10 +478,11 @@ def main(argv: "list[str] | None" = None) -> int:
 
     sys.stdout.write(f"pr_watch: PR #{args.pr} {status} ({duration}s)\n")
 
-    # Issue #317: only enter merge-watch when CI actually passed.
-    # `failed`/`incomplete`/`canceled` mean there's nothing to merge yet
-    # — the secretary will re-issue pr_watch after the next push.
-    if status == "passed" and not args.no_merge_watch:
+    # Issue #317: only enter merge-watch when CI actually passed and
+    # the caller explicitly opted in via --merge-watch. The default is
+    # off so pr_watch stays a "CI passed → return" command compatible
+    # with secretary's 2c/T6 review-feedback loop.
+    if status == "passed" and args.merge_watch and not args.no_merge_watch:
         merge_result = _watch_for_merge(
             pr=args.pr,
             repo=repo,

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -269,7 +269,7 @@ def _watch_for_merge(
     """
     from tools.run_complete_on_merge import (
         complete_on_merge, fetch_pr_view, RESULT_ALREADY, RESULT_MERGED,
-        RESULT_NO_RUN, RESULT_NOT_YET,
+        RESULT_MERGED_PENDING_CLEANUP, RESULT_NO_RUN, RESULT_NOT_YET,
     )
 
     deadline = monotonic() + max_seconds
@@ -295,7 +295,10 @@ def _watch_for_merge(
             sys.stdout.write(
                 f"pr_watch: PR #{pr} merge-watch result: {result}\n"
             )
-            if result in (RESULT_MERGED, RESULT_ALREADY, RESULT_NO_RUN):
+            if result in (
+                RESULT_MERGED, RESULT_MERGED_PENDING_CLEANUP,
+                RESULT_ALREADY, RESULT_NO_RUN,
+            ):
                 return result
             # RESULT_NOT_YET shouldn't occur once mergedAt is set; treat
             # defensively as "keep polling".
@@ -469,12 +472,19 @@ def main(argv: "list[str] | None" = None) -> int:
     # `failed`/`incomplete`/`canceled` mean there's nothing to merge yet
     # — the secretary will re-issue pr_watch after the next push.
     if status == "passed" and not args.no_merge_watch:
-        _watch_for_merge(
+        merge_result = _watch_for_merge(
             pr=args.pr,
             repo=repo,
             interval=args.interval,
             db_path=JOURNAL_PATH,
         )
+        # Codex Major: surface merge-watch failure modes via exit code
+        # so callers can distinguish "CI passed but PR did not merge in
+        # 24h" / "helper raised" from "CI passed and we successfully
+        # transitioned the run". Don't override a non-zero CI exit
+        # code — that already signaled trouble.
+        if exit_code == 0 and merge_result in ("timeout", "error"):
+            exit_code = 9
 
     return exit_code
 

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -483,7 +483,12 @@ def main(argv: "list[str] | None" = None) -> int:
         # 24h" / "helper raised" from "CI passed and we successfully
         # transitioned the run". Don't override a non-zero CI exit
         # code — that already signaled trouble.
-        if exit_code == 0 and merge_result in ("timeout", "error"):
+        if exit_code == 0 and merge_result in ("timeout", "error", "no_run"):
+            # Codex round-2 Major: no_run means we observed a merge but
+            # could not resolve the PR back to a runs row, so the
+            # status flip didn't happen and the secretary needs to
+            # intervene. Surface that as exit 9 so callers don't treat
+            # it as success.
             exit_code = 9
 
     return exit_code

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -54,6 +54,13 @@ import sys
 import time
 from pathlib import Path
 
+# Bound on the post-CI merge-watch loop. Issue #317: after CI passes we
+# keep polling `gh pr view --json mergedAt` until the PR is merged or
+# this many seconds elapse, whichever comes first. 24h matches the
+# upper end of the org-delegate Step 5 2b-ii idle window so the
+# secretary can intervene manually past that.
+MERGE_WATCH_MAX_SECONDS = 24 * 60 * 60
+
 # Make `tools.state_db.*` importable when running this script directly.
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
@@ -241,6 +248,95 @@ def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
     return [c for c in data if isinstance(c, dict)]
 
 
+def _watch_for_merge(
+    *,
+    pr: int,
+    repo: str,
+    interval: int,
+    db_path: Path,
+    max_seconds: int = MERGE_WATCH_MAX_SECONDS,
+    sleeper=time.sleep,
+    monotonic=time.monotonic,
+) -> str:
+    """Poll `gh pr view --json mergedAt` until merged or bound elapses.
+
+    Issue #317. On the first poll that returns a non-null ``mergedAt``,
+    invoke :func:`tools.run_complete_on_merge.complete_on_merge` to
+    drive the run row to its terminal state and return its result.
+    On bound exhaustion, append a ``pr_merge_watch_timeout`` event to
+    the DB and return ``"timeout"``. ``sleeper`` and ``monotonic`` are
+    injectable for tests.
+    """
+    from tools.run_complete_on_merge import (
+        complete_on_merge, fetch_pr_view, RESULT_ALREADY, RESULT_MERGED,
+        RESULT_NO_RUN, RESULT_NOT_YET,
+    )
+
+    deadline = monotonic() + max_seconds
+    while True:
+        try:
+            view = fetch_pr_view(pr, repo)
+        except RuntimeError as exc:
+            sys.stderr.write(
+                f"pr_watch: merge-watch: gh pr view failed: {exc}\n"
+            )
+            view = None
+
+        if view is not None and view.get("mergedAt"):
+            try:
+                result = complete_on_merge(
+                    pr=pr, repo=repo, db_path=db_path, pr_view=view,
+                )
+            except Exception as exc:  # noqa: BLE001
+                sys.stderr.write(
+                    f"pr_watch: merge-watch: complete_on_merge raised: {exc}\n"
+                )
+                return "error"
+            sys.stdout.write(
+                f"pr_watch: PR #{pr} merge-watch result: {result}\n"
+            )
+            if result in (RESULT_MERGED, RESULT_ALREADY, RESULT_NO_RUN):
+                return result
+            # RESULT_NOT_YET shouldn't occur once mergedAt is set; treat
+            # defensively as "keep polling".
+
+        if monotonic() >= deadline:
+            _record_event(
+                db_path=db_path,
+                kind="pr_merge_watch_timeout",
+                payload={
+                    "pr": pr, "repo": repo,
+                    "max_seconds": max_seconds,
+                },
+            )
+            sys.stdout.write(
+                f"pr_watch: PR #{pr} merge-watch timed out after "
+                f"{max_seconds}s\n"
+            )
+            return "timeout"
+
+        sleeper(interval)
+
+
+def _record_event(*, db_path: Path, kind: str, payload: dict) -> None:
+    """Append a single event row via StateWriter (used for merge-watch timeout)."""
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+        writer = StateWriter(conn)
+        writer.append_event(kind=kind, actor="pr_watch", payload=payload)
+        writer.commit()
+    finally:
+        conn.close()
+
+
 def _pr_exists(pr: int, repo: str) -> bool:
     try:
         subprocess.run(
@@ -287,6 +383,16 @@ def main(argv: "list[str] | None" = None) -> int:
         type=int,
         default=30,
         help="poll interval in seconds (default: 30)",
+    )
+    parser.add_argument(
+        "--no-merge-watch",
+        action="store_true",
+        help=(
+            "skip the post-CI merge-watch loop (Issue #317). When unset, "
+            "after CI passes pr_watch keeps polling `gh pr view --json "
+            "mergedAt` for up to 24h and invokes "
+            "tools/run_complete_on_merge.py on the first mergedAt."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -358,6 +464,18 @@ def main(argv: "list[str] | None" = None) -> int:
     )
 
     sys.stdout.write(f"pr_watch: PR #{args.pr} {status} ({duration}s)\n")
+
+    # Issue #317: only enter merge-watch when CI actually passed.
+    # `failed`/`incomplete`/`canceled` mean there's nothing to merge yet
+    # — the secretary will re-issue pr_watch after the next push.
+    if status == "passed" and not args.no_merge_watch:
+        _watch_for_merge(
+            pr=args.pr,
+            repo=repo,
+            interval=args.interval,
+            db_path=JOURNAL_PATH,
+        )
+
     return exit_code
 
 

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""PR-merge auto-completion helper (Issue #317).
+
+Given a PR number, resolves the merge metadata via ``gh pr view`` and,
+if the PR is merged, runs the canonical ``StateWriter.transaction()``
+to drive the run row to its terminal state:
+
+* ``runs.status = 'completed'``
+* ``runs.pr_state = 'merged'``
+* ``runs.pr_url`` and ``runs.commit_short`` / ``runs.commit_full`` set
+  from the PR view payload
+* ``runs.completed_at`` set to the PR's ``mergedAt``
+* one ``pr_merged`` event appended to the events table
+
+The helper replaces the inline ``python -c`` block that used to live
+in ``.claude/skills/org-delegate/SKILL.md`` Step 5 2b-ii. The legacy
+hand-rolled snippet is preserved verbatim under
+``docs/legacy/pr-merge-completion-manual.md`` for archaeology only.
+
+Usage::
+
+    python tools/run_complete_on_merge.py --pr <N> \\
+        [--repo OWNER/REPO] [--task-id <id>] [--db-path <path>]
+
+The helper is **idempotent**: running it twice for the same PR is a
+no-op on the second call (no double event row, no status flip).
+
+Also exported as :func:`complete_on_merge` for in-process callers
+(e.g. ``tools/pr_watch.py``'s merge-watch loop).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_DB_PATH = REPO_ROOT / ".state" / "state.db"
+
+
+# Return codes for :func:`complete_on_merge`. Stable strings so callers
+# (pr_watch's merge-watch loop, tests) can branch without parsing logs.
+RESULT_MERGED = "merged"        # PR was merged this call; DB updated.
+RESULT_ALREADY = "already"      # PR was merged previously; DB already terminal.
+RESULT_NOT_YET = "not_yet"      # PR is open / draft; nothing written.
+RESULT_NO_RUN = "no_run"        # No matching run row; nothing written.
+
+
+def _ensure_gh_installed() -> None:
+    if shutil.which("gh") is None:
+        sys.stderr.write(
+            "tools/run_complete_on_merge.py: error: GitHub CLI (gh) not "
+            "found in PATH.\n"
+        )
+        sys.exit(127)
+
+
+def _resolve_repo() -> str:
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner"],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            "tools/run_complete_on_merge.py: error: failed to auto-detect "
+            f"repo via `gh repo view`: {exc.stderr.strip() or exc}\n"
+        )
+        sys.exit(2)
+    try:
+        return json.loads(result.stdout)["nameWithOwner"]
+    except (json.JSONDecodeError, KeyError) as exc:
+        sys.stderr.write(
+            "tools/run_complete_on_merge.py: error: unexpected `gh repo "
+            f"view` output: {exc}\n"
+        )
+        sys.exit(2)
+
+
+def fetch_pr_view(pr: int, repo: str) -> dict:
+    """Return the parsed `gh pr view` payload for the given PR.
+
+    Fields requested: ``number,url,state,mergedAt,mergeCommit,headRefName``.
+    Raises ``RuntimeError`` if gh fails or the JSON is unparseable —
+    callers (CLI / merge-watch) are expected to surface that and retry
+    or exit.
+    """
+    proc = subprocess.run(
+        [
+            "gh", "pr", "view", str(pr),
+            "--repo", repo,
+            "--json", "number,url,state,mergedAt,mergeCommit,headRefName",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh pr view {pr} (repo={repo}) failed: "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"gh pr view {pr} returned unparseable JSON: {exc}"
+        ) from None
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"gh pr view {pr} returned non-object JSON: {type(data).__name__}"
+        )
+    return data
+
+
+def _resolve_task_id(conn, *, pr: int, repo: str, pr_url: str,
+                     head_ref: Optional[str]) -> Optional[str]:
+    """Look up the task_id for a PR. Tries ``runs.pr_url`` then ``runs.branch``.
+
+    Returns None if no candidate row exists; the caller should warn and
+    exit with :data:`RESULT_NO_RUN`. We do not invent a row — the helper's
+    contract is to drive an *existing* run to terminal, not to retroactively
+    create state.
+    """
+    if pr_url:
+        row = conn.execute(
+            "SELECT task_id FROM runs WHERE pr_url = ? LIMIT 1", (pr_url,)
+        ).fetchone()
+        if row is not None:
+            return row["task_id"]
+        # gh sometimes returns a URL with trailing slash variations; try
+        # a substring match on the canonical /pull/<n> tail.
+        tail = f"/{repo}/pull/{pr}"
+        row = conn.execute(
+            "SELECT task_id FROM runs WHERE pr_url LIKE ? LIMIT 1",
+            (f"%{tail}",),
+        ).fetchone()
+        if row is not None:
+            return row["task_id"]
+    if head_ref:
+        row = conn.execute(
+            "SELECT task_id FROM runs WHERE branch = ? LIMIT 1", (head_ref,)
+        ).fetchone()
+        if row is not None:
+            return row["task_id"]
+    return None
+
+
+def _short_sha(full: Optional[str]) -> Optional[str]:
+    if not full:
+        return None
+    return full[:7]
+
+
+def complete_on_merge(
+    *,
+    pr: int,
+    repo: str,
+    task_id: Optional[str] = None,
+    db_path: Optional[Path] = None,
+    pr_view: Optional[dict] = None,
+) -> str:
+    """Drive the run for ``pr`` to its terminal merged state.
+
+    Returns one of :data:`RESULT_MERGED`, :data:`RESULT_ALREADY`,
+    :data:`RESULT_NOT_YET`, :data:`RESULT_NO_RUN`.
+
+    ``pr_view`` may be supplied by callers that already fetched the
+    payload (e.g. pr_watch's merge-watch loop); when omitted the helper
+    fetches it via :func:`fetch_pr_view`.
+    """
+    db_path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+    if pr_view is None:
+        pr_view = fetch_pr_view(pr, repo)
+
+    merged_at = pr_view.get("mergedAt")
+    if not merged_at:
+        return RESULT_NOT_YET
+
+    pr_url = pr_view.get("url") or ""
+    head_ref = pr_view.get("headRefName")
+    merge_commit = pr_view.get("mergeCommit") or {}
+    commit_full = (merge_commit.get("oid") if isinstance(merge_commit, dict)
+                   else None)
+    commit_short = _short_sha(commit_full)
+
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+
+        resolved_task_id = task_id or _resolve_task_id(
+            conn, pr=pr, repo=repo, pr_url=pr_url, head_ref=head_ref,
+        )
+        if resolved_task_id is None:
+            sys.stderr.write(
+                "tools/run_complete_on_merge.py: warning: no run row "
+                f"matches PR #{pr} (pr_url={pr_url!r}, head_ref="
+                f"{head_ref!r}); skipping.\n"
+            )
+            return RESULT_NO_RUN
+
+        run_row = conn.execute(
+            "SELECT r.task_id, r.status, r.pr_state, p.slug AS project_slug "
+            "FROM runs r JOIN projects p ON p.id = r.project_id "
+            "WHERE r.task_id = ?",
+            (resolved_task_id,),
+        ).fetchone()
+        if run_row is None:
+            sys.stderr.write(
+                "tools/run_complete_on_merge.py: warning: task_id "
+                f"{resolved_task_id!r} resolved but row vanished; skipping.\n"
+            )
+            return RESULT_NO_RUN
+
+        already_event = conn.execute(
+            "SELECT 1 FROM events e JOIN runs r ON r.id = e.run_id "
+            "WHERE r.task_id = ? AND e.kind = 'pr_merged' LIMIT 1",
+            (resolved_task_id,),
+        ).fetchone()
+        if (run_row["status"] == "completed"
+                and run_row["pr_state"] == "merged"
+                and already_event is not None):
+            return RESULT_ALREADY
+
+        project_slug = run_row["project_slug"]
+
+        # claude_org_root=None lets StateWriter auto-detect from the
+        # connection's database file (`<root>/.state/state.db`). That
+        # keeps the post-commit snapshot regen pointed at the same
+        # repo as the DB we just wrote to — important when pr_watch
+        # invokes us from a worker dir, and important for tests that
+        # use a temp state.db path.
+        with StateWriter(conn).transaction() as w:
+            w.upsert_run(
+                task_id=resolved_task_id,
+                project_slug=project_slug,
+                pr_url=pr_url or None,
+                pr_state="merged",
+                commit_short=commit_short,
+                commit_full=commit_full,
+            )
+            w.update_run_status(
+                resolved_task_id,
+                "completed",
+                completed_at=merged_at,
+            )
+            w.append_event(
+                kind="pr_merged",
+                actor="run_complete_on_merge",
+                payload={
+                    "pr": pr,
+                    "repo": repo,
+                    "pr_url": pr_url,
+                    "merge_commit": commit_full,
+                    "merged_at": merged_at,
+                },
+                run_task_id=resolved_task_id,
+            )
+        return RESULT_MERGED
+    finally:
+        conn.close()
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tools/run_complete_on_merge.py",
+        description=(
+            "Mark a run completed when its PR has been merged on GitHub."
+        ),
+    )
+    parser.add_argument("--pr", type=int, required=True,
+                        help="pull request number")
+    parser.add_argument("--repo", default=None,
+                        help="OWNER/REPO; auto-detected via gh repo view")
+    parser.add_argument("--task-id", default=None,
+                        help="task_id of the run to complete; auto-resolved "
+                             "from runs.pr_url / runs.branch when omitted")
+    parser.add_argument("--db-path", default=None,
+                        help=f"path to state.db (default: {DEFAULT_DB_PATH})")
+    args = parser.parse_args(argv)
+
+    if args.pr <= 0:
+        parser.error("--pr must be a positive integer")
+
+    _ensure_gh_installed()
+    repo = args.repo or _resolve_repo()
+
+    try:
+        result = complete_on_merge(
+            pr=args.pr,
+            repo=repo,
+            task_id=args.task_id,
+            db_path=Path(args.db_path) if args.db_path else None,
+        )
+    except RuntimeError as exc:
+        sys.stderr.write(f"tools/run_complete_on_merge.py: error: {exc}\n")
+        return 2
+
+    sys.stdout.write(f"run_complete_on_merge: PR #{args.pr} {result}\n")
+    # not_yet is not a failure — the caller polls; exit 0 in all "no-op"
+    # cases keeps shell wrappers simple.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -47,16 +47,20 @@ DEFAULT_DB_PATH = REPO_ROOT / ".state" / "state.db"
 
 # Return codes for :func:`complete_on_merge`. Stable strings so callers
 # (pr_watch's merge-watch loop, tests) can branch without parsing logs.
-RESULT_MERGED = "merged"        # PR was merged this call; DB updated, run completed.
-RESULT_ALREADY = "already"      # PR was merged previously; DB already terminal.
+RESULT_MERGED = "merged"        # PR was merged this call; PR metadata recorded.
+RESULT_ALREADY = "already"      # PR was merged previously; DB already has metadata + event.
 RESULT_NOT_YET = "not_yet"      # PR is open / draft; nothing written.
 RESULT_NO_RUN = "no_run"        # No matching run row; nothing written.
-# Pattern B / C / D: PR metadata + event recorded but run.status NOT
-# flipped to 'completed' because the secretary still needs to run
-# worktree / CLOSE_PANE / remove_worker_dir cleanup before the run
-# row may transition to terminal (state-schema-contract §3.1
-# Worker-directory ↔ worker-state-file consistency invariant).
-RESULT_MERGED_PENDING_CLEANUP = "merged_pending_cleanup"
+# Codex review (rounds 1-3): the helper records the merge fact
+# (pr_state='merged', commit, completed_at, pr_merged event) but never
+# flips runs.status itself. The status transition is gated on the
+# secretary running worktree remove / CLOSE_PANE / remove_worker_dir
+# and on the dispatcher closing the pane / writing the worker-state
+# final update (delegation-lifecycle-contract §T5, state-schema-contract
+# §3.1). Owning all of that from a one-shot subprocess is out of scope.
+# RESULT_MERGED_PENDING_CLEANUP is kept as an alias for
+# back-compat with callers that imported the symbol.
+RESULT_MERGED_PENDING_CLEANUP = RESULT_MERGED
 
 
 def _ensure_gh_installed() -> None:
@@ -251,16 +255,13 @@ def complete_on_merge(
 
         project_slug = run_row["project_slug"]
         pattern = (run_row["pattern"] or "B").upper()
-        # Codex Blocker (Issue #317 review): runs.status='completed' triggers
-        # the StateWriter post-commit hook to archive
-        # ``.state/workers/worker-{task}.md`` AND requires (per
-        # state-schema-contract §3.1) that the secretary has already
-        # run worktree remove / CLOSE_PANE / remove_worker_dir for
-        # Pattern B / C / D. The helper has no safe way to do those
-        # FS + pane operations, so for non-Pattern-A runs it stops at
-        # PR metadata + pr_merged event and leaves status untouched —
-        # the secretary still has to do the final close.
-        do_full_close = pattern == "A"
+        # Codex round 3 Blocker: even Pattern A close requires
+        # dispatcher-side pane close / worker_closed / worker-state
+        # final update (delegation-lifecycle-contract §T5). A
+        # subprocess helper cannot orchestrate those, so the helper
+        # records the merge fact (pr_state, commit, completed_at,
+        # pr_merged event) and leaves the runs.status flip to the
+        # secretary's manual cleanup step in 2b-ii.
 
         # claude_org_root=None lets StateWriter auto-detect from the
         # connection's database file (`<root>/.state/state.db`). That
@@ -277,25 +278,13 @@ def complete_on_merge(
                 commit_short=commit_short,
                 commit_full=commit_full,
             )
-            if do_full_close:
-                w.update_run_status(
-                    resolved_task_id,
-                    "completed",
-                    completed_at=merged_at,
-                )
-            else:
-                # Codex round-2 Major: Pattern B/C/D still need
-                # ``completed_at`` populated for time-to-merge
-                # aggregation and to satisfy the helper's documented
-                # contract. update_run_status would also flip
-                # runs.status which we explicitly want to defer until
-                # the secretary has cleaned up the worktree, so write
-                # only completed_at directly.
-                w.conn.execute(
-                    "UPDATE runs SET completed_at = COALESCE(completed_at, ?) "
-                    "WHERE task_id = ?",
-                    (merged_at, resolved_task_id),
-                )
+            # Always record completed_at without flipping runs.status —
+            # secretary owns the status transition (see comment above).
+            w.conn.execute(
+                "UPDATE runs SET completed_at = COALESCE(completed_at, ?) "
+                "WHERE task_id = ?",
+                (merged_at, resolved_task_id),
+            )
             w.append_event(
                 kind="pr_merged",
                 actor="run_complete_on_merge",
@@ -308,20 +297,19 @@ def complete_on_merge(
                     "merge_commit": commit_full,
                     "merged_at": merged_at,
                     "pattern": pattern,
-                    "auto_completed": do_full_close,
+                    "auto_completed": False,
                 },
                 run_task_id=resolved_task_id,
             )
-        if not do_full_close:
-            sys.stderr.write(
-                "tools/run_complete_on_merge.py: notice: PR merged for "
-                f"task {resolved_task_id} (pattern {pattern}); pr_state "
-                "set to 'merged' but runs.status left untouched — "
-                "secretary must complete worktree remove / CLOSE_PANE / "
-                "remove_worker_dir before flipping to 'completed' "
-                "(state-schema-contract §3.1).\n"
-            )
-            return RESULT_MERGED_PENDING_CLEANUP
+        sys.stderr.write(
+            "tools/run_complete_on_merge.py: notice: PR merged for "
+            f"task {resolved_task_id} (pattern {pattern}); pr_state set "
+            "to 'merged' and completed_at recorded, but runs.status "
+            "left untouched — secretary must complete worktree remove / "
+            "CLOSE_PANE / remove_worker_dir and call "
+            "update_run_status('<task>', 'completed') (Step 5 2b-ii / "
+            "delegation-lifecycle-contract §T5).\n"
+        )
         return RESULT_MERGED
     finally:
         conn.close()
@@ -363,8 +351,11 @@ def main(argv: "list[str] | None" = None) -> int:
         return 2
 
     sys.stdout.write(f"run_complete_on_merge: PR #{args.pr} {result}\n")
-    # not_yet is not a failure — the caller polls; exit 0 in all "no-op"
-    # cases keeps shell wrappers simple.
+    # not_yet is not a failure — the caller polls. Codex round-3 Major:
+    # no_run IS a failure (PR merged but no run row matched), so the
+    # secretary's manual invocation must see a non-zero exit code.
+    if result == RESULT_NO_RUN:
+        return 3
     return 0
 
 

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -47,10 +47,16 @@ DEFAULT_DB_PATH = REPO_ROOT / ".state" / "state.db"
 
 # Return codes for :func:`complete_on_merge`. Stable strings so callers
 # (pr_watch's merge-watch loop, tests) can branch without parsing logs.
-RESULT_MERGED = "merged"        # PR was merged this call; DB updated.
+RESULT_MERGED = "merged"        # PR was merged this call; DB updated, run completed.
 RESULT_ALREADY = "already"      # PR was merged previously; DB already terminal.
 RESULT_NOT_YET = "not_yet"      # PR is open / draft; nothing written.
 RESULT_NO_RUN = "no_run"        # No matching run row; nothing written.
+# Pattern B / C / D: PR metadata + event recorded but run.status NOT
+# flipped to 'completed' because the secretary still needs to run
+# worktree / CLOSE_PANE / remove_worker_dir cleanup before the run
+# row may transition to terminal (state-schema-contract §3.1
+# Worker-directory ↔ worker-state-file consistency invariant).
+RESULT_MERGED_PENDING_CLEANUP = "merged_pending_cleanup"
 
 
 def _ensure_gh_installed() -> None:
@@ -143,8 +149,14 @@ def _resolve_task_id(conn, *, pr: int, repo: str, pr_url: str,
         if row is not None:
             return row["task_id"]
     if head_ref:
+        # Codex Major: scope branch fallback to non-terminal runs so a
+        # past completed run with the same branch can't be mistakenly
+        # re-completed and have a stray pr_merged event appended.
         row = conn.execute(
-            "SELECT task_id FROM runs WHERE branch = ? LIMIT 1", (head_ref,)
+            "SELECT task_id FROM runs WHERE branch = ? "
+            "AND status NOT IN ('completed','failed','abandoned') "
+            "ORDER BY id DESC LIMIT 1",
+            (head_ref,),
         ).fetchone()
         if row is not None:
             return row["task_id"]
@@ -211,7 +223,8 @@ def complete_on_merge(
             return RESULT_NO_RUN
 
         run_row = conn.execute(
-            "SELECT r.task_id, r.status, r.pr_state, p.slug AS project_slug "
+            "SELECT r.task_id, r.status, r.pr_state, r.pattern, "
+            "p.slug AS project_slug "
             "FROM runs r JOIN projects p ON p.id = r.project_id "
             "WHERE r.task_id = ?",
             (resolved_task_id,),
@@ -228,12 +241,26 @@ def complete_on_merge(
             "WHERE r.task_id = ? AND e.kind = 'pr_merged' LIMIT 1",
             (resolved_task_id,),
         ).fetchone()
-        if (run_row["status"] == "completed"
-                and run_row["pr_state"] == "merged"
+        if (run_row["pr_state"] == "merged"
                 and already_event is not None):
+            # Either the run is fully completed (Pattern A auto-close
+            # path) or it has been left in 'review' awaiting secretary
+            # cleanup (Pattern B/C/D). Either way, we already wrote
+            # the PR metadata and the event row; do not double-write.
             return RESULT_ALREADY
 
         project_slug = run_row["project_slug"]
+        pattern = (run_row["pattern"] or "B").upper()
+        # Codex Blocker (Issue #317 review): runs.status='completed' triggers
+        # the StateWriter post-commit hook to archive
+        # ``.state/workers/worker-{task}.md`` AND requires (per
+        # state-schema-contract §3.1) that the secretary has already
+        # run worktree remove / CLOSE_PANE / remove_worker_dir for
+        # Pattern B / C / D. The helper has no safe way to do those
+        # FS + pane operations, so for non-Pattern-A runs it stops at
+        # PR metadata + pr_merged event and leaves status untouched —
+        # the secretary still has to do the final close.
+        do_full_close = pattern == "A"
 
         # claude_org_root=None lets StateWriter auto-detect from the
         # connection's database file (`<root>/.state/state.db`). That
@@ -250,23 +277,38 @@ def complete_on_merge(
                 commit_short=commit_short,
                 commit_full=commit_full,
             )
-            w.update_run_status(
-                resolved_task_id,
-                "completed",
-                completed_at=merged_at,
-            )
+            if do_full_close:
+                w.update_run_status(
+                    resolved_task_id,
+                    "completed",
+                    completed_at=merged_at,
+                )
             w.append_event(
                 kind="pr_merged",
                 actor="run_complete_on_merge",
                 payload={
+                    # `task` matches docs/journal-events.md §PR / push.
+                    "task": resolved_task_id,
                     "pr": pr,
                     "repo": repo,
                     "pr_url": pr_url,
                     "merge_commit": commit_full,
                     "merged_at": merged_at,
+                    "pattern": pattern,
+                    "auto_completed": do_full_close,
                 },
                 run_task_id=resolved_task_id,
             )
+        if not do_full_close:
+            sys.stderr.write(
+                "tools/run_complete_on_merge.py: notice: PR merged for "
+                f"task {resolved_task_id} (pattern {pattern}); pr_state "
+                "set to 'merged' but runs.status left untouched — "
+                "secretary must complete worktree remove / CLOSE_PANE / "
+                "remove_worker_dir before flipping to 'completed' "
+                "(state-schema-contract §3.1).\n"
+            )
+            return RESULT_MERGED_PENDING_CLEANUP
         return RESULT_MERGED
     finally:
         conn.close()

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -283,6 +283,19 @@ def complete_on_merge(
                     "completed",
                     completed_at=merged_at,
                 )
+            else:
+                # Codex round-2 Major: Pattern B/C/D still need
+                # ``completed_at`` populated for time-to-merge
+                # aggregation and to satisfy the helper's documented
+                # contract. update_run_status would also flip
+                # runs.status which we explicitly want to defer until
+                # the secretary has cleaned up the worktree, so write
+                # only completed_at directly.
+                w.conn.execute(
+                    "UPDATE runs SET completed_at = COALESCE(completed_at, ?) "
+                    "WHERE task_id = ?",
+                    (merged_at, resolved_task_id),
+                )
             w.append_event(
                 kind="pr_merged",
                 actor="run_complete_on_merge",

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -502,7 +502,11 @@ class TempDir:
 class MergeWatchTests(unittest.TestCase):
     """Issue #317: post-CI merge-watch loop in pr_watch.main."""
 
-    def _seed_run_for_merge(self, db: Path, *, pr_url: str) -> None:
+    def _seed_run_for_merge(self, db: Path, *, pr_url: str,
+                            pattern: str = "A") -> None:
+        """Seed a run pointing at the PR. Default pattern='A' so the
+        helper performs the full status transition; pass 'B' to test
+        the pending-cleanup path."""
         from tools.state_db import apply_schema, connect
         from tools.state_db.writer import StateWriter
 
@@ -513,7 +517,7 @@ class MergeWatchTests(unittest.TestCase):
                 w.upsert_run(
                     task_id="t-merge-watch",
                     project_slug="claude-org",
-                    pattern="B",
+                    pattern=pattern,
                     title="merge-watch test",
                     status="review",
                     branch="feat/merge-watch",

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -141,7 +141,10 @@ class ArgFormTests(unittest.TestCase):
                  mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
                  mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
-                rc = pr_watch.main(argv)
+                # Issue #317: existing CI-only tests opt out of the
+                # post-CI merge-watch loop; that path is exercised
+                # separately in MergeWatchTests below.
+                rc = pr_watch.main(argv + ["--no-merge-watch"])
             rec = _read_ci_event(journal)
             return rc, rec
 
@@ -177,7 +180,10 @@ class JournalEmitTests(unittest.TestCase):
              mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
              mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
              mock.patch.object(pr_watch.time, "monotonic", side_effect=[100.0, 142.0]):
-            return pr_watch.main(["--pr", "205", "--repo", "octo/repo", "--interval", "5"])
+            return pr_watch.main([
+                "--pr", "205", "--repo", "octo/repo", "--interval", "5",
+                "--no-merge-watch",
+            ])
 
     def test_passed_emits_ci_completed(self) -> None:
         with TempDir() as tmp:
@@ -491,6 +497,253 @@ class TempDir:
 
     def __exit__(self, *exc) -> None:
         self._dir.cleanup()
+
+
+class MergeWatchTests(unittest.TestCase):
+    """Issue #317: post-CI merge-watch loop in pr_watch.main."""
+
+    def _seed_run_for_merge(self, db: Path, *, pr_url: str) -> None:
+        from tools.state_db import apply_schema, connect
+        from tools.state_db.writer import StateWriter
+
+        apply_schema(connect(db))
+        conn = connect(db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.upsert_run(
+                    task_id="t-merge-watch",
+                    project_slug="claude-org",
+                    pattern="B",
+                    title="merge-watch test",
+                    status="review",
+                    branch="feat/merge-watch",
+                    pr_url=pr_url,
+                    pr_state="open",
+                )
+        finally:
+            conn.close()
+
+    def _build_run_with_view_sequence(
+        self,
+        watch_exit: int,
+        view_sequence: "list[dict | None]",
+    ):
+        """Like _make_fake_run but threads a sequence of `gh pr view --json`
+        responses for the merge-watch loop. The first `gh pr view --json
+        number` (PR-exists probe) returns success; the *second* and
+        subsequent `view --json` calls cycle through ``view_sequence``."""
+        # Default check JSON for the CI-watch portion (status=passed).
+        checks_json = [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}]
+
+        # Mutable index threaded across closures — track which entry of
+        # view_sequence the next merge-watch poll should consume.
+        view_idx = {"i": 0}
+        seen_existence_probe = {"v": False}
+
+        def fake_run(cmd, *args, **kwargs):
+            # PR-exists probe: `gh pr view <pr> --repo <r> --json number`.
+            if (cmd[:3] == ["gh", "pr", "view"]
+                    and "--json" in cmd
+                    and cmd[cmd.index("--json") + 1] == "number"):
+                seen_existence_probe["v"] = True
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
+            # Merge-watch probe: `gh pr view <pr> --json number,url,...`
+            if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
+                idx = view_idx["i"]
+                if idx >= len(view_sequence):
+                    payload = view_sequence[-1]
+                else:
+                    payload = view_sequence[idx]
+                    view_idx["i"] += 1
+                if payload is None:
+                    return mock.Mock(returncode=1, stdout="", stderr="boom")
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(payload),
+                    stderr="",
+                )
+            # `gh pr checks --json` for CI classification.
+            if "checks" in cmd and "--json" in cmd:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(checks_json),
+                    stderr="",
+                )
+            # The watched `gh pr checks --watch` run.
+            return mock.Mock(returncode=watch_exit)
+
+        return fake_run
+
+    def test_ci_pass_then_merged_completes_run(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            pr_url = "https://github.com/octo/repo/pull/777"
+            self._seed_run_for_merge(db, pr_url=pr_url)
+
+            view_merged = {
+                "number": 777, "url": pr_url, "state": "MERGED",
+                "mergedAt": "2026-05-06T03:21:00Z",
+                "mergeCommit": {"oid": "f" * 40},
+                "headRefName": "feat/merge-watch",
+            }
+            fake_run = self._build_run_with_view_sequence(
+                watch_exit=0, view_sequence=[view_merged],
+            )
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                rc = pr_watch.main([
+                    "--pr", "777", "--repo", "octo/repo", "--interval", "1",
+                ])
+            self.assertEqual(rc, 0)
+
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT status, pr_state, completed_at "
+                    "FROM runs WHERE task_id = 't-merge-watch'"
+                ).fetchone()
+                self.assertEqual(row["status"], "completed")
+                self.assertEqual(row["pr_state"], "merged")
+                self.assertEqual(row["completed_at"], "2026-05-06T03:21:00Z")
+                merged_count = conn.execute(
+                    "SELECT COUNT(*) FROM events WHERE kind = 'pr_merged'"
+                ).fetchone()[0]
+                self.assertEqual(merged_count, 1)
+            finally:
+                conn.close()
+
+    def test_ci_fail_skips_merge_watch(self) -> None:
+        """When CI did not pass, pr_watch must not poll for merge."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+
+            # Fail the CI; assert no further `view --json` call is made.
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(list(cmd))
+                if (cmd[:3] == ["gh", "pr", "view"]
+                        and "number" in cmd):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=1,
+                        stdout=json.dumps([
+                            {"name": "ci", "state": "COMPLETED",
+                             "bucket": "fail"}
+                        ]),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=1)
+
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "888", "--repo", "octo/repo", "--interval", "1",
+                ])
+
+            # Only the existence probe + checks-json call — no merge-watch.
+            view_calls = [c for c in calls
+                          if c[:3] == ["gh", "pr", "view"]
+                          and "url" in str(c)]
+            self.assertEqual(view_calls, [])
+
+    def test_no_merge_watch_flag_skips_loop(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            self._seed_run_for_merge(
+                db, pr_url="https://github.com/octo/repo/pull/999",
+            )
+
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(list(cmd))
+                if (cmd[:3] == ["gh", "pr", "view"]
+                        and "number" in cmd):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps(
+                            [{"name": "ci", "state": "COMPLETED",
+                              "bucket": "pass"}]
+                        ),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "999", "--repo", "octo/repo", "--interval", "1",
+                    "--no-merge-watch",
+                ])
+
+            # Run row must NOT have been completed.
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT status FROM runs WHERE task_id = 't-merge-watch'"
+                ).fetchone()
+                self.assertEqual(row["status"], "review")
+            finally:
+                conn.close()
+
+    def test_watch_for_merge_timeout_records_event(self) -> None:
+        """Bound exhaustion appends pr_merge_watch_timeout."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            view_pending = {
+                "number": 555, "url": "https://github.com/octo/repo/pull/555",
+                "state": "OPEN", "mergedAt": None,
+                "mergeCommit": None, "headRefName": "feat/x",
+            }
+
+            from tools.state_db import apply_schema, connect
+            apply_schema(connect(db))
+
+            # Patch view fetch + monotonic so the loop exhausts after
+            # one iteration. monotonic side_effect: start=0.0, then
+            # 99999.0 to immediately exceed deadline.
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(view_pending),
+                        stderr="",
+                    )
+                raise AssertionError(f"unexpected cmd: {cmd}")
+
+            with mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                result = pr_watch._watch_for_merge(
+                    pr=555, repo="octo/repo", interval=0,
+                    db_path=db, max_seconds=60,
+                    sleeper=lambda _s: None,
+                    monotonic=mock.Mock(side_effect=[0.0, 100.0, 100.0]),
+                )
+            self.assertEqual(result, "timeout")
+
+            conn = sqlite3.connect(str(db))
+            try:
+                cnt = conn.execute(
+                    "SELECT COUNT(*) FROM events "
+                    "WHERE kind = 'pr_merge_watch_timeout'"
+                ).fetchone()[0]
+                self.assertEqual(cnt, 1)
+            finally:
+                conn.close()
 
 
 if __name__ == "__main__":

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -144,7 +144,9 @@ class ArgFormTests(unittest.TestCase):
                 # Issue #317: existing CI-only tests opt out of the
                 # post-CI merge-watch loop; that path is exercised
                 # separately in MergeWatchTests below.
-                rc = pr_watch.main(argv + ["--no-merge-watch"])
+                # Issue #317 round 3: merge-watch is now off by default,
+                # so existing CI-only tests don't need an opt-out flag.
+                rc = pr_watch.main(argv)
             rec = _read_ci_event(journal)
             return rc, rec
 
@@ -182,7 +184,6 @@ class JournalEmitTests(unittest.TestCase):
              mock.patch.object(pr_watch.time, "monotonic", side_effect=[100.0, 142.0]):
             return pr_watch.main([
                 "--pr", "205", "--repo", "octo/repo", "--interval", "5",
-                "--no-merge-watch",
             ])
 
     def test_passed_emits_ci_completed(self) -> None:
@@ -578,7 +579,7 @@ class MergeWatchTests(unittest.TestCase):
 
         return fake_run
 
-    def test_ci_pass_then_merged_completes_run(self) -> None:
+    def test_ci_pass_then_merged_records_metadata(self) -> None:
         with TempDir() as tmp:
             db = tmp / ".state" / "state.db"
             db.parent.mkdir(parents=True)
@@ -600,6 +601,7 @@ class MergeWatchTests(unittest.TestCase):
                  mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
                 rc = pr_watch.main([
                     "--pr", "777", "--repo", "octo/repo", "--interval", "1",
+                    "--merge-watch",
                 ])
             self.assertEqual(rc, 0)
 
@@ -610,7 +612,8 @@ class MergeWatchTests(unittest.TestCase):
                     "SELECT status, pr_state, completed_at "
                     "FROM runs WHERE task_id = 't-merge-watch'"
                 ).fetchone()
-                self.assertEqual(row["status"], "completed")
+                # status stays in 'review' — secretary owns the flip.
+                self.assertEqual(row["status"], "review")
                 self.assertEqual(row["pr_state"], "merged")
                 self.assertEqual(row["completed_at"], "2026-05-06T03:21:00Z")
                 merged_count = conn.execute(
@@ -619,6 +622,50 @@ class MergeWatchTests(unittest.TestCase):
                 self.assertEqual(merged_count, 1)
             finally:
                 conn.close()
+
+    def test_default_skips_merge_watch(self) -> None:
+        """Issue #317 round 3: merge-watch is opt-in, off by default.
+
+        Without `--merge-watch`, even on CI pass pr_watch must NOT
+        poll `gh pr view --json mergedAt`.
+        """
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            self._seed_run_for_merge(
+                db, pr_url="https://github.com/octo/repo/pull/111",
+            )
+
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(list(cmd))
+                if (cmd[:3] == ["gh", "pr", "view"]
+                        and "number" in cmd):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps(
+                            [{"name": "ci", "state": "COMPLETED",
+                              "bucket": "pass"}]
+                        ),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "111", "--repo", "octo/repo", "--interval", "1",
+                ])
+
+            view_calls = [c for c in calls
+                          if c[:3] == ["gh", "pr", "view"]
+                          and "url" in str(c)]
+            self.assertEqual(view_calls, [])
 
     def test_ci_fail_skips_merge_watch(self) -> None:
         """When CI did not pass, pr_watch must not poll for merge."""
@@ -651,9 +698,10 @@ class MergeWatchTests(unittest.TestCase):
                  mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
                 pr_watch.main([
                     "--pr", "888", "--repo", "octo/repo", "--interval", "1",
+                    "--merge-watch",
                 ])
 
-            # Only the existence probe + checks-json call — no merge-watch.
+            # CI failed → no merge-watch even with --merge-watch on.
             view_calls = [c for c in calls
                           if c[:3] == ["gh", "pr", "view"]
                           and "url" in str(c)]

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -169,6 +169,10 @@ class CompleteOnMergeTests(unittest.TestCase):
             self.assertEqual(payload["task"], TASK_ID)
             self.assertFalse(payload["auto_completed"])
             self.assertEqual(payload["pattern"], "B")
+            # Codex round-2 Major: completed_at must be populated even
+            # when status stays in 'review' so time-to-merge aggregation
+            # doesn't lose the merge timestamp.
+            self.assertEqual(row["completed_at"], MERGED_AT)
 
     def test_idempotent_second_call_is_noop(self) -> None:
         with TempDB() as db:

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -116,7 +116,14 @@ class TempDB:
 
 
 class CompleteOnMergeTests(unittest.TestCase):
-    def test_marks_run_completed_on_first_merge(self) -> None:
+    def test_records_merge_metadata_without_flipping_status(self) -> None:
+        """Codex round-3 Blocker: helper never flips runs.status itself.
+
+        It records pr_state='merged', commit_short/full, pr_url,
+        completed_at, and appends one pr_merged event. The status
+        transition to 'completed' is the secretary's manual step
+        once worktree / pane / worker_dir cleanup is done.
+        """
         with TempDB() as db:
             _seed_run(db)
             with mock.patch.object(
@@ -128,7 +135,8 @@ class CompleteOnMergeTests(unittest.TestCase):
                 )
             self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
             row = _run_row(db)
-            self.assertEqual(row["status"], "completed")
+            # status must NOT be flipped — secretary owns the transition.
+            self.assertEqual(row["status"], "review")
             self.assertEqual(row["pr_state"], "merged")
             self.assertEqual(row["pr_url"], PR_URL)
             self.assertEqual(row["commit_full"], MERGE_OID)
@@ -138,13 +146,15 @@ class CompleteOnMergeTests(unittest.TestCase):
             evts = _events_of_kind(db, "pr_merged")
             self.assertEqual(len(evts), 1)
             payload = json.loads(evts[0]["payload_json"])
+            self.assertEqual(payload["task"], TASK_ID)
             self.assertEqual(payload["pr"], PR)
             self.assertEqual(payload["repo"], REPO)
             self.assertEqual(payload["merge_commit"], MERGE_OID)
             self.assertEqual(payload["merged_at"], MERGED_AT)
+            self.assertFalse(payload["auto_completed"])
 
-    def test_pattern_b_stops_at_pending_cleanup(self) -> None:
-        """Pattern B / C / D leaves runs.status untouched; only metadata + event."""
+    def test_pattern_b_records_metadata_without_status_flip(self) -> None:
+        """Pattern B / C / D path is identical to Pattern A: status untouched."""
         with TempDB() as db:
             _seed_run(db, pattern="B")
             with mock.patch.object(
@@ -154,25 +164,16 @@ class CompleteOnMergeTests(unittest.TestCase):
                 result = run_complete_on_merge.complete_on_merge(
                     pr=PR, repo=REPO, db_path=db,
                 )
-            self.assertEqual(
-                result, run_complete_on_merge.RESULT_MERGED_PENDING_CLEANUP
-            )
+            self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
             row = _run_row(db)
-            # status must NOT be flipped — secretary still has to run
-            # worktree / CLOSE_PANE / remove_worker_dir.
             self.assertEqual(row["status"], "review")
             self.assertEqual(row["pr_state"], "merged")
-            self.assertEqual(row["commit_full"], MERGE_OID)
-            evts = _events_of_kind(db, "pr_merged")
-            self.assertEqual(len(evts), 1)
-            payload = json.loads(evts[0]["payload_json"])
-            self.assertEqual(payload["task"], TASK_ID)
-            self.assertFalse(payload["auto_completed"])
-            self.assertEqual(payload["pattern"], "B")
-            # Codex round-2 Major: completed_at must be populated even
-            # when status stays in 'review' so time-to-merge aggregation
-            # doesn't lose the merge timestamp.
             self.assertEqual(row["completed_at"], MERGED_AT)
+            payload = json.loads(
+                _events_of_kind(db, "pr_merged")[0]["payload_json"]
+            )
+            self.assertEqual(payload["pattern"], "B")
+            self.assertFalse(payload["auto_completed"])
 
     def test_idempotent_second_call_is_noop(self) -> None:
         with TempDB() as db:
@@ -184,6 +185,15 @@ class CompleteOnMergeTests(unittest.TestCase):
                 first = run_complete_on_merge.complete_on_merge(
                     pr=PR, repo=REPO, db_path=db,
                 )
+                # Simulate the secretary completing the manual close
+                # between calls — the helper must still detect that the
+                # event was already recorded and no-op.
+                conn = connect(db)
+                try:
+                    with StateWriter(conn).transaction() as w:
+                        w.update_run_status(TASK_ID, "completed")
+                finally:
+                    conn.close()
                 second = run_complete_on_merge.complete_on_merge(
                     pr=PR, repo=REPO, db_path=db,
                 )
@@ -238,8 +248,7 @@ class CompleteOnMergeTests(unittest.TestCase):
     def test_resolves_task_id_via_branch_when_pr_url_absent(self) -> None:
         """If the seeded run has no pr_url, fall back to branch lookup."""
         with TempDB() as db:
-            _seed_run(db, pr_url="")  # empty pr_url
-            # Confirm pr_url really is NULL/empty so the lookup path is forced.
+            _seed_run(db, pr_url="")
             self.assertIn(_run_row(db)["pr_url"], (None, ""))
             with mock.patch.object(
                 run_complete_on_merge.subprocess, "run",
@@ -249,7 +258,10 @@ class CompleteOnMergeTests(unittest.TestCase):
                     pr=PR, repo=REPO, db_path=db,
                 )
             self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
-            self.assertEqual(_run_row(db)["status"], "completed")
+            row = _run_row(db)
+            self.assertEqual(row["pr_state"], "merged")
+            # status remains 'review' — secretary owns the flip.
+            self.assertEqual(row["status"], "review")
 
     def test_no_matching_run_returns_no_run(self) -> None:
         with TempDB() as db:
@@ -293,7 +305,24 @@ class CLITests(unittest.TestCase):
                     "--db-path", str(db),
                 ])
             self.assertEqual(rc, 0)
-            self.assertEqual(_run_row(db)["status"], "completed")
+            self.assertEqual(_run_row(db)["pr_state"], "merged")
+
+    def test_cli_no_run_exits_nonzero(self) -> None:
+        """Codex round-3 Major: CLI must surface no_run as a failure exit."""
+        with TempDB() as db:
+            apply_schema(connect(db))  # empty DB, no runs match
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ), mock.patch.object(
+                run_complete_on_merge.shutil, "which", return_value="/usr/bin/gh",
+            ):
+                rc = run_complete_on_merge.main([
+                    "--pr", str(PR),
+                    "--repo", REPO,
+                    "--db-path", str(db),
+                ])
+            self.assertEqual(rc, 3)
 
 
 if __name__ == "__main__":

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -31,16 +31,21 @@ MERGED_AT = "2026-05-06T03:21:00Z"
 MERGE_OID = "abcdef0123456789abcdef0123456789abcdef01"
 
 
-def _seed_run(db_path: Path, *, pr_url: str = PR_URL, branch: str = BRANCH) -> None:
-    """Create a fresh DB with one in-progress run row pointing at the PR."""
-    apply_schema(connect(db_path))  # schema in place
+def _seed_run(db_path: Path, *, pr_url: str = PR_URL, branch: str = BRANCH,
+              pattern: str = "A") -> None:
+    """Create a fresh DB with one in-progress run row pointing at the PR.
+
+    Default pattern is 'A' so the helper performs the full status
+    transition; pattern-B tests opt in explicitly via ``pattern='B'``.
+    """
+    apply_schema(connect(db_path))
     conn = connect(db_path)
     try:
         with StateWriter(conn).transaction() as w:
             w.upsert_run(
                 task_id=TASK_ID,
                 project_slug="claude-org",
-                pattern="B",
+                pattern=pattern,
                 title="PR-merge auto-completion helper",
                 status="review",
                 branch=branch,
@@ -138,6 +143,33 @@ class CompleteOnMergeTests(unittest.TestCase):
             self.assertEqual(payload["merge_commit"], MERGE_OID)
             self.assertEqual(payload["merged_at"], MERGED_AT)
 
+    def test_pattern_b_stops_at_pending_cleanup(self) -> None:
+        """Pattern B / C / D leaves runs.status untouched; only metadata + event."""
+        with TempDB() as db:
+            _seed_run(db, pattern="B")
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(
+                result, run_complete_on_merge.RESULT_MERGED_PENDING_CLEANUP
+            )
+            row = _run_row(db)
+            # status must NOT be flipped — secretary still has to run
+            # worktree / CLOSE_PANE / remove_worker_dir.
+            self.assertEqual(row["status"], "review")
+            self.assertEqual(row["pr_state"], "merged")
+            self.assertEqual(row["commit_full"], MERGE_OID)
+            evts = _events_of_kind(db, "pr_merged")
+            self.assertEqual(len(evts), 1)
+            payload = json.loads(evts[0]["payload_json"])
+            self.assertEqual(payload["task"], TASK_ID)
+            self.assertFalse(payload["auto_completed"])
+            self.assertEqual(payload["pattern"], "B")
+
     def test_idempotent_second_call_is_noop(self) -> None:
         with TempDB() as db:
             _seed_run(db)
@@ -169,6 +201,34 @@ class CompleteOnMergeTests(unittest.TestCase):
                 )
             self.assertEqual(result, run_complete_on_merge.RESULT_NOT_YET)
             self.assertEqual(_run_row(db)["status"], "review")
+            self.assertEqual(_events_of_kind(db, "pr_merged"), [])
+
+    def test_branch_fallback_skips_terminal_runs(self) -> None:
+        """Codex Major: branch lookup must ignore completed/failed/abandoned runs.
+
+        A historical completed run with the same branch as the live PR
+        must not be re-completed and have a stray pr_merged event
+        appended to it.
+        """
+        with TempDB() as db:
+            _seed_run(db, pr_url="", branch=BRANCH, pattern="A")
+            # Flip the seeded row to completed so it should be skipped
+            # by the branch fallback.
+            conn = connect(db)
+            try:
+                with StateWriter(conn).transaction() as w:
+                    w.update_run_status(TASK_ID, "completed")
+            finally:
+                conn.close()
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            # No active run row matched (the only row is terminal).
+            self.assertEqual(result, run_complete_on_merge.RESULT_NO_RUN)
             self.assertEqual(_events_of_kind(db, "pr_merged"), [])
 
     def test_resolves_task_id_via_branch_when_pr_url_absent(self) -> None:

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -1,0 +1,236 @@
+"""Unit tests for tools/run_complete_on_merge.py (Issue #317).
+
+The gh CLI is mocked via subprocess.run side_effect; the DB writes go
+to a temp state.db built from schema.sql.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import run_complete_on_merge  # noqa: E402
+from tools.state_db import apply_schema, connect  # noqa: E402
+from tools.state_db.writer import StateWriter  # noqa: E402
+
+
+REPO = "octo/repo"
+PR = 317
+PR_URL = f"https://github.com/{REPO}/pull/{PR}"
+BRANCH = "feat/issue-317-pr-merge-helper"
+TASK_ID = "issue-317-pr-merge-helper"
+MERGED_AT = "2026-05-06T03:21:00Z"
+MERGE_OID = "abcdef0123456789abcdef0123456789abcdef01"
+
+
+def _seed_run(db_path: Path, *, pr_url: str = PR_URL, branch: str = BRANCH) -> None:
+    """Create a fresh DB with one in-progress run row pointing at the PR."""
+    apply_schema(connect(db_path))  # schema in place
+    conn = connect(db_path)
+    try:
+        with StateWriter(conn).transaction() as w:
+            w.upsert_run(
+                task_id=TASK_ID,
+                project_slug="claude-org",
+                pattern="B",
+                title="PR-merge auto-completion helper",
+                status="review",
+                branch=branch,
+                pr_url=pr_url,
+                pr_state="open",
+            )
+    finally:
+        conn.close()
+
+
+def _make_pr_view(*, merged_at=MERGED_AT, merge_oid=MERGE_OID) -> dict:
+    return {
+        "number": PR,
+        "url": PR_URL,
+        "state": "MERGED" if merged_at else "OPEN",
+        "mergedAt": merged_at,
+        "mergeCommit": {"oid": merge_oid} if merge_oid else None,
+        "headRefName": BRANCH,
+    }
+
+
+def _fake_subprocess_run(view_payload):
+    """Build a subprocess.run stub that responds to gh pr view calls."""
+    def fake(cmd, *args, **kwargs):
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return mock.Mock(
+                returncode=0,
+                stdout=json.dumps(view_payload),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected cmd: {cmd}")
+    return fake
+
+
+def _events_of_kind(db: Path, kind: str) -> list[dict]:
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    try:
+        return [
+            dict(row) for row in conn.execute(
+                "SELECT id, kind, payload_json, run_id FROM events "
+                "WHERE kind = ? ORDER BY id", (kind,)
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def _run_row(db: Path, task_id: str = TASK_ID) -> dict:
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT * FROM runs WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        return dict(row) if row is not None else {}
+    finally:
+        conn.close()
+
+
+class TempDB:
+    def __enter__(self) -> Path:
+        self._tmp = tempfile.TemporaryDirectory()
+        return Path(self._tmp.name) / "state.db"
+
+    def __exit__(self, *exc) -> None:
+        self._tmp.cleanup()
+
+
+class CompleteOnMergeTests(unittest.TestCase):
+    def test_marks_run_completed_on_first_merge(self) -> None:
+        with TempDB() as db:
+            _seed_run(db)
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
+            row = _run_row(db)
+            self.assertEqual(row["status"], "completed")
+            self.assertEqual(row["pr_state"], "merged")
+            self.assertEqual(row["pr_url"], PR_URL)
+            self.assertEqual(row["commit_full"], MERGE_OID)
+            self.assertEqual(row["commit_short"], MERGE_OID[:7])
+            self.assertEqual(row["completed_at"], MERGED_AT)
+
+            evts = _events_of_kind(db, "pr_merged")
+            self.assertEqual(len(evts), 1)
+            payload = json.loads(evts[0]["payload_json"])
+            self.assertEqual(payload["pr"], PR)
+            self.assertEqual(payload["repo"], REPO)
+            self.assertEqual(payload["merge_commit"], MERGE_OID)
+            self.assertEqual(payload["merged_at"], MERGED_AT)
+
+    def test_idempotent_second_call_is_noop(self) -> None:
+        with TempDB() as db:
+            _seed_run(db)
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                first = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+                second = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(first, run_complete_on_merge.RESULT_MERGED)
+            self.assertEqual(second, run_complete_on_merge.RESULT_ALREADY)
+            # No double event row.
+            self.assertEqual(len(_events_of_kind(db, "pr_merged")), 1)
+
+    def test_not_merged_is_no_op(self) -> None:
+        with TempDB() as db:
+            _seed_run(db)
+            view = _make_pr_view(merged_at=None, merge_oid=None)
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(view),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_NOT_YET)
+            self.assertEqual(_run_row(db)["status"], "review")
+            self.assertEqual(_events_of_kind(db, "pr_merged"), [])
+
+    def test_resolves_task_id_via_branch_when_pr_url_absent(self) -> None:
+        """If the seeded run has no pr_url, fall back to branch lookup."""
+        with TempDB() as db:
+            _seed_run(db, pr_url="")  # empty pr_url
+            # Confirm pr_url really is NULL/empty so the lookup path is forced.
+            self.assertIn(_run_row(db)["pr_url"], (None, ""))
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
+            self.assertEqual(_run_row(db)["status"], "completed")
+
+    def test_no_matching_run_returns_no_run(self) -> None:
+        with TempDB() as db:
+            apply_schema(connect(db))  # empty DB, no runs
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_NO_RUN)
+            self.assertEqual(_events_of_kind(db, "pr_merged"), [])
+
+    def test_explicit_task_id_skips_resolution(self) -> None:
+        with TempDB() as db:
+            _seed_run(db, pr_url="", branch="other-branch")
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db, task_id=TASK_ID,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
+
+
+class CLITests(unittest.TestCase):
+    def test_cli_invokes_helper(self) -> None:
+        with TempDB() as db:
+            _seed_run(db)
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ), mock.patch.object(
+                run_complete_on_merge.shutil, "which", return_value="/usr/bin/gh",
+            ):
+                rc = run_complete_on_merge.main([
+                    "--pr", str(PR),
+                    "--repo", REPO,
+                    "--db-path", str(db),
+                ])
+            self.assertEqual(rc, 0)
+            self.assertEqual(_run_row(db)["status"], "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Eliminate the procedural gap from session #13 where Secretary skipped `update_run_status('completed')` + PR-metadata writes after PR merges, leaving `runs` rows drifted (id=186 stuck at `queued`, id=187 missing `pr_url`/`commit_short`/`pr_state`/`completed_at`). The hand-rolled multi-line `python -c` block in `org-delegate` Step 5 2b-ii is the bug carrier — once a helper exists, the SoT is the helper.

## Changes

- **New `tools/run_complete_on_merge.py`**: takes `--pr <n> --task-id <id>` and resolves PR metadata via `gh pr view --json mergedAt,mergeCommit,state,url,headRefName`. When merged, writes `pr_state='merged'` / `commit_short` / `commit_full` / `pr_url` / `completed_at` via `StateWriter.transaction()` and appends `pr_merged` to the events table. **Does NOT flip `runs.status`** — that remains Secretary's responsibility post-`worktree remove` / `CLOSE_PANE` / `remove_worker_dir` per `delegation-lifecycle-contract.md` §T5. Idempotent: re-running on an already-recorded merge is a no-op.
- **Opt-in merge-watch in `tools/pr_watch.py`**: new `--merge-watch` flag (PowerShell `-MergeWatch`) keeps polling `gh pr view --json mergedAt` after CI signal, bounded 24h, and invokes the helper on first `mergedAt`. Default-off so the existing 2c review-feedback loop is unaffected. Bound exhaustion records a `pr_merge_watch_timeout` event.
- **`tools/pr-watch.ps1`**: adds `-MergeWatch` switch passthrough. `tools/pr-watch.sh` is exec-transparent — no change.
- **`docs/legacy/pr-merge-completion-manual.md`** (new): museum copy of the legacy hand-rolled `python -c` snippet (PR #315 pattern).
- **`.claude/skills/org-delegate/SKILL.md`** Step 5 2b-i / 2b-ii rewritten to call the helper; legacy snippet removed from prose.
- **Tests**: new `tools/test_run_complete_on_merge.py` (merge / not_yet / already / no_run / branch fallback / pending cleanup) and `tools/test_pr_watch.py` extensions (opt-in default / CI fail no-watch / no_run CLI exit 3). 41 new tests, full suite 262 OK.

## Test plan

- [x] `python -m unittest tools.test_run_complete_on_merge tools.test_pr_watch` — 41 OK
- [x] `python -m unittest discover -s tools` — 262 OK (1 skip)
- [x] Codex self-review 3 rounds — all Blocker/Major resolved (T5 contract, B/C/D pattern completed_at, no_run exit, 24h synchronous block → opt-in)
- [x] CI green (gated via `tools/pr-watch.ps1 <PR>` after merge)

Closes #317