### PR TITLE
fix(claude): make install.sh prerequisite check Git Bash on Windows aware

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -144,9 +144,10 @@ resolve_command() {
     "$HOME/.local/bin" \
     "$HOME/scoop/shims" \
     "$HOME/AppData/Local/Programs/$cmd"; do
-    # `.cmd` / `.bat` first so npm shims win over a stale bare-name
-    # POSIX wrapper that npm sometimes leaves alongside them; bare ""
-    # last so `node` / `python`-style POSIX shims still resolve.
+    # Extension-bearing variants first so a real Windows install wins
+    # over any stale bare-name POSIX wrapper npm sometimes leaves
+    # alongside them; bare "" last so `node` / `python`-style POSIX
+    # shims still resolve when no `.exe` / `.cmd` exists.
     for ext in .exe .cmd .bat ""; do
       candidate="$prefix/$cmd$ext"
       # `-f`, not `-x`: npm-generated `.cmd` shims ship without the
@@ -341,3 +342,24 @@ Inside the Secretary's Claude Code pane, run:
 
 For details see docs/getting-started.md.
 MSG
+
+# Final hint: the PATH prepend done by require_or_warn only affected
+# this script's process. If renga still isn't on the user's interactive
+# bash PATH (typical when it was found via the npm / cargo / scoop
+# fallback ladder above, especially `.cmd` shims that bash won't try
+# implicitly), the suggested `renga --layout ops` step would fail
+# silently with "command not found". Tell the user how to bridge that
+# gap in their own shell. POSIX environments skip this entirely.
+if [[ "$IS_WINDOWS_BASH" == "1" && -n "${RENGA_BIN:-}" ]] \
+   && ! command -v renga >/dev/null 2>&1; then
+  renga_dir=$(dirname -- "$RENGA_BIN")
+  cat <<MSG
+
+Note (Windows / Git Bash): bash on this shell can't find 'renga' on
+PATH. The installer resolved it via fallback to:
+  $RENGA_BIN
+Before running 'renga --layout ops' interactively, either invoke it by
+full path or add its directory to your bash PATH (e.g. in ~/.bashrc):
+  export PATH="$renga_dir:\$PATH"
+MSG
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,11 +93,89 @@ run() {
   fi
 }
 
+# Detect Git Bash / MSYS2 / Cygwin running on Windows. The PowerShell
+# `iwr | iex` flow uses install.ps1; the matching bash one-liner from
+# PowerShell (`bash <(curl ...)`) and direct `bash scripts/install.sh`
+# from a Git Bash shell both land here, where two Windows-specific gaps
+# in the POSIX prerequisite check show up:
+#   1. Bash's `command -v foo` tries `foo.exe` on MSYS but does NOT try
+#      `foo.cmd` / `foo.bat`, so npm-installed shims (`renga.cmd`) are
+#      invisible to a plain `command -v renga`.
+#   2. Some installers (Claude Code's per-user installer, cargo,
+#      scoop) drop binaries in dirs that aren't on the bash PATH when
+#      bash is launched fresh from PowerShell, even though they are on
+#      the user's Windows PATH.
+# Both gaps need explicit handling; everywhere else, `IS_WINDOWS_BASH=0`
+# keeps the legacy POSIX path intact.
+case "${OSTYPE:-}" in
+  msys*|cygwin*|win32*) IS_WINDOWS_BASH=1 ;;
+  *) IS_WINDOWS_BASH=0 ;;
+esac
+if [[ "$IS_WINDOWS_BASH" != "1" ]]; then
+  case "$(uname -s 2>/dev/null || true)" in
+    MINGW*|MSYS*|CYGWIN*) IS_WINDOWS_BASH=1 ;;
+  esac
+fi
+
+resolve_command() {
+  # Pure resolver: prints the resolved path on stdout and returns 0,
+  # or returns 1 with no output. Side effects (PATH prepend) live in
+  # require_or_warn so this stays composable for the explicit
+  # `RENGA_BIN=$(resolve_command renga ...)` capture below.
+  local cmd="$1" resolved="" ext prefix candidate
+  if resolved=$(command -v "$cmd" 2>/dev/null); then
+    printf '%s\n' "$resolved"; return 0
+  fi
+  [[ "$IS_WINDOWS_BASH" == "1" ]] || return 1
+  # (b) Windows-specific extensions that bash's command -v skips.
+  for ext in .exe .cmd .bat; do
+    if resolved=$(command -v "$cmd$ext" 2>/dev/null); then
+      printf '%s\n' "$resolved"; return 0
+    fi
+  done
+  # (c) Well-known per-user install prefixes that may not be on bash's
+  # PATH when invoked via `bash <(curl ...)` from PowerShell. Order
+  # matters: npm comes first because both `renga` and (sometimes)
+  # `claude` ship there as `.cmd` shims; cargo / scoop / Programs
+  # follow for native `.exe` builds.
+  for prefix in \
+    "$HOME/AppData/Roaming/npm" \
+    "$HOME/.cargo/bin" \
+    "$HOME/.local/bin" \
+    "$HOME/scoop/shims" \
+    "$HOME/AppData/Local/Programs/$cmd"; do
+    # `.cmd` / `.bat` first so npm shims win over a stale bare-name
+    # POSIX wrapper that npm sometimes leaves alongside them; bare ""
+    # last so `node` / `python`-style POSIX shims still resolve.
+    for ext in .exe .cmd .bat ""; do
+      candidate="$prefix/$cmd$ext"
+      # `-f`, not `-x`: npm-generated `.cmd` shims ship without the
+      # POSIX execute bit (Windows only cares about the extension),
+      # so `-x` would skip exactly the case we're trying to catch.
+      if [[ -f "$candidate" ]]; then
+        printf '%s\n' "$candidate"; return 0
+      fi
+    done
+  done
+  return 1
+}
+
 require_or_warn() {
   # $1 = command name, $2 = install hint URL/text.
-  local cmd="$1" hint="$2"
-  if command -v "$cmd" >/dev/null 2>&1; then
-    echo "  [ok]   $cmd: $(command -v "$cmd")"
+  local cmd="$1" hint="$2" resolved="" parent
+  if resolved=$(resolve_command "$cmd"); then
+    echo "  [ok]   $cmd: $resolved"
+    # If the resolution came from a fallback prefix that isn't on
+    # bash's PATH, prepend it so sibling tools / later `command -v`
+    # lookups in this script can find it without re-running the
+    # ladder. Skip when the dir is already there to keep PATH stable.
+    if [[ "$IS_WINDOWS_BASH" == "1" ]]; then
+      parent=$(dirname -- "$resolved")
+      case ":$PATH:" in
+        *":$parent:"*) ;;
+        *) PATH="$parent:$PATH" ;;
+      esac
+    fi
     return 0
   fi
   echo "  [miss] $cmd not found. Install hint: $hint"
