### PR TITLE
fix(claude): redact local path from registry, detect self-edit via git origin URL

### DIFF
--- a/registry/projects.md
+++ b/registry/projects.md
@@ -10,10 +10,11 @@
 - `-` → 新規プロジェクト（clone 元なし）。`git init {worker_dir}` で初期化（clone は実行しない）
 
 注意: この列はワーカーの成果物パスを示すものではない（Issue #267 live-migration 後のレイアウトでは、active ワーカーは `workers/<project>/_runs/<workstream>/<run>/` を作業ルートとし、リサーチ系は `_research/_runs/<workstream>/<run>/`、検証用 sandbox は `_scratch/_runs/_solo/<name>/`、cold 成果物は curator が事後に `_archive/<YYYY-Qx>/<project>/<workstream>/<run>/` へ退避する）。
+
+claude-org-ja 自身（self-edit）は本レジストリに載せない。`tools/resolve_worker_layout.py:is_claude_org_project()` が `claude_org_root` の git origin URL を見て `suisya-systems/claude-org-ja` リポジトリかを判定する。
 この下の Markdown 表はワーカー派遣前に `dashboard/server.py:_parse_projects` で機械パースされるため、本セクションに追加の Markdown 表（`|---|` セパレータ付き）を差し込まないこと。説明を増やす場合はプレーン箇条書きで記述する。
 
 | 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |
 |---|---|---|---|---|
 | 時計アプリ | clock-app | - | Webブラウザで動くデジタル時計 | デザイン変更、機能追加 |
 | renga | renga | https://github.com/suisya-systems/renga | Rust 製の Claude Code 用ターミナルマルチプレクサ（TUI） | 機能追加、バグ修正、Issue 対応 |
-| claude-org-ja | claude-org-ja | C:/Users/iwama/Documents/work/claude-org | Claude Code 多役 AI 組織ハーネス（Secretary / Dispatcher / Curator / Worker）日本語版本体（self-edit はこのローカル checkout の worktree 上で実施） | スキル改善、ドキュメント追記、Issue 対応 |

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -37,18 +38,41 @@ GOLDEN_DIR = REPO_ROOT / "tests" / "fixtures" / "delegate_payload"
 
 
 class _Sandbox:
-    def __init__(self, td: Path):
+    def __init__(self, td: Path, *, with_claude_org_origin: bool = True):
         self.root = td
         self.workers = td / "workers"
         self.workers.mkdir()
         self.claude_org_root = td / "claude-org"
         (self.claude_org_root / ".state").mkdir(parents=True)
         (self.claude_org_root / "registry").mkdir()
+        # Self-edit detection runs off git origin URL. Tests that drive
+        # their own git setup on claude_org_root (e.g. pre-seeding a
+        # ``main`` branch + initial commit for worktree-creation tests)
+        # opt out via ``with_claude_org_origin=False`` to avoid a
+        # ``git init`` race that would silently swallow ``--initial-branch``.
+        if with_claude_org_origin:
+            subprocess.run(
+                ["git", "init", "-q", str(self.claude_org_root)],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(self.claude_org_root), "remote", "add",
+                 "origin", "https://github.com/suisya-systems/claude-org-ja.git"],
+                check=True,
+            )
         (self.claude_org_root / "registry" / "org-config.md").write_text(
             "## Permission Mode\ndefault_permission_mode: auto\n"
             "## Workers Directory\nworkers_dir: ../workers\n",
             encoding="utf-8",
         )
