### PR TITLE
fix(claude): make check_role_configs.py bilingual (ja/en role headings) (#340)

### DIFF
--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -245,6 +245,39 @@ class ExtractRoleBlocksTests(unittest.TestCase):
         blocks = crc.extract_role_blocks(md, MINIMAL_SCHEMA["roles"])
         self.assertEqual(blocks["secretary"]["permissions"]["allow"], ["sec"])
 
+    def test_bilingual_all_alias_table_entries_match(self):
+        # Issue #340 codex round 2: every en alias declared in
+        # ``_JA_TO_EN_ROLE_HEADING_ALIASES`` must be exercised so a
+        # future typo or translation update is caught here. Build a
+        # synthetic schema that covers all five canonical roles.
+        schema = {
+            name: {"docs_section": ja}
+            for name, ja in {
+                "user_common": "ユーザー共通",
+                "secretary": "窓口",
+                "dispatcher": "ディスパッチャー",
+                "curator": "キュレーター",
+                "worker": "ワーカー",
+            }.items()
+        }
+        for ja, aliases in crc._JA_TO_EN_ROLE_HEADING_ALIASES.items():
+            for alias in aliases:
+                md = (
+                    f"## {alias} (`...`)\n\n"
+                    f'```json\n{{"permissions": {{"allow": ["{alias}"]}}}}\n```\n'
+                )
+                blocks = crc.extract_role_blocks(md, schema)
+                # Find which role uses this ja heading and assert the
+                # alias projects to it.
+                role_for_ja = next(
+                    role for role, defn in schema.items()
+                    if defn["docs_section"] == ja
+                )
+                self.assertEqual(
+                    blocks[role_for_ja]["permissions"]["allow"], [alias],
+                    msg=f"alias {alias!r} (for ja {ja!r}) failed to project",
+                )
+
     def test_bilingual_alias_rejects_longer_word(self):
         # ``Lead`` must not match ``Leadership``.
         md = (

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -220,6 +220,40 @@ class ExtractRoleBlocksTests(unittest.TestCase):
         self.assertEqual(blocks["secretary"]["permissions"]["allow"], ["a"])
         self.assertEqual(blocks["worker"]["permissions"]["allow"], ["b"])
 
+    def test_bilingual_secretary_alias_accepted(self):
+        # Issue #340 codex review: the codebase calls the 窓口 role
+        # "Secretary" in schema descriptions; that variant must work
+        # alongside the org-skill-aligned "Lead".
+        md = (
+            "## Secretary (`<repo>/.claude/settings.local.json`)\n\n"
+            "```json\n{\"permissions\": {\"allow\": [\"sec\"]}}\n```\n"
+        )
+        blocks = crc.extract_role_blocks(md, MINIMAL_SCHEMA["roles"])
+        self.assertEqual(blocks["secretary"]["permissions"]["allow"], ["sec"])
+
+    def test_bilingual_alias_does_not_substring_match(self):
+        # Issue #340 codex review: a heading that merely *contains* an
+        # alias as a substring (e.g. parenthetical) must not be
+        # picked up. ``## Dispatcher (Lead-owned)`` had silently been
+        # mis-projected as ``secretary`` under the substring matcher.
+        md = (
+            "## Dispatcher (Lead-owned)\n\n"
+            "```json\n{\"permissions\": {\"allow\": [\"disp\"]}}\n```\n\n"
+            "## Lead\n\n"
+            "```json\n{\"permissions\": {\"allow\": [\"sec\"]}}\n```\n"
+        )
+        blocks = crc.extract_role_blocks(md, MINIMAL_SCHEMA["roles"])
+        self.assertEqual(blocks["secretary"]["permissions"]["allow"], ["sec"])
+
+    def test_bilingual_alias_rejects_longer_word(self):
+        # ``Lead`` must not match ``Leadership``.
+        md = (
+            "## Leadership notes\n\n"
+            "```json\n{\"permissions\": {\"allow\": [\"x\"]}}\n```\n"
+        )
+        blocks = crc.extract_role_blocks(md, MINIMAL_SCHEMA["roles"])
+        self.assertIsNone(blocks["secretary"])
+
     def test_invalid_json_surfaces_parse_error(self):
         md = "## 窓口\n\n```json\n{not json}\n```\n"
         blocks = crc.extract_role_blocks(md, MINIMAL_SCHEMA["roles"])

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -197,6 +197,29 @@ class ExtractRoleBlocksTests(unittest.TestCase):
         blocks = crc.extract_role_blocks(md, MINIMAL_SCHEMA["roles"])
         self.assertIsNone(blocks["worker"])
 
+    def test_bilingual_en_headings_match(self):
+        # Issue #340: an en mirror permissions.md uses English headings.
+        md = (
+            "# heading\n\n"
+            "## Lead (`<repo>/.claude/settings.local.json`)\n\n"
+            "```json\n{\"permissions\": {\"allow\": [\"a\"]}}\n```\n\n"
+            "## Worker (dynamically generated)\n\n"
+            "```json\n{\"permissions\": {\"allow\": [\"b\"]}}\n```\n"
+        )
+        blocks = crc.extract_role_blocks(md, MINIMAL_SCHEMA["roles"])
+        self.assertEqual(blocks["secretary"]["permissions"]["allow"], ["a"])
+        self.assertEqual(blocks["worker"]["permissions"]["allow"], ["b"])
+
+    def test_bilingual_mixed_ja_and_en_headings(self):
+        # A repo mid-translation may have a mix of ja and en headings.
+        md = (
+            "## 窓口\n\n```json\n{\"permissions\": {\"allow\": [\"a\"]}}\n```\n\n"
+            "## Worker\n\n```json\n{\"permissions\": {\"allow\": [\"b\"]}}\n```\n"
+        )
+        blocks = crc.extract_role_blocks(md, MINIMAL_SCHEMA["roles"])
+        self.assertEqual(blocks["secretary"]["permissions"]["allow"], ["a"])
+        self.assertEqual(blocks["worker"]["permissions"]["allow"], ["b"])
+
     def test_invalid_json_surfaces_parse_error(self):
         md = "## 窓口\n\n```json\n{not json}\n```\n"
         blocks = crc.extract_role_blocks(md, MINIMAL_SCHEMA["roles"])

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -14,20 +14,24 @@ module is a thin CLI shim that:
   ``check_worker_settings``) so existing callers — including the test
   suite under ``tests/test_check_role_configs.py`` — keep using
   ``check_role_configs`` as the import surface unchanged.
-* Overrides ``extract_role_blocks`` with a bilingual wrapper that
-  accepts either the canonical ja heading from
-  ``org_extension_schema.json`` (``docs_section``) or its English
-  counterpart (Issue #340, Option A — "make the parser bilingual").
-  The ja repo's ``permissions.md`` ships ja headings; the en mirror
-  translates them to English. Mapping each ja heading to the canonical
-  role key and accepting the en alias as an additional substring
-  marker lets the same parser project roles out of either localisation
-  without forcing the en mirror to keep ja anchors. Options (B) and
-  (C) from Issue #340 were considered: (B) requires every translation
-  to preserve hidden ja anchors (brittle); (C) — schema-driven
-  ``permissions.md`` — is the long-term clean path but a much bigger
-  refactor. (A) is the least-invasive fix that unblocks
-  ``test_docs_projection_is_consistent`` on both localisations.
+* Overrides ``extract_role_blocks`` with a bilingual replacement
+  that accepts either the canonical ja heading from
+  ``org_extension_schema.json`` (``docs_section``) or one of its
+  English aliases (Issue #340, Option A — "make the parser
+  bilingual"). The ja repo's ``permissions.md`` ships ja headings;
+  the en mirror translates them to English. Mapping each ja heading
+  to the canonical role key and accepting en aliases as alternate
+  section markers lets the same parser project roles out of either
+  localisation without forcing the en mirror to keep ja anchors.
+  Matching is anchored at the start of the heading and word-bounded
+  so short aliases (``Lead``, ``Worker``) do not get picked up by
+  unrelated sub-headings such as ``## Dispatcher (Lead-owned)``.
+  Options (B) and (C) from Issue #340 were considered: (B) requires
+  every translation to preserve hidden ja anchors (brittle); (C) —
+  schema-driven ``permissions.md`` — is the long-term clean path but
+  a much bigger refactor. (A) is the least-invasive fix that
+  unblocks ``test_docs_projection_is_consistent`` on both
+  localisations.
 * Keeps the ja-specific behaviour (``check_docs``, ``check_on_disk``,
   ``run``, the CLI argparser, exit-code contract) here, since those
   read from the ja repo layout (permissions.md docs projection, the
@@ -58,28 +62,52 @@ from core_harness.validator import (
 
 # Issue #340: ja → en heading aliases. Keys are the ja heading strings
 # that org_extension_schema.json declares as ``docs_section``; values
-# are the English heading substrings that the en mirror's
-# permissions.md uses for the same role. ``extract_role_blocks`` below
-# treats either as a valid section marker so the same parser projects
-# roles out of either localisation.
-_JA_TO_EN_ROLE_HEADING_ALIASES: dict[str, str] = {
-    "ユーザー共通": "User-wide",
-    "窓口": "Lead",
-    "ディスパッチャー": "Dispatcher",
-    "キュレーター": "Curator",
-    "ワーカー": "Worker",
+# are the lists of English heading prefixes the en mirror's
+# permissions.md may use for the same role. Multiple aliases are
+# allowed because the surrounding codebase mixes ``Lead`` (the
+# org-skill name) and ``Secretary`` (the schema description) for the
+# 窓口 role; either is acceptable as an English heading.
+_JA_TO_EN_ROLE_HEADING_ALIASES: dict[str, tuple[str, ...]] = {
+    "ユーザー共通": ("User-wide", "User Common", "User common"),
+    "窓口": ("Lead", "Secretary"),
+    "ディスパッチャー": ("Dispatcher",),
+    "キュレーター": ("Curator",),
+    "ワーカー": ("Worker",),
 }
+
+
+def _heading_matches(heading: str, marker: str) -> bool:
+    """Return True iff ``heading`` opens with ``marker`` as a whole word.
+
+    The heading argument is the line *after* the ``## `` prefix has
+    been stripped. We require the marker to appear at position 0 and
+    to be followed either by end-of-line or by a non-word character
+    (whitespace, ``(``, ``（``, ``:``, ``：`` …). Substring matching
+    inside the line is *not* enough — Issue #340 review showed that a
+    short alias like ``Lead`` would otherwise be picked up by an
+    unrelated heading such as ``## Dispatcher (Lead-owned)``.
+    """
+    if not heading.startswith(marker):
+        return False
+    rest = heading[len(marker) :]
+    if rest == "":
+        return True
+    nxt = rest[0]
+    return not (nxt.isalnum() or nxt == "_")
 
 
 def extract_role_blocks(md_text: str, roles: dict) -> dict:
     """Extract the first ```json code block under each role's docs heading.
 
-    Bilingual wrapper around ``core_harness.validator.extract_role_blocks``:
-    a section matches if its ``## ``-prefixed heading line contains
-    either the canonical ja ``docs_section`` declared in the schema or
-    its English alias from ``_JA_TO_EN_ROLE_HEADING_ALIASES`` (Issue
+    Bilingual replacement for
+    ``core_harness.validator.extract_role_blocks``: a section matches
+    if its ``## ``-prefixed heading line *opens with* either the
+    canonical ja ``docs_section`` declared in the schema or one of the
+    English aliases from ``_JA_TO_EN_ROLE_HEADING_ALIASES`` (Issue
     #340, Option A). Roles whose ``docs_section`` is null/missing are
-    skipped, mirroring the upstream contract.
+    skipped, mirroring the upstream contract. Word-boundary anchoring
+    (see ``_heading_matches``) prevents short en aliases like ``Lead``
+    from being picked up by unrelated sub-headings.
     """
     results: dict = {}
     sections = re.split(r"(?m)^## ", md_text)
@@ -87,14 +115,11 @@ def extract_role_blocks(md_text: str, roles: dict) -> dict:
         marker = role_def.get("docs_section")
         if not marker:
             continue
-        markers = [marker]
-        en_alias = _JA_TO_EN_ROLE_HEADING_ALIASES.get(marker)
-        if en_alias:
-            markers.append(en_alias)
+        markers = [marker, *_JA_TO_EN_ROLE_HEADING_ALIASES.get(marker, ())]
         block = None
         for section in sections[1:]:
             heading = section.splitlines()[0]
-            if any(m in heading for m in markers):
+            if any(_heading_matches(heading, m) for m in markers):
                 m = re.search(r"```json\n(.*?)\n```", section, re.DOTALL)
                 if m:
                     try:

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -11,10 +11,23 @@ module is a thin CLI shim that:
   ``core_harness.schema.load_framework_schema()``.
 * Re-exports the public engine symbols (``Finding``,
   ``validate_config``, ``validate_schema_integrity``,
-  ``extract_role_blocks``, ``check_worker_settings``) so existing
-  callers — including the test suite under
-  ``tests/test_check_role_configs.py`` — keep using
+  ``check_worker_settings``) so existing callers — including the test
+  suite under ``tests/test_check_role_configs.py`` — keep using
   ``check_role_configs`` as the import surface unchanged.
+* Overrides ``extract_role_blocks`` with a bilingual wrapper that
+  accepts either the canonical ja heading from
+  ``org_extension_schema.json`` (``docs_section``) or its English
+  counterpart (Issue #340, Option A — "make the parser bilingual").
+  The ja repo's ``permissions.md`` ships ja headings; the en mirror
+  translates them to English. Mapping each ja heading to the canonical
+  role key and accepting the en alias as an additional substring
+  marker lets the same parser project roles out of either localisation
+  without forcing the en mirror to keep ja anchors. Options (B) and
+  (C) from Issue #340 were considered: (B) requires every translation
+  to preserve hidden ja anchors (brittle); (C) — schema-driven
+  ``permissions.md`` — is the long-term clean path but a much bigger
+  refactor. (A) is the least-invasive fix that unblocks
+  ``test_docs_projection_is_consistent`` on both localisations.
 * Keeps the ja-specific behaviour (``check_docs``, ``check_on_disk``,
   ``run``, the CLI argparser, exit-code contract) here, since those
   read from the ja repo layout (permissions.md docs projection, the
@@ -29,6 +42,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -37,10 +51,59 @@ from core_harness.schema import load_framework_schema, merge_schemas
 from core_harness.validator import (
     Finding,
     check_worker_settings,
-    extract_role_blocks,
     validate_config,
     validate_schema_integrity,
 )
+
+
+# Issue #340: ja → en heading aliases. Keys are the ja heading strings
+# that org_extension_schema.json declares as ``docs_section``; values
+# are the English heading substrings that the en mirror's
+# permissions.md uses for the same role. ``extract_role_blocks`` below
+# treats either as a valid section marker so the same parser projects
+# roles out of either localisation.
+_JA_TO_EN_ROLE_HEADING_ALIASES: dict[str, str] = {
+    "ユーザー共通": "User-wide",
+    "窓口": "Lead",
+    "ディスパッチャー": "Dispatcher",
+    "キュレーター": "Curator",
+    "ワーカー": "Worker",
+}
+
+
+def extract_role_blocks(md_text: str, roles: dict) -> dict:
+    """Extract the first ```json code block under each role's docs heading.
+
+    Bilingual wrapper around ``core_harness.validator.extract_role_blocks``:
+    a section matches if its ``## ``-prefixed heading line contains
+    either the canonical ja ``docs_section`` declared in the schema or
+    its English alias from ``_JA_TO_EN_ROLE_HEADING_ALIASES`` (Issue
+    #340, Option A). Roles whose ``docs_section`` is null/missing are
+    skipped, mirroring the upstream contract.
+    """
+    results: dict = {}
+    sections = re.split(r"(?m)^## ", md_text)
+    for role_name, role_def in roles.items():
+        marker = role_def.get("docs_section")
+        if not marker:
+            continue
+        markers = [marker]
+        en_alias = _JA_TO_EN_ROLE_HEADING_ALIASES.get(marker)
+        if en_alias:
+            markers.append(en_alias)
+        block = None
+        for section in sections[1:]:
+            heading = section.splitlines()[0]
+            if any(m in heading for m in markers):
+                m = re.search(r"```json\n(.*?)\n```", section, re.DOTALL)
+                if m:
+                    try:
+                        block = json.loads(m.group(1))
+                    except json.JSONDecodeError as exc:
+                        block = {"__parse_error__": str(exc)}
+                break
+        results[role_name] = block
+    return results
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary
- PR #139 follow-up. `tools/check_role_configs.py` previously parsed `permissions.md` using ja-only role headings (`## 窓口` etc.), so on the en mirror — where the file is translated — the parser found no blocks and `tests/test_check_role_configs.py::RealRepoSmokeTests::test_docs_projection_is_consistent` had to be skipped (Issue #340 Option A).
- Add `_JA_TO_EN_ROLE_HEADING_ALIASES` covering 窓口 → Lead/Secretary, ユーザー共通 → User-wide / User Common, ディスパッチャー → Dispatcher, キュレーター → Curator, ワーカー → Worker.
- Reimplement `extract_role_blocks` with leading-word matching to avoid substring false-positives.
- Document the bilingual policy in the module docstring.

## Test plan
- [x] `python -m pytest tests/test_check_role_configs.py` → 39 passed
- [x] `python tools/check_role_configs.py --docs-only` → role_configs: OK
- [x] Smoke check by ja→en swapping the real `permissions.md`: `findings: []` (no false drift)
- [x] Codex self-review 3 rounds; round 1 Major×2 (missing Secretary alias / substring false-match) → fixed; round 2 Minor (full alias coverage in tests) → added; round 3 clean. One Nit (en-side fixture smoke) is left for a follow-up issue.

## README impact
None. README does not reference `check_role_configs.py`. `permissions.md` itself stays ja-canonical; the en mirror just stops breaking when translated.

Closes #340
Refs #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)