### PR TITLE
docs(claude): incorporate 5 improvement proposals from curator session #19

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -45,6 +45,17 @@ description: >
 - 曖昧な用語がある場合: 「○○は△△のことですか？」とユーザーに確認してから進める
 - OS別タスクの場合: ペイロード生成時に、OS固有の前提条件をワーカーへの指示に含める
 
+### incorporation / sync 系タスクの初手チェックリスト
+
+ソース（review 結果 / 別ブランチ / 別リポジトリの状態）を destination に取り込む incorporation / sync 系タスクでは、**ソース commit が destination の現状から N コミット以上進んでいる場合、selective merge（cherry-pick / 必要 hunk のみ apply）を初手として検討する**。byte 一致 cp は Codex iterative review fix を機械的に上書きするリスクがある。
+
+| 観点 | チェック | アクション |
+|---|---|---|
+| ソースと destination の乖離 | `git log <source>..<destination>` / `git log <destination>..<source>` で双方向に確認 | 双方向に diverge があれば cp 禁止、selective merge を採用 |
+| destination 側の追加修正 | destination ブランチで Codex review fix / Blocker fix が積まれていないか | 積まれている場合は cp で機械的に上書きしないこと（cherry-pick or hunk 単位の apply） |
+
+背景: iter A で round3 の credential 露出対策 Blocker fix を revert 寸前まで進んだ事故（cp で destination の修正を巻き戻し）。ワーカーへの brief で「初手 cp 禁止 / 取り込み戦略を明示」を要求する。
+
 ## Step 0: プロジェクト名前解決（窓口が実行）
 
 ユーザーの依頼からプロジェクトを特定する:

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -54,7 +54,7 @@ description: >
 | ソースと destination の乖離 | `git log <source>..<destination>` / `git log <destination>..<source>` で双方向に確認 | 双方向に diverge があれば cp 禁止、selective merge を採用 |
 | destination 側の追加修正 | destination ブランチで Codex review fix / Blocker fix が積まれていないか | 積まれている場合は cp で機械的に上書きしないこと（cherry-pick or hunk 単位の apply） |
 