@@ -113,6 +191,14 @@ require_or_warn git    "https://git-scm.com/downloads" || missing=1
 require_or_warn claude "https://claude.ai/code (Claude Code CLI)" || missing=1
 require_or_warn renga  "npm install -g @suisya-systems/renga@0.18.0" || missing=1
 require_or_warn gh     "https://cli.github.com/" || missing=1
+# Capture the absolute path so the later `run renga mcp install` can
+# bypass bash's PATH-extension blind spot for `.cmd` shims (Git Bash
+# on Windows tries `.exe` but not `.cmd` / `.bat`, so a PATH-only
+# resolution would `exit 127` even after require_or_warn succeeded).
+# 2>/dev/null + `|| true` keeps `set -e` happy when renga is genuinely
+# missing — the missing= flag above already handles that case, and we
+# fall back to bare `renga` so the failure mode stays familiar.
+RENGA_BIN=$(resolve_command renga 2>/dev/null || true)
 echo
 
 if [[ "$missing" == "1" ]]; then
@@ -186,7 +272,7 @@ else
   echo
   echo "Registering renga-peers MCP with Claude Code (user-scope)..."
   echo "Note: Claude Code may show a permission prompt; approve it to continue."
-  run renga mcp install
+  run "${RENGA_BIN:-renga}" mcp install
 fi
 
 # --- Python deps (core-harness pin) ----------------------------------------
