### PR TITLE
fix(claude): align dashboard / queries with Set F state semantics (Issue #352)

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -53,7 +53,7 @@ function setConn(ok) {
 function render(data) {
   renderHeader(data);
   renderWorkers(data.workers || []);
-  renderWorkItems(data.workItems || []);
+  renderWorkItems(data.workItems || [], data.reservedItems || []);
   renderActivity(data.activity || []);
   renderProjects(data.projects || []);
   renderKnowledge(data.knowledge || []);
@@ -138,17 +138,44 @@ function elapsedStr(iso) {
 // Work Items
 // ---------------------------------------------------------------------------
 
+// Set F state-semantics-contract §3 phase icons. The four orthogonal
+// phases (reserved / running / review / terminal) each get a distinct
+// glyph so the operator can tell them apart at a glance:
+//   RESERVED    🔒  queued (T1 reservation, no live pane yet — §3.1 \\ §3.3)
+//   IN_PROGRESS 🟢  in_use (live worker — §3.2)
+//   REVIEW      🟡  review (paused for human review — §3.3 / Set B T4)
+//   COMPLETED   ✅  completed (terminal success — §3.4)
+//   BLOCKED     🔴  failed (terminal failure — §3.4)
+//   ABANDONED   ❌  abandoned (terminal — §3.4)
+//   PENDING     ⚪  suspended (reserved-for-future enum slot — §2 / I4)
 const STATUS_ICON = {
-  IN_PROGRESS: "🟢", COMPLETED: "✅", PENDING: "⚪",
-  BLOCKED: "🔴", REVIEW: "🟡", ABANDONED: "❌",
+  RESERVED: "🔒", IN_PROGRESS: "🟢", REVIEW: "🟡",
+  COMPLETED: "✅", BLOCKED: "🔴", ABANDONED: "❌", PENDING: "⚪",
 };
 
-function renderWorkItems(items) {
+function renderWorkItems(items, reserved) {
   const el = document.getElementById("work-items-list");
-  if (!items.length) {
+  reserved = reserved || [];
+  if (!items.length && !reserved.length) {
     el.innerHTML = '<p class="empty-state">No work items</p>'; return;
   }
-  el.innerHTML = [...items].reverse().map((item) => `
+  // Reserved (queued) rows are kept in a distinct group above the active
+  // list. I8 forbids surfacing them inside Active Work Items proper, but
+  // a stuck T1→T2 row is itself an operator anomaly, so we render them
+  // as a labelled "RESERVED" sub-group rather than dropping them silently.
+  const reservedHtml = reserved.length
+    ? `<div class="wi-group-label">RESERVED — queued, awaiting pane spawn</div>`
+      + [...reserved].reverse().map(workItemRow).join("")
+    : "";
+  const activeHtml = items.length
+    ? (reserved.length ? `<div class="wi-group-label">ACTIVE</div>` : "")
+      + [...items].reverse().map(workItemRow).join("")
+    : "";
+  el.innerHTML = reservedHtml + activeHtml;
+}
+
+function workItemRow(item) {
+  return `
     <div class="work-item">
       <span class="wi-icon">${STATUS_ICON[item.status] || "❓"}</span>
       <div class="wi-body">
@@ -159,7 +186,7 @@ function renderWorkItems(items) {
         <div class="wi-meta">${esc(item.progress || item.status)}${item.worker ? ` — ${esc(item.worker)}` : ""}</div>
       </div>
     </div>
-  `).join("");
+  `;
 }
 
 // ---------------------------------------------------------------------------

--- a/dashboard/org_state_converter.py
+++ b/dashboard/org_state_converter.py
@@ -64,28 +64,41 @@ def parse_org_state_db(db_path):
     finally:
         conn.close()
 
-    # Frontend (dashboard/app.js) renders icons keyed off IN_PROGRESS /
-    # REVIEW / PENDING / COMPLETED / BLOCKED / ABANDONED. Map the DB enum
-    # so the JSON renders the same labels the markdown path used to.
+    # Set F state-semantics-contract §3 phase mapping. Kept in sync with
+    # ``dashboard/server.py:_DB_STATUS_TO_UI`` so the /api/state HTTP
+    # surface and the regenerated org-state.json describe the same DB
+    # row with the same UI status. ``queued`` → RESERVED (§3.1 \\ §3.3,
+    # rendered separately from Active Work Items per I8); terminal
+    # entries are defense-in-depth — ``list_active_runs`` excludes them.
     _STATUS_MAP = {
+        "queued": "RESERVED",
         "in_use": "IN_PROGRESS",
         "review": "REVIEW",
-        "queued": "PENDING",
         "completed": "COMPLETED",
         "failed": "BLOCKED",
         "suspended": "PENDING",
         "abandoned": "ABANDONED",
     }
-    work_items = []
-    for r in summary["active_runs"]:
-        raw = (r["status"] or "").lower()
-        work_items.append({
-            "id": r["task_id"],
-            "title": r["title"] or r["task_id"],
-            "status": _STATUS_MAP.get(raw, raw.upper()),
-            "progress": None,
-            "worker": None,
-        })
+
+    def _shape(rows):
+        out = []
+        for r in rows:
+            raw = (r.get("status") or "").lower()
+            out.append({
+                "id": r["task_id"],
+                "title": r.get("title") or r["task_id"],
+                "status": _STATUS_MAP.get(raw, raw.upper()),
+                "progress": None,
+                "worker": None,
+            })
+        return out
+
+    work_items = _shape(summary["active_runs"])
+    # ``reservedItems`` parallels the /api/state payload (Set F §3.1 \\ §3.3).
+    # Surfacing queued separately in the JSON keeps the derived layer
+    # consistent with the HTTP layer; downstream consumers reading the JSON
+    # see the same anomaly group as the live dashboard.
+    reserved_items = _shape(summary.get("reserved_runs", []))
 
     dispatcher = None
     if session.get("dispatcher_pane_id") or session.get("dispatcher_peer_id"):
@@ -109,6 +122,7 @@ def parse_org_state_db(db_path):
         "status": status,
         "currentObjective": session.get("objective"),
         "workItems": work_items,
+        "reservedItems": reserved_items,
         "workerDirectoryRegistry": registry,
         "dispatcher": dispatcher,
         "curator": curator,

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -193,9 +193,26 @@ def _activity_from_db_events(events):
 # (dashboard/app.js) renders icons / labels for. Without this remap an
 # `in_use` run would render as a `?` because the frontend has no entry for
 # IN_USE. Keep this in sync with app.js's STATUS_* tables.
+# Set F state-semantics-contract §3 pins four orthogonal phase predicates
+# over runs.status. The dashboard renders three of them as distinct UI
+# groups so operators can tell reserved / running / review / terminal apart:
+#
+# * Reserved (§3.1 \\ §3.3, queued only) — rendered as ``reservedItems``,
+#   a separate group above Active Work Items. I8 says queued MUST be
+#   invisible to the user-visible projection; surfacing it as a distinct
+#   anomaly group preserves that while making a stuck T1→T2 transition
+#   visible to the operator.
+# * User-visible (§3.3, in_use / review) — Active Work Items.
+# * Terminal (§3.4) — filtered out of ``list_active_runs`` and not
+#   normally rendered. The terminal entries in the map below stay as
+#   defense-in-depth so a leaked terminal row renders with the right
+#   phase icon instead of "?". ``suspended`` is reserved-for-future
+#   per §2 / I4 — no production path writes it today.
+#
+# Keep this in sync with app.js's STATUS_ICON table.
 _DB_STATUS_TO_UI = {
+    "queued": "RESERVED",
     "in_use": "IN_PROGRESS",
-    "queued": "PENDING",
     "review": "REVIEW",
     "completed": "COMPLETED",
     "failed": "BLOCKED",
@@ -204,11 +221,16 @@ _DB_STATUS_TO_UI = {
 }
 
 
-def _work_items_from_db_runs(active_runs):
-    """Render active runs (in_use / review) into the workItems shape."""
+def _work_items_from_db_runs(runs, default_status="in_use"):
+    """Render run rows into the app.js workItems shape.
+
+    Used for both the Set F §3.3 user-visible projection (in_use / review)
+    and the §3.1 \\ §3.3 reserved-only projection (queued); callers pass the
+    appropriate default_status for the rare row whose status field is empty.
+    """
     items = []
-    for r in active_runs:
-        raw = (r.get("status") or "in_use").lower()
+    for r in runs:
+        raw = (r.get("status") or default_status).lower()
         task_id = r.get("task_id")
         title = r.get("title")
         if title == task_id:
@@ -224,11 +246,16 @@ def _work_items_from_db_runs(active_runs):
 
 
 def _load_state_from_db():
-    """Return (status, objective, work_items, activity) from state.db.
+    """Return (status, objective, work_items, reserved_items, activity).
 
     M4 (Issue #267): the DB is required. Callers must check
     ``STATE_DB_PATH.exists()`` first; this function raises on a missing
     file rather than degrading silently.
+
+    ``work_items`` is the Set F §3.3 user-visible projection (in_use /
+    review); ``reserved_items`` is the §3.1 \\ §3.3 reserved-only group
+    (queued). They are returned separately so app.js can keep the I8
+    anomaly surface visually distinct from Active Work Items.
     """
     conn = _db_connect(STATE_DB_PATH)
     try:
@@ -241,6 +268,9 @@ def _load_state_from_db():
         session.get("status"),
         session.get("objective"),
         _work_items_from_db_runs(summary["active_runs"]),
+        _work_items_from_db_runs(
+            summary.get("reserved_runs", []), default_status="queued"
+        ),
         _activity_from_db_events(events),
     )
 
@@ -264,9 +294,16 @@ def build_state():
             "the dashboard."
         )
         work_items: list = []
+        reserved_items: list = []
         activity: list = []
     else:
-        status, objective, work_items, activity = _load_state_from_db()
+        (
+            status,
+            objective,
+            work_items,
+            reserved_items,
+            activity,
+        ) = _load_state_from_db()
         if not status:
             status = "IDLE"
 
@@ -285,6 +322,7 @@ def build_state():
         "objective": objective,
         "projects": projects,
         "workItems": work_items,
+        "reservedItems": reserved_items,
         "workers": workers,
         "activity": activity,
         "knowledge": knowledge,

--- a/dashboard/style.css
+++ b/dashboard/style.css
@@ -376,6 +376,19 @@ main {
   padding: 8px 0;
 }
 
+/* Phase group label (RESERVED / ACTIVE). Set F §3 distinguishes the
+   queued reservation from active work items; the label makes the
+   I8-anomaly group visually distinct without hiding it. */
+.wi-group-label {
+  font-family: var(--mono);
+  font-size: .7rem;
+  letter-spacing: .12em;
+  color: var(--text-dim);
+  padding: 6px var(--panel-pad) 4px;
+  border-bottom: 1px dashed var(--border);
+  text-transform: uppercase;
+}
+
 .work-item {
   display: flex;
   align-items: flex-start;

--- a/tests/test_state_db_fallback.py
+++ b/tests/test_state_db_fallback.py
@@ -22,6 +22,7 @@ from pathlib import Path
 ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(ROOT))
 
+from tools.state_db import connect
 from tools.state_db.importer import import_full_rebuild
 
 
@@ -96,6 +97,55 @@ class TestServerDbRead(unittest.TestCase):
         ids = [w["id"] for w in state["workItems"]]
         self.assertIn("task-1", ids)
 
+    def test_set_f_phase_groups_split_correctly(self):
+        """Set F §3 — queued lands in reservedItems (RESERVED), in_use
+        in workItems (IN_PROGRESS), terminal rows in neither.
+
+        Regression for Issue #352: dashboard /api/state must keep the
+        active-reservation, user-visible, and terminal phases separated
+        so I8 (queued invisible to user-visible projection) and the
+        4-phase UI distinguishability acceptance criterion both hold.
+        """
+        import_full_rebuild(self.db_path, self.root)
+        # Seed one of each phase against the imported project.
+        conn = connect(self.db_path)
+        try:
+            project_row = conn.execute(
+                "SELECT id FROM projects LIMIT 1"
+            ).fetchone()
+            project_id = project_row[0]
+            conn.execute(
+                "INSERT INTO runs (task_id, project_id, pattern, title, status) "
+                "VALUES ('t-queued', ?, 'A', 't-queued', 'queued')",
+                (project_id,),
+            )
+            conn.execute(
+                "INSERT INTO runs (task_id, project_id, pattern, title, status) "
+                "VALUES ('t-running', ?, 'A', 't-running', 'in_use')",
+                (project_id,),
+            )
+            conn.execute(
+                "INSERT INTO runs (task_id, project_id, pattern, title, status) "
+                "VALUES ('t-done', ?, 'A', 't-done', 'completed')",
+                (project_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        state = self.server.build_state()
+        work_ids = {w["id"]: w["status"] for w in state["workItems"]}
+        reserved_ids = {w["id"]: w["status"] for w in state["reservedItems"]}
+        # Reserved bucket only contains queued (§3.1 \\ §3.3).
+        self.assertEqual(reserved_ids.get("t-queued"), "RESERVED")
+        self.assertNotIn("t-queued", work_ids)
+        # Active bucket contains in_use / review only (§3.3).
+        self.assertEqual(work_ids.get("t-running"), "IN_PROGRESS")
+        self.assertNotIn("t-running", reserved_ids)
+        # Terminal rows are filtered out of both surfaces (§3.4).
+        self.assertNotIn("t-done", work_ids)
+        self.assertNotIn("t-done", reserved_ids)
+
 
 class TestConverterDbOnly(unittest.TestCase):
     def setUp(self) -> None:
@@ -131,6 +181,34 @@ class TestConverterDbOnly(unittest.TestCase):
         self.assertEqual(data.get("_source"), "db")
         self.assertEqual(data["status"], "ACTIVE")
         self.assertEqual(data["currentObjective"], "M4 freeze tests")
+
+    def test_json_emits_reserved_items_alongside_work_items(self):
+        """Set F §3 — queued runs surface in org-state.json as
+        reservedItems, parallel to /api/state. Regression for the
+        derived-layer drift Codex flagged on the Issue #352 review:
+        without this, the JSON projection silently dropped queued rows
+        while the HTTP projection rendered them.
+        """
+        import_full_rebuild(self.db_path, self.root)
+        conn = connect(self.db_path)
+        try:
+            pid = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()[0]
+            conn.execute(
+                "INSERT INTO runs (task_id, project_id, pattern, title, status) "
+                "VALUES ('t-q', ?, 'A', 't-q', 'queued')",
+                (pid,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        ok = self.converter.convert(json_path=self.json_path,
+                                     db_path=self.db_path)
+        self.assertTrue(ok)
+        data = self._read_json()
+        reserved = {w["id"]: w["status"] for w in data.get("reservedItems", [])}
+        work = {w["id"] for w in data.get("workItems", [])}
+        self.assertEqual(reserved.get("t-q"), "RESERVED")
+        self.assertNotIn("t-q", work)
 
 
 if __name__ == "__main__":

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -10,6 +10,23 @@ the M1 markdown overlay is gone, ``org_sessions`` carries Status / Updated /
 Suspended / Resumed / Current Objective / Dispatcher / Curator /
 Resume Instructions, and ``.state/org-state.md`` is regenerated from this
 DB by :mod:`tools.state_db.snapshotter`.
+
+State semantics (Set F — ``docs/contracts/state-semantics-contract.md``):
+the contract pins four orthogonal predicates over ``runs.status`` (§3.5).
+This module exposes those predicates as the named tuples below so resolver,
+snapshotter, and dashboard share one definition. The ``queued`` ⊂
+active-reservation but ⊄ user-visible asymmetry (§3 final paragraph, I8) is
+the central correctness fact:
+
+* ``ACTIVE_RESERVATION_STATUSES`` — the resolver's pattern-selection set
+  (§3.1). A queued reservation already occupies the project's base-clone
+  slot, so a concurrent delegation MUST switch to Pattern B.
+* ``USER_VISIBLE_STATUSES`` — the dashboard / org-state.md Active Work Items
+  set (§3.3). ``queued`` is intentionally excluded so a sub-second
+  reservation does not flicker into the operator UI; lingering queued is an
+  anomaly the dispatcher should surface, not a normal Active Work Item (I8).
+* ``TERMINAL_STATUSES`` — runs that cannot transition further without
+  operator override (§3.4).
 """
 from __future__ import annotations
 
@@ -17,7 +34,17 @@ import sqlite3
 from typing import Any, Optional
 
 
-_ACTIVE_STATUSES: tuple[str, ...] = ("in_use", "review")
+# Set F §3.5 predicate table. Names match the contract's concept labels so
+# `git grep` from the contract lands on the implementation.
+ACTIVE_RESERVATION_STATUSES: tuple[str, ...] = ("queued", "in_use", "review")
+USER_VISIBLE_STATUSES: tuple[str, ...] = ("in_use", "review")
+ACTIVE_EXECUTION_STATUSES: tuple[str, ...] = ("in_use",)
+TERMINAL_STATUSES: tuple[str, ...] = ("completed", "failed", "abandoned")
+
+# Backwards-compatible alias retained for in-tree callers that still import
+# the pre-Set-F name. Points at the user-visible projection (the prior
+# meaning) rather than the broader active-reservation set.
+_ACTIVE_STATUSES: tuple[str, ...] = USER_VISIBLE_STATUSES
 
 
 def _row_to_dict(row: sqlite3.Row | None) -> Optional[dict[str, Any]]:
@@ -36,7 +63,19 @@ def _rows_to_dicts(rows) -> list[dict[str, Any]]:
 
 
 def list_active_runs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
-    """Return runs whose status is in_use or review (Worker Directory Registry)."""
+    """Return runs in the user-visible projection (Set F §3.3).
+
+    Predicate: ``runs.status IN ('in_use', 'review')`` —
+    ``USER_VISIBLE_STATUSES``. ``queued`` is intentionally excluded per
+    contract §3.3 / I8: a fresh T1 reservation has not yet produced a pane,
+    and surfacing it in Active Work Items would flicker the operator UI for
+    sub-second reservations. Use :func:`list_reserved_runs` to see queued
+    rows separately, or :func:`list_active_reservation_runs` to get the
+    union (the resolver's pattern-selection set §3.1).
+
+    Used by the dashboard's Active Work Items list and the snapshotter's
+    ``## Active Work Items`` rendering.
+    """
     rows = conn.execute(
         """
         SELECT
@@ -66,6 +105,41 @@ def list_active_runs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
         LEFT JOIN workstreams w     ON w.id = r.workstream_id
         LEFT JOIN worker_dirs d     ON d.id = r.worker_dir_id
         WHERE r.status IN ('in_use', 'review')
+        ORDER BY r.dispatched_at DESC, r.id DESC
+        """
+    ).fetchall()
+    return _rows_to_dicts(rows)
+
+
+def list_reserved_runs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Return runs in the active-reservation-only projection (Set F §3.1 \\ §3.3).
+
+    Predicate: ``runs.status = 'queued'``. These rows occupy a project's
+    base-clone slot (so the resolver must consider them for Pattern B
+    selection — §3.1) but are not yet user-visible in Active Work Items
+    (§3.3). The dashboard surfaces them as a separate "reserved" group so
+    operators can spot a stuck T1→T2 transition (I8): a row that lingers
+    here for more than a few seconds is itself a signal of a failed
+    ``spawn_claude_pane`` step that never flipped the row to ``in_use``.
+    """
+    rows = conn.execute(
+        """
+        SELECT
+            r.id            AS run_id,
+            r.task_id       AS task_id,
+            r.title         AS title,
+            r.pattern       AS pattern,
+            r.status        AS status,
+            r.branch        AS branch,
+            r.dispatched_at AS dispatched_at,
+            p.slug          AS project_slug,
+            p.display_name  AS project_name,
+            d.abs_path      AS worker_dir,
+            d.lifecycle     AS worker_dir_lifecycle
+        FROM runs r
+        JOIN projects p         ON p.id = r.project_id
+        LEFT JOIN worker_dirs d ON d.id = r.worker_dir_id
+        WHERE r.status = 'queued'
         ORDER BY r.dispatched_at DESC, r.id DESC
         """
     ).fetchall()
@@ -221,7 +295,8 @@ def get_org_state_summary(conn: sqlite3.Connection) -> dict[str, Any]:
     Shape:
         {
           "session": {... org_sessions row ...} | None,
-          "active_runs": [...],            # in_use / review
+          "active_runs": [...],            # Set F §3.3 user-visible (in_use / review)
+          "reserved_runs": [...],          # Set F §3.1 \\ §3.3 (queued only)
           "active_worker_dirs": [...],     # lifecycle='active'
           "recent_events": [...],          # 20 newest
           "run_status_counts": {status: count},
@@ -239,6 +314,7 @@ def get_org_state_summary(conn: sqlite3.Connection) -> dict[str, Any]:
     return {
         "session": get_session(conn),
         "active_runs": list_active_runs(conn),
+        "reserved_runs": list_reserved_runs(conn),
         "active_worker_dirs": list_worker_dirs(conn, lifecycle="active"),
         "recent_events": list_recent_events(conn, limit=20),
         "run_status_counts": _run_status_counts(conn),
@@ -282,7 +358,12 @@ def get_resume_briefing(conn: sqlite3.Connection) -> dict[str, Any]:
 
 
 __all__ = [
+    "ACTIVE_RESERVATION_STATUSES",
+    "USER_VISIBLE_STATUSES",
+    "ACTIVE_EXECUTION_STATUSES",
+    "TERMINAL_STATUSES",
     "list_active_runs",
+    "list_reserved_runs",
     "list_runs_with_dirs",
     "get_run_by_task_id",
     "list_worker_dirs",

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -70,8 +70,10 @@ def list_active_runs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     contract §3.3 / I8: a fresh T1 reservation has not yet produced a pane,
     and surfacing it in Active Work Items would flicker the operator UI for
     sub-second reservations. Use :func:`list_reserved_runs` to see queued
-    rows separately, or :func:`list_active_reservation_runs` to get the
-    union (the resolver's pattern-selection set §3.1).
+    rows separately; the resolver's pattern-selection set (§3.1, the
+    union of queued + in_use + review) is exposed as the
+    ``ACTIVE_RESERVATION_STATUSES`` constant for callers that need to
+    build their own predicate.
 
     Used by the dashboard's Active Work Items list and the snapshotter's
     ``## Active Work Items`` rendering.

--- a/tools/state_db/snapshotter.py
+++ b/tools/state_db/snapshotter.py
@@ -27,6 +27,8 @@ import tempfile
 from pathlib import Path
 from typing import Iterable
 
+from .queries import USER_VISIBLE_STATUSES
+
 
 # ---------------------------------------------------------------------------
 # Heading taxonomy
@@ -177,15 +179,21 @@ _DB_STATUS_TO_MD_LABEL = {
 def _render_active_work_items(runs: Iterable[dict]) -> str:
     """Render ``## Active Work Items`` from the runs table.
 
-    M4 (Issue #267): "active" = run.status in (in_use, review). The
-    legacy passthrough that surfaced operator-curated COMPLETED /
-    ABANDONED bullets is gone; those entries should live in
-    ``notes/sessions/`` (extracted by
+    Predicate: ``USER_VISIBLE_STATUSES`` (Set F §3.3 — ``in_use`` / ``review``).
+    ``queued`` is excluded per I8: a fresh T1 reservation has not yet
+    spawned a pane, and surfacing it here would conflate "secretary
+    reserved a slot" with "org has an in-flight delegation". The
+    operator anomaly surface for stuck queued rows is the dashboard /
+    dispatcher notification, not this markdown projection.
+
+    M4 (Issue #267): the legacy passthrough that surfaced
+    operator-curated COMPLETED / ABANDONED bullets is gone; those
+    entries should live in ``notes/sessions/`` (extracted by
     :mod:`tools.state_db.extract_freetext`) or be reflected by an
     actual run row whose ``status`` columns model the lifecycle.
     """
     active = [r for r in runs
-              if (r.get("status") or "") in ("in_use", "review")]
+              if (r.get("status") or "") in USER_VISIBLE_STATUSES]
     if not active:
         return ""
     out = io.StringIO()

--- a/tools/state_db/test_queries.py
+++ b/tools/state_db/test_queries.py
@@ -19,11 +19,15 @@ from pathlib import Path
 from tools.state_db import apply_schema, connect
 from tools.state_db.importer import import_full_rebuild
 from tools.state_db.queries import (
+    ACTIVE_RESERVATION_STATUSES,
+    TERMINAL_STATUSES,
+    USER_VISIBLE_STATUSES,
     get_org_state_summary,
     get_resume_briefing,
     get_run_by_task_id,
     list_active_runs,
     list_recent_events,
+    list_reserved_runs,
     list_worker_dirs,
 )
 from tools.state_db.test_importer import _seed_claude_org_root
@@ -49,6 +53,9 @@ class TestEmptyDB(unittest.TestCase):
     def test_list_active_runs_empty(self):
         self.assertEqual(list_active_runs(self.conn), [])
 
+    def test_list_reserved_runs_empty(self):
+        self.assertEqual(list_reserved_runs(self.conn), [])
+
     def test_list_worker_dirs_empty(self):
         self.assertEqual(list_worker_dirs(self.conn), [])
         self.assertEqual(list_worker_dirs(self.conn, lifecycle="active"), [])
@@ -62,6 +69,7 @@ class TestEmptyDB(unittest.TestCase):
     def test_get_org_state_summary_empty(self):
         s = get_org_state_summary(self.conn)
         self.assertEqual(s["active_runs"], [])
+        self.assertEqual(s["reserved_runs"], [])
         self.assertEqual(s["active_worker_dirs"], [])
         self.assertEqual(s["recent_events"], [])
         self.assertEqual(s["run_status_counts"], {})
@@ -212,6 +220,37 @@ class TestEdgeCases(unittest.TestCase):
         # Payload survives as raw JSON text (caller decodes).
         self.assertEqual(json.loads(b["last_suspend_payload"])["reason"],
                          "end of day")
+
+    def test_status_set_constants_match_contract(self):
+        # Set F §3.5 — pin the four predicates so a future edit cannot
+        # silently drift the resolver / dashboard / snapshotter contract.
+        self.assertEqual(
+            ACTIVE_RESERVATION_STATUSES, ("queued", "in_use", "review")
+        )
+        self.assertEqual(USER_VISIBLE_STATUSES, ("in_use", "review"))
+        self.assertEqual(
+            TERMINAL_STATUSES, ("completed", "failed", "abandoned")
+        )
+
+    def test_reserved_runs_returns_only_queued(self):
+        # Seed one queued + one in_use + one completed and verify the
+        # reserved query returns only the queued row (Set F §3.1 \\ §3.3).
+        self.conn.execute(
+            "INSERT INTO runs (task_id, project_id, pattern, title, status) "
+            "VALUES ('t-queued', 1, 'A', 't-queued', 'queued')"
+        )
+        self.conn.execute(
+            "INSERT INTO runs (task_id, project_id, pattern, title, status) "
+            "VALUES ('t-done', 1, 'A', 't-done', 'completed')"
+        )
+        self.conn.commit()
+        reserved = list_reserved_runs(self.conn)
+        self.assertEqual([r["task_id"] for r in reserved], ["t-queued"])
+        self.assertEqual(reserved[0]["status"], "queued")
+        # And the user-visible projection (in_use / review only) excludes it.
+        active_ids = {r["task_id"] for r in list_active_runs(self.conn)}
+        self.assertNotIn("t-queued", active_ids)
+        self.assertIn("t-null-ws", active_ids)  # the in_use seed row
 
     def test_recent_events_negative_limit_is_safe(self):
         # Defensive: a caller passing limit=-1 should not blow up.


### PR DESCRIPTION
## Summary
- Align the query layer, snapshotter, dashboard backend, JSON converter, and frontend with the canonical state semantics from Set F (`docs/contracts/state-semantics-contract.md`, #351 / PR #359).
- Make the asymmetry the contract calls out — `queued` ⊂ active-reservation but ⊄ user-visible — explicit in the four layers operators consult.
- `tools/state_db/queries.py`: introduce `ACTIVE_RESERVATION_STATUSES` / `USER_VISIBLE_STATUSES` / `TERMINAL_STATUSES` constants and a `list_reserved_runs` API.
- `tools/state_db/snapshotter.py`: render Active Work Items off the same shared constants.
- `dashboard/server.py` and `dashboard/org_state_converter.py`: emit a separate `reservedItems` payload mapping `queued` runs to a RESERVED phase, so the HTTP and JSON-derived paths agree.
- `dashboard/app.js` + `style.css`: surface RESERVED 🔒 with a "RESERVED / ACTIVE" group label so operators can distinguish reserved-but-not-yet-running from running.

## I8 interpretation
Codex round-1 raised a Blocker reading I8 ("not dashboard rendering") as forbidding `reservedItems` itself. After advisor reconcile we kept the implementation. Our reading: I8 scopes the anomaly-detection mechanism, not the UI rendering of the contract's own queued/in_use/review/terminal vocabulary. Issue #352's acceptance criteria explicitly require that "a queued run is handled intentionally, not accidentally omitted" and that operators can distinguish reserved / running / review / terminal — both are satisfied by the RESERVED phase. Flagged for reviewer judgment.

## Test plan
- [x] `python -m unittest discover -s tests` → 166 passed
- [x] `python -m unittest discover -s tools/state_db` → 129 passed
- [x] Smoke check via `build_state()` confirmed `queued → RESERVED` mapping and presence of `reservedItems` payload.
- [x] Codex self-review round 2 clean (no new Blocker / Major).

## README impact
None. README only mentions the dashboard at a single high level and does not enumerate phases or work items.

Closes #352
Refs #351 #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)