### PR TITLE
fix(claude): resolver detects claude-org mirror clone for claude-org / claude-org-en slugs

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -1045,11 +1045,11 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         self.assertTrue((worker_dir / "CLAUDE.md").exists())
 
 
-class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
+class TestPatternBClaudeOrgRepoWorktreePlan(unittest.TestCase):
     """Issue #370: ``build_delegate_plan`` must populate ``base_repo`` for
-    the ``en_repo_worktree`` variant so ``apply`` can run
-    ``git worktree add`` against the en mirror clone instead of failing
-    with ``no usable base repo could be determined``."""
+    the ``claude_org_repo_worktree`` variant so ``apply`` can run
+    ``git worktree add`` against the claude-org mirror clone instead of
+    failing with ``no usable base repo could be determined``."""
 
     def setUp(self) -> None:
         try:
@@ -1060,7 +1060,7 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
         self._td = tempfile.TemporaryDirectory()
         self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
         # Reset the auto-seeded registry to drop the synthesized
-        # claude-org-ja row; otherwise it'd fight the en-mirror detection
+        # claude-org-ja row; otherwise it'd fight the claude-org detection
         # for the claude-org slug. (The registry has clock-app only.)
         (self.sb.claude_org_root / "registry" / "projects.md").write_text(
             "# Projects\n\n"
@@ -1081,11 +1081,11 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
                 "GIT_COMMITTER_EMAIL": "test@example.com",
             }
         )
-        # en mirror clone with the canonical origin.
-        self.en_clone = self.sb.workers / "claude-org"
-        self.en_clone.mkdir()
+        # claude-org mirror clone with the canonical origin.
+        self.clone = self.sb.workers / "claude-org"
+        self.clone.mkdir()
         self._init_repo_with_origin_main(
-            self.en_clone, "https://github.com/suisya-systems/claude-org.git"
+            self.clone, "https://github.com/suisya-systems/claude-org.git"
         )
 
     def _init_repo_with_origin_main(self, base: Path, origin_url: str) -> None:
@@ -1120,7 +1120,7 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
         self.sb.add_active_run(
             task_id=f"prev-{slug}",
             project_slug=slug,
-            worker_dir=str(self.en_clone),
+            worker_dir=str(self.clone),
         )
 
     def test_plan_for_claude_org_slug_populates_base_repo(self):
@@ -1135,14 +1135,14 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self.assertEqual(plan.layout.pattern, "B")
-        self.assertEqual(plan.layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(plan.layout.pattern_variant, "claude_org_repo_worktree")
         self.assertIsNotNone(plan.base_repo)
         self.assertEqual(
-            Path(plan.base_repo).resolve(), self.en_clone.resolve()
+            Path(plan.base_repo).resolve(), self.clone.resolve()
         )
         self.assertEqual(
             Path(plan.layout.worker_dir),
-            (self.en_clone / ".worktrees" / "en-issue-370-1").resolve(),
+            (self.clone / ".worktrees" / "en-issue-370-1").resolve(),
         )
 
     def test_plan_for_claude_org_en_slug_populates_base_repo(self):
@@ -1157,9 +1157,9 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self.assertEqual(plan.layout.pattern, "B")
-        self.assertEqual(plan.layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(plan.layout.pattern_variant, "claude_org_repo_worktree")
         self.assertEqual(
-            Path(plan.base_repo).resolve(), self.en_clone.resolve()
+            Path(plan.base_repo).resolve(), self.clone.resolve()
         )
 
     def test_plan_normalizes_alias_slug_to_canonical(self):
@@ -1179,8 +1179,8 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
         # Plan-level project_slug is the canonical form, regardless of input alias.
         self.assertEqual(plan.project_slug, "claude-org")
 
-    def test_plan_rejects_en_variant_with_bad_worker_dir(self):
-        """Codex Round 2 Major: pattern_variant=en_repo_worktree with a
+    def test_plan_rejects_variant_with_bad_worker_dir(self):
+        """Codex Round 2 Major: pattern_variant=claude_org_repo_worktree with a
         worker_dir whose parent.parent is not a local git repo would silently
         run ``git worktree add`` against an unrelated directory. Reject."""
         with self.assertRaises(ValueError):
@@ -1191,15 +1191,15 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
                 state_db_path=self.sb.db_path,
                 layout_overrides={
                     "pattern": "B",
-                    "pattern_variant": "en_repo_worktree",
+                    "pattern_variant": "claude_org_repo_worktree",
                     "worker_dir": str(Path(self._td.name) / "not" / "a-repo"),
                 },
             )
 
-    def test_plan_rejects_en_variant_pointing_at_unrelated_git_repo(self):
+    def test_plan_rejects_variant_pointing_at_unrelated_git_repo(self):
         """Codex Round 3 Major: a worker_dir whose parent.parent IS a git
         repo — but a different one — used to slip through the validation.
-        Re-running origin-URL detection against the canonical en clone
+        Re-running origin-URL detection against the canonical claude-org clone
         path catches this."""
         import subprocess as _sp
         unrelated = Path(self._td.name) / "unrelated-repo"
@@ -1215,7 +1215,7 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
                 state_db_path=self.sb.db_path,
                 layout_overrides={
                     "pattern": "B",
-                    "pattern_variant": "en_repo_worktree",
+                    "pattern_variant": "claude_org_repo_worktree",
                     "worker_dir": str(unrelated / ".worktrees" / "evil-task"),
                 },
             )
@@ -1236,10 +1236,10 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
         self.assertEqual(plan.layout.pattern, "A")
         self.assertEqual(plan.project_slug, "claude-org")
 
