### PR TITLE
chore: bump claude-org-runtime pin to >=0.1.4,<0.2 (Refs #376)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.3,<0.2",
+    "claude-org-runtime>=0.1.4,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
-claude-org-runtime>=0.1.3,<0.2
+claude-org-runtime>=0.1.4,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).

--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -35,7 +35,7 @@ from pathlib import Path
 # requirements.txt. Keep this constant in sync when widening the pin
 # (Phase 5e+ scope per CLAUDE.local.md). Stored as tuples for ordered
 # comparison; only major.minor.micro are honoured.
-RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 3)
+RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 4)
 RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary

Bump `claude-org-runtime` pin from `>=0.1.3,<0.2` to `>=0.1.4,<0.2` to pick up Phase 3 sandbox case E (WSL Layer 3 suppression) shipped in runtime [v0.1.4](https://github.com/suisya-systems/claude-org-runtime/releases/tag/v0.1.4).

Same scope as merged #396 (which bumped 0.1.2 → 0.1.3).

Refs: #376 (Linux sandbox 対応 Epic), #392 (Phase 3 implementation tracking).

### Files

- `pyproject.toml`: dependency pin
- `requirements.txt`: same
- `tools/check_runtime_schema_drift.py`: `RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 4)`

## Test plan

- [x] Local `python tools/check_runtime_schema_drift.py` exits 0 (WARN-only because installed 0.1.3 is below new pin window; CI installs 0.1.4 fresh and validates)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)