### PR TITLE
fix(claude): add PR-pending-merge idle category to stall classifier (Closes #304)

### DIFF
--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -119,7 +119,7 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 
 - 最初のワーカー派遣完了後 `/loop 3m` で監視ループを開始、全ワーカーペインが閉じたら停止
 - 各サイクルで `poll_events` → `check_messages` → `list_panes` → `inspect_pane` → stall / relay gap 評価の順
-- stall 検出 (Step 5) は通常 lookback `STALL_SECRETARY_LOOKBACK_MIN = 15` 分で評価するが、worker が `pr_opened` event を出して `pr_merged` が未記録の **PR-pending-merge sub-state** では `STALL_PR_MERGE_LOOKBACK_MIN = 60` 分に拡張する (Issue #304、session #12 の merge 承認待ち誤発火を抑制)。詳細は [`.dispatcher/references/worker-monitoring.md` Step 5 (b-2)](references/worker-monitoring.md)
+- stall 検出 (Step 5) は通常 lookback `STALL_SECRETARY_LOOKBACK_MIN = 15` 分で評価するが、対象 worker の task に対して `pr_opened` event が journal に記録済みかつ `pr_merged` が未記録の **PR-pending-merge sub-state** では `STALL_PR_MERGE_LOOKBACK_MIN = 60` 分に拡張する (Issue #304、session #12 の merge 承認待ち誤発火を抑制)。`pr_opened` / `pr_merged` は Secretary が emit する event (`docs/journal-events.md` 参照) で、worker が直接書く event ではない。詳細は [`.dispatcher/references/worker-monitoring.md` Step 5 (b-2)](references/worker-monitoring.md)
 - ディスパッチャーが自動で承認・拒否することはしない (ユーザー判断が必要)
 - ワーカーペインがない場合は監視ループを停止する
 - 監視対象のペイン名は `.state/workers/worker-{peer_id}.md` の Pane Name から取得する

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -119,6 +119,7 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 
 - 最初のワーカー派遣完了後 `/loop 3m` で監視ループを開始、全ワーカーペインが閉じたら停止
 - 各サイクルで `poll_events` → `check_messages` → `list_panes` → `inspect_pane` → stall / relay gap 評価の順
+- stall 検出 (Step 5) は通常 lookback `STALL_SECRETARY_LOOKBACK_MIN = 15` 分で評価するが、worker が `pr_opened` event を出して `pr_merged` が未記録の **PR-pending-merge sub-state** では `STALL_PR_MERGE_LOOKBACK_MIN = 60` 分に拡張する (Issue #304、session #12 の merge 承認待ち誤発火を抑制)。詳細は [`.dispatcher/references/worker-monitoring.md` Step 5 (b-2)](references/worker-monitoring.md)
 - ディスパッチャーが自動で承認・拒否することはしない (ユーザー判断が必要)
 - ワーカーペインがない場合は監視ループを停止する
 - 監視対象のペイン名は `.state/workers/worker-{peer_id}.md` の Pane Name から取得する

--- a/.dispatcher/references/worker-monitoring.md
+++ b/.dispatcher/references/worker-monitoring.md
@@ -188,12 +188,12 @@
    #### (b-2) PR-pending-merge sub-state 判定 (Issue #304)
    stall 候補について、(c) の補助シグナル取得に進む **前に** PR-pending-merge sub-state を判定し、(c)(1) で使う lookback window を選択する。これは「worker が完了報告を出した後、Secretary が PR を open し、user が merge 承認するまでの待機」を通常 stall と区別するためのカテゴリ (Issue #304、session #12 で誤発火実測)。
 
-   `.state/journal.jsonl` を一度走査し、`task == "{task_id}"` (= bare task_id、`worker-` prefix を **含まない**。`pr_opened` / `pr_merged` の payload field 名は `task` で値は task_id 本体、`docs/journal-events.md` の Worker lifecycle 表参照) で次の 2 件を取得:
-   - 最新 `event == "pr_opened"` の有無 (`T_pr_opened`)
-   - 同じ task_id で `event == "pr_merged"` の有無 (`T_pr_merged`)
+   `.state/journal.jsonl` を一度走査し、`task == "{task_id}"` (= bare task_id、`worker-` prefix を **含まない**。`pr_opened` / `pr_merged` は `docs/journal-events.md` の "PR / push" 表で Writer = secretary、Emitted by = secretary、payload field `task` 値は task_id 本体と定義済) で次 2 件の **存在有無のみ** を取得 (timestamp は判定に使わない):
+   - `event == "pr_opened"` で同 task_id の行が 1 件以上ある
+   - `event == "pr_merged"` で同 task_id の行が 1 件以上ある
 
    分岐:
-   - `pr_opened` あり かつ `pr_merged` なし → **PR-pending-merge sub-state**。(c)(1) の lookback に `STALL_PR_MERGE_LOOKBACK_MIN = 60` を採用する
+   - `pr_opened` あり かつ `pr_merged` なし → **PR-pending-merge sub-state**。(c)(1) の lookback に `STALL_PR_MERGE_LOOKBACK_MIN = 60` を採用する。`pr_opened` / `pr_merged` は同一 task に対して各 1 件しか記録されない契約 (`tools/run_complete_on_merge.py` 等の helper が idempotent 化) なので、複数行を時系列比較する必要はない (= 「最新の行」を選ぶ必要なし、存在有無で十分)
    - 上記以外 (PR 未 open、または既に merge 済み) → 通常 sub-state。(c)(1) の lookback は `STALL_SECRETARY_LOOKBACK_MIN = 15` のまま
 
    ```bash
@@ -275,6 +275,7 @@
    #### (f) 設計メモ
    - **`STALL_SECRETARY_LOOKBACK_MIN = 15` の根拠**: Secretary が人間に判断を仰いでから応答を返すまで 5–10 分のオーダーが典型で、その間ワーカーは idle のまま待機する。15 分 window で「直近やり取りあり」を担保すれば、人間応答待ちの誤発火を実用上排除できる。短くすると判断待ちワーカーが timeout 経路に落ちて誤発火、長くすると完了後ペインの reactivation 痕跡を拾い続けて stuck が見逃される。中間値の 15 分が現状のスイートスポット
    - **`STALL_PR_MERGE_LOOKBACK_MIN = 60` の根拠 (Issue #304)**: PR open 後の merge 承認は user の手動操作で 15–60 分かかるのが典型。worker は完了報告済みで idle のまま正しく待機している (= stuck ではない) が、15 分 lookback では `worker_completed` が window から外れて誤 STALL 発火する (session #12 で実測)。`pr_opened` 済 / `pr_merged` 未の sub-state を event ledger だけで判定し、その期間だけ lookback を 60 分に拡張する。merge 後は `pr_merged` が記録されて即座に通常 sub-state に戻る
+   - **60 分超過時の挙動 (Issue #304 long-tail)**: PR が 60 分以上 open のまま (週末越え / レビュー長期化) で `worker_completed` が window から外れると timeout 経路で再び STALL_SUSPECTED が発火する。これは仕様上「60 分を越えたら sticky な PR-pending-merge は人間判断対象として再通知する」設計で、Issue #304 の指定どおり。30 秒 de-dup のため 3 分サイクルごとに再通知される点はノイズだが、`org-pull-request` SKILL の close condition (24–48h レビュー idle で人間判断、参照: [`.claude/skills/org-pull-request/SKILL.md`](../../.claude/skills/org-pull-request/SKILL.md)) と組み合わせて運用判断する。長期 PR を完全 silence したい場合は将来 Issue で「`pr_opened` 済 task は STALL を一切上げない」へ変更する選択肢があるが、本 PR では「60 分まで猶予」の lookback 延長に留める (Issue 仕様準拠)
    - **journal scan を primary にした理由**: renga の `poll_events` は現状 pane lifecycle event (`pane_started` / `pane_exited` / `events_dropped` / `heartbeat`) のみで `send_message` を流さない (`.claude/skills/org-delegate/references/renga-error-codes.md` の type 表参照)。一方、secretary 受信時の `worker_escalation` / `worker_reported` は authoritative な ledger として既に永続化されている。再利用が正解
    - **soft-note を残す意味**: 後で「なぜ STALL_SUSPECTED が発火しなかったか」を retro / debug で再現できる。silent skip にすると、誤検出疑いが起きたとき journal だけでは判別不能になる。Step 4 と同じ `anomaly_observed` event を再利用するので、event catalog (`docs/journal-events.md`) への新規追記は不要 (kind は `stall_acked`、sub-state は `note` field で `awaiting_secretary_lookback_15m` / `awaiting_pr_merge_lookback_60m` を区別)
    - **想定シナリオ (Issue #304 acceptance)**:

--- a/.dispatcher/references/worker-monitoring.md
+++ b/.dispatcher/references/worker-monitoring.md
@@ -154,6 +154,8 @@
 
    **定数**: `STALL_SECRETARY_LOOKBACK_MIN = 15` (補助シグナル look-back window、分単位)。値変更が必要な場合は本ファイルのこの行を直接書き換える (env 化は将来課題)。
 
+   **定数 (PR-pending-merge 用)**: `STALL_PR_MERGE_LOOKBACK_MIN = 60` (PR が open 済みかつ未 merge の worker に対する補助シグナル look-back window、分単位)。Issue #304。`pr_opened` を出してから user が merge 承認するまで 15–60 分かかるのが典型で、その間 worker は完了済みで idle のまま正しく待機する。15 分の通常 lookback では `worker_completed` が window から外れて誤発火 (session #12 で実測)。値変更が必要な場合は本ファイルのこの行を直接書き換える。
+
    #### (a) 動機
    Step 4 の inspect_pane 単独では、ワーカーが「Secretary に判断仰ぎを送って人間応答を待っている」状態と「stuck (異常停止)」を区別できない。判断仰ぎ中は worker pane の Claude session は継続中で画面 idle、APPROVAL_BLOCKED の regex にも該当しない。誤って STALL_SUSPECTED を発火すると、判断待ちワーカーに対してサイクル毎に窓口 escalation を投げ続ける。Issue #287 で実インシデント発覚 (session #12 / `worker-issue-283-delegate-payload`)。
    
@@ -183,10 +185,40 @@
    - 再起動時の挙動: ファイルが消失/読めない場合は全 worker `idle_streak_cycles = 0` から再観測する (誤検出より見逃しを優先、stall は数サイクル後に再評価される)
    - 本 PR では JSON ファイル経由の prose 契約に留め、helper script 化 (`tools/journal_append.sh` 相当) は将来課題
    
-   #### (c) 補助シグナル取得 — 直近の worker→secretary コミュニケーション
-   stall 候補が見つかったら、STALL_SUSPECTED を発火する **前に** 補助シグナルを取得する:
+   #### (b-2) PR-pending-merge sub-state 判定 (Issue #304)
+   stall 候補について、(c) の補助シグナル取得に進む **前に** PR-pending-merge sub-state を判定し、(c)(1) で使う lookback window を選択する。これは「worker が完了報告を出した後、Secretary が PR を open し、user が merge 承認するまでの待機」を通常 stall と区別するためのカテゴリ (Issue #304、session #12 で誤発火実測)。
 
-   1. **journal scan (primary, authoritative)**: `.state/journal.jsonl` を読み、`.ts >= now - STALL_SECRETARY_LOOKBACK_MIN minutes` でフィルタし、以下のいずれかの event を持つ行が 1 件でもあるか確認する:
+   `.state/journal.jsonl` を一度走査し、`task == "{task_id}"` (= bare task_id、`worker-` prefix を **含まない**。`pr_opened` / `pr_merged` の payload field 名は `task` で値は task_id 本体、`docs/journal-events.md` の Worker lifecycle 表参照) で次の 2 件を取得:
+   - 最新 `event == "pr_opened"` の有無 (`T_pr_opened`)
+   - 同じ task_id で `event == "pr_merged"` の有無 (`T_pr_merged`)
+
+   分岐:
+   - `pr_opened` あり かつ `pr_merged` なし → **PR-pending-merge sub-state**。(c)(1) の lookback に `STALL_PR_MERGE_LOOKBACK_MIN = 60` を採用する
+   - 上記以外 (PR 未 open、または既に merge 済み) → 通常 sub-state。(c)(1) の lookback は `STALL_SECRETARY_LOOKBACK_MIN = 15` のまま
+
+   ```bash
+   # ディスパッチャーの cwd は .dispatcher/ なので 1 階層上の .state/journal.jsonl を読む。
+   # task_id を bare 値で渡す (worker- prefix 無し)。
+   has_pr_opened=$(jq -c --arg t "{task_id}" 'select(.event == "pr_opened" and .task == $t)' ../.state/journal.jsonl | head -1)
+   has_pr_merged=$(jq -c --arg t "{task_id}" 'select(.event == "pr_merged" and .task == $t)' ../.state/journal.jsonl | head -1)
+   if [ -n "$has_pr_opened" ] && [ -z "$has_pr_merged" ]; then
+     lookback_min=60   # PR-pending-merge
+   else
+     lookback_min=15   # default
+   fi
+   ```
+
+   **設計メモ**:
+   - `pr_opened` / `pr_merged` は `docs/journal-events.md` で Writer = secretary、`task` payload field は task_id (bare) と定義済みなので、新規 event を導入せず既存 ledger だけで判定できる (Issue #304 提案 option 1)
+   - `STALL_PR_MERGE_LOOKBACK_MIN = 60` の根拠: PR レビュー / merge 承認の人間応答時間スケール。短すぎると (15 分) `worker_completed` が window から外れて誤発火、長すぎると stuck が見逃される。Issue #304 / session #12 観測の中間値
+   - PR-pending-merge を別 event ではなく lookback の延長で扱う理由: (c)(1) の補助シグナル軸 (`worker_completed` を含む 5 種) はそのまま再利用でき、acked 経路に乗せれば既存の de-dup / 通知抑制と整合する。新カテゴリ追加は最小差分
+   - merge 後 `pr_merged` event が記録されると次サイクルで sub-state が解け、lookback は 15 分に戻る。merge 後 `worker_completed` の `ts` が 15 分窓から外れた状態で worker pane がまだ open していれば通常 stall として扱われる (運用上は merge と同時に CLOSE_PANE が走るので実質的にこの経路には乗らない)
+   - `T_pr_opened` 自体の経過時間は判定に使わない (PR open から 60 分以内/超過の評価は不要)。代わりに (c)(1) の lookback を 60 分に拡張することで、`worker_completed` 等の最新 worker→secretary event が 60 分以内であれば acked、超えれば timeout という同一フォーマットの判定を維持する
+
+   #### (c) 補助シグナル取得 — 直近の worker→secretary コミュニケーション
+   stall 候補が見つかったら、STALL_SUSPECTED を発火する **前に** 補助シグナルを取得する。lookback は (b-2) で選択した値 (`STALL_SECRETARY_LOOKBACK_MIN = 15` または `STALL_PR_MERGE_LOOKBACK_MIN = 60`) を使う:
+
+   1. **journal scan (primary, authoritative)**: `.state/journal.jsonl` を読み、`.ts >= now - lookback_min minutes` ((b-2) で選択した値) でフィルタし、以下のいずれかの event を持つ行が 1 件でもあるか確認する:
       - `event == "worker_escalation"` かつ `worker == "worker-{task_id}"` (judgment request の受信)
       - `event == "worker_reported"` かつ `worker == "worker-{task_id}"` (mid-task progress の受信)
       - `event == "worker_completed"` かつ `worker == "worker-{task_id}"` (完了報告の受信、`REVIEW` 待機中の idle 区別用)
@@ -197,8 +229,9 @@
 
       ```bash
       # ディスパッチャーの cwd は .dispatcher/ なので 1 階層上の .state/journal.jsonl を読む。
-      # 時間窓ベースの抽出 (行数 cap で打ち切らないこと、journal が長期間追記され続けても 15 分窓は ts で正確に区切る)。
-      jq -c --arg cutoff "$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" '
+      # 時間窓ベースの抽出 (行数 cap で打ち切らないこと、journal が長期間追記され続けても lookback 窓は ts で正確に区切る)。
+      # 通常時 lookback_min=15、PR-pending-merge sub-state では lookback_min=60 ((b-2) で決定)。
+      jq -c --arg cutoff "$(date -u -d "${lookback_min} minutes ago" +%Y-%m-%dT%H:%M:%SZ)" '
         select(.ts >= $cutoff) |
         select(.event == "worker_escalation"
             or .event == "worker_reported"
@@ -213,17 +246,20 @@
    2. **renga-peers poll_events (forward-compat、現状は補助のみ)**: 現状 `mcp__renga-peers__poll_events` は pane lifecycle event のみを流し、`send_message` は流れない (`.claude/skills/org-delegate/references/renga-error-codes.md` の type 表参照)。さらに `since` は時刻ではなく前サイクルから受け取る **opaque cursor** で、初回省略時は「今以降」セマンティクス (過去履歴は返らない) なので、本判定で「過去 15 分」をピンポイント検索する用途には今は使えない。journal scan を **authoritative source** とする。将来 renga が `send_message` event を `poll_events` に流すようになれば、Step 1 で既に保持している `.state/dispatcher-event-cursor.txt` の cursor 経由で受信した worker→secretary の送信を `(worker, kind=stall_acked)` ledger に変換するルートを追加する想定 (本 PR ではプレースホルダとして記述するに留める)。
 
    #### (d) 分岐 (acked vs timeout)
-   - **acked** — どちらかの系統で 1 件以上ヒット: 「Secretary 判断待ち idle」とみなし、STALL_SUSPECTED を **発火しない**。Step 4 (e) と同じ `anomaly_observed` ledger に soft-note として記録 (新 event 名は導入せず既存 catalog を再利用):
+   - **acked** — どちらかの系統で 1 件以上ヒット: 「Secretary 判断待ち idle」または「PR-pending-merge 待機 idle」とみなし、STALL_SUSPECTED を **発火しない**。Step 4 (e) と同じ `anomaly_observed` ledger に soft-note として記録 (新 event 名は導入せず既存 catalog を再利用)。`note` は (b-2) で選択した sub-state を反映する:
      ```bash
+     # 通常 sub-state (lookback 15m)
      bash ../tools/journal_append.sh anomaly_observed source=stall_check worker=worker-{task_id} kind=stall_acked confidence=n/a note=awaiting_secretary_lookback_15m
+     # PR-pending-merge sub-state (lookback 60m, Issue #304)
+     bash ../tools/journal_append.sh anomaly_observed source=stall_check worker=worker-{task_id} kind=stall_acked confidence=n/a note=awaiting_pr_merge_lookback_60m
      ```
      以降のサイクルで journal entry が lookback window から外れて 0 件になれば、改めて (c) → (d) を再評価する (持続的 stuck の検出が遅れる代償として、判断待ちの誤発火を避ける trade-off)。
 
-   - **timeout** — 両系統とも痕跡なし、idle 継続: 従来通り stall として扱い、窓口に通知:
+   - **timeout** — 両系統とも痕跡なし、idle 継続: 従来通り stall として扱い、窓口に通知 (lookback は (b-2) で選択した値、通知文に分単位で埋める):
      ```
      mcp__renga-peers__send_message(to_id="secretary", message="
        STALL_SUSPECTED: worker-{task_id} が直近 3 サイクル idle、
-       過去 15 分以内に secretary 向け worker→secretary 送信痕跡
+       過去 {lookback_min} 分以内に secretary 向け worker→secretary 送信痕跡
        (worker_escalation / worker_reported / worker_completed /
        plan_delivered / prep_delivered) なし。stuck の可能性あり、確認願います。
      ")
@@ -238,8 +274,12 @@
 
    #### (f) 設計メモ
    - **`STALL_SECRETARY_LOOKBACK_MIN = 15` の根拠**: Secretary が人間に判断を仰いでから応答を返すまで 5–10 分のオーダーが典型で、その間ワーカーは idle のまま待機する。15 分 window で「直近やり取りあり」を担保すれば、人間応答待ちの誤発火を実用上排除できる。短くすると判断待ちワーカーが timeout 経路に落ちて誤発火、長くすると完了後ペインの reactivation 痕跡を拾い続けて stuck が見逃される。中間値の 15 分が現状のスイートスポット
+   - **`STALL_PR_MERGE_LOOKBACK_MIN = 60` の根拠 (Issue #304)**: PR open 後の merge 承認は user の手動操作で 15–60 分かかるのが典型。worker は完了報告済みで idle のまま正しく待機している (= stuck ではない) が、15 分 lookback では `worker_completed` が window から外れて誤 STALL 発火する (session #12 で実測)。`pr_opened` 済 / `pr_merged` 未の sub-state を event ledger だけで判定し、その期間だけ lookback を 60 分に拡張する。merge 後は `pr_merged` が記録されて即座に通常 sub-state に戻る
    - **journal scan を primary にした理由**: renga の `poll_events` は現状 pane lifecycle event (`pane_started` / `pane_exited` / `events_dropped` / `heartbeat`) のみで `send_message` を流さない (`.claude/skills/org-delegate/references/renga-error-codes.md` の type 表参照)。一方、secretary 受信時の `worker_escalation` / `worker_reported` は authoritative な ledger として既に永続化されている。再利用が正解
-   - **soft-note を残す意味**: 後で「なぜ STALL_SUSPECTED が発火しなかったか」を retro / debug で再現できる。silent skip にすると、誤検出疑いが起きたとき journal だけでは判別不能になる。Step 4 と同じ `anomaly_observed` event を再利用するので、event catalog (`docs/journal-events.md`) への新規追記は不要 (kind だけ `stall_acked` を新設)
+   - **soft-note を残す意味**: 後で「なぜ STALL_SUSPECTED が発火しなかったか」を retro / debug で再現できる。silent skip にすると、誤検出疑いが起きたとき journal だけでは判別不能になる。Step 4 と同じ `anomaly_observed` event を再利用するので、event catalog (`docs/journal-events.md`) への新規追記は不要 (kind は `stall_acked`、sub-state は `note` field で `awaiting_secretary_lookback_15m` / `awaiting_pr_merge_lookback_60m` を区別)
+   - **想定シナリオ (Issue #304 acceptance)**:
+     - regression: worker が `worker_completed` 報告 → secretary が PR 作成 (`pr_opened`) → CI green → user が 30 分後に merge 承認。30 分時点で (b-2) は PR-pending-merge sub-state (60m lookback)、`worker_completed` は 30 分 < 60 分で acked 経路、STALL_SUSPECTED は **発火しない** ✓
+     - inverse: worker が完全停止 (PR 未 open、`worker_completed` も無し)。(b-2) は通常 sub-state (15m lookback)、journal scan で痕跡 0 件、idle streak ≥ 3 サイクルで timeout 経路、STALL_SUSPECTED **従来通り発火する** ✓
 
 <a id="step-5-1"></a>
 5.1. **secretary relay gap 検出 (SECRETARY_RELAY_GAP_SUSPECTED)** — Step 5 の sibling、worker→secretary→user の relay の **secretary 側中継漏れ** を検知する独立チャネル:


### PR DESCRIPTION
## Summary

- Adds a PR-pending-merge sub-state to the dispatcher's STALL classifier so that the awaiting-human-merge window doesn't false-fire STALL_SUSPECTED.
- When the worker's task has a `pr_opened` event in the journal but no matching `pr_merged`, the supplementary-signal lookback is extended from 15 min (`STALL_SECRETARY_LOOKBACK_MIN`) to 60 min (`STALL_PR_MERGE_LOOKBACK_MIN`).
- Event-based detection (option 1 from the issue) — no new state file, reuses existing journal events.

## Test plan

- [x] `python tools/audit_link_paths.py` — OK (37 files scanned)
- [x] Prose-only contract change (no runtime tests required)
- [x] Codex self-review round 1 applied — Major retained per issue spec (60-min lookback) with long-tail design note; Minors fixed in `e438d4d`
- [x] Acceptance scenarios documented in `.dispatcher/references/worker-monitoring.md` Step 5 (f) — regression case (worker_completed → PR open → CI green → 30-min user wait, no STALL page) and inverse case (no PR open, idle 15 min, STALL still fires)

Closes #304
Refs #287 #292