-    def test_apply_creates_en_repo_worktree(self):
+    def test_apply_creates_claude_org_repo_worktree(self):
         """End-to-end: the original repro (apply fails with `no usable
         base repo`) is gone — apply succeeds and registers the worktree
-        against the en clone."""
+        against the claude-org clone."""
         import subprocess as _sp
         self._force_pattern_b("claude-org")
         plan = gdp.build_delegate_plan(
@@ -1259,7 +1259,7 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
         self.assertTrue(worker_dir.exists())
         self.assertTrue((worker_dir / ".git").exists())
         out = _sp.check_output(
-            ["git", "-C", str(self.en_clone),
+            ["git", "-C", str(self.clone),
              "worktree", "list", "--porcelain"],
         ).decode("utf-8", errors="replace")
         registered = {

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -1162,6 +1162,40 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
             Path(plan.base_repo).resolve(), self.en_clone.resolve()
         )
 
+    def test_plan_normalizes_alias_slug_to_canonical(self):
+        """Codex Round 2 Major: alias slugs must be normalized to the
+        post-migration canonical slug (``claude-org`` per migrate_workers
+        PROJECT_RENAMES) before reaching state.db, otherwise the same
+        physical repo's runs split across two project rows in the
+        dashboard."""
+        self._force_pattern_b("claude-org-en")
+        plan = gdp.build_delegate_plan(
+            task_id="alias-norm-task",
+            project_slug="claude-org-en",
+            description="test alias normalization",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        # Plan-level project_slug is the canonical form, regardless of input alias.
+        self.assertEqual(plan.project_slug, "claude-org")
+
+    def test_plan_rejects_en_variant_with_bad_worker_dir(self):
+        """Codex Round 2 Major: pattern_variant=en_repo_worktree with a
+        worker_dir whose parent.parent is not a local git repo would silently
+        run ``git worktree add`` against an unrelated directory. Reject."""
+        with self.assertRaises(ValueError):
+            gdp.build_delegate_plan(
+                task_id="bad-shape-task",
+                project_slug="claude-org",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={
+                    "pattern": "B",
+                    "pattern_variant": "en_repo_worktree",
+                    "worker_dir": str(Path(self._td.name) / "not" / "a-repo"),
+                },
+            )
+
     def test_apply_creates_en_repo_worktree(self):
         """End-to-end: the original repro (apply fails with `no usable
         base repo`) is gone — apply succeeds and registers the worktree

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -1045,6 +1045,157 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         self.assertTrue((worker_dir / "CLAUDE.md").exists())
 
 
+class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
+    """Issue #370: ``build_delegate_plan`` must populate ``base_repo`` for
+    the ``en_repo_worktree`` variant so ``apply`` can run
+    ``git worktree add`` against the en mirror clone instead of failing
+    with ``no usable base repo could be determined``."""
+
+    def setUp(self) -> None:
+        try:
+            import subprocess as _sp
+            _sp.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
+        # Reset the auto-seeded registry to drop the synthesized
+        # claude-org-ja row; otherwise it'd fight the en-mirror detection
+        # for the claude-org slug. (The registry has clock-app only.)
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| 時計アプリ | clock-app | - | Web 時計 | デザイン |\n",
+            encoding="utf-8",
+        )
+        # claude_org_root needs to be a real git repo with a main branch
+        # (the worktree-creation tests do the same dance).
+        import os
+        self._git_env = os.environ.copy()
+        self._git_env.update(
+            {
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+        # en mirror clone with the canonical origin.
+        self.en_clone = self.sb.workers / "claude-org"
+        self.en_clone.mkdir()
+        self._init_repo_with_origin_main(
+            self.en_clone, "https://github.com/suisya-systems/claude-org.git"
+        )
+
+    def _init_repo_with_origin_main(self, base: Path, origin_url: str) -> None:
+        import subprocess as _sp
+        _sp.run(["git", "-C", str(base), "init", "-q", "-b", "main"], check=True)
+        _sp.run(
+            ["git", "-C", str(base), "remote", "add", "origin", origin_url],
+            check=True,
+        )
+        _sp.run(
+            ["git", "-C", str(base), "commit", "--allow-empty", "-m", "init", "-q"],
+            check=True, env=self._git_env,
+        )
+        sha = _sp.check_output(
+            ["git", "-C", str(base), "rev-parse", "main"]
+        ).decode().strip()
+        _sp.run(
+            ["git", "-C", str(base), "update-ref",
+             "refs/remotes/origin/main", sha],
+            check=True,
+        )
+        _sp.run(
+            ["git", "-C", str(base), "symbolic-ref",
+             "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _force_pattern_b(self, slug: str) -> None:
+        self.sb.add_active_run(
+            task_id=f"prev-{slug}",
+            project_slug=slug,
+            worker_dir=str(self.en_clone),
+        )
+
+    def test_plan_for_claude_org_slug_populates_base_repo(self):
+        """Issue #370 repro 1: slug=claude-org Pattern B used to leave
+        base_repo=None, causing apply to raise WorktreeApplyError."""
+        self._force_pattern_b("claude-org")
+        plan = gdp.build_delegate_plan(
+            task_id="en-issue-370-1",
+            project_slug="claude-org",
+            description="install runtime classify",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertEqual(plan.layout.pattern_variant, "en_repo_worktree")
+        self.assertIsNotNone(plan.base_repo)
+        self.assertEqual(
+            Path(plan.base_repo).resolve(), self.en_clone.resolve()
+        )
+        self.assertEqual(
+            Path(plan.layout.worker_dir),
+            (self.en_clone / ".worktrees" / "en-issue-370-1").resolve(),
+        )
+
+    def test_plan_for_claude_org_en_slug_populates_base_repo(self):
+        """Issue #370 repro 2: slug=claude-org-en used to land on Pattern C
+        ephemeral; now Pattern B with base_repo anchored on the clone."""
+        self._force_pattern_b("claude-org-en")
+        plan = gdp.build_delegate_plan(
+            task_id="en-issue-370-2",
+            project_slug="claude-org-en",
+            description="docs sweep",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertEqual(plan.layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(
+            Path(plan.base_repo).resolve(), self.en_clone.resolve()
+        )
+
+    def test_apply_creates_en_repo_worktree(self):
+        """End-to-end: the original repro (apply fails with `no usable
+        base repo`) is gone — apply succeeds and registers the worktree
+        against the en clone."""
+        import subprocess as _sp
+        self._force_pattern_b("claude-org")
+        plan = gdp.build_delegate_plan(
+            task_id="en-issue-370-apply",
+            project_slug="claude-org",
+            description="add resolver fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        worker_dir = Path(plan.layout.worker_dir).resolve()
+        self.assertTrue(worker_dir.exists())
+        self.assertTrue((worker_dir / ".git").exists())
+        out = _sp.check_output(
+            ["git", "-C", str(self.en_clone),
+             "worktree", "list", "--porcelain"],
+        ).decode("utf-8", errors="replace")
+        registered = {
+            Path(line[len("worktree "):].strip()).resolve()
+            for line in out.splitlines() if line.startswith("worktree ")
+        }
+        self.assertIn(worker_dir, registered)
+        self.assertTrue((worker_dir / "CLAUDE.md").exists())
+
+
 def _env_update_goldens() -> bool:
     import os
     return os.environ.get("UPDATE_GOLDENS") == "1"

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -1196,6 +1196,46 @@ class TestPatternBEnRepoWorktreePlan(unittest.TestCase):
                 },
             )
 
+    def test_plan_rejects_en_variant_pointing_at_unrelated_git_repo(self):
+        """Codex Round 3 Major: a worker_dir whose parent.parent IS a git
+        repo — but a different one — used to slip through the validation.
+        Re-running origin-URL detection against the canonical en clone
+        path catches this."""
+        import subprocess as _sp
+        unrelated = Path(self._td.name) / "unrelated-repo"
+        unrelated.mkdir()
+        self._init_repo_with_origin_main(
+            unrelated, "https://github.com/some-other-org/unrelated.git"
+        )
+        with self.assertRaises(ValueError):
+            gdp.build_delegate_plan(
+                task_id="evil-task",
+                project_slug="claude-org",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={
+                    "pattern": "B",
+                    "pattern_variant": "en_repo_worktree",
+                    "worker_dir": str(unrelated / ".worktrees" / "evil-task"),
+                },
+            )
+
+    def test_plan_normalizes_alias_slug_for_pattern_a_too(self):
+        """Codex Round 3 Major: Pattern A (no active concurrent run, variant
+        None) on slug=claude-org-en still anchors worker_dir on the shared
+        clone, so the same alias-split must be normalized for Pattern A,
+        not just Pattern B."""
+        # No add_active_run call — this is Pattern A.
+        plan = gdp.build_delegate_plan(
+            task_id="alias-norm-pattern-a",
+            project_slug="claude-org-en",
+            description="docs sync",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "A")
+        self.assertEqual(plan.project_slug, "claude-org")
+
     def test_apply_creates_en_repo_worktree(self):
         """End-to-end: the original repro (apply fails with `no usable
         base repo`) is gone — apply succeeds and registers the worktree

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -785,5 +785,202 @@ class TestIsClaudeOrgProject(unittest.TestCase):
         self.assertFalse(rwl.is_claude_org_project("claude-org-ja", repo))
 
 
+# ---------------------------------------------------------------------------
+# Issue #370: Pattern B en_repo_worktree variant for the claude-org en mirror
+# ---------------------------------------------------------------------------
+
+
+class TestPatternBEnRepoWorktree(unittest.TestCase):
+    """Issue #370: the en-canonical claude-org clone at
+    ``{workers_dir}/claude-org`` is detected via origin URL (no registry row),
+    and Pattern B routes worktrees under it regardless of which alias slug
+    the caller passed (``claude-org`` or ``claude-org-en``).
+
+    Requires `git` on PATH. Skipped when unavailable."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            raise unittest.SkipTest("git not available")
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        self.en_clone = self.sb.workers / "claude-org"
+        self.en_clone.mkdir()
+        _Sandbox.init_git_with_origin(
+            self.en_clone, "https://github.com/suisya-systems/claude-org.git"
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_pattern_a_for_claude_org_slug_anchors_on_en_clone(self):
+        layout = rwl.resolve(
+            task_id="en-task-a",
+            project_slug="claude-org",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertIsNone(layout.pattern_variant)
+        self.assertEqual(Path(layout.worker_dir), self.en_clone.resolve())
+        self.assertEqual(layout.planned_branch, "feat/en-task-a")
+
+    def test_pattern_a_for_claude_org_en_slug_anchors_on_en_clone(self):
+        """slug=claude-org-en (registry-style alias) must still land on the
+        same physical clone — the resolver overrides worker_dir off the
+        clone path, not the slug."""
+        layout = rwl.resolve(
+            task_id="en-task-en",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(Path(layout.worker_dir), self.en_clone.resolve())
+
+    def test_pattern_b_for_claude_org_slug_emits_en_repo_worktree(self):
+        """Issue #370 repro 1: slug=claude-org with active concurrent run
+        used to emit Pattern B with variant=None and base_repo unresolvable."""
+        self.sb.add_run(
+            task_id="other-en-task",
+            project_slug="claude-org",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.en_clone),
+        )
+        layout = rwl.resolve(
+            task_id="en-issue-159",
+            project_slug="claude-org",
+            description="install runtime classify",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.en_clone / ".worktrees" / "en-issue-159").resolve(),
+        )
+        self.assertEqual(layout.planned_branch, "feat/en-issue-159")
+        self.assertEqual(layout.role, "default")
+        self.assertFalse(layout.self_edit)
+
+    def test_pattern_b_for_claude_org_en_slug_emits_en_repo_worktree(self):
+        """Issue #370 repro 2: slug=claude-org-en used to fall through to
+        Pattern C ephemeral. Now anchors on the en clone with the new
+        variant — even though the slug differs from the clone's dirname."""
+        self.sb.add_run(
+            task_id="other-en-task",
+            project_slug="claude-org-en",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.en_clone),
+        )
+        layout = rwl.resolve(
+            task_id="en-task-b-alias",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.en_clone / ".worktrees" / "en-task-b-alias").resolve(),
+        )
+
+    def test_no_en_clone_falls_through_to_pattern_c_ephemeral(self):
+        """Without a clone at workers_dir/claude-org, the slug is still
+        unknown → Pattern C ephemeral (regression guard for the no-en-clone
+        deployment)."""
+        import shutil as _shutil
+        _shutil.rmtree(self.en_clone)
+        layout = rwl.resolve(
+            task_id="en-task-no-clone",
+            project_slug="claude-org",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "C")
+        self.assertEqual(layout.pattern_variant, "ephemeral")
+
+    def test_en_clone_with_unrelated_origin_does_not_match(self):
+        """A repo at workers_dir/claude-org that happens to be an unrelated
+        github repo (e.g. a typo'd clone) must not be promoted to en mirror."""
+        subprocess.run(
+            ["git", "-C", str(self.en_clone), "remote", "set-url",
+             "origin", "https://github.com/someone-else/claude-org-fork.git"],
+            check=True,
+        )
+        layout = rwl.resolve(
+            task_id="en-task-bad-origin",
+            project_slug="claude-org",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "C")
+        self.assertEqual(layout.pattern_variant, "ephemeral")
+
+    def test_registry_url_path_falls_back_to_local_en_clone(self):
+        """Live deployment regression: ``registry/projects.md`` carries
+        ``| claude-org-en | claude-org | https://github.com/.../claude-org |``
+        (path = remote URL). Before the fix the resolver would land on the
+        registry row, see ``is_local_git_repo(URL)=False``, run state.db
+        Pattern B, and emit ``variant=None`` + ``base_repo=None`` because
+        the URL can't be a worktree base. With the en-clone fallback, we
+        re-pin onto the local clone and tag the variant."""
+        self.sb.write_registry(
+            [
+                ("時計", "clock-app", "-", "Demo clock"),
+                (
+                    "claude-org-en",
+                    "claude-org",
+                    "https://github.com/suisya-systems/claude-org",
+                    "en mirror",
+                ),
+            ]
+        )
+        self.sb.add_run(
+            task_id="other-en-task",
+            project_slug="claude-org",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.en_clone),
+        )
+        layout = rwl.resolve(
+            task_id="en-task-live",
+            project_slug="claude-org",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.en_clone / ".worktrees" / "en-task-live").resolve(),
+        )
+
+    def test_unrelated_slug_does_not_match_even_with_clone_present(self):
+        """Slug gate: a non-en slug (clock-app, renga) must not be promoted
+        even when the en clone is on disk."""
+        layout = rwl.resolve(
+            task_id="clock-task",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        # clock-app is in the registry as Pattern A under workers_dir/clock-app.
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "clock-app").resolve(),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -965,6 +965,70 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             (self.en_clone / ".worktrees" / "en-task-live").resolve(),
         )
 
+    def test_active_run_under_other_alias_forces_pattern_b(self):
+        """Codex Major regression: alias slugs share the same physical clone,
+        so an active run under ``claude-org`` must gate ``claude-org-en``
+        (and vice versa) into Pattern B. Without this both would land on
+        Pattern A in the same worker_dir simultaneously."""
+        self.sb.add_run(
+            task_id="run-under-claude-org",
+            project_slug="claude-org",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.en_clone),
+        )
+        layout = rwl.resolve(
+            task_id="incoming-en-alias",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.en_clone / ".worktrees" / "incoming-en-alias").resolve(),
+        )
+
+    def test_layout_overrides_en_repo_worktree_re_derives_worker_dir(self):
+        """Codex Minor regression: layout_overrides supplying pattern=B +
+        variant=en_repo_worktree without an explicit worker_dir must re-pin
+        worker_dir to {en_clone}/.worktrees/{task_id}, otherwise
+        gen_delegate_payload would derive base_repo from a stale path."""
+        layout = rwl.resolve(
+            task_id="explicit-en",
+            project_slug="claude-org",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={
+                "pattern": "B",
+                "pattern_variant": "en_repo_worktree",
+            },
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.en_clone / ".worktrees" / "explicit-en").resolve(),
+        )
+
+    def test_layout_overrides_en_repo_worktree_without_clone_raises(self):
+        """When the override requests en_repo_worktree but no clone exists,
+        we'd silently emit an unusable layout — fail loudly instead."""
+        import shutil as _shutil
+        _shutil.rmtree(self.en_clone)
+        with self.assertRaises(rwl.ResolveError):
+            rwl.resolve(
+                task_id="explicit-en-no-clone",
+                project_slug="claude-org",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={
+                    "pattern": "B",
+                    "pattern_variant": "en_repo_worktree",
+                },
+            )
+
     def test_unrelated_slug_does_not_match_even_with_clone_present(self):
         """Slug gate: a non-en slug (clock-app, renga) must not be promoted
         even when the en clone is on disk."""

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -786,15 +786,16 @@ class TestIsClaudeOrgProject(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Issue #370: Pattern B en_repo_worktree variant for the claude-org en mirror
+# Issue #370: Pattern B claude_org_repo_worktree variant for the claude-org mirror
 # ---------------------------------------------------------------------------
 
 
-class TestPatternBEnRepoWorktree(unittest.TestCase):
-    """Issue #370: the en-canonical claude-org clone at
-    ``{workers_dir}/claude-org`` is detected via origin URL (no registry row),
-    and Pattern B routes worktrees under it regardless of which alias slug
-    the caller passed (``claude-org`` or ``claude-org-en``).
+class TestPatternBClaudeOrgRepoWorktree(unittest.TestCase):
+    """Issue #370: the canonical claude-org mirror clone at
+    ``{workers_dir}/claude-org`` is detected via origin URL (no registry
+    row), and Pattern B routes worktrees under it. The registry-display
+    alias ``claude-org-en`` is normalized to the canonical project slug
+    ``claude-org`` at the resolve() boundary.
 
     Requires `git` on PATH. Skipped when unavailable."""
 
@@ -809,16 +810,16 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
         self._td = tempfile.TemporaryDirectory()
         self.sb = _Sandbox(Path(self._td.name))
         self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
-        self.en_clone = self.sb.workers / "claude-org"
-        self.en_clone.mkdir()
+        self.clone = self.sb.workers / "claude-org"
+        self.clone.mkdir()
         _Sandbox.init_git_with_origin(
-            self.en_clone, "https://github.com/suisya-systems/claude-org.git"
+            self.clone, "https://github.com/suisya-systems/claude-org.git"
         )
 
     def tearDown(self) -> None:
         self._td.cleanup()
 
-    def test_pattern_a_for_claude_org_slug_anchors_on_en_clone(self):
+    def test_pattern_a_for_claude_org_slug_anchors_on_clone(self):
         layout = rwl.resolve(
             task_id="en-task-a",
             project_slug="claude-org",
@@ -827,10 +828,10 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
         )
         self.assertEqual(layout.pattern, "A")
         self.assertIsNone(layout.pattern_variant)
-        self.assertEqual(Path(layout.worker_dir), self.en_clone.resolve())
+        self.assertEqual(Path(layout.worker_dir), self.clone.resolve())
         self.assertEqual(layout.planned_branch, "feat/en-task-a")
 
-    def test_pattern_a_for_claude_org_en_slug_anchors_on_en_clone(self):
+    def test_pattern_a_for_claude_org_en_slug_anchors_on_clone(self):
         """slug=claude-org-en (registry-style alias) must still land on the
         same physical clone — the resolver overrides worker_dir off the
         clone path, not the slug."""
@@ -841,9 +842,9 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self.assertEqual(layout.pattern, "A")
-        self.assertEqual(Path(layout.worker_dir), self.en_clone.resolve())
+        self.assertEqual(Path(layout.worker_dir), self.clone.resolve())
 
-    def test_pattern_b_for_claude_org_slug_emits_en_repo_worktree(self):
+    def test_pattern_b_for_claude_org_slug_emits_claude_org_repo_worktree(self):
         """Issue #370 repro 1: slug=claude-org with active concurrent run
         used to emit Pattern B with variant=None and base_repo unresolvable."""
         self.sb.add_run(
@@ -851,7 +852,7 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             project_slug="claude-org",
             pattern="A",
             status="in_use",
-            worker_dir_abs=str(self.en_clone),
+            worker_dir_abs=str(self.clone),
         )
         layout = rwl.resolve(
             task_id="en-issue-159",
@@ -861,25 +862,25 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self.assertEqual(layout.pattern, "B")
-        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(layout.pattern_variant, "claude_org_repo_worktree")
         self.assertEqual(
             Path(layout.worker_dir),
-            (self.en_clone / ".worktrees" / "en-issue-159").resolve(),
+            (self.clone / ".worktrees" / "en-issue-159").resolve(),
         )
         self.assertEqual(layout.planned_branch, "feat/en-issue-159")
         self.assertEqual(layout.role, "default")
         self.assertFalse(layout.self_edit)
 
-    def test_pattern_b_for_claude_org_en_slug_emits_en_repo_worktree(self):
-        """Issue #370 repro 2: slug=claude-org-en used to fall through to
-        Pattern C ephemeral. Now anchors on the en clone with the new
-        variant — even though the slug differs from the clone's dirname."""
+    def test_pattern_b_for_alias_slug_emits_claude_org_repo_worktree(self):
+        """Issue #370 repro 2: slug=claude-org-en (registry-display alias)
+        used to fall through to Pattern C ephemeral. Now normalizes to the
+        canonical slug and anchors on the mirror clone with the new variant."""
         self.sb.add_run(
             task_id="other-en-task",
             project_slug="claude-org-en",
             pattern="A",
             status="in_use",
-            worker_dir_abs=str(self.en_clone),
+            worker_dir_abs=str(self.clone),
         )
         layout = rwl.resolve(
             task_id="en-task-b-alias",
@@ -888,18 +889,18 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self.assertEqual(layout.pattern, "B")
-        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(layout.pattern_variant, "claude_org_repo_worktree")
         self.assertEqual(
             Path(layout.worker_dir),
-            (self.en_clone / ".worktrees" / "en-task-b-alias").resolve(),
+            (self.clone / ".worktrees" / "en-task-b-alias").resolve(),
         )
 
-    def test_no_en_clone_falls_through_to_pattern_c_ephemeral(self):
+    def test_no_clone_falls_through_to_pattern_c_ephemeral(self):
         """Without a clone at workers_dir/claude-org, the slug is still
         unknown → Pattern C ephemeral (regression guard for the no-en-clone
         deployment)."""
         import shutil as _shutil
-        _shutil.rmtree(self.en_clone)
+        _shutil.rmtree(self.clone)
         layout = rwl.resolve(
             task_id="en-task-no-clone",
             project_slug="claude-org",
@@ -909,11 +910,12 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
         self.assertEqual(layout.pattern, "C")
         self.assertEqual(layout.pattern_variant, "ephemeral")
 
-    def test_en_clone_with_unrelated_origin_does_not_match(self):
+    def test_clone_with_unrelated_origin_does_not_match(self):
         """A repo at workers_dir/claude-org that happens to be an unrelated
-        github repo (e.g. a typo'd clone) must not be promoted to en mirror."""
+        github repo (e.g. a typo'd clone) must not be promoted to claude-org
+        mirror."""
         subprocess.run(
-            ["git", "-C", str(self.en_clone), "remote", "set-url",
+            ["git", "-C", str(self.clone), "remote", "set-url",
              "origin", "https://github.com/someone-else/claude-org-fork.git"],
             check=True,
         )
@@ -926,7 +928,7 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
         self.assertEqual(layout.pattern, "C")
         self.assertEqual(layout.pattern_variant, "ephemeral")
 
-    def test_registry_url_path_falls_back_to_local_en_clone(self):
+    def test_registry_url_path_falls_back_to_local_clone(self):
         """Live deployment regression: ``registry/projects.md`` carries
         ``| claude-org-en | claude-org | https://github.com/.../claude-org |``
         (path = remote URL). Before the fix the resolver would land on the
@@ -941,7 +943,7 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
                     "claude-org-en",
                     "claude-org",
                     "https://github.com/suisya-systems/claude-org",
-                    "en mirror",
+                    "mirror",
                 ),
             ]
         )
@@ -950,7 +952,7 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             project_slug="claude-org",
             pattern="A",
             status="in_use",
-            worker_dir_abs=str(self.en_clone),
+            worker_dir_abs=str(self.clone),
         )
         layout = rwl.resolve(
             task_id="en-task-live",
@@ -959,10 +961,10 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self.assertEqual(layout.pattern, "B")
-        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(layout.pattern_variant, "claude_org_repo_worktree")
         self.assertEqual(
             Path(layout.worker_dir),
-            (self.en_clone / ".worktrees" / "en-task-live").resolve(),
+            (self.clone / ".worktrees" / "en-task-live").resolve(),
         )
 
     def test_active_run_under_other_alias_forces_pattern_b(self):
@@ -975,7 +977,7 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             project_slug="claude-org",
             pattern="A",
             status="in_use",
-            worker_dir_abs=str(self.en_clone),
+            worker_dir_abs=str(self.clone),
         )
         layout = rwl.resolve(
             task_id="incoming-en-alias",
@@ -984,16 +986,16 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self.assertEqual(layout.pattern, "B")
-        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(layout.pattern_variant, "claude_org_repo_worktree")
         self.assertEqual(
             Path(layout.worker_dir),
-            (self.en_clone / ".worktrees" / "incoming-en-alias").resolve(),
+            (self.clone / ".worktrees" / "incoming-en-alias").resolve(),
         )
 
-    def test_layout_overrides_en_repo_worktree_re_derives_worker_dir(self):
+    def test_layout_overrides_claude_org_repo_worktree_re_derives_worker_dir(self):
         """Codex Minor regression: layout_overrides supplying pattern=B +
-        variant=en_repo_worktree without an explicit worker_dir must re-pin
-        worker_dir to {en_clone}/.worktrees/{task_id}, otherwise
+        variant=claude_org_repo_worktree without an explicit worker_dir must re-pin
+        worker_dir to {clone}/.worktrees/{task_id}, otherwise
         gen_delegate_payload would derive base_repo from a stale path."""
         layout = rwl.resolve(
             task_id="explicit-en",
@@ -1002,21 +1004,21 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
             state_db_path=self.sb.db_path,
             layout_overrides={
                 "pattern": "B",
-                "pattern_variant": "en_repo_worktree",
+                "pattern_variant": "claude_org_repo_worktree",
             },
         )
         self.assertEqual(layout.pattern, "B")
-        self.assertEqual(layout.pattern_variant, "en_repo_worktree")
+        self.assertEqual(layout.pattern_variant, "claude_org_repo_worktree")
         self.assertEqual(
             Path(layout.worker_dir),
-            (self.en_clone / ".worktrees" / "explicit-en").resolve(),
+            (self.clone / ".worktrees" / "explicit-en").resolve(),
         )
 
-    def test_layout_overrides_en_repo_worktree_without_clone_raises(self):
-        """When the override requests en_repo_worktree but no clone exists,
+    def test_layout_overrides_claude_org_repo_worktree_without_clone_raises(self):
+        """When the override requests claude_org_repo_worktree but no clone exists,
         we'd silently emit an unusable layout — fail loudly instead."""
         import shutil as _shutil
-        _shutil.rmtree(self.en_clone)
+        _shutil.rmtree(self.clone)
         with self.assertRaises(rwl.ResolveError):
             rwl.resolve(
                 task_id="explicit-en-no-clone",
@@ -1025,13 +1027,13 @@ class TestPatternBEnRepoWorktree(unittest.TestCase):
                 state_db_path=self.sb.db_path,
                 layout_overrides={
                     "pattern": "B",
-                    "pattern_variant": "en_repo_worktree",
+                    "pattern_variant": "claude_org_repo_worktree",
                 },
             )
 
     def test_unrelated_slug_does_not_match_even_with_clone_present(self):
-        """Slug gate: a non-en slug (clock-app, renga) must not be promoted
-        even when the en clone is on disk."""
+        """Slug gate: a non-canonical slug (clock-app, renga) must not be
+        promoted even when the claude-org clone is on disk."""
         layout = rwl.resolve(
             task_id="clock-task",
             project_slug="clock-app",

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -134,8 +134,8 @@ def _pattern_label(layout: rwl.WorkerLayout) -> str:
         return "C: gitignored サブモード (registered repo 直接編集)"
     if layout.pattern_variant == "live_repo_worktree":
         return "B: worktree (live_repo_worktree — Secretary live repo 配下)"
-    if layout.pattern_variant == "en_repo_worktree":
-        return "B: worktree (en_repo_worktree — claude-org en mirror 配下)"
+    if layout.pattern_variant == "claude_org_repo_worktree":
+        return "B: worktree (claude_org_repo_worktree — claude-org mirror 配下)"
     return base
 
 
@@ -260,20 +260,21 @@ def build_delegate_plan(
     brief_filename = _brief_filename(self_edit)
     brief_out_path = Path(layout.worker_dir) / brief_filename
 
-    # Issue #370 (Codex Round 2/3 Major): the en mirror has two alias slugs
-    # in the wild (``claude-org`` / ``claude-org-en``) but they point at the
-    # same physical clone. Normalize to the post-migration canonical slug
-    # (``claude-org`` per ``tools/state_db/migrate_workers.py:PROJECT_RENAMES``)
-    # before storing, so state.db / dashboard aggregations don't split the
-    # repo's runs across two project rows. Round 3 widened this to ALL
-    # patterns (A / B / C-gitignored) — Pattern A's variant is None but the
-    # en mirror still anchors worker_dir on the shared clone, so the same
-    # split would occur for Pattern A delegations.
+    # Issue #370: the claude-org mirror's registry-display alias
+    # ``claude-org-en`` (the 通称 column) and the canonical project slug
+    # ``claude-org`` both point at the same physical clone. Normalize to
+    # the canonical slug (matches both
+    # ``tools/state_db/migrate_workers.py:PROJECT_RENAMES`` and the github
+    # repo name) before storing, so state.db / dashboard aggregations
+    # don't split the repo's runs across two project rows. Applies to ALL
+    # patterns (A / B / C-gitignored) — Pattern A's variant is None but
+    # the mirror still anchors worker_dir on the shared clone.
     workers_dir_for_norm = workers_dir or rwl.resolve_workers_dir(
         Path(claude_org_root)
     )
-    if rwl.find_claude_org_en_clone(project_slug, Path(workers_dir_for_norm)) is not None:
-        project_slug = rwl._CLAUDE_ORG_EN_CLONE_DIRNAME
+    canonical_slug = rwl._CLAUDE_ORG_SLUG_ALIASES.get(project_slug, project_slug)
+    if rwl.find_claude_org_clone(canonical_slug, Path(workers_dir_for_norm)) is not None:
+        project_slug = rwl._CLAUDE_ORG_CLONE_DIRNAME
 
     permission_mode = parse_permission_mode(Path(claude_org_root))
 
@@ -310,28 +311,28 @@ def build_delegate_plan(
     if layout.pattern == "B":
         if layout.pattern_variant == "live_repo_worktree":
             base_repo = Path(claude_org_root).resolve()
-        elif layout.pattern_variant == "en_repo_worktree":
-            # Issue #370: worker_dir = {en_clone}/.worktrees/<task>. Codex
-            # Round 3 Major: a generic git-repo check on parent.parent let
+        elif layout.pattern_variant == "claude_org_repo_worktree":
+            # Issue #370: worker_dir = {clone}/.worktrees/<task>. A generic
+            # git-repo check on parent.parent let
             # ``layout_overrides.worker_dir=<unrelated_repo>/.worktrees/<task>``
             # slip through. Re-run the origin-URL match against
             # ``workers_dir/claude-org`` and assert the derived base equals
-            # that canonical en clone path, so worktree creation can't be
+            # that canonical clone path, so worktree creation can't be
             # redirected at an arbitrary repo via override.
             candidate = Path(layout.worker_dir).parent.parent.resolve()
-            expected = rwl.find_claude_org_en_clone(
-                rwl._CLAUDE_ORG_EN_CLONE_DIRNAME,
+            expected = rwl.find_claude_org_clone(
+                rwl._CLAUDE_ORG_CLONE_DIRNAME,
                 Path(workers_dir_for_norm),
             )
             if expected is None or candidate != expected.resolve():
                 raise ValueError(
-                    f"pattern_variant='en_repo_worktree' requires "
-                    f"worker_dir of shape <en_clone>/.worktrees/<task> "
-                    f"where en_clone is the canonical claude-org mirror at "
-                    f"{Path(workers_dir_for_norm) / rwl._CLAUDE_ORG_EN_CLONE_DIRNAME}. "
+                    f"pattern_variant='claude_org_repo_worktree' requires "
+                    f"worker_dir of shape <clone>/.worktrees/<task> where "
+                    f"<clone> is the canonical claude-org mirror at "
+                    f"{Path(workers_dir_for_norm) / rwl._CLAUDE_ORG_CLONE_DIRNAME}. "
                     f"worker_dir={layout.worker_dir!r} derives "
-                    f"base_repo={candidate!s} which does not match the en "
-                    "clone."
+                    f"base_repo={candidate!s} which does not match the "
+                    "canonical clone."
                 )
             base_repo = candidate
         elif project_path and rwl.is_local_git_repo(project_path):

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -260,13 +260,19 @@ def build_delegate_plan(
     brief_filename = _brief_filename(self_edit)
     brief_out_path = Path(layout.worker_dir) / brief_filename
 
-    # Issue #370 (Codex Round 2 Major): the en mirror has two alias slugs in
-    # the wild (``claude-org`` / ``claude-org-en``) but they point at the
+    # Issue #370 (Codex Round 2/3 Major): the en mirror has two alias slugs
+    # in the wild (``claude-org`` / ``claude-org-en``) but they point at the
     # same physical clone. Normalize to the post-migration canonical slug
     # (``claude-org`` per ``tools/state_db/migrate_workers.py:PROJECT_RENAMES``)
     # before storing, so state.db / dashboard aggregations don't split the
-    # repo's runs across two project rows.
-    if layout.pattern_variant == "en_repo_worktree":
+    # repo's runs across two project rows. Round 3 widened this to ALL
+    # patterns (A / B / C-gitignored) — Pattern A's variant is None but the
+    # en mirror still anchors worker_dir on the shared clone, so the same
+    # split would occur for Pattern A delegations.
+    workers_dir_for_norm = workers_dir or rwl.resolve_workers_dir(
+        Path(claude_org_root)
+    )
+    if rwl.find_claude_org_en_clone(project_slug, Path(workers_dir_for_norm)) is not None:
         project_slug = rwl._CLAUDE_ORG_EN_CLONE_DIRNAME
 
     permission_mode = parse_permission_mode(Path(claude_org_root))
@@ -305,21 +311,27 @@ def build_delegate_plan(
         if layout.pattern_variant == "live_repo_worktree":
             base_repo = Path(claude_org_root).resolve()
         elif layout.pattern_variant == "en_repo_worktree":
-            # Issue #370: worker_dir = {en_clone}/.worktrees/<task>; the en
-            # clone has no registry row, so derive base_repo from the
-            # worker_dir layout convention rather than re-running origin URL
-            # detection here. Codex Round 2 Major: validate the derived
-            # path is a real local git repo so a malformed override (any
-            # worker_dir whose parent.parent isn't the en clone) fails fast
-            # instead of silently running `git worktree add` against an
-            # unrelated directory.
+            # Issue #370: worker_dir = {en_clone}/.worktrees/<task>. Codex
+            # Round 3 Major: a generic git-repo check on parent.parent let
+            # ``layout_overrides.worker_dir=<unrelated_repo>/.worktrees/<task>``
+            # slip through. Re-run the origin-URL match against
+            # ``workers_dir/claude-org`` and assert the derived base equals
+            # that canonical en clone path, so worktree creation can't be
+            # redirected at an arbitrary repo via override.
             candidate = Path(layout.worker_dir).parent.parent.resolve()
-            if not rwl.is_local_git_repo(str(candidate)):
+            expected = rwl.find_claude_org_en_clone(
+                rwl._CLAUDE_ORG_EN_CLONE_DIRNAME,
+                Path(workers_dir_for_norm),
+            )
+            if expected is None or candidate != expected.resolve():
                 raise ValueError(
-                    f"pattern_variant='en_repo_worktree' requires worker_dir "
-                    f"of shape <en_clone>/.worktrees/<task>, but "
-                    f"{layout.worker_dir!r} derives base_repo={candidate!s} "
-                    "which is not a local git repo."
+                    f"pattern_variant='en_repo_worktree' requires "
+                    f"worker_dir of shape <en_clone>/.worktrees/<task> "
+                    f"where en_clone is the canonical claude-org mirror at "
+                    f"{Path(workers_dir_for_norm) / rwl._CLAUDE_ORG_EN_CLONE_DIRNAME}. "
+                    f"worker_dir={layout.worker_dir!r} derives "
+                    f"base_repo={candidate!s} which does not match the en "
+                    "clone."
                 )
             base_repo = candidate
         elif project_path and rwl.is_local_git_repo(project_path):

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -134,6 +134,8 @@ def _pattern_label(layout: rwl.WorkerLayout) -> str:
         return "C: gitignored サブモード (registered repo 直接編集)"
     if layout.pattern_variant == "live_repo_worktree":
         return "B: worktree (live_repo_worktree — Secretary live repo 配下)"
+    if layout.pattern_variant == "en_repo_worktree":
+        return "B: worktree (en_repo_worktree — claude-org en mirror 配下)"
     return base
 
 
@@ -293,6 +295,12 @@ def build_delegate_plan(
     if layout.pattern == "B":
         if layout.pattern_variant == "live_repo_worktree":
             base_repo = Path(claude_org_root).resolve()
+        elif layout.pattern_variant == "en_repo_worktree":
+            # Issue #370: worker_dir = {en_clone}/.worktrees/<task>; the en
+            # clone has no registry row, so derive base_repo from the
+            # worker_dir layout convention rather than re-running origin URL
+            # detection here.
+            base_repo = Path(layout.worker_dir).parent.parent.resolve()
         elif project_path and rwl.is_local_git_repo(project_path):
             base_repo = Path(project_path).resolve()
 

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -260,6 +260,15 @@ def build_delegate_plan(
     brief_filename = _brief_filename(self_edit)
     brief_out_path = Path(layout.worker_dir) / brief_filename
 
+    # Issue #370 (Codex Round 2 Major): the en mirror has two alias slugs in
+    # the wild (``claude-org`` / ``claude-org-en``) but they point at the
+    # same physical clone. Normalize to the post-migration canonical slug
+    # (``claude-org`` per ``tools/state_db/migrate_workers.py:PROJECT_RENAMES``)
+    # before storing, so state.db / dashboard aggregations don't split the
+    # repo's runs across two project rows.
+    if layout.pattern_variant == "en_repo_worktree":
+        project_slug = rwl._CLAUDE_ORG_EN_CLONE_DIRNAME
+
     permission_mode = parse_permission_mode(Path(claude_org_root))
 
     # Look up project.path for the DELEGATE body label.
@@ -299,8 +308,20 @@ def build_delegate_plan(
             # Issue #370: worker_dir = {en_clone}/.worktrees/<task>; the en
             # clone has no registry row, so derive base_repo from the
             # worker_dir layout convention rather than re-running origin URL
-            # detection here.
-            base_repo = Path(layout.worker_dir).parent.parent.resolve()
+            # detection here. Codex Round 2 Major: validate the derived
+            # path is a real local git repo so a malformed override (any
+            # worker_dir whose parent.parent isn't the en clone) fails fast
+            # instead of silently running `git worktree add` against an
+            # unrelated directory.
+            candidate = Path(layout.worker_dir).parent.parent.resolve()
+            if not rwl.is_local_git_repo(str(candidate)):
+                raise ValueError(
+                    f"pattern_variant='en_repo_worktree' requires worker_dir "
+                    f"of shape <en_clone>/.worktrees/<task>, but "
+                    f"{layout.worker_dir!r} derives base_repo={candidate!s} "
+                    "which is not a local git repo."
+                )
+            base_repo = candidate
         elif project_path and rwl.is_local_git_repo(project_path):
             base_repo = Path(project_path).resolve()
 

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -79,7 +79,12 @@ VALID_PATTERNS = ("A", "B", "C")
 # tasks: the worktree base is Secretary's live repo (claude_org_root) instead
 # of the conventional {workers_dir}/{project_slug}/. See Issue #289 and
 # references/claude-org-self-edit.md for the rationale.
-VALID_VARIANTS = ("ephemeral", "gitignored_repo_root", "live_repo_worktree")
+VALID_VARIANTS = (
+    "ephemeral",
+    "gitignored_repo_root",
+    "live_repo_worktree",
+    "en_repo_worktree",
+)
 VALID_ROLES = ("default", "claude-org-self-edit", "doc-audit")
 
 # Active reservation states — these mean someone else is occupying the base
@@ -299,6 +304,47 @@ def _git_origin_url(repo_path: Path) -> Optional[str]:
     return out or None
 
 
+# claude-org en mirror — the English-canonical sibling clone of claude-org-ja.
+# Like the ja self-edit target, the en mirror has no registry row to avoid
+# leaking a user-specific local path; detection runs off the clone's git
+# origin URL. Two signals must hold:
+# 1. The slug is one of the recognized aliases (Issue #370 — both
+#    ``claude-org`` and ``claude-org-en`` are observed in the wild because
+#    no slug is canonical without a registry row).
+# 2. ``{workers_dir}/claude-org`` exists as a git repo whose origin URL
+#    points at a github repo named ``claude-org`` (no ``-ja`` / ``-en``
+#    suffix). Owner is intentionally NOT pinned: forks contribute the same
+#    way claude-org-ja does (see ``CONTRIBUTING.md``).
+_CLAUDE_ORG_EN_SLUGS: tuple[str, ...] = ("claude-org", "claude-org-en")
+_CLAUDE_ORG_EN_REPO_NAMES: tuple[str, ...] = ("claude-org",)
+_CLAUDE_ORG_EN_CLONE_DIRNAME = "claude-org"
+
+
+def find_claude_org_en_clone(
+    project_slug: str, workers_dir: Path
+) -> Optional[Path]:
+    """Return the en-canonical claude-org clone path if slug + origin URL
+    match, else None.
+
+    Issue #370: the en mirror lives at ``{workers_dir}/claude-org``. Without
+    this detection the resolver returned Pattern C ephemeral for unknown
+    slugs (or Pattern B with ``variant=None`` + ``base_repo=None`` when a
+    legacy registry row was present), and ``apply`` failed with "no usable
+    base repo could be determined". Anchoring on the clone's origin URL
+    makes detection independent of registry state.
+    """
+    if project_slug not in _CLAUDE_ORG_EN_SLUGS:
+        return None
+    candidate = (Path(workers_dir) / _CLAUDE_ORG_EN_CLONE_DIRNAME).resolve()
+    if not is_local_git_repo(str(candidate)):
+        return None
+    url = _git_origin_url(candidate)
+    if url is None:
+        return None
+    repo_name = _extract_github_repo_name(url)
+    return candidate if repo_name in _CLAUDE_ORG_EN_REPO_NAMES else None
+
+
 def is_claude_org_project(project_slug: str, claude_org_root: Path) -> bool:
     """True iff this delegation targets claude-org self-edit.
 
@@ -396,6 +442,31 @@ def resolve(
             common_tasks="",
         )
 
+    # Issue #370: en mirror at {workers_dir}/claude-org should anchor any
+    # Pattern A/B for the en repo regardless of whether the slug is missing
+    # from the registry, present with a URL path (the live deployment, where
+    # the row reads ``| claude-org-en | claude-org | https://github.com/...``),
+    # or present with a placeholder. We always re-pin onto the local clone
+    # when detection succeeds — synthesizing a virtual project record when
+    # the registry row is absent or carries a non-local path so downstream
+    # Pattern A/B logic and ``gen_delegate_payload``'s ``base_repo`` derivation
+    # can reach it. The override block below also relocates worker_dir for
+    # the slug=claude-org-en case (where the slug differs from the clone's
+    # dirname).
+    en_clone: Optional[Path] = find_claude_org_en_clone(
+        project_slug, workers_dir
+    )
+    if en_clone is not None and (
+        project is None or not is_local_git_repo(project.path)
+    ):
+        project = RegistryProject(
+            name=project_slug,
+            nickname=project.nickname if project is not None else project_slug,
+            path=str(en_clone),
+            description=project.description if project is not None else "",
+            common_tasks=project.common_tasks if project is not None else "",
+        )
+
     # --- Role decision (computed first so Pattern B can branch on it) -----
     role = decide_role(mode=mode, project_slug=project_slug, claude_org_root=claude_org_root)
     self_edit = role == "claude-org-self-edit"
@@ -446,6 +517,20 @@ def resolve(
             worker_dir = workers_dir / project_slug
 
     worker_dir = worker_dir.resolve() if worker_dir.is_absolute() else worker_dir.resolve()
+
+    # --- en mirror anchoring (Issue #370) ---------------------------------
+    # Re-pin worker_dir on the actual clone (which lives at
+    # ``{workers_dir}/claude-org`` regardless of which alias slug the caller
+    # passed). For Pattern B, also tag the variant so gen_delegate_payload
+    # can derive base_repo from worker_dir.parent.parent without needing a
+    # registry row. Skipped for Pattern C / gitignored cases — those already
+    # use the synthesized project.path directly.
+    if en_clone is not None and pattern in ("A", "B"):
+        if pattern == "B":
+            variant = "en_repo_worktree"
+            worker_dir = (en_clone / ".worktrees" / task_id).resolve()
+        else:
+            worker_dir = en_clone.resolve()
 
     # --- TOML [worker] block overrides (Issue #290 defect 1) --------------
     # Honor explicit values from the caller (typically a worker_brief.toml

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -83,7 +83,7 @@ VALID_VARIANTS = (
     "ephemeral",
     "gitignored_repo_root",
     "live_repo_worktree",
-    "en_repo_worktree",
+    "claude_org_repo_worktree",
 )
 VALID_ROLES = ("default", "claude-org-self-edit", "doc-audit")
 
@@ -264,8 +264,8 @@ _CLAUDE_ORG_SELF_EDIT_SLUG = "claude-org-ja"
 # project documents fork-based contribution (see CONTRIBUTING.md), and a
 # fork's ``origin`` points at the contributor's fork (e.g.
 # ``git@github.com:<user>/claude-org-ja.git``), not at suisya-systems'.
-# Tuple constant so adding the en mirror (e.g. ``claude-org-en``) is a
-# one-line change.
+# Tuple constant so adding additional self-edit repo names is a one-line
+# change.
 _CLAUDE_ORG_REPO_NAMES: tuple[str, ...] = ("claude-org-ja",)
 
 # Capture <owner>/<repo> from common github URL forms:
@@ -304,45 +304,58 @@ def _git_origin_url(repo_path: Path) -> Optional[str]:
     return out or None
 
 
-# claude-org en mirror — the English-canonical sibling clone of claude-org-ja.
-# Like the ja self-edit target, the en mirror has no registry row to avoid
-# leaking a user-specific local path; detection runs off the clone's git
-# origin URL. Two signals must hold:
-# 1. The slug is one of the recognized aliases (Issue #370 — both
-#    ``claude-org`` and ``claude-org-en`` are observed in the wild because
-#    no slug is canonical without a registry row).
+# claude-org mirror clone — the sibling clone of claude-org-ja. Like the ja
+# self-edit target, the mirror has no registry row to avoid leaking a
+# user-specific local path; detection runs off the clone's git origin URL.
+# The canonical project slug is ``claude-org`` (matches the github repo
+# name and ``tools/state_db/migrate_workers.py:PROJECT_RENAMES``); the
+# 通称 ``claude-org-en`` is recognized as a registry-display alias and
+# normalized to the canonical slug at the resolve() boundary.
+# Two signals must hold for detection:
+# 1. The (already-normalized) slug equals ``claude-org``.
 # 2. ``{workers_dir}/claude-org`` exists as a git repo whose origin URL
-#    points at a github repo named ``claude-org`` (no ``-ja`` / ``-en``
-#    suffix). Owner is intentionally NOT pinned: forks contribute the same
-#    way claude-org-ja does (see ``CONTRIBUTING.md``).
-_CLAUDE_ORG_EN_SLUGS: tuple[str, ...] = ("claude-org", "claude-org-en")
-_CLAUDE_ORG_EN_REPO_NAMES: tuple[str, ...] = ("claude-org",)
-_CLAUDE_ORG_EN_CLONE_DIRNAME = "claude-org"
+#    points at a github repo named ``claude-org`` (no ``-ja`` suffix).
+#    Owner is intentionally NOT pinned: forks contribute the same way
+#    claude-org-ja does (see ``CONTRIBUTING.md``).
+_CLAUDE_ORG_MIRROR_REPO_NAMES: tuple[str, ...] = ("claude-org",)
+_CLAUDE_ORG_CLONE_DIRNAME = "claude-org"
+
+# Registry-display aliases that resolve to the canonical project slug. The
+# checked-in registry's 通称 column carries ``claude-org-en`` for
+# readability; normalize at the boundary so downstream code only sees the
+# canonical project slug.
+_CLAUDE_ORG_SLUG_ALIASES: dict[str, str] = {
+    "claude-org-en": "claude-org",
+}
 
 
-def find_claude_org_en_clone(
+def find_claude_org_clone(
     project_slug: str, workers_dir: Path
 ) -> Optional[Path]:
-    """Return the en-canonical claude-org clone path if slug + origin URL
+    """Return the canonical claude-org clone path if slug + origin URL
     match, else None.
 
-    Issue #370: the en mirror lives at ``{workers_dir}/claude-org``. Without
+    Issue #370: the mirror lives at ``{workers_dir}/claude-org``. Without
     this detection the resolver returned Pattern C ephemeral for unknown
     slugs (or Pattern B with ``variant=None`` + ``base_repo=None`` when a
     legacy registry row was present), and ``apply`` failed with "no usable
     base repo could be determined". Anchoring on the clone's origin URL
     makes detection independent of registry state.
+
+    Caller must pass the already-normalized canonical slug (``claude-org``).
+    The resolve() boundary maps registry-display aliases via
+    :data:`_CLAUDE_ORG_SLUG_ALIASES` before reaching here.
     """
-    if project_slug not in _CLAUDE_ORG_EN_SLUGS:
+    if project_slug != _CLAUDE_ORG_CLONE_DIRNAME:
         return None
-    candidate = (Path(workers_dir) / _CLAUDE_ORG_EN_CLONE_DIRNAME).resolve()
+    candidate = (Path(workers_dir) / _CLAUDE_ORG_CLONE_DIRNAME).resolve()
     if not is_local_git_repo(str(candidate)):
         return None
     url = _git_origin_url(candidate)
     if url is None:
         return None
     repo_name = _extract_github_repo_name(url)
-    return candidate if repo_name in _CLAUDE_ORG_EN_REPO_NAMES else None
+    return candidate if repo_name in _CLAUDE_ORG_MIRROR_REPO_NAMES else None
 
 
 def is_claude_org_project(project_slug: str, claude_org_root: Path) -> bool:
@@ -413,6 +426,11 @@ def resolve(
     if mode not in VALID_MODES:
         raise ResolveError(f"mode must be one of {VALID_MODES}, got {mode!r}")
 
+    # Normalize registry-display aliases to the canonical project slug.
+    # ``claude-org-en`` is the 通称 (display name) for the ``claude-org``
+    # mirror; downstream code only operates on the canonical form.
+    project_slug = _CLAUDE_ORG_SLUG_ALIASES.get(project_slug, project_slug)
+
     targets = list(targets or [])
     claude_org_root = Path(claude_org_root).resolve()
     if registry_path is None:
@@ -442,27 +460,26 @@ def resolve(
             common_tasks="",
         )
 
-    # Issue #370: en mirror at {workers_dir}/claude-org should anchor any
-    # Pattern A/B for the en repo regardless of whether the slug is missing
-    # from the registry, present with a URL path (the live deployment, where
-    # the row reads ``| claude-org-en | claude-org | https://github.com/...``),
-    # or present with a placeholder. We always re-pin onto the local clone
-    # when detection succeeds — synthesizing a virtual project record when
-    # the registry row is absent or carries a non-local path so downstream
-    # Pattern A/B logic and ``gen_delegate_payload``'s ``base_repo`` derivation
-    # can reach it. The override block below also relocates worker_dir for
-    # the slug=claude-org-en case (where the slug differs from the clone's
-    # dirname).
-    en_clone: Optional[Path] = find_claude_org_en_clone(
+    # Issue #370: claude-org mirror at {workers_dir}/claude-org should
+    # anchor any Pattern A/B for that repo regardless of whether the slug
+    # is missing from the registry, present with a URL path (the live
+    # deployment, where the row reads
+    # ``| claude-org-en | claude-org | https://github.com/...``), or present
+    # with a placeholder. We always re-pin onto the local clone when
+    # detection succeeds — synthesizing a virtual project record when the
+    # registry row is absent or carries a non-local path so downstream
+    # Pattern A/B logic and ``gen_delegate_payload``'s ``base_repo``
+    # derivation can reach it.
+    claude_org_clone: Optional[Path] = find_claude_org_clone(
         project_slug, workers_dir
     )
-    if en_clone is not None and (
+    if claude_org_clone is not None and (
         project is None or not is_local_git_repo(project.path)
     ):
         project = RegistryProject(
             name=project_slug,
             nickname=project.nickname if project is not None else project_slug,
-            path=str(en_clone),
+            path=str(claude_org_clone),
             description=project.description if project is not None else "",
             common_tasks=project.common_tasks if project is not None else "",
         )
@@ -492,15 +509,16 @@ def resolve(
         # for "no concurrent work known". The dispatcher / Stage 3 apply step
         # will re-validate before actually creating any worktree.
         active = False
-        # Issue #370 (Codex Major): when the en mirror is in play, the two
-        # alias slugs (``claude-org`` / ``claude-org-en``) point at the same
-        # physical clone, so an active run recorded under one alias must
-        # gate the other into Pattern B too. Otherwise back-to-back
-        # delegations under different aliases would land in the same
-        # Pattern A worker_dir simultaneously.
+        # Issue #370: legacy state.db rows may still carry the registry-display
+        # alias ``claude-org-en`` (the post-migration canonical is
+        # ``claude-org``). When the mirror is in play, gate on either form
+        # so an active run recorded before normalization still forces
+        # Pattern B for the new delegation.
         active_run_slugs: tuple[str, ...]
-        if en_clone is not None:
-            active_run_slugs = _CLAUDE_ORG_EN_SLUGS
+        if claude_org_clone is not None:
+            active_run_slugs = (project_slug,) + tuple(
+                k for k, v in _CLAUDE_ORG_SLUG_ALIASES.items() if v == project_slug
+            )
         else:
             active_run_slugs = (project_slug,)
         if state_db_path is not None and Path(state_db_path).exists():
@@ -531,19 +549,18 @@ def resolve(
 
     worker_dir = worker_dir.resolve() if worker_dir.is_absolute() else worker_dir.resolve()
 
-    # --- en mirror anchoring (Issue #370) ---------------------------------
+    # --- claude-org mirror anchoring (Issue #370) -------------------------
     # Re-pin worker_dir on the actual clone (which lives at
-    # ``{workers_dir}/claude-org`` regardless of which alias slug the caller
-    # passed). For Pattern B, also tag the variant so gen_delegate_payload
-    # can derive base_repo from worker_dir.parent.parent without needing a
-    # registry row. Skipped for Pattern C / gitignored cases — those already
-    # use the synthesized project.path directly.
-    if en_clone is not None and pattern in ("A", "B"):
+    # ``{workers_dir}/claude-org``). For Pattern B, also tag the variant so
+    # gen_delegate_payload can derive base_repo from worker_dir.parent.parent
+    # without needing a registry row. Skipped for Pattern C / gitignored
+    # cases — those already use the synthesized project.path directly.
+    if claude_org_clone is not None and pattern in ("A", "B"):
         if pattern == "B":
-            variant = "en_repo_worktree"
-            worker_dir = (en_clone / ".worktrees" / task_id).resolve()
+            variant = "claude_org_repo_worktree"
+            worker_dir = (claude_org_clone / ".worktrees" / task_id).resolve()
         else:
-            worker_dir = en_clone.resolve()
+            worker_dir = claude_org_clone.resolve()
 
     # --- TOML [worker] block overrides (Issue #290 defect 1) --------------
     # Honor explicit values from the caller (typically a worker_brief.toml
@@ -573,26 +590,26 @@ def resolve(
             # → re-derive to claude_org_root/.worktrees/{task_id}/ (Issue #289).
             if pattern == "B" and variant == "live_repo_worktree" and not explicit_worker_dir:
                 worker_dir = (claude_org_root / ".worktrees" / task_id).resolve()
-            # Issue #370 (Codex Minor): same re-derivation for the en
-            # mirror variant — without it, an explicit override leaves
-            # worker_dir at whatever auto-derive produced (often the clone
-            # root) and gen_delegate_payload's
+            # Issue #370 (Codex Minor): same re-derivation for the
+            # claude-org mirror variant — without it, an explicit override
+            # leaves worker_dir at whatever auto-derive produced (often the
+            # clone root) and gen_delegate_payload's
             # ``base_repo = worker_dir.parent.parent`` derivation lands on
             # the wrong directory.
-            if pattern == "B" and variant == "en_repo_worktree" and not explicit_worker_dir:
-                en_clone_for_override = en_clone or find_claude_org_en_clone(
+            if pattern == "B" and variant == "claude_org_repo_worktree" and not explicit_worker_dir:
+                clone_for_override = claude_org_clone or find_claude_org_clone(
                     project_slug, workers_dir
                 )
-                if en_clone_for_override is None:
+                if clone_for_override is None:
                     raise ResolveError(
                         "layout_overrides requested pattern=B "
-                        "variant=en_repo_worktree but no claude-org en mirror "
+                        "variant=claude_org_repo_worktree but no claude-org "
                         f"clone was detected at {workers_dir}/"
-                        f"{_CLAUDE_ORG_EN_CLONE_DIRNAME} (slug={project_slug!r}). "
+                        f"{_CLAUDE_ORG_CLONE_DIRNAME} (slug={project_slug!r}). "
                         "Either supply layout_overrides['worker_dir'] "
-                        "explicitly or clone the en mirror at that path."
+                        "explicitly or clone the mirror at that path."
                     )
-                worker_dir = (en_clone_for_override / ".worktrees" / task_id).resolve()
+                worker_dir = (clone_for_override / ".worktrees" / task_id).resolve()
         if "worker_dir" in layout_overrides and layout_overrides["worker_dir"]:
             worker_dir = Path(layout_overrides["worker_dir"]).resolve()
         if "role" in layout_overrides and layout_overrides["role"]:

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -492,11 +492,24 @@ def resolve(
         # for "no concurrent work known". The dispatcher / Stage 3 apply step
         # will re-validate before actually creating any worktree.
         active = False
+        # Issue #370 (Codex Major): when the en mirror is in play, the two
+        # alias slugs (``claude-org`` / ``claude-org-en``) point at the same
+        # physical clone, so an active run recorded under one alias must
+        # gate the other into Pattern B too. Otherwise back-to-back
+        # delegations under different aliases would land in the same
+        # Pattern A worker_dir simultaneously.
+        active_run_slugs: tuple[str, ...]
+        if en_clone is not None:
+            active_run_slugs = _CLAUDE_ORG_EN_SLUGS
+        else:
+            active_run_slugs = (project_slug,)
         if state_db_path is not None and Path(state_db_path).exists():
             try:
                 conn = db_connect(state_db_path)
                 try:
-                    active = project_has_active_run(conn, project_slug)
+                    active = any(
+                        project_has_active_run(conn, s) for s in active_run_slugs
+                    )
                 finally:
                     conn.close()
             except sqlite3.Error:
@@ -560,6 +573,26 @@ def resolve(
             # → re-derive to claude_org_root/.worktrees/{task_id}/ (Issue #289).
             if pattern == "B" and variant == "live_repo_worktree" and not explicit_worker_dir:
                 worker_dir = (claude_org_root / ".worktrees" / task_id).resolve()
+            # Issue #370 (Codex Minor): same re-derivation for the en
+            # mirror variant — without it, an explicit override leaves
+            # worker_dir at whatever auto-derive produced (often the clone
+            # root) and gen_delegate_payload's
+            # ``base_repo = worker_dir.parent.parent`` derivation lands on
+            # the wrong directory.
+            if pattern == "B" and variant == "en_repo_worktree" and not explicit_worker_dir:
+                en_clone_for_override = en_clone or find_claude_org_en_clone(
+                    project_slug, workers_dir
+                )
+                if en_clone_for_override is None:
+                    raise ResolveError(
+                        "layout_overrides requested pattern=B "
+                        "variant=en_repo_worktree but no claude-org en mirror "
+                        f"clone was detected at {workers_dir}/"
+                        f"{_CLAUDE_ORG_EN_CLONE_DIRNAME} (slug={project_slug!r}). "
+                        "Either supply layout_overrides['worker_dir'] "
+                        "explicitly or clone the en mirror at that path."
+                    )
+                worker_dir = (en_clone_for_override / ".worktrees" / task_id).resolve()
         if "worker_dir" in layout_overrides and layout_overrides["worker_dir"]:
             worker_dir = Path(layout_overrides["worker_dir"]).resolve()
         if "role" in layout_overrides and layout_overrides["role"]:


### PR DESCRIPTION
## Summary
- `tools/gen_delegate_payload.py apply` was failing for the en mirror repo (`suisya-systems/claude-org`) because the resolver returned `Pattern B / variant=None / base_repo=None` for `--project-slug claude-org`, and `Pattern C ephemeral` for the registry alias `claude-org-en`.
- Resolver now detects the en mirror clone at `../workers/claude-org` (origin = `suisya-systems/claude-org`) and emits `Pattern B` with new variant `claude_org_repo_worktree`, populating `base_repo` so `git worktree add` succeeds for both slug forms.
- Internal naming follows the canonical project name `claude-org` (no `en` suffix); the registry alias `claude-org-en` is normalized at the boundary via `_CLAUDE_ORG_SLUG_ALIASES`.
- Slug normalization is wired through Pattern A as well so active-run aliases share one logical run, and unrelated git repos passed via overrides are rejected by a path-shape guard.

## Test plan
- [x] `python -m unittest tests.test_resolve_worker_layout tests.test_gen_delegate_payload` (83 tests pass; 14 new cases cover both slug forms, no-clone fallback, wrong-origin guard, layout overrides, end-to-end apply, alias active-run sharing, path-shape rejection).
- [x] Smoke: `python tools/resolve_worker_layout.py --task-id smoke --project-slug claude-org-en` returns `pattern=B variant=claude_org_repo_worktree worker_dir=workers/claude-org/.worktrees/smoke`.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)