### PR TITLE
feat(claude): en から settings.json と install.ps1 の修正を back-port

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,7 @@
       "Bash(renga mcp uninstall:*)",
       "Bash(renga mcp status:*)",
       "Bash(renga mcp --help)",
+      "Bash(gh pr merge:*)",
       "mcp__renga-peers__set_summary",
       "mcp__renga-peers__list_peers",
       "mcp__renga-peers__send_message",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -189,22 +189,57 @@ if ($SkipMcp) {
 # claude-org-runtime package. Phase 5c (Issue #130) moved the install
 # path from `requirements.txt` to `pyproject.toml`; we prefer the
 # editable install so the dep set comes from the canonical source.
-$pyCmd = $null
-foreach ($cand in @('python', 'python3', 'py')) {
-    if (Get-Command $cand -ErrorAction SilentlyContinue) { $pyCmd = $cand; break }
-}
 $pyprojectFile = Join-Path $Dir 'pyproject.toml'
 $reqFile = Join-Path $Dir 'requirements.txt'
+
+# Skip the whole detection block on older refs / fixtures that ship
+# neither dependency file: invoking `python --version` there would
+# pointlessly touch the Microsoft Store App Execution Alias stub on
+# stock Windows boxes, surfacing a Store dialog where the previous
+# behaviour cleanly skipped without side effects.
+#
+# On a default Windows install only `py.exe` (the launcher) ends up
+# on PATH — bare `python` / `python3` are missing — so we add a
+# `py -3` fallback after the POSIX-friendly names. `-3` pins the
+# launcher to a Python 3 interpreter rather than letting it pick the
+# most recent installed version, which could surprise on dual-install
+# boxes still carrying 2.7. Each candidate is its own token list so
+# the launcher flag rides with the executable through Invoke-Step.
+#
+# Each candidate is then probed with `--version` to weed out the
+# Microsoft Store App Execution Alias stub — Windows preinstalls
+# `python.exe` under `...\WindowsApps\` even without a real Python,
+# and that stub exits non-zero (or pops the Store) on any real call.
+# A successful `--version` proves a working interpreter is on the
+# other end while still accepting genuine Store-installed Pythons.
+$pyCmd = $null
+if ((Test-Path -LiteralPath $pyprojectFile) -or (Test-Path -LiteralPath $reqFile)) {
+    $pyCandidates = @(
+        ,@('python'),
+        ,@('python3'),
+        ,@('py', '-3')
+    )
+    foreach ($cand in $pyCandidates) {
+        if (-not (Get-Command $cand[0] -ErrorAction SilentlyContinue)) { continue }
+        $rest = if ($cand.Length -gt 1) { $cand[1..($cand.Length - 1)] } else { @() }
+        try {
+            & $cand[0] @($rest + @('--version')) > $null 2>&1
+            if ($LASTEXITCODE -eq 0) { $pyCmd = $cand; break }
+        } catch {
+            # candidate is on PATH but failed to launch; try the next one
+        }
+    }
+}
 if ((Test-Path -LiteralPath $pyprojectFile) -and $pyCmd) {
     Write-Host ''
     Write-Host 'Installing Python deps via pyproject.toml (editable) ...'
-    Invoke-Step @($pyCmd, '-m', 'pip', 'install', '--user', '-e', $Dir)
+    Invoke-Step ($pyCmd + @('-m', 'pip', 'install', '--user', '-e', $Dir))
 } elseif ((Test-Path -LiteralPath $reqFile) -and $pyCmd) {
     # Backward-compat path for refs that predate Phase 5c (no
     # pyproject.toml) but post-date Step B (have requirements.txt).
     Write-Host ''
     Write-Host 'Installing Python deps (core-harness pin, requirements.txt) ...'
-    Invoke-Step @($pyCmd, '-m', 'pip', 'install', '--user', '-r', $reqFile)
+    Invoke-Step ($pyCmd + @('-m', 'pip', 'install', '--user', '-r', $reqFile))
 } elseif (-not ((Test-Path -LiteralPath $pyprojectFile) -or (Test-Path -LiteralPath $reqFile))) {
     # Older refs / fixtures predate Step B and ship neither file.
     # The shim CLIs only exist on Step-B-or-later commits, so skipping


### PR DESCRIPTION
## 概要
en (claude-org) で先行マージされた以下 2 件を ja に back-port します。auto-mirror で en に流れる runtime ファイルなので、ja 側に同等変更を入れないと次回同期で en 側が上書きされます。

- `feat(claude): allow Bash(gh pr merge:*) for secretary` — en PR #146 相当
- `feat(claude): add py -3 fallback to install.ps1 python detection` — en PR #144 相当（4 commit を 1 commit に集約）

## 差分
- `.claude/settings.json`: `permissions.allow` に `Bash(gh pr merge:*)` を 1 行追加（`Bash(renga mcp --help)` 直後）
- `scripts/install.ps1`: Python 検出ロジックに `py -3` フォールバック追加 / Microsoft Store stub を `--version` exit code で除外 / `pyproject.toml` または `requirements.txt` 存在時のみ probe

## 検証
- `tests/run-all.sh`: 229 tests pass / 0 fail
- `pytest tests/`: 164 passed
- en (claude-org) main HEAD との diff 検証で完全一致を確認

## 既知の指摘（en 元 PR と整合のため未対応）
Codex セルフレビューで以下が出ましたが、いずれも en 元 PR で議論済み・採用済みの設計です。ja 側で独自修正すると drift するため faithful back-port を優先しました。en 側で対応する場合に back-port 対象として扱う方針です。

- Major: `Bash(gh pr merge:*)` が curator にも広がる権限拡大
- Major: install.ps1 候補順 (python → python3 → py -3) で WindowsApps stub を最初に踏む可能性
- Minor: WARN メッセージが requirements.txt 分岐に対応していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)