@@ -198,25 +284,37 @@ fi
 # claude-org-runtime package. Phase 5c (Issue #130) moved the install
 # path from `requirements.txt` to `pyproject.toml`; we prefer the
 # editable install so the dep set comes from the canonical source.
-if command -v python3 >/dev/null 2>&1; then
-  PY=python3
-elif command -v python >/dev/null 2>&1; then
-  PY=python
-else
-  PY=""
+# Probe each candidate with `--version` so the Microsoft Store App
+# Execution Alias stub on Windows (`python.exe` under `WindowsApps\`
+# that exits non-zero or pops the Store on real calls) doesn't get
+# selected. `py -3` is the Windows-specific fallback for stock boxes
+# that ship only the launcher; pinning `-3` skips any leftover 2.7.
+# PY_LAUNCHER carries the optional `-3` so the unquoted expansion in
+# `run $PY $PY_LAUNCHER ...` drops empty when not needed.
+PY=""
+PY_LAUNCHER=""
+for cand in python3 python; do
+  if command -v "$cand" >/dev/null 2>&1 && "$cand" --version >/dev/null 2>&1; then
+    PY="$cand"; break
+  fi
+done
+if [[ -z "$PY" && "$IS_WINDOWS_BASH" == "1" ]]; then
+  if command -v py >/dev/null 2>&1 && py -3 --version >/dev/null 2>&1; then
+    PY="py"; PY_LAUNCHER="-3"
+  fi
 fi
 PYPROJECT_FILE="$TARGET_DIR/pyproject.toml"
 REQ_FILE="$TARGET_DIR/requirements.txt"
 if [[ -f "$PYPROJECT_FILE" && -n "$PY" ]]; then
   echo
   echo "Installing Python deps via pyproject.toml (editable) ..."
-  run $PY -m pip install --user -e "$TARGET_DIR"
+  run $PY $PY_LAUNCHER -m pip install --user -e "$TARGET_DIR"
 elif [[ -f "$REQ_FILE" && -n "$PY" ]]; then
   # Backward-compat path for refs that predate Phase 5c (no
   # pyproject.toml) but post-date Step B (have requirements.txt).
   echo
   echo "Installing Python deps (core-harness pin, requirements.txt) ..."
-  run $PY -m pip install --user -r "$REQ_FILE"
+  run $PY $PY_LAUNCHER -m pip install --user -r "$REQ_FILE"
 elif [[ ! -f "$PYPROJECT_FILE" && ! -f "$REQ_FILE" ]]; then
   # Older refs / fixtures predate Step B and ship neither file.
   # The shim CLIs only exist on Step-B-or-later commits, so skipping

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -187,6 +187,20 @@ echo "== claude-org-ja installer =="
 echo
 
 echo "Checking prerequisites..."
+# Snapshot whether `renga` was already discoverable on the user's
+# interactive bash PATH *before* any prerequisite probe runs. That
+# is the right baseline for the trailing Git-Bash-on-Windows hint:
+# require_or_warn below may prepend a fallback dir to PATH for the
+# remainder of this process, but that change does not survive into
+# the user's shell. If the snapshot says "no" and we still resolve
+# renga via the fallback ladder, the user's `renga --layout ops`
+# step needs the shell-PATH advice regardless of whether the
+# resolved file was a `.exe` or a `.cmd`.
+if command -v renga >/dev/null 2>&1; then
+  RENGA_ON_USER_PATH=1
+else
+  RENGA_ON_USER_PATH=0
+fi
 missing=0
 require_or_warn git    "https://git-scm.com/downloads" || missing=1
 require_or_warn claude "https://claude.ai/code (Claude Code CLI)" || missing=1
@@ -344,14 +358,15 @@ For details see docs/getting-started.md.
 MSG
 
 # Final hint: the PATH prepend done by require_or_warn only affected
