### PR TITLE
feat(claude): cover --repo cross-repo path in set_run_pr_open tests (Closes #331)

### DIFF
--- a/tools/set_run_pr_open.py
+++ b/tools/set_run_pr_open.py
@@ -181,7 +181,8 @@ def main(argv: "list[str] | None" = None) -> int:
     parser.add_argument("--pr", type=int, required=True,
                         help="pull request number")
     parser.add_argument("--repo", default=None,
-                        help="OWNER/REPO; auto-detected via gh repo view")
+                        help=("OWNER/REPO for cross-repo PRs (Issue #331); "
+                              "auto-detected via gh repo view when omitted"))
     parser.add_argument("--db-path", default=None,
                         help=f"path to state.db (default: {DEFAULT_DB_PATH})")
     args = parser.parse_args(argv)

--- a/tools/set_run_pr_open.py
+++ b/tools/set_run_pr_open.py
@@ -181,7 +181,7 @@ def main(argv: "list[str] | None" = None) -> int:
     parser.add_argument("--pr", type=int, required=True,
                         help="pull request number")
     parser.add_argument("--repo", default=None,
-                        help=("OWNER/REPO for cross-repo PRs (Issue #331); "
+                        help=("OWNER/REPO for cross-repo PRs; "
                               "auto-detected via gh repo view when omitted"))
     parser.add_argument("--db-path", default=None,
                         help=f"path to state.db (default: {DEFAULT_DB_PATH})")

--- a/tools/test_set_run_pr_open.py
+++ b/tools/test_set_run_pr_open.py
@@ -192,6 +192,141 @@ class TestSetRunPrOpenHelper(unittest.TestCase):
             )
 
 
