### PR TITLE
feat(claude): add Read() deny entries for Phase 2 Read tool gap rows (#376)

### DIFF
--- a/docs/sandbox-probe/profiles/profile-tightened.json
+++ b/docs/sandbox-probe/profiles/profile-tightened.json
@@ -50,7 +50,12 @@
       "Bash(git -C * worktree remove --force*)",
       "Bash(git -C * worktree remove * --force*)",
       "Read(~/.ssh/*)",
-      "Read(~/.aws/*)"
+      "Read(~/.aws/*)",
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/credentials*)",
+      "Read(**/*.pem)",
+      "Read(~/.config/gh/hosts.yml)"
     ]
   },
   "hooks": {

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -296,7 +296,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {
@@ -354,7 +359,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {


### PR DESCRIPTION
## Summary

Phase 2 prevention: add 5 `Read()` deny entries to `tools/org_extension_schema.json` for `worker_roles.default` and `worker_roles.claude-org-self-edit`. Closes the Read-tool gap rows surfaced by sandbox-probe iter-c §4.3 #2 (Layer 2 `perms.deny` had no Read entries; Layer 3 `sandbox.denyRead` is Bash-tool-only).

## Changes

`tools/org_extension_schema.json`: add to both `worker_roles.default.permissions.deny` and `worker_roles.claude-org-self-edit.permissions.deny`:

- `Read(.env)`
- `Read(.env.*)`
- `Read(**/credentials*)`
- `Read(**/*.pem)`
- `Read(~/.config/gh/hosts.yml)`

`docs/sandbox-probe/profiles/profile-tightened.json`: same 5 entries added to keep the experimental profile in lockstep.

## Why

iter-c §4.3 #2 (sandbox-probe) found 4 gap rows (`worker_dir/.env`, `creds/credentials.json`, `key.pem`, `~/.config/gh/hosts.yml`) that bypassed both Layer 2 and Layer 3 deny under `profile-tightened`:

- Layer 2 `perms.deny` had no entries matching the Read tool path syntax
- Layer 3 `sandbox.denyRead` only intercepts Bash-tool subprocess reads, not the Read tool itself

These 5 entries close Phase 2 prevention by adding Layer 2 `perms.deny` rules that the Read tool itself honors.

## Verification

- `python tools/check_runtime_schema_drift.py`: `OK (claude-org-runtime 0.1.3 bundled schema matches org_extension_schema.json)` (runtime 0.1.3 was released to PyPI just before this PR; ja's pin `>=0.1.1,<0.2` resolves to 0.1.3 → schema is byte-identical)
- claude-org-runtime PR `suisya-systems/claude-org-runtime#9` synced these same entries to runtime's bundled schema (released as v0.1.3)

## Follow-up (out of scope)

Codex review on the runtime sync PR raised these as Major findings (deferred to ja-side follow-ups since they require ja schema change first):

- `roles.worker.required_deny` should also include the 5 entries (audit detection completeness)
- `worker_roles.doc-audit.permissions.deny` should also include the 5 entries (Read-only investigators are still credential exposure surface)

Refs #376