### PR TITLE
docs: add cwd-safety warnings to org-delegate / org-pull-request skills (Refs #398)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -261,6 +261,10 @@ gh issue view <dogfood_issue> --json state -q .state
 
 ## Step 5: 進捗管理（窓口が実行）
 
+### ⚠️ cwd 注意: state.db touching tools
+
+`tools/journal_append.sh` / `tools/journal_append.py` / `tools/set_run_pr_open.py` / `python -c "... StateWriter ..."` 等、`state.db` を相対パスで開く tool は ja root 相対前提。worker / worktree cwd から起動すると `no such table: runs` / `no such table: events` でサイレント or クラッシュ失敗し、後段の post-commit hook や snapshot 再生成も走らない。必ず `cd <ja-root>` してから実行すること。Issue #398 で根本対応中。
+
 ### DELEGATE_COMPLETE 受信時
 
 ディスパッチャーから派遣完了報告を受け取ったら、各ワーカーに挨拶メッセージを送る:

--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -39,6 +39,10 @@ description: >
 - PR レビューで指摘が来た場合は 2c のフローで同ワーカーに `send_message` 追指示を送り、同ペインで修正コミットを積ませる（新ワーカー再派遣は避ける — Issue / diff / 判断境界の再構築コストを払うことになる）
 - **dogfood 対象 PR の場合（Issue #338）**: `registry/dogfood_pending.md` で当該 task_id の `status=pending` 行を探し、(a) `impl_pr=#<PR>` を埋め、(b) `gh issue create --title "dogfood follow-up: <surface>" --body-file <rendered template>` で paired follow-up issue を作成（template: [`.claude/skills/org-delegate/references/dogfood-issue-template.md`](../org-delegate/references/dogfood-issue-template.md)）、(c) 作成された issue 番号を `dogfood_issue=#<MMM>` に埋め、`status` を `pending → open` に遷移、(d) PR 本文末に `Paired dogfood issue: #<MMM>` を追記する。protocol 全体は [`.claude/skills/org-delegate/SKILL.md`](../org-delegate/SKILL.md) Step 1.8 を SoT とする
 
+### ⚠️ cwd 注意: pr-watch 起動時
+
+`tools/pr-watch.sh` / `tools/pr-watch.ps1` / `tools/pr_watch.py` は `state.db` を相対パスで開くため、起動時の cwd が ja root でないと CI 完了 event 書き込みでクラッシュし、peer 通知 (`CI_COMPLETED` / `PR_MERGED` 等) が飛ばない。直前に `cd .worktrees/...` していた場合は必ず `cd <ja-root> && nohup bash tools/pr-watch.sh <PR> ...` の形で起動すること。Issue #398 で根本対応中（cwd 非依存化）。
+
 ## 2c. レビュー指摘 / CI 失敗のフィードバックループ
 
 人間がフィードバック・修正指示を出した場合、または CI が失敗してユーザーが「直してもらって」と指示した場合:


### PR DESCRIPTION
## Summary

Add short cwd-safety guard sections to two Secretary skills, capturing the recurring 2026-05-10 mistake where state.db-touching tools were invoked from a worktree cwd, causing silent or crash failures.

Refs: #398 (proper cwd-independent fix tracked separately).

### Background

During Issue #376 Phase 3 follow-up work, the Secretary repeatedly invoked state.db-touching tools from a worktree cwd:

1. `python -c "... StateWriter ..."` worker run-status update — failed (`no such table: runs`)
2. `bash tools/journal_append.sh ...` event append — silently failed with `no such table: events`
3. `nohup bash tools/pr-watch.sh ...` for PR #397 — `pr_watch.py` crashed mid-flight after detecting CI pass; the `ci_completed` event was never recorded and the renga-peers `CI_COMPLETED` peer message was never delivered

This PR adds skill-level guardrails until #398 lands the proper tool fix.

### Changes

- `.claude/skills/org-delegate/SKILL.md` (+4): "⚠️ cwd 注意: state.db touching tools" subsection at the top of Step 5, warning about `journal_append.sh`/`.py`, `set_run_pr_open.py`, and `python -c "... StateWriter ..."` from non-ja-root cwd.
- `.claude/skills/org-pull-request/SKILL.md` (+4): "⚠️ cwd 注意: pr-watch 起動時" subsection at the end of 2b-i, warning that `pr-watch.sh`/`.ps1`/`.py` must be launched with cwd at ja root or the CI completion event write crashes and peer notifications are never delivered.

Total: 2 files, +8 -0.

## Test plan

- [x] Both skill diffs read coherently and reference #398
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)