### PR TITLE
chore(claude): bump claude-org-runtime pin to >=0.1.3,<0.2 (Refs #376)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.1,<0.2",
+    "claude-org-runtime>=0.1.3,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
-claude-org-runtime>=0.1.1,<0.2
+claude-org-runtime>=0.1.3,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).

--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -35,7 +35,7 @@ from pathlib import Path
 # requirements.txt. Keep this constant in sync when widening the pin
 # (Phase 5e+ scope per CLAUDE.local.md). Stored as tuples for ordered
 # comparison; only major.minor.micro are honoured.
-RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 1)
+RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 3)
 RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary

Hygiene pin bump: lift the lower bound of the `claude-org-runtime` pin from 0.1.1 to 0.1.3, now that v0.1.3 is on PyPI (released by `suisya-systems/claude-org-runtime#9`). The pin already resolved to 0.1.3 in CI via the existing `>=0.1.1,<0.2` upper bound; this PR just updates the lower bound and the drift-check tolerance window so future contributors cannot accidentally install a pre-sync runtime.

## Changes

- `pyproject.toml`: `claude-org-runtime>=0.1.1,<0.2` → `>=0.1.3,<0.2`
- `requirements.txt`: same
- `tools/check_runtime_schema_drift.py`: `RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 1)` → `(0, 1, 3)`

## Verification

- `pip install -r requirements.txt` resolves `claude-org-runtime==0.1.3`
- `python tools/check_runtime_schema_drift.py` exits 0 (`OK (claude-org-runtime 0.1.3 bundled schema matches org_extension_schema.json)`) — confirms ja schema and runtime 0.1.3 bundled schema are byte-identical
- `pytest`: 256 passed

Refs #376