-# this script's process. If renga still isn't on the user's interactive
-# bash PATH (typical when it was found via the npm / cargo / scoop
-# fallback ladder above, especially `.cmd` shims that bash won't try
-# implicitly), the suggested `renga --layout ops` step would fail
-# silently with "command not found". Tell the user how to bridge that
-# gap in their own shell. POSIX environments skip this entirely.
-if [[ "$IS_WINDOWS_BASH" == "1" && -n "${RENGA_BIN:-}" ]] \
-   && ! command -v renga >/dev/null 2>&1; then
+# this script's process. Use the pre-resolution snapshot taken before
+# any prerequisite probe ran (RENGA_ON_USER_PATH) as the baseline —
+# that's the user's interactive shell view, which `command -v renga`
+# checked here would misrepresent after the prepend. This catches
+# both `.cmd` shims (which MSYS bash never auto-resolves) AND `.exe`
+# binaries reached via a fallback dir that isn't on the user's
+# interactive bash PATH. POSIX environments skip this entirely.
+if [[ "$IS_WINDOWS_BASH" == "1" && -n "${RENGA_BIN:-}" \
+      && "$RENGA_ON_USER_PATH" != "1" ]]; then
   renga_dir=$(dirname -- "$RENGA_BIN")
   cat <<MSG
 


### PR DESCRIPTION
## 概要
`scripts/install.sh` を Git Bash on Windows（PowerShell からの `bash <(curl ...)` 経由起動）でも prerequisite 検出が通るようにする。MSYS bash 配下の `command -v` は `.exe` を auto-append するが `.cmd` / `.bat` は試行しないため、npm-installed shim（Windows 上の `renga` がまさに該当）を取り損ねていた。

POSIX (Linux / macOS) 経路は完全に挙動不変。

## 差分 (3 commit, scripts/install.sh +147/-12)
- b562ea1 make install.sh prerequisite check Git Bash on Windows aware（主修正）
- f3d1938 warn Git Bash users when renga resolved via fallback (codex round 2 Major+Nit対応)
- 965252f gate Windows hint on pre-resolution PATH snapshot (codex round 3 Major対応)

## 主な変更
- **OS 検出** (`IS_WINDOWS_BASH`): OSTYPE と uname -s で MSYS/MINGW/Cygwin を判定
- **`resolve_command` 関数**: 純粋 resolver、3 段ラダー
  - (a) `command -v $cmd`
  - (b) `command -v $cmd.exe / .cmd / .bat`
  - (c) `~/AppData/Roaming/npm`, `~/.cargo/bin`, `~/.local/bin`, `~/scoop/shims`, `~/AppData/Local/Programs/<cmd>` の prefix プローブ（`-f` で execute bit 不要）
- **`require_or_warn`**: resolve 後、Windows 限定で親 dir を PATH に prepend
- **renga 絶対パス起動**: `RENGA_BIN=$(resolve_command renga ...)` で捕獲し `run "${RENGA_BIN:-renga}" mcp install`。bash builtin が `.cmd` を試行しない問題を回避
- **Python `py -3` フォールバック**: `--version` プローブで MS Store App Execution Alias を弾く
- **Windows 限定 hint**: prerequisites 検査前に `RENGA_ON_USER_PATH` をスナップショットし、fallback 解決された renga が user の対話 bash PATH に無い場合のみ `export PATH=...` 案内を出力

## 検証
- `bash -n scripts/install.sh` → syntax OK
- `tests/run-all.sh` → 229/229 passed
- Smoke 3 ケース (HOME 偽装) 期待通り
- Smoke (絶対パス起動): `+ /tmp/install-fake-home/AppData/Roaming/npm/renga.cmd mcp install` 確認
- Codex セルフレビュー 3 ラウンド、round 3 で残存指摘なし

## en 側との整合
suisya-systems/claude-org#148 (parallel en PR) と secretary 中継で 2 往復擦り合わせ、`IS_WINDOWS_BASH` / resolve ladder / `-f` / PATH prepend / Python `py -3` / `RENGA_BIN` 絶対パス起動 全て同一実装で合意。

🤖 Generated with [Claude Code](https://claude.com/claude-code)