### PR TITLE
docs: note runtime 0.1.4 Layer 3 suppression in profile-tightened + add verification §10.2 (Refs #376 #392)

### DIFF
--- a/docs/sandbox-probe/profiles/profile-tightened.json
+++ b/docs/sandbox-probe/profiles/profile-tightened.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Issue #376 Pre-Phase 0 spike — handcraft tightened sandbox profile (Pattern A worker). Layered on profile-baseline: (a) git -C 形式の dangerous-git / forced worktree remove deny を追加、(b) sandbox denyWrite を ~/.claude / ~/.ssh / ~/.aws まで拡張、(c) additionalDirectories に worker_dir のみ明示、(d) sandbox denyRead に ~/.aws / ~/.ssh を追加し、permissions.deny の Read() と二重化。",
+  "$comment": "Issue #376 Pre-Phase 0 spike — handcraft tightened sandbox profile (Pattern A worker). Layered on profile-baseline: (a) git -C 形式の dangerous-git / forced worktree remove deny を追加、(b) sandbox denyWrite を ~/.claude / ~/.ssh / ~/.aws まで拡張、(c) additionalDirectories に worker_dir のみ明示、(d) sandbox denyRead に ~/.aws / ~/.ssh を追加し、permissions.deny の Read() と二重化。 As of runtime 0.1.4 (claude-org-runtime#10) + ja PR #397, the equivalent Layer 3 suppression that this handcraft profile documented is now generated automatically by render_role_with_metadata() based on realpath escape detection. This handcraft profile is preserved as the Phase 0 spike reference baseline and as a fall-back for non-WSL deployments or environments where sandbox field-driven generation is disabled.",
   "permissions": {
     "allow": [
       "Bash(git add:*)",

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -458,6 +458,50 @@ WSL2 などで `bubblewrap` 未導入時に sandbox init が silent no-op fallba
 
 ---
 
+## 10.2. Phase 3 sandbox case E 実機検証 (WSL Layer 3 suppression, runtime 0.1.4+)
+
+**目的**: runtime 0.1.4 で導入された WSL Layer 3 suppression が期待通り発火することを確認する。具体的には worker_dir の realpath が sandbox read roots を escape する場合（典型: WSL の `/home/user/...` が `/mnt/c/...` へ resolve）、`sandbox.filesystem.denyRead` / `denyWrite` の該当 entry が rendered `settings.local.json` から自動的に dropped されること。
+
+**前提**: `claude-org-runtime>=0.1.4` が install されていること（`pyproject.toml` / `requirements.txt` 経由）。
+
+**手順**:
+
+1. WSL 環境で fresh worker dir を用意し、以下を実行:
+   ```bash
+   claude-org-runtime settings show \
+       --explain --json \
+       --role default \
+       --worker-dir <worker_dir> \
+       --claude-org-path <ja root>
+   ```
+2. 出力 JSON の `wsl_detected` が `true`、`sandbox_read_roots` が `<worker_dir>` + `additionalDirectories` を含むことを確認。
+3. `suppressions` 配列に少なくとも 1 件、以下のフィールドを持つエントリが含まれることを確認:
+   - `layer == 'sandbox.filesystem.denyRead'` または `'sandbox.filesystem.denyWrite'`
+   - `reason == 'realpath escapes sandbox read roots'`
+   - `realpath`, `sandbox_read_roots`
+
+   WSL では typically `~/.aws/*` や `~/.ssh/*` 系の Layer 3 entries が realpath escape で suppressed される。
+4. rendered `settings.local.json` を別途 generate し、`suppressions` に含まれた entries が `sandbox.filesystem.denyRead` / `denyWrite` から消えていることを確認。逆に `permissions.deny` の `Read(~/.aws/*)` / `Read(~/.ssh/*)` は Layer 2 として **必ず存在する** こと（runtime contract: Layer 2 は never suppressed）。
+5. 非 WSL Linux 環境（GitHub Actions `ubuntu-latest` 等）で同様に `settings show --explain` を実行し、`wsl_detected=false` / `suppressions=[]` / Layer 3 entries が rendered settings に残ることを確認。
+
+**期待結果と判断**:
+- WSL では Layer 3 が adaptive に dropped、Layer 2 は常に保持。
+- 非 WSL では Layer 3 はそのまま残る。
+- 両方で `permissions.deny` は intact。
+
+**失敗時の切り分け**:
+- (a) `wsl_detected` が `false` なのに `/mnt/c` が realpath に出る → `/proc/version` / `osrelease` 検出ロジックの不具合（runtime issue）。
+- (b) `suppressions` が空でも rendered settings から entries が消えている → `render_role` と `show` のソースが乖離。
+- (c) Layer 2 entries が消えている → runtime regression、即座に runtime 側に escalation。
+
+**関連 §Phase 2a portability fix (§10.1) との関係**: Phase 2a fix は「home dotfiles を sandbox スコープ外として `permissions.deny` で防御する」baseline であり、Phase 3 case E はその上で「WSL では Layer 3 entries も含めて自動的に dropped」という adaptive behavior を追加する。両者は併存し、非 WSL や bwrap 未導入環境では Phase 2a fix のまま動作する（§10.2 は WSL 環境向けの追加検証）。
+
+**Reference**:
+- runtime 0.1.4 release notes: https://github.com/suisya-systems/claude-org-runtime/releases/tag/v0.1.4
+- claude-org-runtime#10 (Phase 3 case E MVP)
+
+---
+
 ## 11. MCP 疎通テスト（環境確認）
 
 **目的**: `renga-peers` MCP サーバが Claude Code に接続済みで、14 ツール全てが tool surface として登録されていることを確認し、副作用なしで呼び出せるツールについてはサンプル呼び出しで応答を検証する。副作用の大きいツール（`send_keys` / `spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` / `new_tab` / `set_pane_identity`）の実動作確認は Test 1-10 の E2E フローでカバーされるため、本テストでは登録確認のみに留める。


### PR DESCRIPTION
## Summary

Phase 3 case E ja-side documentation follow-ups, the deferred items called out in claude-org-runtime#10's deferred section after PR #397 landed the runtime 0.1.4 pin bump.

Refs: #376 (Linux sandbox 対応 Epic), #392 (Phase 3 implementation tracking).

## Changes

### `docs/sandbox-probe/profiles/profile-tightened.json` (+1 -1)

Append to the top-level `$comment`: as of runtime 0.1.4 (claude-org-runtime#10) + ja PR #397, the equivalent Layer 3 suppression that this handcraft profile documented is now generated automatically by `render_role_with_metadata()` based on realpath escape detection. The handcraft profile is preserved as the Phase 0 spike reference baseline and as a fall-back for non-WSL deployments / sandbox-disabled environments.

JSON semantics below `$comment` are unchanged.

### `docs/verification.md` (+44 -0)

Add `§10.2 Phase 3 sandbox case E 実機検証 (WSL Layer 3 suppression, runtime 0.1.4+)` between §10.1 (Phase 2a portability fix) and §11 (MCP 疎通). Covers:

- 目的 / 前提 (`claude-org-runtime>=0.1.4`)
- 5-step verification flow using `claude-org-runtime settings show --explain --json`
- Expected `wsl_detected` / `sandbox_read_roots` / `suppressions` shape
- Non-WSL control case (`ubuntu-latest` etc.: `wsl_detected=false`, `suppressions=[]`)
- Layer 2 invariant (`permissions.deny Read(...)` never suppressed)
- 失敗時の切り分け (3 paths: detection bug / source divergence / Layer 2 regression)
- 関連 §10.1 Phase 2a portability fix との併存関係
- Reference links to runtime release notes and PR

## Test plan

- [x] Diffs read coherently and reference runtime 0.1.4 release / claude-org-runtime#10 / ja PR #397
- [x] No JSON semantics change in profile-tightened.json (only `$comment` appended)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)