### PR TITLE
feat: add semantic golden drift fixtures + check function for runtime schema (Refs #378 #376)

### DIFF
--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/README.md
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/README.md
@@ -1,0 +1,68 @@
+# Sandbox-intent semantic drift fixtures
+
+Inputs for the semantic golden drift check in
+[`tools/check_runtime_schema_drift.py`](../../../../tools/check_runtime_schema_drift.py).
+Each fixture pairs a small input schema fragment with the expected
+`SandboxMetadata.to_jsonable()` (the "explain JSON") output of
+`claude_org_runtime.settings.generator.render_role_with_metadata()`.
+The byte-identical schema check (existing path) catches structural
+divergence; this semantic check catches behavioural divergence in the
+suppression evaluator on top of identical schema bytes.
+
+## Fixture format
+
+```jsonc
+{
+  "description": "what this fixture exercises",
+  "inputs": {
+    "role": "...",                // required, key inside schema_fragment.worker_roles or schema_fragment.roles
+    "role_kind": "worker"|"org",  // optional, defaults to "worker"
+    "worker_dir": "...",          // required absolute path
+    "claude_org_path": "...",     // required absolute path
+    "base_clone": "...",          // optional, Pattern B placeholder
+    "task_id": "...",             // optional, Pattern B placeholder
+    "branch_ref": "...",          // optional, Pattern B placeholder
+    "pattern": "A"|"B"|"C"|null,  // optional, informational only
+    "wsl_detected": true|false,   // stub for runtime's wsl_detector
+    "realpath_map": [             // fake realpath rules; first match wins
+      {"prefix": "/some/path", "replacement": "/another/path"}
+    ],
+    "schema_fragment": { ... }    // a minimal schema dict the renderer can load
+  },
+  "expected_explain": { ... }     // SandboxMetadata.to_jsonable() output
+}
+```
+
+`realpath_map` rules apply to a path `p` when `p == prefix` or
+`p.startswith(prefix + "/")`. The matched prefix is replaced and the
+result is returned. Paths that match no rule pass through unchanged.
+
+## Out-of-scope intentionally
+
+- **`verification_depth`**: this is a delegate-payload / brief
+  convention surfaced via `tools/gen_delegate_payload.py`, not a
+  sandbox enforcement dimension. The renderer's
+  `render_role_with_metadata()` does not branch on it and the explain
+  JSON does not include it. Fixtures here MUST NOT add a
+  `verification_depth` field to either `inputs` or
+  `expected_explain` — depth is enforcement-out-of-scope by design.
+- **`anchor: "home"`**: skipped to keep fixtures host-independent.
+  `os.path.expanduser("~")` resolves against the running user's
+  `HOME` env var and would make goldens differ across machines.
+- **Concrete sandbox bodies for shipped roles**: the `schema_fragment`
+  in each fixture is a self-contained minimal example; it does not
+  need to match the in-tree
+  [`tools/org_extension_schema.json`](../../../../tools/org_extension_schema.json)
+  contents. Concrete bodies for `secretary` / `dispatcher` / `curator`
+  / worker `default` (A/B/C) / `claude-org-self-edit` / `doc-audit`
+  are added in a later changeset.
+
+## Adding a new fixture
+
+1. Drop the JSON file into this directory.
+2. Run `python tools/check_runtime_schema_drift.py --semantic` and
+   confirm it prints OK. Mismatches print a unified diff between the
+   committed `expected_explain` and the runtime's actual output.
+3. The pytest companion at
+   [`tests/test_runtime_schema_drift_semantic.py`](../../../test_runtime_schema_drift_semantic.py)
+   discovers fixtures by glob, so no test wiring is needed.

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_default_pattern_a.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_default_pattern_a.json
@@ -1,0 +1,45 @@
+{
+  "description": "Worker default role, Pattern A. WSL host-cross symlink causes the structured anchor=worker_dir denyRead entry to be suppressed; sandbox_read_roots reflects worker_dir as the only read root.",
+  "inputs": {
+    "role": "default",
+    "role_kind": "worker",
+    "worker_dir": "/home/u/work/wd",
+    "claude_org_path": "/home/u/co",
+    "pattern": "A",
+    "wsl_detected": true,
+    "realpath_map": [
+      {"prefix": "/home/u/work/wd", "replacement": "/mnt/c/Users/u/wd"}
+    ],
+    "schema_fragment": {
+      "worker_roles": {
+        "default": {
+          "permissions": {"deny": ["Read(.env)"]},
+          "sandbox": {
+            "enabled": true,
+            "filesystem": {
+              "denyRead": [
+                {"anchor": "worker_dir", "path": "secrets.env", "suppressOnSymlinkEscape": true}
+              ],
+              "additionalDirectories": []
+            },
+            "failIfUnavailable": false
+          }
+        }
+      }
+    }
+  },
+  "expected_explain": {
+    "enabled": true,
+    "wsl_detected": true,
+    "sandbox_read_roots": ["/home/u/work/wd"],
+    "suppressions": [
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {"anchor": "worker_dir", "path": "secrets.env", "suppressOnSymlinkEscape": true},
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/mnt/c/Users/u/wd/secrets.env",
+        "sandbox_read_roots": ["/home/u/work/wd"]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_doc_audit.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_doc_audit.json
@@ -1,0 +1,36 @@
+{
+  "description": "doc-audit role, Pattern A, non-WSL. The anchored relative pure-glob denyWrite entry resolves to worker_dir under the identity realpath (no host-cross symlink), so it is kept. failIfUnavailable=true on the schema is informational and is not part of the explain metadata.",
+  "inputs": {
+    "role": "doc-audit",
+    "role_kind": "worker",
+    "worker_dir": "/home/u/work/wd",
+    "claude_org_path": "/home/u/co",
+    "pattern": "A",
+    "wsl_detected": false,
+    "realpath_map": [],
+    "schema_fragment": {
+      "worker_roles": {
+        "doc-audit": {
+          "permissions": {"deny": ["Edit", "Write", "MultiEdit", "NotebookEdit"]},
+          "sandbox": {
+            "enabled": true,
+            "filesystem": {
+              "denyRead": [],
+              "denyWrite": [
+                {"anchor": "worker_dir", "path": "**", "suppressOnSymlinkEscape": false}
+              ],
+              "additionalDirectories": []
+            },
+            "failIfUnavailable": true
+          }
+        }
+      }
+    }
+  },
+  "expected_explain": {
+    "enabled": true,
+    "wsl_detected": false,
+    "sandbox_read_roots": ["/home/u/work/wd"],
+    "suppressions": []
+  }
+}

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_pattern_b_self_edit.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_pattern_b_self_edit.json
@@ -1,0 +1,42 @@
+{
+  "description": "Worker self-edit role, Pattern B. Demonstrates {base_clone} placeholder substitution in entry path and {base_clone}/{worker_dir} substitution in additionalDirectories. The denyWrite entry resolves inside the base-clone .git tree, so it is kept (no suppression) and read_roots show the substituted directories.",
+  "inputs": {
+    "role": "claude-org-self-edit",
+    "role_kind": "worker",
+    "worker_dir": "/home/u/repo/.git/worktrees/T123",
+    "claude_org_path": "/home/u/repo",
+    "base_clone": "/home/u/repo",
+    "task_id": "T123",
+    "branch_ref": "feat/self-edit",
+    "pattern": "B",
+    "wsl_detected": false,
+    "realpath_map": [],
+    "schema_fragment": {
+      "worker_roles": {
+        "claude-org-self-edit": {
+          "permissions": {"deny": ["Bash(git push *)"]},
+          "sandbox": {
+            "enabled": true,
+            "filesystem": {
+              "denyWrite": [
+                {"anchor": "absolute", "path": "{base_clone}/.git/objects", "suppressOnSymlinkEscape": true}
+              ],
+              "additionalDirectories": ["{base_clone}/.git", "{worker_dir}"]
+            },
+            "failIfUnavailable": false
+          }
+        }
+      }
+    }
+  },
+  "expected_explain": {
+    "enabled": true,
+    "wsl_detected": false,
+    "sandbox_read_roots": [
+      "/home/u/repo/.git/worktrees/T123",
+      "/home/u/repo/.git",
+      "/home/u/repo/.git/worktrees/T123"
+    ],
+    "suppressions": []
+  }
+}

--- a/tests/test_runtime_schema_drift_semantic.py
+++ b/tests/test_runtime_schema_drift_semantic.py
@@ -1,0 +1,125 @@
+"""Semantic golden drift tests for ``tools/check_runtime_schema_drift.py``.
+
+The byte-identical schema check that lives in
+``check_runtime_schema_drift`` validates that
+``tools/org_extension_schema.json`` and the schema bundled with
+``claude-org-runtime`` agree as JSON. That is necessary but not
+sufficient: the runtime's ``render_role_with_metadata()`` evaluator
+may change the shape of the rendered explain JSON (suppression
+reason wording, ``sandbox_read_roots`` order, structured-anchor
+substitution, etc.) without touching the schema bytes at all.
+
+These tests render each fixture under
+``tests/fixtures/runtime_schema_drift/sandbox_intent/`` through the
+fixture-supplied fake ``realpath`` shim and assert that the rendered
+``SandboxMetadata.to_jsonable()`` matches the committed
+``expected_explain``. Discovery is glob-based so adding a fixture
+requires no test wiring.
+
+The check intentionally bypasses the pin-window guard in
+``check_runtime_schema_drift.main`` because the fixtures depend on
+the *currently importable* runtime, not on whatever pin range
+``pyproject.toml`` declares. The pin guard exists to prevent a
+contributor's locally-previewed runtime from blocking unrelated PRs;
+inside the test runner we run against whatever runtime is installed
+and surface drift as a hard failure.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import check_runtime_schema_drift as csd  # noqa: E402
+
+
+FIXTURE_DIR = (
+    REPO_ROOT / "tests" / "fixtures" / "runtime_schema_drift" / "sandbox_intent"
+)
+
+
+def _fixture_paths() -> list[Path]:
+    return sorted(FIXTURE_DIR.glob("*.json"))
+
+
+class FixtureExplainGoldenTest(unittest.TestCase):
+    """Each fixture's ``expected_explain`` matches what the installed
+    ``claude_org_runtime.settings.generator.render_role_with_metadata``
+    actually produces for the fixture inputs."""
+
+    def test_fixture_directory_is_populated(self) -> None:
+        # Smoke check: at least one fixture exists, otherwise the per-
+        # fixture loop below would silently pass with zero cases.
+        self.assertTrue(
+            _fixture_paths(),
+            f"No semantic fixtures found in {FIXTURE_DIR}; the semantic "
+            "drift check would be a no-op.",
+        )
+
+    def test_fixture_explain_matches_runtime(self) -> None:
+        for fixture_path in _fixture_paths():
+            with self.subTest(fixture=fixture_path.name):
+                fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+                expected = fixture["expected_explain"]
+                actual = csd._render_fixture_explain(fixture)
+                self.assertEqual(
+                    actual,
+                    expected,
+                    f"Semantic drift in {fixture_path.name}:\n"
+                    f"expected: "
+                    f"{json.dumps(expected, indent=2, sort_keys=True)}\n"
+                    f"actual:   "
+                    f"{json.dumps(actual, indent=2, sort_keys=True)}",
+                )
+
+    def test_fixture_does_not_carry_verification_depth_field(self) -> None:
+        # ``verification_depth`` is a delegate-payload convention, not a
+        # sandbox enforcement dimension. Fixtures must not introduce it
+        # into either ``inputs`` or ``expected_explain`` so the check
+        # keeps a tight enforcement surface.
+        for fixture_path in _fixture_paths():
+            with self.subTest(fixture=fixture_path.name):
+                fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+                for section in ("inputs", "expected_explain"):
+                    self.assertNotIn(
+                        "verification_depth",
+                        fixture.get(section, {}),
+                        f"{fixture_path.name}: 'verification_depth' must not "
+                        f"appear in '{section}'; depth is convention-only "
+                        "and not part of the sandbox semantic contract.",
+                    )
+
+
+class RealpathShimTest(unittest.TestCase):
+    """Unit-level tests for the fake-realpath helper."""
+
+    def test_prefix_replacement(self) -> None:
+        fn = csd._build_realpath_fn(
+            [{"prefix": "/home/u/wd", "replacement": "/mnt/c/Users/u/wd"}]
+        )
+        self.assertEqual(fn("/home/u/wd"), "/mnt/c/Users/u/wd")
+        self.assertEqual(
+            fn("/home/u/wd/secrets.env"),
+            "/mnt/c/Users/u/wd/secrets.env",
+        )
+        self.assertEqual(fn("/home/u/wdother"), "/home/u/wdother")
+        self.assertEqual(fn("/elsewhere"), "/elsewhere")
+
+    def test_first_match_wins(self) -> None:
+        fn = csd._build_realpath_fn(
+            [
+                {"prefix": "/a/b", "replacement": "/X"},
+                {"prefix": "/a", "replacement": "/Y"},
+            ]
+        )
+        self.assertEqual(fn("/a/b/c"), "/X/c")
+        self.assertEqual(fn("/a/c"), "/Y/c")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_schema_drift_semantic.py
+++ b/tests/test_runtime_schema_drift_semantic.py
@@ -79,20 +79,21 @@ class FixtureExplainGoldenTest(unittest.TestCase):
 
     def test_fixture_does_not_carry_verification_depth_field(self) -> None:
         # ``verification_depth`` is a delegate-payload convention, not a
-        # sandbox enforcement dimension. Fixtures must not introduce it
-        # into either ``inputs`` or ``expected_explain`` so the check
-        # keeps a tight enforcement surface.
+        # sandbox enforcement dimension. Fixtures must not introduce
+        # it anywhere in the file (top-level *or* nested inside
+        # ``schema_fragment``) so the check keeps a tight enforcement
+        # surface. Reuses the same recursive helper the CLI runs so
+        # both surfaces give the same answer.
         for fixture_path in _fixture_paths():
             with self.subTest(fixture=fixture_path.name):
                 fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
-                for section in ("inputs", "expected_explain"):
-                    self.assertNotIn(
-                        "verification_depth",
-                        fixture.get(section, {}),
-                        f"{fixture_path.name}: 'verification_depth' must not "
-                        f"appear in '{section}'; depth is convention-only "
-                        "and not part of the sandbox semantic contract.",
-                    )
+                violations = csd._validate_fixture_policy(fixture_path, fixture)
+                self.assertEqual(
+                    violations,
+                    [],
+                    f"{fixture_path.name} violates the out-of-scope-field "
+                    f"policy: {violations}",
+                )
 
 
 class RealpathShimTest(unittest.TestCase):

--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -249,6 +249,34 @@ def _check_byte_drift(installed_str: str) -> int:
 _FIXTURE_OUT_OF_SCOPE_FIELDS = ("verification_depth",)
 
 
+def _find_forbidden_keys(
+    obj: Any, forbidden: tuple[str, ...]
+) -> list[tuple[str, str]]:
+    """Walk ``obj`` and return ``(json_pointer, key)`` for every
+    forbidden key found at any depth.
+
+    Recurses through dicts and lists; ignores everything else. The
+    ``json_pointer`` is a slash-joined path so violations point at
+    the offending location even when the forbidden key is nested
+    inside ``inputs.schema_fragment.worker_roles.<role>.…``.
+    """
+    hits: list[tuple[str, str]] = []
+
+    def _walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                child_path = f"{path}/{key}" if path else key
+                if key in forbidden:
+                    hits.append((child_path, key))
+                _walk(value, child_path)
+        elif isinstance(node, list):
+            for idx, value in enumerate(node):
+                _walk(value, f"{path}/{idx}")
+
+    _walk(obj, "")
+    return hits
+
+
 def _validate_fixture_policy(
     fixture_path: Path, fixture: dict[str, Any]
 ) -> list[str]:
@@ -257,23 +285,23 @@ def _validate_fixture_policy(
     Currently enforces only that the out-of-scope fields listed in
     ``_FIXTURE_OUT_OF_SCOPE_FIELDS`` (notably ``verification_depth``,
     which is a delegate-payload convention rather than a sandbox
-    enforcement dimension) do not appear in either the fixture's
-    ``inputs`` or its ``expected_explain``. Mirrors the policy check
-    in ``tests/test_runtime_schema_drift_semantic.py`` so the manual
-    CLI run gives the same answer as pytest.
+    enforcement dimension) do not appear *anywhere* in the fixture —
+    not just at the top level of ``inputs`` / ``expected_explain``,
+    but also nested inside ``schema_fragment``. A shallow check would
+    let a fixture sneak ``verification_depth`` into the schema body
+    and silently establish a precedent the rest of the codebase has
+    to maintain. Mirrors the policy check in
+    ``tests/test_runtime_schema_drift_semantic.py`` so the manual CLI
+    run gives the same answer as the unittest suite.
     """
     violations: list[str] = []
-    for section in ("inputs", "expected_explain"):
-        section_obj = fixture.get(section, {})
-        if not isinstance(section_obj, dict):
-            continue
-        for field_name in _FIXTURE_OUT_OF_SCOPE_FIELDS:
-            if field_name in section_obj:
-                violations.append(
-                    f"{fixture_path.name}: {field_name!r} must not appear "
-                    f"in {section!r} (out-of-scope for sandbox semantic "
-                    "contract; see fixture-dir README)."
-                )
+    hits = _find_forbidden_keys(fixture, _FIXTURE_OUT_OF_SCOPE_FIELDS)
+    for path, key in hits:
+        violations.append(
+            f"{fixture_path.name}: {key!r} must not appear in fixture "
+            f"(found at {path!r}; out-of-scope for sandbox semantic "
+            "contract; see fixture-dir README)."
+        )
     return violations
 
 
@@ -339,9 +367,10 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Drift check between ja's tools/org_extension_schema.json and "
-            "the bundled claude-org-runtime schema. Without flags runs the "
-            "byte-identical check; --semantic adds a render-output golden "
-            "diff against fixture explain JSON."
+            "the bundled claude-org-runtime schema. With no flags runs the "
+            "byte-identical check; --semantic switches to the render-output "
+            "golden diff against fixture explain JSON; pass --byte "
+            "--semantic together to run both."
         ),
     )
     parser.add_argument(

--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -13,14 +13,17 @@ Pin-window tolerance
 --------------------
 ja pins ``claude-org-runtime`` to a narrow window (see
 ``RUNTIME_PIN_LOWER_INCLUSIVE`` / ``RUNTIME_PIN_UPPER_EXCLUSIVE``).
-When the installed runtime is *outside* that window (e.g. a contributor
-previewed a new minor locally before ja widened its pin), this check
-**skips with a warning** rather than failing — the bundled schema is by
+When the installed runtime is *outside* that window, the **byte check
+skips with a warning** rather than failing — the bundled schema is by
 definition allowed to evolve ahead of ja's pin window, and a hard
-failure here would just block unrelated PRs.
+failure here would just block unrelated PRs. Inside the window the
+byte check treats any structural difference as a hard failure.
 
-When the installed runtime is *inside* the window, the byte check
-treats any structural difference as a hard failure.
+The ``--semantic`` check, in contrast, runs unconditionally when
+explicitly requested: an operator invoking it against a preview
+runtime is asking "does my evaluator-shape golden still match?", and
+silently skipping would defeat the point of the flag. The same
+unconditional semantics apply to the matching pytest test.
 
 Two drift dimensions
 --------------------
@@ -243,6 +246,37 @@ def _check_byte_drift(installed_str: str) -> int:
     return 1
 
 
+_FIXTURE_OUT_OF_SCOPE_FIELDS = ("verification_depth",)
+
+
+def _validate_fixture_policy(
+    fixture_path: Path, fixture: dict[str, Any]
+) -> list[str]:
+    """Return a list of policy violations for one fixture.
+
+    Currently enforces only that the out-of-scope fields listed in
+    ``_FIXTURE_OUT_OF_SCOPE_FIELDS`` (notably ``verification_depth``,
+    which is a delegate-payload convention rather than a sandbox
+    enforcement dimension) do not appear in either the fixture's
+    ``inputs`` or its ``expected_explain``. Mirrors the policy check
+    in ``tests/test_runtime_schema_drift_semantic.py`` so the manual
+    CLI run gives the same answer as pytest.
+    """
+    violations: list[str] = []
+    for section in ("inputs", "expected_explain"):
+        section_obj = fixture.get(section, {})
+        if not isinstance(section_obj, dict):
+            continue
+        for field_name in _FIXTURE_OUT_OF_SCOPE_FIELDS:
+            if field_name in section_obj:
+                violations.append(
+                    f"{fixture_path.name}: {field_name!r} must not appear "
+                    f"in {section!r} (out-of-scope for sandbox semantic "
+                    "contract; see fixture-dir README)."
+                )
+    return violations
+
+
 def _check_semantic_drift(installed_str: str) -> int:
     if not SEMANTIC_FIXTURE_DIR.is_dir():
         print(
@@ -260,8 +294,10 @@ def _check_semantic_drift(installed_str: str) -> int:
         )
         return 1
     drift_seen = False
+    policy_violations: list[str] = []
     for fixture_path in fixture_paths:
         fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        policy_violations.extend(_validate_fixture_policy(fixture_path, fixture))
         expected = fixture["expected_explain"]
         actual = _render_fixture_explain(fixture)
         if expected == actual:
@@ -276,6 +312,12 @@ def _check_semantic_drift(installed_str: str) -> int:
         diff = _format_explain_diff(fixture_path, expected, actual)
         if diff:
             print(diff, file=sys.stderr)
+    if policy_violations:
+        for v in policy_violations:
+            print(
+                f"check_runtime_schema_drift: FIXTURE POLICY — {v}",
+                file=sys.stderr,
+            )
     if drift_seen:
         print(
             "  Update the affected fixture(s) under "
@@ -283,6 +325,8 @@ def _check_semantic_drift(installed_str: str) -> int:
             "behaviour change is intended, or fix the runtime if it is not.",
             file=sys.stderr,
         )
+        return 1
+    if policy_violations:
         return 1
     print(
         f"check_runtime_schema_drift: semantic OK (claude-org-runtime "
@@ -333,21 +377,34 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
     installed = _parse_version(installed_str)
-    if not _runtime_in_pin_window(installed):
-        print(
-            f"check_runtime_schema_drift: WARN — installed claude-org-runtime "
-            f"{installed_str} is outside ja's pin window "
-            f">={'.'.join(map(str, RUNTIME_PIN_LOWER_INCLUSIVE))},"
-            f"<{'.'.join(map(str, RUNTIME_PIN_UPPER_EXCLUSIVE[:2]))}; "
-            "skipping strict drift check (runtime is allowed to ship a new "
-            "minor before ja widens the pin)."
-        )
-        return 0
+    in_window = _runtime_in_pin_window(installed)
 
     rc = 0
     if run_byte:
-        rc = _check_byte_drift(installed_str) or rc
+        # Byte check honours the pin window: a runtime preview release
+        # is allowed to ship a schema ahead of ja's pin, so a hard
+        # failure here would just block unrelated PRs. Skip with a
+        # warning when out-of-window.
+        if not in_window:
+            print(
+                f"check_runtime_schema_drift: WARN — installed "
+                f"claude-org-runtime {installed_str} is outside ja's pin "
+                f"window "
+                f">={'.'.join(map(str, RUNTIME_PIN_LOWER_INCLUSIVE))},"
+                f"<{'.'.join(map(str, RUNTIME_PIN_UPPER_EXCLUSIVE[:2]))}; "
+                "skipping byte drift check (runtime is allowed to ship a "
+                "new minor before ja widens the pin)."
+            )
+        else:
+            rc = _check_byte_drift(installed_str) or rc
     if run_semantic:
+        # Semantic check runs unconditionally when explicitly
+        # requested. Operators invoking `--semantic` against a
+        # 0.2-preview runtime want exactly this answer ("does the
+        # explain JSON still match my goldens against the new
+        # evaluator?"), and silently skipping would defeat the point
+        # of the flag. The matching pytest test is the same shape:
+        # it always runs against whatever runtime is importable.
         rc = _check_semantic_drift(installed_str) or rc
     return rc
 

--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -11,25 +11,48 @@ runtime-incompatible schema change.
 
 Pin-window tolerance
 --------------------
-ja pins ``claude-org-runtime>=0.1.1,<0.2``. When the installed runtime
-is *outside* that window (e.g. a contributor previewed 0.2.0 locally
-before ja widened its pin), this check **skips with a warning** rather
-than failing — the bundled schema is by definition allowed to evolve
-ahead of ja's pin window, and a hard failure here would just block
-unrelated PRs.
+ja pins ``claude-org-runtime`` to a narrow window (see
+``RUNTIME_PIN_LOWER_INCLUSIVE`` / ``RUNTIME_PIN_UPPER_EXCLUSIVE``).
+When the installed runtime is *outside* that window (e.g. a contributor
+previewed a new minor locally before ja widened its pin), this check
+**skips with a warning** rather than failing — the bundled schema is by
+definition allowed to evolve ahead of ja's pin window, and a hard
+failure here would just block unrelated PRs.
 
-When the installed runtime is *inside* the window, any difference is a
-hard failure: the two schemas are supposed to be byte-identical.
+When the installed runtime is *inside* the window, the byte check
+treats any structural difference as a hard failure.
+
+Two drift dimensions
+--------------------
+The byte-identical schema check is necessary but not sufficient. Two
+schemas can be byte-identical and still produce divergent rendered
+sandbox suppression metadata if the runtime's
+``render_role_with_metadata()`` evaluator changes shape (e.g. a new
+suppression reason wording, a new placeholder substituted, a different
+``sandbox_read_roots`` order). The "byte-identical" framing alone is
+therefore incomplete after the Phase 1 sandbox-intent work landed.
+
+The ``--semantic`` flag adds a complementary semantic golden drift
+check: small in-repo fixtures under
+``tests/fixtures/runtime_schema_drift/sandbox_intent/`` carry both an
+input schema fragment and the expected explain JSON
+(``SandboxMetadata.to_jsonable()``). The check renders each fixture
+through ``render_role_with_metadata()`` with a fixture-supplied fake
+``realpath`` shim (so platform-dependent paths don't pollute the
+diff) and asserts the rendered explain JSON matches byte-for-byte.
 
 Exit codes: 0 = OK or skipped (out-of-window), 1 = drift detected.
 """
 
 from __future__ import annotations
 
+import argparse
+import difflib
 import json
 import sys
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
+from typing import Any, Callable
 
 # Mirror of the ``claude-org-runtime`` pin in pyproject.toml /
 # requirements.txt. Keep this constant in sync when widening the pin
@@ -40,6 +63,9 @@ RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 JA_SCHEMA = REPO_ROOT / "tools" / "org_extension_schema.json"
+SEMANTIC_FIXTURE_DIR = (
+    REPO_ROOT / "tests" / "fixtures" / "runtime_schema_drift" / "sandbox_intent"
+)
 
 
 def _parse_version(ver: str) -> tuple[int, ...]:
@@ -100,29 +126,83 @@ def _normalise(obj: object) -> object:
     return obj
 
 
-def main(argv: list[str] | None = None) -> int:
-    del argv  # currently no flags; kept for signature consistency
-    try:
-        installed_str = _pkg_version("claude-org-runtime")
-    except PackageNotFoundError:
-        print(
-            "check_runtime_schema_drift: claude-org-runtime is not installed; "
-            "run `pip install -e .` first.",
-            file=sys.stderr,
-        )
-        return 1
-    installed = _parse_version(installed_str)
-    if not _runtime_in_pin_window(installed):
-        print(
-            f"check_runtime_schema_drift: WARN — installed claude-org-runtime "
-            f"{installed_str} is outside ja's pin window "
-            f">={'.'.join(map(str, RUNTIME_PIN_LOWER_INCLUSIVE))},"
-            f"<{'.'.join(map(str, RUNTIME_PIN_UPPER_EXCLUSIVE[:2]))}; "
-            "skipping strict drift check (runtime is allowed to ship a new "
-            "minor before ja widens the pin)."
-        )
-        return 0
+def _build_realpath_fn(
+    rules: list[dict[str, str]],
+) -> Callable[[str], str]:
+    """Build a deterministic ``realpath`` shim from fixture rules.
 
+    Each rule is a ``{"prefix", "replacement"}`` pair. For an input path
+    ``p`` the first matching rule wins: a rule matches when ``p`` equals
+    ``prefix`` or starts with ``prefix + "/"``; the matched prefix is
+    swapped for ``replacement``. Paths with no matching rule pass
+    through unchanged. The behaviour mirrors the fake-realpath stubs
+    used by the runtime's own settings-generator unit tests.
+    """
+    compiled = list(rules or [])
+
+    def _realpath(p: str) -> str:
+        for rule in compiled:
+            prefix = rule["prefix"]
+            replacement = rule["replacement"]
+            if p == prefix:
+                return replacement
+            if p.startswith(prefix + "/"):
+                return replacement + p[len(prefix):]
+        return p
+
+    return _realpath
+
+
+def _render_fixture_explain(fixture: dict[str, Any]) -> dict[str, Any]:
+    """Render one fixture and return the canonical explain JSON.
+
+    Imports the runtime lazily so a missing install surfaces the same
+    way the byte check does.
+    """
+    from claude_org_runtime.settings.generator import (  # noqa: PLC0415
+        render_role_with_metadata,
+    )
+
+    inputs = fixture["inputs"]
+    realpath_fn = _build_realpath_fn(inputs.get("realpath_map", []))
+    wsl_detected = bool(inputs.get("wsl_detected", False))
+    result = render_role_with_metadata(
+        inputs["schema_fragment"],
+        role=inputs["role"],
+        worker_dir=inputs["worker_dir"],
+        claude_org_path=inputs["claude_org_path"],
+        role_kind=inputs.get("role_kind", "worker"),
+        base_clone=inputs.get("base_clone"),
+        task_id=inputs.get("task_id"),
+        branch_ref=inputs.get("branch_ref"),
+        pattern=inputs.get("pattern"),
+        realpath_fn=realpath_fn,
+        wsl_detector=lambda: wsl_detected,
+    )
+    return result.sandbox.to_jsonable()
+
+
+def _format_explain_diff(
+    fixture_path: Path,
+    expected: dict[str, Any],
+    actual: dict[str, Any],
+) -> str:
+    expected_text = json.dumps(expected, indent=2, sort_keys=True).splitlines(
+        keepends=True
+    )
+    actual_text = json.dumps(actual, indent=2, sort_keys=True).splitlines(
+        keepends=True
+    )
+    diff = difflib.unified_diff(
+        expected_text,
+        actual_text,
+        fromfile=f"expected ({fixture_path.name})",
+        tofile=f"actual ({fixture_path.name})",
+    )
+    return "".join(diff)
+
+
+def _check_byte_drift(installed_str: str) -> int:
     bundled_path = _bundled_schema_path()
     if not bundled_path.is_file():
         print(
@@ -161,6 +241,115 @@ def main(argv: list[str] | None = None) -> int:
         file=sys.stderr,
     )
     return 1
+
+
+def _check_semantic_drift(installed_str: str) -> int:
+    if not SEMANTIC_FIXTURE_DIR.is_dir():
+        print(
+            f"check_runtime_schema_drift: semantic fixture dir not found at "
+            f"{SEMANTIC_FIXTURE_DIR}",
+            file=sys.stderr,
+        )
+        return 1
+    fixture_paths = sorted(SEMANTIC_FIXTURE_DIR.glob("*.json"))
+    if not fixture_paths:
+        print(
+            f"check_runtime_schema_drift: no semantic fixtures found in "
+            f"{SEMANTIC_FIXTURE_DIR}",
+            file=sys.stderr,
+        )
+        return 1
+    drift_seen = False
+    for fixture_path in fixture_paths:
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        expected = fixture["expected_explain"]
+        actual = _render_fixture_explain(fixture)
+        if expected == actual:
+            continue
+        drift_seen = True
+        print(
+            "check_runtime_schema_drift: SEMANTIC DRIFT — "
+            f"{fixture_path.relative_to(REPO_ROOT)} explain JSON differs "
+            f"from claude-org-runtime {installed_str} render output.",
+            file=sys.stderr,
+        )
+        diff = _format_explain_diff(fixture_path, expected, actual)
+        if diff:
+            print(diff, file=sys.stderr)
+    if drift_seen:
+        print(
+            "  Update the affected fixture(s) under "
+            f"{SEMANTIC_FIXTURE_DIR.relative_to(REPO_ROOT)}/ if the runtime "
+            "behaviour change is intended, or fix the runtime if it is not.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"check_runtime_schema_drift: semantic OK (claude-org-runtime "
+        f"{installed_str}, {len(fixture_paths)} fixture(s))"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Drift check between ja's tools/org_extension_schema.json and "
+            "the bundled claude-org-runtime schema. Without flags runs the "
+            "byte-identical check; --semantic adds a render-output golden "
+            "diff against fixture explain JSON."
+        ),
+    )
+    parser.add_argument(
+        "--semantic",
+        action="store_true",
+        help=(
+            "Run the semantic golden drift check against fixtures under "
+            "tests/fixtures/runtime_schema_drift/sandbox_intent/. "
+            "Without --byte this replaces the byte check; combine with "
+            "--byte to run both."
+        ),
+    )
+    parser.add_argument(
+        "--byte",
+        action="store_true",
+        help=(
+            "Run the byte-identical schema check (the default when no "
+            "flags are passed). Combine with --semantic to run both."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    run_byte = args.byte or not args.semantic
+    run_semantic = args.semantic
+
+    try:
+        installed_str = _pkg_version("claude-org-runtime")
+    except PackageNotFoundError:
+        print(
+            "check_runtime_schema_drift: claude-org-runtime is not installed; "
+            "run `pip install -e .` first.",
+            file=sys.stderr,
+        )
+        return 1
+    installed = _parse_version(installed_str)
+    if not _runtime_in_pin_window(installed):
+        print(
+            f"check_runtime_schema_drift: WARN — installed claude-org-runtime "
+            f"{installed_str} is outside ja's pin window "
+            f">={'.'.join(map(str, RUNTIME_PIN_LOWER_INCLUSIVE))},"
+            f"<{'.'.join(map(str, RUNTIME_PIN_UPPER_EXCLUSIVE[:2]))}; "
+            "skipping strict drift check (runtime is allowed to ship a new "
+            "minor before ja widens the pin)."
+        )
+        return 0
+
+    rc = 0
+    if run_byte:
+        rc = _check_byte_drift(installed_str) or rc
+    if run_semantic:
+        rc = _check_semantic_drift(installed_str) or rc
+    return rc
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 1 ja-side follow-up PR2 of 3. Extends `tools/check_runtime_schema_drift.py` with a semantic golden drift check on top of the existing byte-equality check. Adds in-repo fixture infrastructure under `tests/fixtures/runtime_schema_drift/sandbox_intent/` so that role × pattern sandbox intent can be verified independently of platform-dependent realpath resolution.

Refs #378, #376.

## Changes

### `tools/check_runtime_schema_drift.py`

- New functions: `_check_semantic_drift` / `_render_fixture_explain` / `_build_realpath_fn` / `_validate_fixture_policy`
- New CLI flags: `--semantic` / `--byte` (existing byte check unchanged when run without flags)
- Docstring extended to describe two drift dimensions (byte + semantic)
- **`RUNTIME_PIN_LOWER_INCLUSIVE` not touched** — that's PR1's territory (already merged as #408)

### `tests/fixtures/runtime_schema_drift/sandbox_intent/`

3 starter fixtures + README:
- `sandbox_default_pattern_a.json` — worker default Pattern A, WSL realpath escape, structured `anchor=worker_dir` entry
- `sandbox_pattern_b_self_edit.json` — Pattern B, `{base_clone}` substitution + `additionalDirectories`
- `sandbox_doc_audit.json` — doc-audit with structured anchored-glob `denyWrite` entries
- `README.md` — fixture format spec + scope-out fields (e.g. `verification_depth` / `anchor=home`) with rationale

### `tests/test_runtime_schema_drift_semantic.py`

unittest covering fixture goldens + realpath shim + `verification_depth` policy. Auto-runs under existing `python -m unittest discover` CI.

## Out of scope (deferred to PR3)

- Concrete sandbox bodies for any role
- doc-audit `failIfUnavailable: true` revisions
- `verification_depth` field at the schema level (settled as convention only per Codex review; documented in fixture README)

## Test plan

- [x] `python -m unittest discover -s tests` — 261 tests pass
- [x] `python tools/check_runtime_schema_drift.py` — byte check skip (installed runtime metadata 0.1.3 outside pin window)
- [x] `python tools/check_runtime_schema_drift.py --semantic` — `semantic OK (3 fixture(s))`
- [x] `python tools/check_runtime_schema_drift.py --byte --semantic` — both modes succeed in one invocation
- [x] Codex self-review 3 rounds: Round 1 Major 1 + Minor 1 → addressed; Round 2 Minor 1 + Nit 1 → addressed; Round 3 no further issues
- [ ] CI green

## Commits (3, on top of main)

- `a48bc83` feat(claude): add semantic golden drift fixtures + check function for runtime schema
- `fbf1eac` feat(claude): address Codex round-1 — run --semantic outside pin window + CLI fixture-policy parity
- `eff252a` feat(claude): address Codex round-2 — deep verification_depth policy check + argparse wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)