+        # The checked-in registry/projects.md no longer carries a
+        # claude-org-ja row (origin-URL detection replaces the path
+        # lookup), but several tests in this module still exercise the
+        # legacy *registry-driven* code paths (Pattern A doc-audit on a
+        # registered claude-org-ja path, gitignored sub-mode, etc.).
+        # The sandbox row uses the per-test temp dir as its path, so it
+        # doesn't leak any user-specific data — keeping it lets the legacy
+        # paths stay covered while the production registry stays clean.
         (self.claude_org_root / "registry" / "projects.md").write_text(
             "# Projects\n\n"
             "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
@@ -684,7 +708,10 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         except (FileNotFoundError):
             self.skipTest("git not available")
         self._td = tempfile.TemporaryDirectory()
-        self.sb = _Sandbox(Path(self._td.name))
+        # This class drives its own ``git init -b main`` + initial commit on
+        # claude_org_root, so we opt out of the sandbox-level git init that
+        # would otherwise re-init and silently swallow ``--initial-branch``.
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
         # Initialize claude_org_root as a real git repo so live_repo_worktree
         # can branch from it.
         import os

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -33,12 +33,14 @@ class TestParseProjects(unittest.TestCase):
     def test_real_registry_fixture(self):
         path = PROJECT_ROOT / "registry" / "projects.md"
         projects = parse_projects(path)
-        # The actual checked-in registry has at least the 3 well-known
-        # projects (clock-app, renga, claude-org-ja).
+        # The checked-in registry carries the public, non-user-specific
+        # projects only. claude-org-ja self-edit is detected via the live
+        # repo's git origin URL (resolve_worker_layout.is_claude_org_project)
+        # and intentionally has no row here.
         names = [p.name for p in projects]
         self.assertIn("clock-app", names)
         self.assertIn("renga", names)
-        self.assertIn("claude-org-ja", names)
+        self.assertNotIn("claude-org-ja", names)
         # All rows are fully populated Project instances.
         for p in projects:
             self.assertIsInstance(p, Project)

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -366,6 +366,28 @@ class TestRoleDetection(unittest.TestCase):
         self.assertEqual(layout.role, "doc-audit")
         self.assertFalse(layout.self_edit)
 
+    def test_audit_mode_for_claude_org_keeps_pattern_a_via_synthesized_project(self):
+        """Regression: the production registry no longer carries a
+        claude-org-ja row, but ``mode='audit'`` on this slug must still
+        land on Pattern A with worker_dir under workers_dir/claude-org-ja
+        (read-only audit clone) — not silently fall through to Pattern C
+        ephemeral. The resolver synthesizes a virtual project entry from
+        the slug + matching git origin so the legacy pattern logic keeps
+        working."""
+        layout = rwl.resolve(
+            task_id="audit-task",
+            project_slug="claude-org-ja",
+            mode="audit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "doc-audit")
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "claude-org-ja").resolve(),
+        )
+
     def test_audit_mode_for_non_claude_org_also_doc_audit(self):
         layout = rwl.resolve(
             task_id="t-4",
@@ -507,13 +529,22 @@ class TestPatternBLiveRepoWorktree(unittest.TestCase):
 
     def setUp(self) -> None:
         self._td = tempfile.TemporaryDirectory()
-        # Self-edit detection runs off git origin, not the registry, and
-        # always picks Pattern B + live_repo_worktree (no active-run gate).
+        # Self-edit detection runs off git origin (claude-org-ja has no
+        # registry row); the active-run gate on Pattern B vs A still
+        # applies the same way it did when the row was present.
         self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=True)
         self.sb.write_registry(
             [
                 ("時計", "clock-app", "-", "Demo clock"),
             ]
+        )
+        # An active run on claude-org-ja forces Pattern B for the next task.
+        self.sb.add_run(
+            task_id="self-edit-prev",
+            project_slug="claude-org-ja",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.sb.claude_org_root),
         )
 
     def tearDown(self) -> None:
@@ -684,8 +715,10 @@ class TestIsClaudeOrgProject(unittest.TestCase):
                  "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
         )
         worker_clone = self.tmp / "worker"
+        # Pass the source as a ``file://`` URI so Git for Windows does not
+        # mistake a ``C:\...`` argument for a ``host:path`` SSH form.
         subprocess.run(
-            ["git", "clone", "-q", str(upstream), str(worker_clone)],
+            ["git", "clone", "-q", upstream.as_uri(), str(worker_clone)],
             check=True,
         )
         self.assertFalse(rwl.is_claude_org_project("claude-org-ja", worker_clone))