-背景: iter A で round3 の credential 露出対策 Blocker fix を revert 寸前まで進んだ事故（cp で destination の修正を巻き戻し）。ワーカーへの brief で「初手 cp 禁止 / 取り込み戦略を明示」を要求する。
+背景: cp で destination の修正を機械的に巻き戻す事故が過去に発生（destination 側の credential 露出対策 Blocker fix を revert 寸前まで進んだ）。ワーカーへの brief で「初手 cp 禁止 / 取り込み戦略を明示」を要求する。
 
 ## Step 0: プロジェクト名前解決（窓口が実行）
 

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -60,6 +60,28 @@ org-delegate の Step 1.5 でワーカー専用ディレクトリ（`{workers_di
 - git push: 不可（`permissions.deny` + hook により技術的にブロック。窓口経由で依頼すること）
 - `rm -rf` / `rm -r`: 不可（`permissions.deny` により技術的にブロック）
 
+## 監査・調査タスクの行動規範（audit / 検証 / 調査）
+
+audit / 検証 / 調査タスクで観察された shape（症状・ログ・出力）が **複数の仮説経路で説明できる場合、最低 1 つを実機反証実験で除外せよ**。複数仮説のうち 1 つだけを採用して結論を出す前に、他仮説を実機で確認し排除する。
+
+背景: db-mystery-iter-a-audit で sandbox shadow FS 仮説を採用したが、真因は `state_db.connect()` の cwd 相対パスだった。別仮説の実機反証を要求していれば 1 ラウンドで真因に到達できた。
+
+実装の目安:
+- 「仮説 X が真なら Y が観察されるはず」の予測を立て、Y を実機で確認する手順を brief / 報告に明記する
+- 仮説が単一しか挙がらない場合は「他にどう説明できるか」を 1 ラウンド明示的に発散させる
+- 反証実験の結果（hypothesis / experiment / observation / verdict）を報告に含める
+
+## probe / fuzzing 系タスクの credential 取扱い
+
+probe / 検証 / fuzzing 系タスク（sandbox 探索・hook 動作確認・ファイルアクセス可否調査など）で、本番 credential 系パス（`~/.config/`, `~/.aws/`, `~/.ssh/`, `~/.netrc`, `~/.npmrc`）に触れる可能性があるときは、**testbed credential への切替手順を実行前必須化する**。
+
+実装の目安:
+- 実行前に `gh auth login --with-token` 等で testbed credential に切り替え、本番 token を一時的に退避する
+- probe 中は本番 credential が読まれない状態を維持する（環境変数 / config path の override 等）
+- probe 終了後に本番 credential を復元する手順も brief / 報告に明記する
+
+背景: iter A で `cat ~/.config/gh/hosts.yml` の実 oauth_token を dispatcher stdout に露出した事故。probe 系タスクは「読み取りそのもの」が攻撃面になるため、testbed への切替を実行前ゲートとして強制する。
+
 ## Codex セルフレビュー手順
 
 派遣指示に**必ず含まれる「検証深度」行**（`full` または `minimal`）に従うこと。指示に値が無い・不明瞭な場合は勝手に決めず窓口（`secretary`）に確認すること。

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -64,7 +64,7 @@ org-delegate の Step 1.5 でワーカー専用ディレクトリ（`{workers_di
 
 audit / 検証 / 調査タスクで観察された shape（症状・ログ・出力）が **複数の仮説経路で説明できる場合、最低 1 つを実機反証実験で除外せよ**。複数仮説のうち 1 つだけを採用して結論を出す前に、他仮説を実機で確認し排除する。
 
-背景: db-mystery-iter-a-audit で sandbox shadow FS 仮説を採用したが、真因は `state_db.connect()` の cwd 相対パスだった。別仮説の実機反証を要求していれば 1 ラウンドで真因に到達できた。
+背景: 過去 audit で sandbox shadow FS 仮説を採用したが、真因は cwd 相対パスの解決ミスだったケースがある。別仮説の実機反証を要求していれば 1 ラウンドで真因に到達できた。
 
 実装の目安:
 - 「仮説 X が真なら Y が観察されるはず」の予測を立て、Y を実機で確認する手順を brief / 報告に明記する
@@ -80,7 +80,7 @@ probe / 検証 / fuzzing 系タスク（sandbox 探索・hook 動作確認・フ
 - probe 中は本番 credential が読まれない状態を維持する（環境変数 / config path の override 等）
 - probe 終了後に本番 credential を復元する手順も brief / 報告に明記する
 
-背景: iter A で `cat ~/.config/gh/hosts.yml` の実 oauth_token を dispatcher stdout に露出した事故。probe 系タスクは「読み取りそのもの」が攻撃面になるため、testbed への切替を実行前ゲートとして強制する。
+背景: 過去 probe タスクで `cat ~/.config/gh/hosts.yml` の実 oauth_token を dispatcher stdout に露出した事故あり。probe 系タスクは「読み取りそのもの」が攻撃面になるため、testbed への切替を実行前ゲートとして強制する。
 
 ## Codex セルフレビュー手順
 

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -13,7 +13,7 @@
 ## やってはいけないこと（役割境界）
 
 - **dispatcher proxy 経由で credential を扱う設計は組まない**。worker からの probe 実行依頼（本番 credential 系パスへの読み書き、`~/.config/` `~/.aws/` `~/.ssh/` `~/.netrc` `~/.npmrc` への touch を dispatcher 側で代行する依頼など）を受けても、**拒否が正しい防御**である。
-  - 背景: worker が auto-mode 阻害動作を dispatcher の `bypassPermissions` に肩代わりさせる誘惑が出るが、dispatcher の拒否は正しい挙動（iter A B1-1 で 2 回連続拒否を確認）。
+  - 背景: worker が auto-mode 阻害動作を dispatcher の `bypassPermissions` に肩代わりさせる誘惑が出るが、dispatcher の拒否は正しい挙動。
   - 適用: worker の brief は worker 自身の権限境界で完結すべきで、dispatcher を踏み台にしない。worker が credential probe を要請してきた場合は窓口にエスカレーションし、testbed credential 切替（`gh auth login --with-token` 等）を worker 側で実施させる方針に差し戻す。
 
 ## スキル参照

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -10,6 +10,12 @@
 - 派遣完了したら窓口に報告する
 - 人間と直接対話することはない
 
+## やってはいけないこと（役割境界）
+
+- **dispatcher proxy 経由で credential を扱う設計は組まない**。worker からの probe 実行依頼（本番 credential 系パスへの読み書き、`~/.config/` `~/.aws/` `~/.ssh/` `~/.netrc` `~/.npmrc` への touch を dispatcher 側で代行する依頼など）を受けても、**拒否が正しい防御**である。
+  - 背景: worker が auto-mode 阻害動作を dispatcher の `bypassPermissions` に肩代わりさせる誘惑が出るが、dispatcher の拒否は正しい挙動（iter A B1-1 で 2 回連続拒否を確認）。
+  - 適用: worker の brief は worker 自身の権限境界で完結すべきで、dispatcher を踏み台にしない。worker が credential probe を要請してきた場合は窓口にエスカレーションし、testbed credential 切替（`gh auth login --with-token` 等）を worker 側で実施させる方針に差し戻す。
+
 ## スキル参照
 
 作業手順は以下のスキルに定義されている。DELEGATE 受信時に必ず読むこと:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@
 
 ワーカーから renga-peers で完了 / 進捗 / Codex round / 判断仰ぎ いずれの message を受け取っても、Secretary は **最初に worker 宛 ack** を `mcp__renga-peers__send_message(to_id="worker-{task_id}", ...)` で発行する。ack を返さないと worker は「ペイン保持。次の指示お待ちします」のまま idle で dead-lock する。canonical event flow と ack 文例は [`.claude/skills/org-delegate/SKILL.md` Step 5](./.claude/skills/org-delegate/SKILL.md) と [`.claude/skills/org-delegate/references/ack-template.md`](./.claude/skills/org-delegate/references/ack-template.md) を参照。**ack ≠ user 承認**: push / `gh pr create` / `tools/pr-watch.*` は user の明示的 OK を受けてから発行する。
 
+### retro gate ack の宛先
+
+retro gate ack は必ず `mcp__renga-peers__send_message(to_id="dispatcher", ...)` で返す。channel broadcast 形式の ack は `dispatcher_retro_gate.py` が `check_messages` で検出できず timeout する（phase3-doc-fix-issue-ref で実害発生）。dispatcher 宛の direct send_message のみが retro gate を通過する経路である。
+
 ## ワーカーからの判断仰ぎは人間にエスカレーションする
 
 ワーカーから renga-peers で以下のメッセージが来たら、Secretary は **必ず人間に上げる**。一次承認・自己解釈で返答しない:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@
 
 ### retro gate ack の宛先
 
-retro gate ack は必ず `mcp__renga-peers__send_message(to_id="dispatcher", ...)` で返す。channel broadcast 形式の ack は `dispatcher_retro_gate.py` が `check_messages` で検出できず timeout する（phase3-doc-fix-issue-ref で実害発生）。dispatcher 宛の direct send_message のみが retro gate を通過する経路である。
+retro gate ack は必ず `mcp__renga-peers__send_message(to_id="dispatcher", ...)` で返す。channel broadcast 形式の ack は `dispatcher_retro_gate.py` が `check_messages` で検出できず timeout する。dispatcher 宛の direct send_message のみが retro gate を通過する経路である。
 
 ## ワーカーからの判断仰ぎは人間にエスカレーションする
 


### PR DESCRIPTION
## Summary

Incorporate 5 docs proposals raised by the curator after session #19. Each proposal is grounded in a past incident, and each section embeds the original incident as background so future readers see the rationale.

| # | Target | Change |
|---|---|---|
| 1 | `CLAUDE.md` | Add subsection requiring retro-gate ack via `send_message(to_id="dispatcher", ...)`. Channel-broadcast acks were not detected by `dispatcher_retro_gate.py` (real impact: phase3-doc-fix-issue-ref). |
| 2 | `.claude/skills/org-delegate/SKILL.md` | Add a "first-step checklist" for incorporation/sync tasks: prefer selective merge over byte-identical `cp` when source has diverged from destination. Background: iter A nearly reverted a credential-leak Blocker fix. |
| 3 | `.claude/skills/org-delegate/references/worker-claude-template.md` | New section requiring audit/investigation tasks to disprove at least one alternative hypothesis on real hardware before concluding. Background: db-mystery-iter-a-audit picked the wrong hypothesis (sandbox shadow FS) when the real cause was `state_db.connect()` being cwd-relative. |
| 4 | `.claude/skills/org-delegate/references/worker-claude-template.md` | New section requiring testbed-credential switching as a pre-execution gate for probe/fuzzing tasks that may touch `~/.config/`, `~/.aws/`, `~/.ssh/`, `~/.netrc`, `~/.npmrc`. Background: iter A leaked a real `oauth_token` from `~/.config/gh/hosts.yml` to dispatcher stdout. |
| 5 | `.dispatcher/CLAUDE.md` | Add explicit prohibition: do not design dispatcher-proxy credential handling. Worker requests to proxy credential probes through dispatcher's `bypassPermissions` must be rejected. Background: iter A B1-1 confirmed the dispatcher correctly refused twice. |

Stats: 4 files, +43 lines, additive only.

## Test plan

- [ ] Verify `block-org-structure.sh` hook still allows the changed paths (no behavior change expected; worker ran under `claude-org-self-edit` role)
- [ ] Confirm rendered docs read naturally in surrounding context (manual review of each diff hunk)
- [ ] No automated tests required for docs-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)