### PR TITLE
feat: make state.db tools cwd-independent (Closes #398)

### DIFF
--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -1,0 +1,32 @@
+"""pytest fixtures shared across tools/ test modules.
+
+Issue #398 follow-up: several tool tests exercise `pr_watch.main()` end-to-end,
+which calls `_notify_peer` -> `tools.peer_notify.notify_peer` -> spawns
+`renga mcp-peer` when ``RENGA_SOCKET`` is set. Inside a live Claude Code /
+renga session that environment variable is set, so test runs with a real
+`renga` binary on PATH leak fake CI / merge messages onto the production
+peer channel. The existing tests didn't notice this because CI runners
+have neither the env var nor the binary.
+
+This autouse fixture scrubs ``RENGA_SOCKET`` for the duration of every
+test in ``tools/``. Tests that explicitly want to test peer-emit behaviour
+should mock ``tools.peer_notify.notify_peer`` directly instead.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scrub_renga_socket(monkeypatch):
+    """Disable renga peer-emit fall-through for the test's duration.
+
+    `peer_notify.notify_peer` returns False immediately when
+    ``RENGA_SOCKET`` is unset, which short-circuits the whole subprocess
+    handshake. That is exactly the behaviour we want for hermetic tests
+    that aren't asserting on the peer channel.
+    """
+    monkeypatch.delenv("RENGA_SOCKET", raising=False)
+    yield

--- a/tools/journal_append.py
+++ b/tools/journal_append.py
@@ -48,18 +48,21 @@ def _parse_kv(pair: str) -> "tuple[str, str]":
     return key, val
 
 
-def _db_append(repo_root: Path, event: str, payload: dict) -> None:
+def _db_append(db_path: Path, event: str, payload: dict) -> None:
     """M4 canonical path: DB write only (no jsonl side-output)."""
     from tools.state_db import apply_schema, connect
+    from tools.state_db.discover import verify_or_exit
     from tools.state_db.writer import StateWriter
 
-    db_path = repo_root / ".state" / "state.db"
+    db_path = Path(db_path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
     is_new_db = not db_path.exists()
     conn = connect(db_path)
     try:
         if is_new_db:
             apply_schema(conn)
+        else:
+            verify_or_exit(db_path, conn=conn, prog="tools/journal_append.py")
         writer = StateWriter(conn)
         actor = None
         if isinstance(payload, dict) and isinstance(payload.get("actor"), str):
@@ -88,7 +91,14 @@ def main(argv: "list[str] | None" = None) -> int:
         default=None,
         help="JSON object to merge into the payload (typed values).",
     )
-    repo_root = Path(__file__).resolve().parent.parent
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help=(
+            "Override the resolved state.db path. Highest precedence: "
+            "--db-path > $STATE_DB_PATH > discovery (Issue #398)."
+        ),
+    )
     parser.add_argument("--path", default=None, help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
 
@@ -115,9 +125,18 @@ def main(argv: "list[str] | None" = None) -> int:
             parser.error("--json must encode a JSON object")
         payload.update(extra)
 
+    from tools.state_db.discover import resolve_state_db_path
+    db_path = resolve_state_db_path(
+        Path(args.db_path) if args.db_path else None
+    )
+
     try:
-        _db_append(repo_root, args.event, payload)
+        _db_append(db_path, args.event, payload)
         return 0
+    except SystemExit:
+        # verify_or_exit -> sys.exit on schema mismatch — let it through
+        # so the caller sees the prepared error code.
+        raise
     except Exception as exc:
         sys.stderr.write(
             "tools/journal_append.py: DB write failed "

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -66,11 +66,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from tools.state_db.discover import resolve_state_db_path  # noqa: E402
+
 # Path used by tests via mock.patch — kept as a module-level Path so the
 # legacy test seam (`mock.patch.object(pr_watch, "JOURNAL_PATH", ...)`)
-# continues to redirect writes at the tempdir. M4 made the file be the
-# state DB rather than journal.jsonl.
-JOURNAL_PATH = REPO_ROOT / ".state" / "state.db"
+# continues to redirect writes at the tempdir. Issue #398: resolved
+# via discovery so worktree-cwd invocations target the main checkout's
+# state.db, not the worktree's empty `.state/`.
+JOURNAL_PATH = resolve_state_db_path()
 
 # Issue #326: after writing a CI-completion / merge / timeout event,
 # also push a peer message to secretary so it doesn't have to poll the
@@ -100,6 +103,7 @@ def _record_ci_completed(*, db_path: Path, pr: int, repo: str,
                          status: str, duration: int) -> None:
     """Append a ``ci_completed`` event to the DB events table."""
     from tools.state_db import apply_schema, connect
+    from tools.state_db.discover import verify_or_exit
     from tools.state_db.writer import StateWriter
 
     db_path = Path(db_path)
@@ -109,6 +113,8 @@ def _record_ci_completed(*, db_path: Path, pr: int, repo: str,
     try:
         if is_new_db:
             apply_schema(conn)
+        else:
+            verify_or_exit(db_path, conn=conn, prog="tools/pr_watch.py")
         writer = StateWriter(conn)
         writer.append_event(
             kind="ci_completed",
@@ -361,6 +367,7 @@ def _watch_for_merge(
 def _record_event(*, db_path: Path, kind: str, payload: dict) -> None:
     """Append a single event row via StateWriter (used for merge-watch timeout)."""
     from tools.state_db import apply_schema, connect
+    from tools.state_db.discover import verify_or_exit
     from tools.state_db.writer import StateWriter
 
     db_path = Path(db_path)
@@ -370,6 +377,8 @@ def _record_event(*, db_path: Path, kind: str, payload: dict) -> None:
     try:
         if is_new_db:
             apply_schema(conn)
+        else:
+            verify_or_exit(db_path, conn=conn, prog="tools/pr_watch.py")
         writer = StateWriter(conn)
         writer.append_event(kind=kind, actor="pr_watch", payload=payload)
         writer.commit()

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -42,7 +42,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-DEFAULT_DB_PATH = REPO_ROOT / ".state" / "state.db"
+from tools.state_db.discover import resolve_state_db_path  # noqa: E402
+
+# Issue #398: discovery-based default so worktree-cwd invocations target
+# the main checkout's state.db rather than an empty `.worktrees/<task>/.state/`.
+DEFAULT_DB_PATH = resolve_state_db_path()
 
 
 # Return codes for :func:`complete_on_merge`. Stable strings so callers
@@ -190,7 +194,10 @@ def complete_on_merge(
     payload (e.g. pr_watch's merge-watch loop); when omitted the helper
     fetches it via :func:`fetch_pr_view`.
     """
-    db_path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+    db_path = (
+        resolve_state_db_path(Path(db_path)) if db_path is not None
+        else resolve_state_db_path()
+    )
     if pr_view is None:
         pr_view = fetch_pr_view(pr, repo)
 
@@ -206,6 +213,7 @@ def complete_on_merge(
     commit_short = _short_sha(commit_full)
 
     from tools.state_db import apply_schema, connect
+    from tools.state_db.discover import verify_or_exit
     from tools.state_db.writer import StateWriter
 
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -214,6 +222,10 @@ def complete_on_merge(
     try:
         if is_new_db:
             apply_schema(conn)
+        else:
+            verify_or_exit(
+                db_path, conn=conn, prog="tools/run_complete_on_merge.py",
+            )
 
         resolved_task_id = task_id or _resolve_task_id(
             conn, pr=pr, repo=repo, pr_url=pr_url, head_ref=head_ref,

--- a/tools/set_run_pr_open.py
+++ b/tools/set_run_pr_open.py
@@ -44,7 +44,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-DEFAULT_DB_PATH = REPO_ROOT / ".state" / "state.db"
+from tools.state_db.discover import resolve_state_db_path  # noqa: E402
+
+# Issue #398: discovery-based default so worktree-cwd invocations target
+# the main checkout's state.db rather than an empty `.worktrees/<task>/.state/`.
+DEFAULT_DB_PATH = resolve_state_db_path()
 
 
 def _ensure_gh_installed() -> None:
@@ -128,7 +132,10 @@ def set_run_pr_open(
     ``pr_view`` may be supplied by callers that already fetched the
     payload; otherwise it is fetched via :func:`fetch_pr_view`.
     """
-    db_path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+    db_path = (
+        resolve_state_db_path(Path(db_path)) if db_path is not None
+        else resolve_state_db_path()
+    )
     if pr_view is None:
         pr_view = fetch_pr_view(pr, repo)
 
@@ -141,6 +148,7 @@ def set_run_pr_open(
         )
 
     from tools.state_db import apply_schema, connect
+    from tools.state_db.discover import verify_or_exit
     from tools.state_db.writer import StateWriter
 
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -149,6 +157,8 @@ def set_run_pr_open(
     try:
         if is_new_db:
             apply_schema(conn)
+        else:
+            verify_or_exit(db_path, conn=conn, prog="tools/set_run_pr_open.py")
 
         row = conn.execute(
             "SELECT 1 FROM runs WHERE task_id = ?", (task_id,)

--- a/tools/state_db/discover.py
+++ b/tools/state_db/discover.py
@@ -67,6 +67,13 @@ def _resolve_main_checkout_from_worktree(git_file: Path) -> Optional[Path]:
     pointing at ``<main_git>/worktrees/<name>``. The main checkout is
     three parents up from that gitdir (gitdir → worktrees → .git → main).
 
+    The gitdir path may be absolute or relative. Per gitrepository-layout
+    (and confirmed by ``git worktree add --relative-paths``), a relative
+    gitdir is resolved against the directory holding the ``.git`` file —
+    NOT the cwd. We must honour that here, otherwise invocations from a
+    different cwd would resolve the wrong target and silently fall back
+    to the worktree's own ``.state/`` (the bug we're fixing).
+
     Returns None if the file is not a valid worktree pointer or the
     inferred main checkout doesn't itself look like the right project
     (sanity-check via :data:`_PROJECT_NAME_MARKER`).
@@ -79,6 +86,8 @@ def _resolve_main_checkout_from_worktree(git_file: Path) -> Optional[Path]:
     if not text.startswith(prefix):
         return None
     gitdir = Path(text[len(prefix):].strip())
+    if not gitdir.is_absolute():
+        gitdir = (git_file.parent / gitdir).resolve()
     # gitdir = <main>/.git/worktrees/<name>
     # parents: gitdir.parent = .git/worktrees, .parent.parent = .git,
     # .parent.parent.parent = main checkout root.
@@ -177,7 +186,12 @@ def verify_state_db_schema(
     (callers that already hold an open connection can pass it to avoid
     re-opening). Raises :class:`StateDbSchemaError` with an actionable
     message on failure — callers translate that into a non-zero exit
-    code (see :func:`exit_on_schema_error`).
+    code (see :func:`verify_or_exit`).
+
+    A corrupt sqlite file (e.g. random bytes planted at the resolved
+    path) raises ``sqlite3.DatabaseError`` from the schema-introspection
+    query; we wrap that into :class:`StateDbSchemaError` too so callers
+    see a single, actionable error type instead of a bare traceback.
     """
     db_path = Path(db_path)
     if not db_path.exists():
@@ -188,9 +202,17 @@ def verify_state_db_schema(
         conn = sqlite3.connect(str(db_path))
         own_conn = True
     try:
-        rows = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'"
-        ).fetchall()
+        try:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        except sqlite3.DatabaseError as exc:
+            raise StateDbSchemaError(
+                _format_missing_message(
+                    db_path,
+                    f"is not a valid sqlite database ({exc})",
+                )
+            ) from exc
         present = {row[0] for row in rows}
         missing = [t for t in _REQUIRED_TABLES if t not in present]
         if missing:

--- a/tools/state_db/discover.py
+++ b/tools/state_db/discover.py
@@ -1,0 +1,238 @@
+"""Repo-root + state.db path discovery for cwd-independent tools (Issue #398).
+
+Several tools (`pr_watch.py`, `journal_append.py`, `set_run_pr_open.py`,
+`run_complete_on_merge.py`) need to open ``<repo_root>/.state/state.db``
+regardless of the cwd they were invoked from. Pre-#398 they anchored the
+path off ``Path(__file__).resolve().parent.parent``, which works when the
+script lives in the main checkout, but resolves to the **worktree** root
+when the script is invoked through a `.worktrees/<task>/` checkout. The
+worktree's ``.state/`` is empty (only ``.gitkeep`` + ``workers/``), so
+opens silently created an empty DB at the wrong path and downstream
+SELECT/INSERT crashed with "no such table: runs/events".
+
+Discovery contract:
+
+1. Walk up from this file's directory until we find a ``pyproject.toml``
+   whose ``[project] name = "claude-org-ja"``. ``.git`` alone is not
+   sufficient — it exists in worktrees too (as a file pointer).
+2. If the found root is a worktree (``.git`` is a file containing
+   ``gitdir: ...``), resolve back to the main checkout that owns the
+   real ``.git`` directory. The canonical state.db lives in the main
+   checkout, not in worktree-private ``.state/`` directories.
+3. Honor the ``STATE_DB_PATH`` environment variable as an override.
+4. Callers may pass an explicit path (e.g. CLI ``--db-path``) which
+   trumps both env and discovery — used by tests and for debugging
+   against a custom DB.
+
+Precedence for :func:`resolve_state_db_path`:
+    explicit (``cli_override``)  >  ``$STATE_DB_PATH``  >  discovered
+
+Schema verification (:func:`verify_state_db_schema`) is the loud-failure
+mode for the bug class above: when the resolved path points at a file
+that exists but is missing the ``runs`` / ``events`` tables, raise with
+an actionable message instead of letting the next SELECT/INSERT crash
+with the bare sqlite error.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+# String marker we look for in pyproject.toml. Doing a substring search
+# is intentional — it avoids pulling tomllib (3.11+) / tomli (3.10) into
+# every tool just to read one field, and the marker is a stable canary
+# string in this repo's own pyproject.
+_PROJECT_NAME_MARKER = 'name = "claude-org-ja"'
+
+# Required tables for state.db to be usable by event-recording tools.
+# The schema has more (projects, workstreams, …) but `runs` + `events`
+# are the two that pr_watch / journal_append / set_run_pr_open touch.
+_REQUIRED_TABLES = ("runs", "events")
+
+
+def _pyproject_has_marker(pyproject: Path) -> bool:
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return _PROJECT_NAME_MARKER in text
+
+
+def _resolve_main_checkout_from_worktree(git_file: Path) -> Optional[Path]:
+    """Given a worktree's ``.git`` file, return the main checkout's root.
+
+    Worktree ``.git`` files contain a single ``gitdir: <path>`` line
+    pointing at ``<main_git>/worktrees/<name>``. The main checkout is
+    three parents up from that gitdir (gitdir → worktrees → .git → main).
+
+    Returns None if the file is not a valid worktree pointer or the
+    inferred main checkout doesn't itself look like the right project
+    (sanity-check via :data:`_PROJECT_NAME_MARKER`).
+    """
+    try:
+        text = git_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    prefix = "gitdir:"
+    if not text.startswith(prefix):
+        return None
+    gitdir = Path(text[len(prefix):].strip())
+    # gitdir = <main>/.git/worktrees/<name>
+    # parents: gitdir.parent = .git/worktrees, .parent.parent = .git,
+    # .parent.parent.parent = main checkout root.
+    main_root = gitdir.parent.parent.parent
+    if not main_root.is_dir():
+        return None
+    main_pyproject = main_root / "pyproject.toml"
+    if not main_pyproject.is_file() or not _pyproject_has_marker(main_pyproject):
+        return None
+    return main_root
+
+
+def discover_repo_root(start: Optional[Path] = None) -> Path:
+    """Walk up from ``start`` (default: this file's directory) to find the
+    claude-org-ja main checkout.
+
+    Returns the absolute path of the directory whose ``pyproject.toml``
+    declares ``name = "claude-org-ja"``. If that directory is itself a
+    worktree (``.git`` is a file pointer), redirects to the main checkout.
+
+    Raises :class:`RuntimeError` if no candidate is found.
+    """
+    if start is None:
+        start = Path(__file__).resolve().parent
+    else:
+        start = Path(start).resolve()
+
+    for candidate in [start, *start.parents]:
+        pyproject = candidate / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        if not _pyproject_has_marker(pyproject):
+            continue
+        git_path = candidate / ".git"
+        if git_path.is_file():
+            main_root = _resolve_main_checkout_from_worktree(git_path)
+            if main_root is not None:
+                return main_root
+            # Worktree pointer was malformed; fall through to candidate
+            # rather than failing — better to return the worktree root
+            # than to raise, callers will get a schema-mismatch error
+            # downstream that points to the same fix.
+        return candidate
+
+    raise RuntimeError(
+        "could not locate claude-org-ja repo root (no pyproject.toml with "
+        f'{_PROJECT_NAME_MARKER!r} found walking up from {start})'
+    )
+
+
+def resolve_state_db_path(cli_override: Optional[Path] = None) -> Path:
+    """Resolve ``state.db`` path with precedence: explicit > env > discovery.
+
+    * ``cli_override`` — typically the value of a CLI ``--db-path`` flag.
+    * ``$STATE_DB_PATH`` — environment variable override.
+    * discovery — walks up from this file to the main checkout.
+
+    The returned path is absolute. The file may or may not exist;
+    callers can pair this with :func:`verify_state_db_schema` to assert
+    schema validity before reads/writes.
+    """
+    if cli_override is not None:
+        return Path(cli_override).resolve()
+    env_override = os.environ.get("STATE_DB_PATH")
+    if env_override:
+        return Path(env_override).resolve()
+    return discover_repo_root() / ".state" / "state.db"
+
+
+class StateDbSchemaError(RuntimeError):
+    """Raised when state.db is missing or its schema is incomplete.
+
+    Carries an actionable message including the resolved path and the
+    invocation cwd so the operator can immediately see whether they are
+    pointed at the wrong file.
+    """
+
+
+def _format_missing_message(db_path: Path, reason: str) -> str:
+    cwd = os.getcwd()
+    return (
+        f"state.db {reason} at {db_path}; run cwd was {cwd}. "
+        "Try --db-path <path> or set STATE_DB_PATH to the canonical "
+        "<repo_root>/.state/state.db. (Issue #398: tools must run from "
+        "the main checkout's state.db, not a worktree's empty .state/.)"
+    )
+
+
+def verify_state_db_schema(
+    db_path: Path,
+    conn: Optional[sqlite3.Connection] = None,
+) -> None:
+    """Assert ``db_path`` exists and contains the required tables.
+
+    Opens a short-lived sqlite connection if ``conn`` is not supplied
+    (callers that already hold an open connection can pass it to avoid
+    re-opening). Raises :class:`StateDbSchemaError` with an actionable
+    message on failure — callers translate that into a non-zero exit
+    code (see :func:`exit_on_schema_error`).
+    """
+    db_path = Path(db_path)
+    if not db_path.exists():
+        raise StateDbSchemaError(_format_missing_message(db_path, "not found"))
+
+    own_conn = False
+    if conn is None:
+        conn = sqlite3.connect(str(db_path))
+        own_conn = True
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        present = {row[0] for row in rows}
+        missing = [t for t in _REQUIRED_TABLES if t not in present]
+        if missing:
+            raise StateDbSchemaError(
+                _format_missing_message(
+                    db_path,
+                    f"is missing required table(s) {missing!r}",
+                )
+            )
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def verify_or_exit(
+    db_path: Path,
+    conn: Optional[sqlite3.Connection] = None,
+    *,
+    prog: str = "tool",
+    exit_code: int = 2,
+) -> None:
+    """Convenience wrapper: verify schema and ``sys.exit`` on failure.
+
+    Tools call this right after opening the connection (and before any
+    SELECT/INSERT) so a wrong-path / corrupted-DB invocation surfaces as
+    a clean stderr message + non-zero exit instead of a stack trace from
+    sqlite3.OperationalError. ``prog`` is the script name used in the
+    stderr prefix; ``exit_code`` defaults to 2 (usage / configuration
+    error, matching the rest of the affected CLIs).
+    """
+    import sys
+    try:
+        verify_state_db_schema(db_path, conn=conn)
+    except StateDbSchemaError as exc:
+        sys.stderr.write(f"{prog}: error: {exc}\n")
+        sys.exit(exit_code)
+
+
+__all__ = [
+    "StateDbSchemaError",
+    "discover_repo_root",
+    "resolve_state_db_path",
+    "verify_or_exit",
+    "verify_state_db_schema",
+]

--- a/tools/test_state_db_discover.py
+++ b/tools/test_state_db_discover.py
@@ -1,0 +1,611 @@
+"""Unit + subprocess tests for tools/state_db/discover.py (Issue #398).
+
+Covers:
+
+* :func:`discover_repo_root` — finds pyproject.toml with claude-org-ja
+  marker; resolves a worktree-style ``.git`` file to the main checkout.
+* :func:`resolve_state_db_path` — precedence (cli > env > discovery).
+* :func:`verify_state_db_schema` — passes on a freshly-applied schema,
+  fails on missing file / missing tables / corrupt file.
+* End-to-end subprocess invocation of the three CLIs (pr_watch.py,
+  journal_append.py, set_run_pr_open.py) from a tmp_path cwd plus a
+  worktree-style cwd, asserting each writes to the canonical state.db
+  resolved via discovery — not to a stray ``./.state/state.db``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.state_db import apply_schema, connect  # noqa: E402
+from tools.state_db.discover import (  # noqa: E402
+    StateDbSchemaError,
+    discover_repo_root,
+    resolve_state_db_path,
+    verify_state_db_schema,
+)
+
+
+def _make_fake_repo(root: Path) -> Path:
+    """Lay out a minimal fake claude-org-ja checkout under ``root``.
+
+    Includes pyproject.toml with the recognised marker, a real ``.git``
+    directory (so the worktree-redirect path doesn't trigger), and an
+    empty ``.state/`` directory ready for state.db.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text(
+        textwrap.dedent('''
+            [project]
+            name = "claude-org-ja"
+            version = "0.0.1"
+        ''').strip() + "\n",
+        encoding="utf-8",
+    )
+    (root / ".git").mkdir()
+    (root / ".state").mkdir()
+    return root
+
+
+def _make_fake_worktree(main_root: Path, name: str) -> Path:
+    """Return a worktree-style checkout pointing at ``main_root``.
+
+    Lays out ``<main>/.git/worktrees/<name>`` (any contents — discover
+    only reads parent paths) and a sibling worktree directory containing
+    its own pyproject.toml + ``.git`` *file* with a ``gitdir:`` line.
+    """
+    worktree_internal = main_root / ".git" / "worktrees" / name
+    worktree_internal.mkdir(parents=True, exist_ok=True)
+
+    worktree_root = main_root.parent / f"worktree-{name}"
+    worktree_root.mkdir(parents=True, exist_ok=True)
+    (worktree_root / "pyproject.toml").write_text(
+        textwrap.dedent('''
+            [project]
+            name = "claude-org-ja"
+            version = "0.0.1"
+        ''').strip() + "\n",
+        encoding="utf-8",
+    )
+    (worktree_root / ".git").write_text(
+        f"gitdir: {worktree_internal}\n", encoding="utf-8",
+    )
+    return worktree_root
+
+
+class DiscoverRepoRootTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_finds_marker_via_walk_up(self) -> None:
+        repo = _make_fake_repo(self.tmp / "fake-repo")
+        nested = repo / "tools" / "state_db"
+        nested.mkdir(parents=True)
+        result = discover_repo_root(start=nested)
+        self.assertEqual(result, repo)
+
+    def test_redirects_worktree_to_main_checkout(self) -> None:
+        main = _make_fake_repo(self.tmp / "main-repo")
+        wt = _make_fake_worktree(main, "feat-x")
+        nested = wt / "tools" / "state_db"
+        nested.mkdir(parents=True)
+        # Walking up from inside the worktree should resolve to the main
+        # checkout, not the worktree root — that's the whole point of
+        # Issue #398.
+        result = discover_repo_root(start=nested)
+        self.assertEqual(result, main)
+        self.assertNotEqual(result, wt)
+
+    def test_raises_when_no_marker(self) -> None:
+        bare = self.tmp / "bare"
+        bare.mkdir()
+        with self.assertRaises(RuntimeError):
+            discover_repo_root(start=bare)
+
+    def test_ignores_pyproject_without_marker(self) -> None:
+        # A nearby project with a different name must be skipped — we
+        # only want to anchor to claude-org-ja.
+        outer = self.tmp / "outer"
+        outer.mkdir()
+        (outer / "pyproject.toml").write_text(
+            '[project]\nname = "other-thing"\n', encoding="utf-8",
+        )
+        repo = _make_fake_repo(outer / "claude-repo")
+        nested = repo / "tools"
+        nested.mkdir()
+        self.assertEqual(discover_repo_root(start=nested), repo)
+
+
+class ResolveStateDbPathTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._td.name)
+        self._saved_env = os.environ.pop("STATE_DB_PATH", None)
+
+    def tearDown(self) -> None:
+        if self._saved_env is not None:
+            os.environ["STATE_DB_PATH"] = self._saved_env
+        else:
+            os.environ.pop("STATE_DB_PATH", None)
+        self._td.cleanup()
+
+    def test_explicit_override_wins_over_env(self) -> None:
+        explicit = self.tmp / "explicit.db"
+        os.environ["STATE_DB_PATH"] = str(self.tmp / "env.db")
+        result = resolve_state_db_path(cli_override=explicit)
+        self.assertEqual(result, explicit.resolve())
+
+    def test_env_wins_over_discovery(self) -> None:
+        env_path = self.tmp / "env.db"
+        os.environ["STATE_DB_PATH"] = str(env_path)
+        result = resolve_state_db_path()
+        self.assertEqual(result, env_path.resolve())
+
+    def test_discovery_fallback(self) -> None:
+        # No override + no env → discovery walks up from discover.py and
+        # lands on the real checkout's .state/state.db. We don't pin the
+        # exact path (varies by checkout) but it must end with the
+        # canonical tail.
+        result = resolve_state_db_path()
+        self.assertEqual(result.parts[-2:], (".state", "state.db"))
+
+
+class VerifyStateDbSchemaTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_missing_file_raises(self) -> None:
+        missing = self.tmp / "absent.db"
+        with self.assertRaises(StateDbSchemaError) as ctx:
+            verify_state_db_schema(missing)
+        msg = str(ctx.exception)
+        self.assertIn("not found", msg)
+        self.assertIn(str(missing), msg)
+        self.assertIn("STATE_DB_PATH", msg)
+
+    def test_empty_file_raises(self) -> None:
+        empty = self.tmp / "empty.db"
+        empty.write_bytes(b"")
+        with self.assertRaises(StateDbSchemaError) as ctx:
+            verify_state_db_schema(empty)
+        self.assertIn("missing required table", str(ctx.exception))
+
+    def test_no_runs_table_raises(self) -> None:
+        partial = self.tmp / "partial.db"
+        conn = sqlite3.connect(str(partial))
+        try:
+            conn.execute(
+                "CREATE TABLE events (id INTEGER PRIMARY KEY)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        with self.assertRaises(StateDbSchemaError) as ctx:
+            verify_state_db_schema(partial)
+        self.assertIn("runs", str(ctx.exception))
+
+    def test_full_schema_passes(self) -> None:
+        good = self.tmp / "good.db"
+        conn = connect(good)
+        apply_schema(conn)
+        conn.close()
+        verify_state_db_schema(good)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Subprocess integration tests
+# ---------------------------------------------------------------------------
+
+
+class _SubprocessFixture:
+    """Helper: spin up a fake repo with a populated state.db and run CLIs.
+
+    Each test gets a fresh tmp containing:
+
+        <tmp>/main-repo/pyproject.toml
+        <tmp>/main-repo/.git/                          (real dir)
+        <tmp>/main-repo/.state/state.db                (schema applied)
+        <tmp>/main-repo/tools/                         (symlinked from real repo)
+        <tmp>/main-repo/tools/state_db/                (real subpackage)
+
+    The fake tools/ tree is a copy of the real repo's tools/ + state_db/
+    so the python entry points (pr_watch.py, journal_append.py, etc.)
+    can resolve their imports against the fake repo's pyproject anchor.
+    """
+
+    def __init__(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._td.name)
+        self.main = self.tmp / "main-repo"
+        self.main.mkdir()
+        # Replicate the marker pyproject.toml so discovery walks land here.
+        (self.main / "pyproject.toml").write_text(
+            textwrap.dedent('''
+                [project]
+                name = "claude-org-ja"
+                version = "0.0.1"
+            ''').strip() + "\n",
+            encoding="utf-8",
+        )
+        # Real .git directory (not a worktree pointer).
+        (self.main / ".git").mkdir()
+        # Copy the real tools/ tree so Python imports resolve relative to
+        # the fake main-repo. We need: tools/__init__.py-or-equivalent,
+        # state_db/, plus the four CLI scripts.
+        src_tools = REPO_ROOT / "tools"
+        dst_tools = self.main / "tools"
+        dst_tools.mkdir()
+        # Copy state_db package wholesale.
+        shutil.copytree(src_tools / "state_db", dst_tools / "state_db")
+        # Copy individual CLI scripts + their immediate helper modules.
+        for name in (
+            "pr_watch.py",
+            "journal_append.py",
+            "set_run_pr_open.py",
+            "run_complete_on_merge.py",
+            "peer_notify.py",
+        ):
+            shutil.copy2(src_tools / name, dst_tools / name)
+        # Initialise an empty schema'd state.db at the canonical path.
+        self.state_dir = self.main / ".state"
+        self.state_dir.mkdir()
+        self.state_db = self.state_dir / "state.db"
+        conn = connect(self.state_db)
+        apply_schema(conn)
+        conn.close()
+
+    def cleanup(self) -> None:
+        self._td.cleanup()
+
+    def make_worktree(self, name: str) -> Path:
+        """Create a fake worktree pointing at the main checkout."""
+        worktree_internal = self.main / ".git" / "worktrees" / name
+        worktree_internal.mkdir(parents=True)
+        wt = self.tmp / f"worktree-{name}"
+        wt.mkdir()
+        (wt / "pyproject.toml").write_text(
+            textwrap.dedent('''
+                [project]
+                name = "claude-org-ja"
+                version = "0.0.1"
+            ''').strip() + "\n",
+            encoding="utf-8",
+        )
+        (wt / ".git").write_text(
+            f"gitdir: {worktree_internal}\n", encoding="utf-8",
+        )
+        # Worktrees have an empty .state/ (modulo workers/ + .gitkeep).
+        (wt / ".state").mkdir()
+        return wt
+
+    def event_count(self, kind: str) -> int:
+        conn = sqlite3.connect(str(self.state_db))
+        try:
+            return int(conn.execute(
+                "SELECT COUNT(*) FROM events WHERE kind = ?", (kind,),
+            ).fetchone()[0])
+        finally:
+            conn.close()
+
+
+class JournalAppendCwdTests(unittest.TestCase):
+    """End-to-end: journal_append.py from various cwds writes to the
+    canonical state.db."""
+
+    def setUp(self) -> None:
+        self.sb = _SubprocessFixture()
+
+    def tearDown(self) -> None:
+        self.sb.cleanup()
+
+    def _invoke(self, cwd: Path, *extra: str) -> subprocess.CompletedProcess:
+        env = {**os.environ}
+        # Strip any STATE_DB_PATH leak from the parent environment so we
+        # exercise the discovery path, not an ambient override.
+        env.pop("STATE_DB_PATH", None)
+        return subprocess.run(
+            [
+                sys.executable,
+                str(self.sb.main / "tools" / "journal_append.py"),
+                "worker_progress",
+                "task=cwd_test",
+                "note=cwd_smoke",
+                *extra,
+            ],
+            cwd=str(cwd), capture_output=True, text=True, env=env, check=False,
+        )
+
+    def test_runs_from_main_checkout_cwd(self) -> None:
+        proc = self._invoke(self.sb.main)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(self.sb.event_count("worker_progress"), 1)
+
+    def test_runs_from_unrelated_tmp_cwd(self) -> None:
+        # cwd is a tmp directory unrelated to the repo. Discovery anchors
+        # off __file__, not cwd, so the canonical state.db must still be
+        # the write target.
+        proc = self._invoke(self.sb.tmp)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(self.sb.event_count("worker_progress"), 1)
+
+    def test_runs_from_worktree_cwd_writes_to_main_state_db(self) -> None:
+        # Issue #398 canonical scenario: invocation from
+        # `.worktrees/<task>/` must NOT create a stray state.db inside
+        # the worktree's empty `.state/`.
+        wt = self.sb.make_worktree("feat-cwd-fix")
+        proc = self._invoke(wt)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(self.sb.event_count("worker_progress"), 1)
+        worktree_state = wt / ".state" / "state.db"
+        self.assertFalse(
+            worktree_state.exists(),
+            f"worktree state.db must NOT be auto-created; saw {worktree_state}",
+        )
+
+    def test_state_db_path_env_override(self) -> None:
+        # Explicit env var pointing at a custom DB wins over discovery.
+        custom = self.sb.tmp / "custom.db"
+        conn = connect(custom)
+        apply_schema(conn)
+        conn.close()
+        env = {**os.environ, "STATE_DB_PATH": str(custom)}
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(self.sb.main / "tools" / "journal_append.py"),
+                "worker_progress",
+                "task=env_test",
+            ],
+            cwd=str(self.sb.tmp), capture_output=True, text=True,
+            env=env, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        # Event landed in the env-pointed DB, NOT the canonical one.
+        custom_count = sqlite3.connect(str(custom)).execute(
+            "SELECT COUNT(*) FROM events WHERE kind='worker_progress'"
+        ).fetchone()[0]
+        self.assertEqual(custom_count, 1)
+        self.assertEqual(self.sb.event_count("worker_progress"), 0)
+
+    def test_db_path_cli_flag_wins_over_env(self) -> None:
+        cli_db = self.sb.tmp / "cli.db"
+        conn = connect(cli_db)
+        apply_schema(conn)
+        conn.close()
+        env_db = self.sb.tmp / "env.db"
+        conn = connect(env_db)
+        apply_schema(conn)
+        conn.close()
+        env = {**os.environ, "STATE_DB_PATH": str(env_db)}
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(self.sb.main / "tools" / "journal_append.py"),
+                "worker_progress",
+                "task=precedence_test",
+                "--db-path", str(cli_db),
+            ],
+            cwd=str(self.sb.tmp), capture_output=True, text=True,
+            env=env, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(
+            sqlite3.connect(str(cli_db)).execute(
+                "SELECT COUNT(*) FROM events"
+            ).fetchone()[0], 1,
+        )
+        self.assertEqual(
+            sqlite3.connect(str(env_db)).execute(
+                "SELECT COUNT(*) FROM events"
+            ).fetchone()[0], 0,
+        )
+
+
+class JournalAppendSchemaMismatchTests(unittest.TestCase):
+    """Hard-fail behaviour when the resolved DB exists but lacks schema."""
+
+    def setUp(self) -> None:
+        self.sb = _SubprocessFixture()
+
+    def tearDown(self) -> None:
+        self.sb.cleanup()
+
+    def test_corrupt_state_db_via_env_override_exits_nonzero(self) -> None:
+        # Plant an empty file at the env-overridden path so schema is
+        # missing. The CLI must surface that with a clear error rather
+        # than silently writing nothing or crashing on OperationalError.
+        bogus = self.sb.tmp / "bogus.db"
+        bogus.write_bytes(b"")
+        env = {**os.environ, "STATE_DB_PATH": str(bogus)}
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(self.sb.main / "tools" / "journal_append.py"),
+                "worker_progress",
+                "task=schema_check",
+            ],
+            cwd=str(self.sb.tmp), capture_output=True, text=True,
+            env=env, check=False,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("missing required table", proc.stderr)
+        self.assertIn("STATE_DB_PATH", proc.stderr)
+
+
+class PrWatchCwdTests(unittest.TestCase):
+    """pr_watch.py picks up the canonical state.db via discovery."""
+
+    def setUp(self) -> None:
+        self.sb = _SubprocessFixture()
+
+    def tearDown(self) -> None:
+        self.sb.cleanup()
+
+    def _make_fake_gh_dir(self) -> Path:
+        """Create a directory containing a fake `gh` shim; prepend to PATH."""
+        bin_dir = self.sb.tmp / "fake-bin"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        # POSIX-only: a shell script that returns canned JSON. Tests are
+        # skipped on Windows below.
+        gh.write_text(textwrap.dedent('''
+            #!/usr/bin/env bash
+            # Minimal gh stub: emits canned JSON for pr view / pr checks
+            # and exits 0 for pr checks --watch.
+            case "$1 $2" in
+              "pr view")
+                # Fake "PR exists" and "checks" payloads for our test.
+                if [[ "$*" == *"--json number"* ]]; then
+                  echo '{"number": 4242}'
+                fi
+                ;;
+              "pr checks")
+                if [[ "$*" == *"--watch"* ]]; then
+                  exit 0
+                fi
+                if [[ "$*" == *"--json bucket"* ]]; then
+                  echo '[{"bucket":"pass","state":"SUCCESS","name":"ci"}]'
+                fi
+                ;;
+              "repo view")
+                echo '{"nameWithOwner": "octo/repo"}'
+                ;;
+            esac
+            exit 0
+        ''').lstrip())
+        gh.chmod(0o755)
+        return bin_dir
+
+    def test_runs_from_worktree_cwd_writes_to_main_state_db(self) -> None:
+        if sys.platform == "win32":
+            self.skipTest("bash gh-stub is POSIX-only")
+        wt = self.sb.make_worktree("pr-watch-cwd")
+        bin_dir = self._make_fake_gh_dir()
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        }
+        env.pop("STATE_DB_PATH", None)
+        # Scrub RENGA_SOCKET so peer_notify silently no-ops — otherwise
+        # the test would emit a real "CI_COMPLETED PR #4242" message to
+        # a live renga instance (the secretary running this test).
+        env.pop("RENGA_SOCKET", None)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(self.sb.main / "tools" / "pr_watch.py"),
+                "--pr", "4242",
+                "--repo", "octo/repo",
+                "--interval", "1",
+            ],
+            cwd=str(wt), capture_output=True, text=True,
+            env=env, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(self.sb.event_count("ci_completed"), 1)
+        worktree_state = wt / ".state" / "state.db"
+        self.assertFalse(
+            worktree_state.exists(),
+            f"worktree state.db must NOT be auto-created; saw {worktree_state}",
+        )
+
+
+class SetRunPrOpenCwdTests(unittest.TestCase):
+    """set_run_pr_open.py picks up the canonical state.db via discovery."""
+
+    def setUp(self) -> None:
+        self.sb = _SubprocessFixture()
+        # Seed a runs row so the back-fill has something to update.
+        from tools.state_db.writer import StateWriter
+        conn = connect(self.sb.state_db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.upsert_run(
+                    task_id="t-cwd",
+                    project_slug="claude-org",
+                    pattern="B",
+                    title="t-cwd",
+                    status="review",
+                    branch="feat/t-cwd",
+                )
+        finally:
+            conn.close()
+
+    def tearDown(self) -> None:
+        self.sb.cleanup()
+
+    def test_runs_from_worktree_cwd_back_fills_main_state_db(self) -> None:
+        if sys.platform == "win32":
+            self.skipTest("bash gh-stub is POSIX-only")
+        wt = self.sb.make_worktree("setpr-cwd")
+        bin_dir = self.sb.tmp / "fake-bin-setpr"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        gh.write_text(textwrap.dedent('''
+            #!/usr/bin/env bash
+            case "$1 $2" in
+              "pr view")
+                echo '{"url":"https://github.com/octo/repo/pull/777","headRefName":"feat/t-cwd"}'
+                ;;
+              "repo view")
+                echo '{"nameWithOwner": "octo/repo"}'
+                ;;
+            esac
+            exit 0
+        ''').lstrip())
+        gh.chmod(0o755)
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        }
+        env.pop("STATE_DB_PATH", None)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(self.sb.main / "tools" / "set_run_pr_open.py"),
+                "--task-id", "t-cwd",
+                "--pr", "777",
+                "--repo", "octo/repo",
+            ],
+            cwd=str(wt), capture_output=True, text=True,
+            env=env, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        # Verify the canonical state.db has the back-filled pr_url.
+        conn = sqlite3.connect(str(self.sb.state_db))
+        try:
+            row = conn.execute(
+                "SELECT pr_url FROM runs WHERE task_id = ?", ("t-cwd",),
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNotNone(row)
+        self.assertEqual(row[0], "https://github.com/octo/repo/pull/777")
+        worktree_state = wt / ".state" / "state.db"
+        self.assertFalse(
+            worktree_state.exists(),
+            f"worktree state.db must NOT be auto-created; saw {worktree_state}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_state_db_discover.py
+++ b/tools/test_state_db_discover.py
@@ -111,6 +111,31 @@ class DiscoverRepoRootTests(unittest.TestCase):
         self.assertEqual(result, main)
         self.assertNotEqual(result, wt)
 
+    def test_redirects_worktree_with_relative_gitdir(self) -> None:
+        # Codex review Major 1: ``git worktree add --relative-paths``
+        # writes a relative ``gitdir:`` line. Discovery has to resolve
+        # it relative to the .git file's parent, not cwd, otherwise an
+        # invocation from a different cwd would silently fall back to
+        # the worktree's own .state/.
+        main = _make_fake_repo(self.tmp / "main-rel-repo")
+        wt = _make_fake_worktree(main, "feat-rel")
+        # Replace the absolute gitdir with a relative one. The expected
+        # main_root resolution is independent of cwd.
+        worktree_internal = main / ".git" / "worktrees" / "feat-rel"
+        rel = os.path.relpath(worktree_internal, wt)
+        (wt / ".git").write_text(f"gitdir: {rel}\n", encoding="utf-8")
+        nested = wt / "tools"
+        nested.mkdir()
+        # Switch cwd to an unrelated directory before discovery to prove
+        # the relative resolution does not leak cwd.
+        prior = os.getcwd()
+        try:
+            os.chdir(str(self.tmp))
+            result = discover_repo_root(start=nested)
+        finally:
+            os.chdir(prior)
+        self.assertEqual(result, main)
+
     def test_raises_when_no_marker(self) -> None:
         bare = self.tmp / "bare"
         bare.mkdir()
@@ -203,6 +228,18 @@ class VerifyStateDbSchemaTests(unittest.TestCase):
             verify_state_db_schema(partial)
         self.assertIn("runs", str(ctx.exception))
 
+    def test_corrupt_sqlite_file_raises_schema_error(self) -> None:
+        # Codex review Major 2: a non-sqlite file at the resolved path
+        # makes ``conn.execute`` raise ``sqlite3.DatabaseError``. Without
+        # explicit handling, that propagates as a bare traceback.
+        # verify_state_db_schema must wrap it into StateDbSchemaError
+        # so callers see a single, actionable failure type.
+        corrupt = self.tmp / "corrupt.db"
+        corrupt.write_bytes(b"this is not a sqlite database " + b"\x00" * 200)
+        with self.assertRaises(StateDbSchemaError) as ctx:
+            verify_state_db_schema(corrupt)
+        self.assertIn("not a valid sqlite database", str(ctx.exception))
+
     def test_full_schema_passes(self) -> None:
         good = self.tmp / "good.db"
         conn = connect(good)
@@ -276,8 +313,16 @@ class _SubprocessFixture:
     def cleanup(self) -> None:
         self._td.cleanup()
 
-    def make_worktree(self, name: str) -> Path:
-        """Create a fake worktree pointing at the main checkout."""
+    def make_worktree(self, name: str, *, mirror_tools: bool = True) -> Path:
+        """Create a fake worktree pointing at the main checkout.
+
+        When ``mirror_tools`` is True (default), copies the same tools/
+        tree into the worktree — that's what real ``git worktree add``
+        produces. Tests that exercise discovery from a worktree-relative
+        ``__file__`` need this so the tool script's ``Path(__file__)``
+        starts inside ``wt/tools/`` (the actual production scenario for
+        Issue #398), not under ``main/tools/``.
+        """
         worktree_internal = self.main / ".git" / "worktrees" / name
         worktree_internal.mkdir(parents=True)
         wt = self.tmp / f"worktree-{name}"
@@ -295,6 +340,8 @@ class _SubprocessFixture:
         )
         # Worktrees have an empty .state/ (modulo workers/ + .gitkeep).
         (wt / ".state").mkdir()
+        if mirror_tools:
+            shutil.copytree(self.main / "tools", wt / "tools")
         return wt
 
     def event_count(self, kind: str) -> int:
@@ -354,6 +401,37 @@ class JournalAppendCwdTests(unittest.TestCase):
         wt = self.sb.make_worktree("feat-cwd-fix")
         proc = self._invoke(wt)
         self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(self.sb.event_count("worker_progress"), 1)
+        worktree_state = wt / ".state" / "state.db"
+        self.assertFalse(
+            worktree_state.exists(),
+            f"worktree state.db must NOT be auto-created; saw {worktree_state}",
+        )
+
+    def test_runs_worktree_owned_script_from_worktree_cwd(self) -> None:
+        # Codex review Minor: the actual production scenario is
+        # ``cd .worktrees/<task> && python tools/journal_append.py …``,
+        # i.e. invoking the worktree's own copy of the script. That
+        # makes Python's ``Path(__file__)`` start inside the worktree —
+        # discovery has to walk up from there and successfully redirect
+        # to the main checkout's state.db. Running ``main/tools/...``
+        # from the worktree cwd doesn't exercise the same code path.
+        wt = self.sb.make_worktree("feat-cwd-fix-owned")
+        env = {**os.environ}
+        env.pop("STATE_DB_PATH", None)
+        env.pop("RENGA_SOCKET", None)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(wt / "tools" / "journal_append.py"),
+                "worker_progress",
+                "task=cwd_test_owned",
+                "note=worktree_owned_script",
+            ],
+            cwd=str(wt), capture_output=True, text=True, env=env, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        # Event landed in the main state.db — not the worktree's.
         self.assertEqual(self.sb.event_count("worker_progress"), 1)
         worktree_state = wt / ".state" / "state.db"
         self.assertFalse(


### PR DESCRIPTION
## Summary

Make state.db-touching tools cwd-independent so that invocation from a worktree cwd (e.g. `.worktrees/<task>/`) targets the parent repo's `.state/state.db` instead of crashing with `OperationalError: no such table: ...` on a stray empty file.

Closes #398. Refs #376.

## Background

During Issue #376 Phase 3 follow-up work, the Secretary repeatedly hit the same root cause across four tools in one session:

1. `python -c "... StateWriter ..."` worker run-status update — failed (`no such table: runs`)
2. `bash tools/journal_append.sh ...` event append — silently failed with `no such table: events`
3. `nohup bash tools/pr-watch.sh ...` for PR #397 — `pr_watch.py` crashed mid-flight after detecting CI pass; the `ci_completed` event was never recorded and the renga-peers `CI_COMPLETED` peer message was never delivered (silent failure was the worst part)
4. Repeat of (3) cleanup paths

PR #399 added skill-level cwd warnings as a band-aid. This PR is the proper code fix.

## Changes

### New: `tools/state_db/discover.py` (+260)

`pyproject.toml` の `name = "claude-org-ja"` をマーカーに repo root を walk-up 探索し、`.state/state.db` の絶対パスを返す。worktree (`.git` が file pointer) は main checkout に redirect する。precedence は `--db-path` > `STATE_DB_PATH` env > discovery。

スキーマ検証 (`verify_state_db_schema` / `verify_or_exit`) も同梱。壊れた DB / テーブル欠損は bare `OperationalError` ではなく actionable な `StateDbSchemaError` に変換し、エラーメッセージで `--db-path` / `STATE_DB_PATH` の escape hatch を案内する。

### Updated tools (4 files, ~80 LoC)

- `tools/journal_append.py` — `JOURNAL_PATH` を `resolve_state_db_path()` 経由に。新規 `--db-path` フラグ追加
- `tools/pr_watch.py` — `DEFAULT_DB_PATH` を discovery 経由に。schema verify 追加
- `tools/run_complete_on_merge.py` — 同上
- `tools/set_run_pr_open.py` — 同上

### Tests: `tools/test_state_db_discover.py` (+689, 新規)

22 tests covering:
- discovery walk (multi-level)
- worktree → main checkout redirect (incl. relative gitdir)
- precedence (`--db-path` > env > discovery)
- schema verify (valid / missing tables / corrupt sqlite)
- 3 CLI E2E via subprocess from `tmp_path` / unrelated cwd / worktree cwd
- worktree-owned script invocation

### Test infrastructure: `tools/conftest.py` (+32, 新規)

autouse fixture で `RENGA_SOCKET` を scrub し、本番 `renga-peers` チャネル汚染を一括防御。既存 `test_pr_watch.py` の MergeWatch テストが renga binary 経由で実通信に漏れていた問題を併せて修正（本セッション中に観測された fake `CI_COMPLETED: PR #4242 / repo octo/repo` 等の漏れも同 fixture で塞がれる）。

## Test plan

- [x] `pytest tests/ tools/` 全件: 563 passed, 4 skipped, 3 subtests passed (新規 22 件含む)
- [x] 手動: `cd .worktrees/tools-cwd-independent-fix && python tools/journal_append.py worker_progress task=test_smoke note=cwd_test_smoke` → main checkout の `.state/state.db` に書き込まれることを確認、worktree 側の `.state/` には stray DB 生成なし
- [x] Codex セルフレビュー round 1 で Major 2 + Minor 1 + Nit 1 → 全修正、round 2 で残課題なし
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)