@@ -716,6 +749,18 @@ class TestIsClaudeOrgProject(unittest.TestCase):
         repo.mkdir()
         _Sandbox.init_git_with_origin(
             repo, "git@github.com:suisya-systems/claude-org-ja.git"
+        )
+        self.assertTrue(rwl.is_claude_org_project("claude-org-ja", repo))
+
+    def test_fork_origin_still_matches(self):
+        """CONTRIBUTING.md documents fork-based contribution: a fork's
+        ``origin`` points at the contributor's fork, not at suisya-systems.
+        Self-edit detection must still fire so fork-based maintainers
+        keep getting Pattern B + CLAUDE.local.md."""
+        repo = self.tmp / "fork-origin"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "git@github.com:some-contributor/claude-org-ja.git"
         )
         self.assertTrue(rwl.is_claude_org_project("claude-org-ja", repo))
 

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -35,7 +35,7 @@ from tools.state_db.writer import StateWriter  # noqa: E402
 class _Sandbox:
     """One self-contained claude-org-like tree for a single test."""
 
-    def __init__(self, td: Path):
+    def __init__(self, td: Path, *, with_claude_org_origin: bool = False):
         self.root = td
         self.workers = td / "workers"
         self.workers.mkdir()
@@ -44,6 +44,11 @@ class _Sandbox:
         self.claude_org_root.mkdir()
         (self.claude_org_root / ".state").mkdir()
         (self.claude_org_root / "registry").mkdir()
+        if with_claude_org_origin:
+            self.init_git_with_origin(
+                self.claude_org_root,
+                "https://github.com/suisya-systems/claude-org-ja.git",
+            )
         # workers_dir relative to claude-org root → ../workers
         (self.claude_org_root / "registry" / "org-config.md").write_text(
             "## Workers Directory\nworkers_dir: ../workers\n",
@@ -54,6 +59,20 @@ class _Sandbox:
         conn = connect(self.db_path)
         apply_schema(conn)
         conn.close()
+
+    # ---- git helpers -------------------------------------------------------
+
+    @staticmethod
+    def init_git(repo: Path) -> None:
+        subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+
+    @classmethod
+    def init_git_with_origin(cls, repo: Path, origin_url: str) -> None:
+        cls.init_git(repo)
+        subprocess.run(
+            ["git", "-C", str(repo), "remote", "add", "origin", origin_url],
+            check=True,
+        )
 
     # ---- registry helpers --------------------------------------------------
 
@@ -301,18 +320,13 @@ class TestPatternCGitignored(unittest.TestCase):
 class TestRoleDetection(unittest.TestCase):
     def setUp(self) -> None:
         self._td = tempfile.TemporaryDirectory()
-        self.sb = _Sandbox(Path(self._td.name))
-        # Register the sandbox claude-org root as a project so role detection
-        # has something to compare against.
+        # claude-org-ja self-edit detection runs off the sandbox's git origin
+        # URL, so the sandbox needs ``with_claude_org_origin=True`` and no
+        # registry row for the self-edit target.
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=True)
         self.sb.write_registry(
             [
                 ("時計", "clock-app", "-", "Demo clock"),
-                (
-                    "claude-org-ja",
-                    "claude-org-ja",
-                    str(self.sb.claude_org_root),
-                    "claude-org self",
-                ),
             ]
         )
 
@@ -493,25 +507,13 @@ class TestPatternBLiveRepoWorktree(unittest.TestCase):
 
     def setUp(self) -> None:
         self._td = tempfile.TemporaryDirectory()
-        self.sb = _Sandbox(Path(self._td.name))
+        # Self-edit detection runs off git origin, not the registry, and
+        # always picks Pattern B + live_repo_worktree (no active-run gate).
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=True)
         self.sb.write_registry(
             [
                 ("時計", "clock-app", "-", "Demo clock"),
-                (
-                    "claude-org-ja",
-                    "claude-org-ja",
-                    str(self.sb.claude_org_root),
-                    "claude-org self",
-                ),
             ]
-        )
-        # An active run on claude-org-ja forces Pattern B for the next task.
-        self.sb.add_run(
-            task_id="self-edit-prev",
-            project_slug="claude-org-ja",
-            pattern="A",
-            status="in_use",
-            worker_dir_abs=str(self.sb.claude_org_root),
         )
 
     def tearDown(self) -> None:
@@ -634,6 +636,97 @@ class TestPatternBLiveRepoWorktree(unittest.TestCase):
             Path(layout.worker_dir),
             (self.sb.claude_org_root / ".worktrees" / "explicit-self-edit").resolve(),
         )