+class TestSetRunPrOpenCrossRepoCli(unittest.TestCase):
+    """Issue #331: --repo flag must be forwarded to ``gh pr view`` so the
+    helper can back-fill cross-repo PRs (e.g. delegating into another
+    repo) instead of querying the cwd-resolved repo and failing with
+    GraphQL "Could not resolve to a PullRequest"."""
+
+    FOREIGN_REPO = "suisya-systems/renga"
+    FOREIGN_PR = 216
+    FOREIGN_BRANCH = "feat/renga-214-files-pane-handle"
+    FOREIGN_TASK_ID = "renga-214-files-pane-handle"
+    FOREIGN_URL = (
+        f"https://github.com/{FOREIGN_REPO}/pull/{FOREIGN_PR}"
+    )
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.db = Path(self._td.name) / "state.db"
+        conn = connect(self.db)
+        apply_schema(conn)
+        with StateWriter(conn).transaction() as w:
+            w.upsert_run(
+                task_id=self.FOREIGN_TASK_ID,
+                project_slug="renga",
+                pattern="B",
+                title=self.FOREIGN_TASK_ID,
+                status="review",
+                branch=self.FOREIGN_BRANCH,
+            )
+        conn.close()
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _fake_run_factory(self, captured: list):
+        """Return a subprocess.run stand-in that records argv lists and
+        emits a ``gh pr view`` payload for the foreign PR."""
+
+        class _Result:
+            def __init__(self, stdout: str):
+                self.stdout = stdout
+                self.stderr = ""
+                self.returncode = 0
+
+        def _fake_run(argv, *args, **kwargs):
+            captured.append(list(argv))
+            if argv[:3] == ["gh", "pr", "view"]:
+                payload = json.dumps({
+                    "url": self.FOREIGN_URL,
+                    "headRefName": self.FOREIGN_BRANCH,
+                })
+                return _Result(payload)
+            if argv[:3] == ["gh", "repo", "view"]:
+                payload = json.dumps({"nameWithOwner": "octo/cwd-repo"})
+                return _Result(payload)
+            raise AssertionError(f"unexpected argv: {argv}")
+
+        return _fake_run
+
+    def test_repo_flag_is_forwarded_to_gh_pr_view(self):
+        captured: list = []
+        argv = [
+            "--task-id", self.FOREIGN_TASK_ID,
+            "--pr", str(self.FOREIGN_PR),
+            "--repo", self.FOREIGN_REPO,
+            "--db-path", str(self.db),
+        ]
+        with mock.patch.object(
+            set_run_pr_open.subprocess, "run",
+            side_effect=self._fake_run_factory(captured),
+        ), mock.patch.object(
+            set_run_pr_open.shutil, "which", return_value="/usr/bin/gh",
+        ):
+            rc = set_run_pr_open.main(argv)
+        self.assertEqual(rc, 0)
+
+        pr_view_calls = [a for a in captured if a[:3] == ["gh", "pr", "view"]]
+        self.assertEqual(len(pr_view_calls), 1)
+        self.assertEqual(
+            pr_view_calls[0],
+            [
+                "gh", "pr", "view", str(self.FOREIGN_PR),
+                "--repo", self.FOREIGN_REPO,
+                "--json", "url,headRefName",
+            ],
+        )
+        # No cwd-resolution call should have been made when --repo is set.
+        self.assertEqual(
+            [a for a in captured if a[:3] == ["gh", "repo", "view"]], [],
+        )
+
+        conn = sqlite3.connect(str(self.db))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT pr_url, branch FROM runs WHERE task_id = ?",
+                (self.FOREIGN_TASK_ID,),
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(row["pr_url"], self.FOREIGN_URL)
+        self.assertEqual(row["branch"], self.FOREIGN_BRANCH)
+
+    def test_no_repo_flag_falls_back_to_cwd_resolution(self):
+        captured: list = []
+        argv = [
+            "--task-id", self.FOREIGN_TASK_ID,
+            "--pr", str(self.FOREIGN_PR),
+            "--db-path", str(self.db),
+        ]
+        with mock.patch.object(
+            set_run_pr_open.subprocess, "run",
+            side_effect=self._fake_run_factory(captured),
+        ), mock.patch.object(
+            set_run_pr_open.shutil, "which", return_value="/usr/bin/gh",
+        ):
+            rc = set_run_pr_open.main(argv)
+        self.assertEqual(rc, 0)
+
+        # cwd auto-resolve must run, then pr view uses the resolved repo.
+        repo_view_calls = [
+            a for a in captured if a[:3] == ["gh", "repo", "view"]
+        ]
+        self.assertEqual(len(repo_view_calls), 1)
+        pr_view_calls = [a for a in captured if a[:3] == ["gh", "pr", "view"]]
+        self.assertEqual(len(pr_view_calls), 1)
+        self.assertEqual(
+            pr_view_calls[0],
+            [
+                "gh", "pr", "view", str(self.FOREIGN_PR),
+                "--repo", "octo/cwd-repo",
+                "--json", "url,headRefName",
+            ],
+        )
+
+
 # ---------------------------------------------------------------------------
 # Integration: gen_delegate_payload.apply → set_run_pr_open → run_complete_on_merge
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Issue #331 was filed thinking `tools/set_run_pr_open.py --repo` was missing, after a cross-repo back-fill attempt failed. Investigation showed the flag was actually shipped in PR #325 (the original `set_run_pr_open` PR) — the failure was just the Secretary forgetting to pass `--repo` on the CLI. Implementation is therefore unchanged; this PR closes the gap by adding the test coverage that was listed in the acceptance criteria.

## Changes

- **`tools/test_set_run_pr_open.py`** — new `TestSetRunPrOpenCrossRepoCli` class with two cases:
  - `test_repo_flag_is_forwarded_to_gh_pr_view`: when `--repo OWNER/REPO` is specified, `gh pr view <pr> --repo OWNER/REPO --json url,headRefName` is dispatched verbatim, `gh repo view` is NOT called, and `runs.pr_url` ends up populated with the foreign-repo URL.
  - `test_no_repo_flag_falls_back_to_cwd_resolution`: when `--repo` is omitted, `gh repo view` resolves the repo from cwd and `gh pr view --repo <resolved>` follows.
- **`tools/set_run_pr_open.py`** — minor: `--repo` argparse help text reworded to "OWNER/REPO for cross-repo PRs; auto-detected via `gh repo view` when omitted". Removes an internal issue number leak from the help.

## Test plan

- [x] `python -m unittest tools.test_set_run_pr_open` — 11 tests OK (9 pre-existing + 2 new)
- [x] Codex self-review 1 round (full depth) — Blocker / Major / Minor: none. Nit (issue number in help) addressed in 9da2cea.
- [ ] CI green (gated via `tools/pr-watch.ps1 <PR>`).

Closes #331