### PR TITLE
test(claude): convert test_real_registry_fixture to fixture-based parse (#339)

### DIFF
--- a/tests/fixtures/registry/projects.md
+++ b/tests/fixtures/registry/projects.md
@@ -1,0 +1,15 @@
+# Projects Registry (Fixture)
+
+`tests/test_registry_parser.test_real_registry_fixture` 用の固定 fixture。
+本物の `registry/projects.md` は ja / en / fork で divergence-allowed なので
+（[`docs/sync-policy.md`](../../../docs/sync-policy.md) 参照）、
+parser のスナップショットテストはこの固定ファイルに対して行う。
+
+claude-org-ja 自身（self-edit）は live registry 同様このフィクスチャにも載せない。
+`tools/resolve_worker_layout.py:is_claude_org_project()` が live repo の git origin
+URL を見て判定する責務を負う。
+
+| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |
+|---|---|---|---|---|
+| 時計アプリ | clock-app | - | Webブラウザで動くデジタル時計 | デザイン変更、機能追加 |
+| renga | renga | https://github.com/suisya-systems/renga | Rust 製の Claude Code 用ターミナルマルチプレクサ（TUI） | 機能追加、バグ修正、Issue 対応 |

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -55,8 +55,11 @@ class TestParseProjects(unittest.TestCase):
         path = PROJECT_ROOT / "registry" / "projects.md"
         if not path.exists():  # pragma: no cover - safety for fork checkouts
             self.skipTest("live registry/projects.md not present")
+        # parse_projects must not raise. An empty registry is valid (e.g.
+        # fresh checkout / fork that has not registered any project yet —
+        # see test_parsers.py for the build_state() side); we only check
+        # well-formedness of any rows that are present.
         projects = parse_projects(path)
-        self.assertGreater(len(projects), 0)
         for p in projects:
             self.assertIsInstance(p, Project)
             self.assertTrue(p.nickname)

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -68,14 +68,19 @@ class TestParseProjects(unittest.TestCase):
             self.assertIsInstance(p, Project)
             self.assertTrue(p.nickname)
             self.assertTrue(p.name)
-        has_data_lines = any(
-            r.kind == "data" or r.kind == "mismatch" for r in iter_rows(text)
+        # Detect "looks like a markdown table" by counting pipe-prefixed
+        # lines, not by iter_rows() kinds: when the separator row is missing
+        # iter_rows classifies every `| ... |` line (header AND would-be
+        # data rows) as "header", so a kind-based check would silently miss
+        # exactly the corruption mode we want to catch.
+        pipe_lines = sum(
+            1 for ln in text.splitlines() if ln.lstrip().startswith("|")
         )
-        if has_data_lines:
+        if pipe_lines >= 2:
             self.assertGreater(
                 len(projects), 0,
-                "live registry has table rows but none parsed — likely "
-                "separator/header corruption",
+                "live registry has pipe-table lines but none parsed — "
+                "likely separator/header corruption",
             )
 
     def test_happy_path(self):

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -55,15 +55,28 @@ class TestParseProjects(unittest.TestCase):
         path = PROJECT_ROOT / "registry" / "projects.md"
         if not path.exists():  # pragma: no cover - safety for fork checkouts
             self.skipTest("live registry/projects.md not present")
-        # parse_projects must not raise. An empty registry is valid (e.g.
-        # fresh checkout / fork that has not registered any project yet —
-        # see test_parsers.py for the build_state() side); we only check
-        # well-formedness of any rows that are present.
-        projects = parse_projects(path)
+        # parse_projects must not raise and must not emit malformed-row
+        # warnings against the live file. An empty registry is valid (fresh
+        # checkout / fork) — but if the file *contains* table data rows, at
+        # least one must parse cleanly, otherwise the registry is silently
+        # corrupt (e.g. separator dropped → every row classified as
+        # non_table and parser returns []).
+        text = path.read_text(encoding="utf-8")
+        with self.assertNoLogs("tools.registry_parser", level="WARNING"):
+            projects = parse_projects(path)
         for p in projects:
             self.assertIsInstance(p, Project)
             self.assertTrue(p.nickname)
             self.assertTrue(p.name)
+        has_data_lines = any(
+            r.kind == "data" or r.kind == "mismatch" for r in iter_rows(text)
+        )
+        if has_data_lines:
+            self.assertGreater(
+                len(projects), 0,
+                "live registry has table rows but none parsed — likely "
+                "separator/header corruption",
+            )
 
     def test_happy_path(self):
         text = _build(

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -31,17 +31,32 @@ def _build(*body_lines: str, intro: str = "# Projects Registry\n\n") -> str:
 class TestParseProjects(unittest.TestCase):
 
     def test_real_registry_fixture(self):
-        path = PROJECT_ROOT / "registry" / "projects.md"
+        # Parses a checked-in fixture (not the live registry/projects.md), since
+        # the live registry is divergence-allowed across ja / en / forks per
+        # docs/sync-policy.md. The fixture pins a known project list so this
+        # test stays deterministic regardless of the host repo's roster.
+        path = PROJECT_ROOT / "tests" / "fixtures" / "registry" / "projects.md"
         projects = parse_projects(path)
-        # The checked-in registry carries the public, non-user-specific
-        # projects only. claude-org-ja self-edit is detected via the live
-        # repo's git origin URL (resolve_worker_layout.is_claude_org_project)
-        # and intentionally has no row here.
         names = [p.name for p in projects]
         self.assertIn("clock-app", names)
         self.assertIn("renga", names)
         self.assertNotIn("claude-org-ja", names)
         # All rows are fully populated Project instances.
+        for p in projects:
+            self.assertIsInstance(p, Project)
+            self.assertTrue(p.nickname)
+            self.assertTrue(p.name)
+
+    def test_live_registry_smoke(self):
+        # Smoke check: the live registry/projects.md (which may diverge per
+        # repo/fork) must remain parseable and yield at least one well-formed
+        # row. We do NOT assert specific project names here — that is the
+        # fixture-based test's job.
+        path = PROJECT_ROOT / "registry" / "projects.md"
+        if not path.exists():  # pragma: no cover - safety for fork checkouts
+            self.skipTest("live registry/projects.md not present")
+        projects = parse_projects(path)
+        self.assertGreater(len(projects), 0)
         for p in projects:
             self.assertIsInstance(p, Project)
             self.assertTrue(p.nickname)


### PR DESCRIPTION
## Summary
- PR #139 follow-up. `test_real_registry_fixture` was relaxed to assert only `len(projects) > 0` plus per-row well-formedness because `registry/projects.md` is divergence-allowed and the ja/en checkouts have different rosters.
- Replace the live-registry assertion with a true fixture file at `tests/fixtures/registry/projects.md` containing a known minimal project list (clock-app + renga, intentionally without claude-org-ja).
- Add `test_live_registry_smoke` that still parses the real registry but only checks well-formedness, plus a silent-corruption guard via `assertNoLogs` and a pipe-line-count predicate that catches the case where a missing separator turns every row into a header.

## Test plan
- [x] `python -m pytest tests/test_registry_parser.py` → 13 passed
- [x] Reproduced the silent-corruption case (separator removed); the new pipe-line-count predicate catches it.
- [x] Codex self-review 3 rounds; round 1 Major (drop row-count assert from the live smoke) → fixed; round 2 Medium (tighten live smoke / silent-corruption) → fixed; round 3 (separator-missing predicate) → fixed. No remaining Minor / Nit.

## README impact
None. README does not reference `registry_parser`.

Closes #339
Refs #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)