+
+
+# ---------------------------------------------------------------------------
+# is_claude_org_project() — git origin URL based self-edit detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsClaudeOrgProject(unittest.TestCase):
+    """Self-edit detection runs off ``git -C <claude_org_root> remote
+    get-url origin`` so the claude-org-ja target has no registry row to
+    leak a user-specific local path. Two signals must both hold: the
+    canonical slug AND a matching origin URL."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_live_claude_org_checkout_returns_true(self):
+        """(a) Inside the live claude-org-ja checkout (origin =
+        ``https://github.com/suisya-systems/claude-org-ja.git``) returns
+        True for the canonical slug."""
+        repo = self.tmp / "live"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "https://github.com/suisya-systems/claude-org-ja.git"
+        )
+        self.assertTrue(rwl.is_claude_org_project("claude-org-ja", repo))
+
+    def test_worker_dir_clone_returns_false(self):
+        """(b) A worker-dir clone has origin pointing at a local filesystem
+        path (no github.com segment), so detection returns False even for
+        the canonical slug."""
+        upstream = self.tmp / "upstream"
+        upstream.mkdir()
+        _Sandbox.init_git(upstream)
+        # Need an initial commit so ``git clone`` succeeds. Identity vars
+        # are passed via env so the test does not depend on the user's
+        # global git config.
+        subprocess.run(
+            ["git", "-C", str(upstream), "commit", "--allow-empty", "-q", "-m", "init"],
+            check=True,
+            env={**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+                 "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+        )
+        worker_clone = self.tmp / "worker"
+        subprocess.run(
+            ["git", "clone", "-q", str(upstream), str(worker_clone)],
+            check=True,
+        )
+        self.assertFalse(rwl.is_claude_org_project("claude-org-ja", worker_clone))
+
+    def test_repo_without_remote_returns_false(self):
+        """(c) A fresh git repo with no ``origin`` remote returns False."""
+        repo = self.tmp / "noremote"
+        repo.mkdir()
+        _Sandbox.init_git(repo)
+        self.assertFalse(rwl.is_claude_org_project("claude-org-ja", repo))
+
+    def test_non_self_edit_slug_returns_false_even_with_matching_origin(self):
+        """Slug gate: even with a matching origin URL, a non-canonical slug
+        (clock-app, renga, ...) must not be flagged as self-edit. Without
+        this gate every edit task run from inside the live claude-org
+        checkout would misfire as self-edit, since Secretary always
+        operates from there."""
+        repo = self.tmp / "live"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "https://github.com/suisya-systems/claude-org-ja.git"
+        )
+        self.assertFalse(rwl.is_claude_org_project("clock-app", repo))
+
+    def test_ssh_origin_form_normalizes(self):
+        """``git@github.com:suisya-systems/claude-org-ja.git`` → match."""
+        repo = self.tmp / "ssh"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "git@github.com:suisya-systems/claude-org-ja.git"
+        )
+        self.assertTrue(rwl.is_claude_org_project("claude-org-ja", repo))
+
+    def test_unrelated_github_repo_returns_false(self):
+        """A different github repo (e.g. an unrelated fork) must not match."""
+        repo = self.tmp / "fork"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "https://github.com/someone-else/some-other-repo.git"
+        )
+        self.assertFalse(rwl.is_claude_org_project("claude-org-ja", repo))
 
 
 if __name__ == "__main__":

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -248,28 +248,86 @@ def infer_branch(task_id: str, description: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def is_claude_org_project(project: Optional[RegistryProject], claude_org_root: Path) -> bool:
-    """True iff the registered project resolves to the same dir as claude-org root."""
-    if project is None:
-        return False
-    if not project.path or project.path == "-" or "://" in project.path:
-        return False
+# Canonical claude-org self-edit slug. The resolver short-circuits Pattern B +
+# live_repo_worktree for this slug when claude_org_root's git origin matches
+# one of the canonical repos below. Detection runs off the origin URL so the
+# registry need not carry a user-specific local path for the self-edit target.
+_CLAUDE_ORG_SELF_EDIT_SLUG = "claude-org-ja"
+
+# Owner/repo identifiers (lowercased, no scheme, no trailing .git) that count
+# as claude-org self-edit targets. Tuple constant so adding the en mirror
+# (e.g. "suisya-systems/claude-org-en") is a one-line change.
+_CLAUDE_ORG_REPOS: tuple[str, ...] = ("suisya-systems/claude-org-ja",)
+
+# Capture <owner>/<repo> from common github URL forms:
+#   https://github.com/owner/repo(.git)
+#   git@github.com:owner/repo(.git)
+#   ssh://git@github.com/owner/repo(.git)
+_GITHUB_OWNER_REPO_RE = re.compile(r"github\.com[:/]([^/:\s]+/[^/:\s]+?)(?:\.git)?/?$")
+
+
+def _normalize_remote_url(url: str) -> Optional[str]:
+    """Return ``<owner>/<repo>`` lowercased if ``url`` is a github remote, else None.
+
+    A worker-dir clone has origin pointing at a local filesystem path
+    (e.g. ``C:/Users/.../claude-org``); that has no ``github.com`` segment,
+    so this returns None and self-edit detection naturally fails.
+    """
+    s = url.strip().lower()
+    if not s:
+        return None
+    m = _GITHUB_OWNER_REPO_RE.search(s)
+    return m.group(1) if m else None
+
+
+def _git_origin_url(repo_path: Path) -> Optional[str]:
+    """Return ``git -C repo_path remote get-url origin`` stdout, or None."""
     try:
-        return Path(project.path).resolve() == claude_org_root.resolve()
-    except (OSError, RuntimeError):
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    return out or None
+
+
+def is_claude_org_project(project_slug: str, claude_org_root: Path) -> bool:
+    """True iff this delegation targets claude-org self-edit.
+
+    Two signals must both hold:
+    1. ``project_slug`` equals the canonical self-edit slug
+       (``claude-org-ja``). Without this gate any edit task — clock-app,
+       renga, etc. — would be flagged self-edit because Secretary always
+       runs the resolver from inside the live claude-org checkout.
+    2. ``claude_org_root``'s ``origin`` remote URL normalizes to a known
+       claude-org repo (``suisya-systems/claude-org-ja``). A worker-dir
+       clone has origin set to a local Windows path, so it does not
+       match; a fresh repo without any remote also does not match.
+    """
+    if project_slug != _CLAUDE_ORG_SELF_EDIT_SLUG:
         return False
+    url = _git_origin_url(claude_org_root)
+    if url is None:
+        return False
+    normalized = _normalize_remote_url(url)
+    return normalized in _CLAUDE_ORG_REPOS
 
 
 def decide_role(
     *,
     mode: str,
-    project: Optional[RegistryProject],
+    project_slug: str,
     claude_org_root: Path,
 ) -> str:
     if mode == "audit":
         return "doc-audit"
     if mode == "edit":
-        if is_claude_org_project(project, claude_org_root):
+        if is_claude_org_project(project_slug, claude_org_root):
             return "claude-org-self-edit"
         return "default"
     raise ResolveError(f"unknown mode: {mode!r} (expected one of {VALID_MODES})")
@@ -317,7 +375,7 @@ def resolve(
     project = find_project(projects, project_slug)
 
     # --- Role decision (computed first so Pattern B can branch on it) -----
-    role = decide_role(mode=mode, project=project, claude_org_root=claude_org_root)
+    role = decide_role(mode=mode, project_slug=project_slug, claude_org_root=claude_org_root)
     self_edit = role == "claude-org-self-edit"
 
     # --- Pattern decision --------------------------------------------------
@@ -325,7 +383,17 @@ def resolve(
     variant: Optional[str]
     worker_dir: Path
 
-    if project is None:
+    if self_edit:
+        # claude-org self-edit always uses Pattern B + live_repo_worktree under
+        # claude_org_root/.worktrees/{task_id}/ (single .git, no two-clone
+        # sync). The self-edit target has no registry row — origin-URL
+        # detection is what makes this branch fire — so this short-circuit
+        # must come before the ``project is None → Pattern C ephemeral``
+        # fallback below.
+        pattern = "B"
+        variant = "live_repo_worktree"
+        worker_dir = claude_org_root / ".worktrees" / task_id
+    elif project is None:
         # Unknown project → Pattern C ephemeral.
         pattern, variant = "C", "ephemeral"
         worker_dir = workers_dir / task_id

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -254,30 +254,33 @@ def infer_branch(task_id: str, description: str) -> str:
 # registry need not carry a user-specific local path for the self-edit target.
 _CLAUDE_ORG_SELF_EDIT_SLUG = "claude-org-ja"
 
-# Owner/repo identifiers (lowercased, no scheme, no trailing .git) that count
-# as claude-org self-edit targets. Tuple constant so adding the en mirror
-# (e.g. "suisya-systems/claude-org-en") is a one-line change.
-_CLAUDE_ORG_REPOS: tuple[str, ...] = ("suisya-systems/claude-org-ja",)
+# Repo names (lowercased, no owner, no trailing ``.git``) that count as
+# claude-org self-edit targets. Owner is intentionally NOT pinned: the
+# project documents fork-based contribution (see CONTRIBUTING.md), and a
+# fork's ``origin`` points at the contributor's fork (e.g.
+# ``git@github.com:<user>/claude-org-ja.git``), not at suisya-systems'.
+# Tuple constant so adding the en mirror (e.g. ``claude-org-en``) is a
+# one-line change.
+_CLAUDE_ORG_REPO_NAMES: tuple[str, ...] = ("claude-org-ja",)
 
 # Capture <owner>/<repo> from common github URL forms:
 #   https://github.com/owner/repo(.git)
 #   git@github.com:owner/repo(.git)
 #   ssh://git@github.com/owner/repo(.git)
-_GITHUB_OWNER_REPO_RE = re.compile(r"github\.com[:/]([^/:\s]+/[^/:\s]+?)(?:\.git)?/?$")
+# A local-path origin (worker-dir clones use these) has no ``github.com``
+# segment, so the regex naturally rejects it — even when the upstream dir
+# happens to be named ``claude-org-ja``.
+_GITHUB_OWNER_REPO_RE = re.compile(r"github\.com[:/]([^/:\s]+)/([^/:\s]+?)(?:\.git)?/?$")
 
 
-def _normalize_remote_url(url: str) -> Optional[str]:
-    """Return ``<owner>/<repo>`` lowercased if ``url`` is a github remote, else None.
-
-    A worker-dir clone has origin pointing at a local filesystem path
-    (e.g. ``C:/Users/.../claude-org``); that has no ``github.com`` segment,
-    so this returns None and self-edit detection naturally fails.
-    """
+def _extract_github_repo_name(url: str) -> Optional[str]:
+    """Return the lowercased repo name (no ``.git``) if ``url`` is a github
+    remote, else None."""
     s = url.strip().lower()
     if not s:
         return None
     m = _GITHUB_OWNER_REPO_RE.search(s)
-    return m.group(1) if m else None
+    return m.group(2) if m else None
 
 
 def _git_origin_url(repo_path: Path) -> Optional[str]:
@@ -304,18 +307,22 @@ def is_claude_org_project(project_slug: str, claude_org_root: Path) -> bool:
        (``claude-org-ja``). Without this gate any edit task — clock-app,
        renga, etc. — would be flagged self-edit because Secretary always
        runs the resolver from inside the live claude-org checkout.
-    2. ``claude_org_root``'s ``origin`` remote URL normalizes to a known
-       claude-org repo (``suisya-systems/claude-org-ja``). A worker-dir
-       clone has origin set to a local Windows path, so it does not
-       match; a fresh repo without any remote also does not match.
+    2. ``claude_org_root``'s ``origin`` remote URL points at a github
+       repo whose name matches a known claude-org target. Owner is not
+       pinned — fork-based contribution is the documented workflow and a
+       fork's origin is ``<contributor>/claude-org-ja``, not
+       ``suisya-systems/claude-org-ja``. A worker-dir clone has origin
+       set to a local filesystem path (no github.com segment), so it
+       does not match; a fresh repo without any remote also does not
+       match.
     """
     if project_slug != _CLAUDE_ORG_SELF_EDIT_SLUG:
         return False
     url = _git_origin_url(claude_org_root)
     if url is None:
         return False
-    normalized = _normalize_remote_url(url)
-    return normalized in _CLAUDE_ORG_REPOS
+    repo_name = _extract_github_repo_name(url)
+    return repo_name in _CLAUDE_ORG_REPO_NAMES
 
 
 def decide_role(
@@ -374,6 +381,21 @@ def resolve(
         projects = []
     project = find_project(projects, project_slug)
 
+    # claude-org-ja is intentionally absent from the checked-in registry
+    # (the row used to leak a user-specific local path). When the slug +
+    # claude_org_root's git origin both signal self-edit, synthesize a
+    # virtual project pointing at the live checkout so audit mode and the
+    # active-run/state.db driven Pattern A↔B logic below keep treating it
+    # the same as a registered project.
+    if project is None and is_claude_org_project(project_slug, claude_org_root):
+        project = RegistryProject(
+            name=project_slug,
+            nickname=project_slug,
+            path=str(claude_org_root),
+            description="",
+            common_tasks="",
+        )
+
     # --- Role decision (computed first so Pattern B can branch on it) -----
     role = decide_role(mode=mode, project_slug=project_slug, claude_org_root=claude_org_root)
     self_edit = role == "claude-org-self-edit"
@@ -383,17 +405,7 @@ def resolve(
     variant: Optional[str]
     worker_dir: Path
 
-    if self_edit:
-        # claude-org self-edit always uses Pattern B + live_repo_worktree under
-        # claude_org_root/.worktrees/{task_id}/ (single .git, no two-clone
-        # sync). The self-edit target has no registry row — origin-URL
-        # detection is what makes this branch fire — so this short-circuit
-        # must come before the ``project is None → Pattern C ephemeral``
-        # fallback below.
-        pattern = "B"
-        variant = "live_repo_worktree"
-        worker_dir = claude_org_root / ".worktrees" / task_id
-    elif project is None:
+    if project is None:
         # Unknown project → Pattern C ephemeral.
         pattern, variant = "C", "ephemeral"
         worker_dir = workers_dir / task_id

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -309,6 +309,17 @@ class FromTaskSubcommand(unittest.TestCase):
         self.claude_org_root = td / "claude-org"
         (self.claude_org_root / ".state").mkdir(parents=True)
         (self.claude_org_root / "registry").mkdir()
+        # Self-edit detection runs off the live repo's git origin URL, so
+        # the sandbox needs an initialised git repo with the canonical
+        # origin set for the claude-org-ja → CLAUDE.local.md auto-switch
+        # to fire.
+        import subprocess as _sp
+        _sp.run(["git", "init", "-q", str(self.claude_org_root)], check=True)
+        _sp.run(
+            ["git", "-C", str(self.claude_org_root), "remote", "add",
+             "origin", "https://github.com/suisya-systems/claude-org-ja.git"],
+            check=True,
+        )
         (self.claude_org_root / "registry" / "org-config.md").write_text(
             "## Workers Directory\nworkers_dir: ../workers\n",
             encoding="utf-8",


### PR DESCRIPTION
## Summary

Resolves #345. The `registry/projects.md` previously exposed a contributor's local Windows checkout path on the `claude-org-ja` row, which leaked publicly on every push.

This PR removes the user-specific row entirely and changes how the resolver identifies self-edit:

- `registry/projects.md`: drop the `claude-org-ja` row. Add a short note explaining that self-edit is detected from the live repo's git origin URL (so future contributors aren't surprised by the absence).
- `tools/resolve_worker_layout.py:is_claude_org_project()`: switch from registry-path lookup to git origin URL match against `suisya-systems/claude-org-ja`. The owner segment is intentionally left flexible (any `*/claude-org-ja` origin matches) to support fork workflows. SSH and HTTPS remote forms are both handled.
- The resolver synthesises a virtual `RegistryProject` for self-edit when the registry doesn't carry the row, so existing Pattern A/B/audit branches keep working without registry coupling.

## Verification

- `python -m pytest tests/ tools/` → 449 passed, 1 pre-existing skip.
- 7 new resolver tests covering: (a) live claude-org-ja checkout → True, (b) worker dir clone → False, (c) repo with no remote → False, (d) fork origin → True, (e) unrelated repo → False, (f) ssh-form remote → True, (g) Pattern A audit regression on a registry-listed row.
- Codex self-review (full mode, 2 rounds): Round 1 caught a Pattern C regression on audit mode and a fork-owner over-restriction (both fixed in `5739c24`); Round 2 clean (Blocker / Major none, 1 Minor on Codex sandbox `file://` clone behavior accepted).

## Out of scope

General mechanism for users to add their own private projects without committing them. Not currently a problem (no other user-specific rows exist); revisit if/when needed.

Closes #345