### PR TITLE
perf(claude): trim org-resume Phase 1 briefing payload to reduce Secretary context overhead (Closes #412)

### DIFF
--- a/.claude/skills/org-resume/SKILL.md
+++ b/.claude/skills/org-resume/SKILL.md
@@ -28,21 +28,23 @@ description: >
    ```
 
    exit 0 なら続行。exit 1（未対応 version 残存）/ exit 2（migration ループ異常）なら人間に報告して停止する。
-1. **DB から前回状態を取得する**:
+1. **DB から前回状態を取得する**（Phase 1 は軽量 briefing API、Issue #412）:
    - `.state/state.db` が存在 → DB をクエリ:
      ```bash
-     python -c "from tools.state_db import connect; from tools.state_db.queries import get_resume_briefing; import json; \
+     python -c "from tools.state_db import connect; from tools.state_db.queries import get_resume_briefing_light; import json; \
        conn = connect('.state/state.db'); \
-       print(json.dumps(get_resume_briefing(conn), ensure_ascii=False, indent=2, default=str))"
+       print(json.dumps(get_resume_briefing_light(conn), ensure_ascii=False, indent=2, default=str))"
      ```
-     `active_runs` / `recent_events` / `last_suspend_at` でブリーフィング素材を作る。
-     Status / Current Objective / Resume Instructions も `org_sessions` に格納される。
+     `active_runs` / `reserved_runs` / `recent_events` / `last_suspend_summary` でブリーフィング素材を作る。
+     `session` には Status / Current Objective / suspended_at / resumed_at / resume_summary が圧縮されて入る（raw `resume_instructions` 本文と raw event `payload_json` は含まれない）。
+     `active_inventory_dirs` は `runs.status` から逆引きした worker_dir 集合（state-semantics-contract I7 — `worker_dirs.lifecycle='active'` ではない）。
+     必要があれば（極稀ケース）`get_resume_briefing` で raw payload / 完全な resume_instructions を取得できるが、起動時 Phase 1 では使わない。
    - DB が無い → 人間に rebuild を促す:
      「state.db not found. Run: `python -m tools.state_db.importer --db .state/state.db --root . --rebuild`」
 2. 人間に簡潔なサマリーを提示する:
-   - 全体の目標 (DB の `objective`)
-   - 各作業アイテムの状態 (完了/進行中/保留/ブロック、DB の active_runs)
-   - 中断時刻 (DB の `last_suspend_at`)
+   - 全体の目標 (briefing の `session.objective`)
+   - 各作業アイテムの状態 (完了/進行中/保留/ブロック、briefing の `active_runs` / `reserved_runs`)
+   - 中断時刻 (briefing の `last_suspend_summary.occurred_at`、reason / counts も同 dict)
 3. `notes/` 配下にある自由記述 (学び / Pending Lead / セッションサマリー) を確認する
 
 ## Phase 2: 現実との照合

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -471,10 +471,34 @@ _BRIEFING_PAYLOAD_FIELDS: dict[str, tuple[str, ...]] = {
 _BRIEFING_FIELD_MAX_LEN = 120
 
 
-def _truncate(value: Any) -> Any:
-    if isinstance(value, str) and len(value) > _BRIEFING_FIELD_MAX_LEN:
-        return value[:_BRIEFING_FIELD_MAX_LEN] + "…"
-    return value
+def _briefing_value(value: Any) -> Any:
+    """Coerce a payload value to the scalar subset the briefing accepts.
+
+    The allowlist only enumerates *which keys* survive into the briefing
+    — it doesn't say anything about the value shape, and
+    ``tools/journal_append.py --json '{...}'`` cheerfully accepts nested
+    objects. So a single allowlisted ``summary`` field that happens to
+    carry a 30-KB list would re-inflate the briefing past the
+    Issue #412 budget. Restrict to JSON scalars; downgrade list/dict to
+    a length-only marker so the operator still sees that *something*
+    was there without the bytes coming along.
+    """
+    if isinstance(value, str):
+        if len(value) > _BRIEFING_FIELD_MAX_LEN:
+            return value[:_BRIEFING_FIELD_MAX_LEN] + "…"
+        return value
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, list):
+        return {"_type": "list", "_len": len(value)}
+    if isinstance(value, dict):
+        return {"_type": "dict", "_keys": len(value)}
+    # Fallback: a JSON-decodable but unexpected scalar type. Stringify
+    # the type name; never echo ``repr(value)`` since that would inline
+    # the bytes the caller is trying to suppress.
+    return {"_type": type(value).__name__}
 
 
 def _extract_briefing_payload(
@@ -489,7 +513,7 @@ def _extract_briefing_payload(
         return {}
     if not isinstance(payload, dict):
         return {}
-    return {f: _truncate(payload[f]) for f in fields if f in payload}
+    return {f: _briefing_value(payload[f]) for f in fields if f in payload}
 
 
 def list_recent_events_for_briefing(
@@ -501,46 +525,54 @@ def list_recent_events_for_briefing(
 
     * default ``limit`` is 5 (vs. 50): the briefing renders a short
       headline list, not the full activity tail.
-    * ``BRIEFING_EVENT_KINDS_NOISE`` rows are excluded.
+    * ``BRIEFING_EVENT_KINDS_NOISE`` rows are excluded *in the SQL
+      WHERE clause* so the LIMIT counts only signal rows. A previous
+      Python-side filter could return < ``limit`` rows when a busy
+      tail of dispatcher noise crowded out the older signal.
     * each row is the ``event_summary`` shape — ``id, occurred_at, actor,
       kind, fields`` — where ``fields`` is the per-kind payload allowlist
       extraction (see ``_BRIEFING_PAYLOAD_FIELDS``). Raw ``payload_json``
       is never returned. Unknown kinds get an empty ``fields`` map and
       fall back to ``{kind, actor, occurred_at}`` for identification.
-
-    The query over-fetches before noise filtering so a window of five
-    interesting events is still returned even if a recent suspend was
-    preceded by, say, four ``events_dropped`` rows.
     """
     if limit <= 0:
         return []
-    # Over-fetch ×4 (capped at 200) so the noise filter still has room
-    # to deliver ``limit`` signal rows on a noisy tail.
-    fetch_limit = min(limit * 4 + len(BRIEFING_EVENT_KINDS_NOISE), 200)
-    rows = conn.execute(
-        """
-        SELECT id, occurred_at, actor, kind, payload_json
-        FROM events
-        ORDER BY id DESC
-        LIMIT ?
-        """,
-        (fetch_limit,),
-    ).fetchall()
-    out: list[dict[str, Any]] = []
-    for r in rows:
-        kind = r["kind"]
-        if kind in BRIEFING_EVENT_KINDS_NOISE:
-            continue
-        out.append({
+    # Build the NOT IN clause from the noise constant rather than
+    # hard-coding it, so the SQL stays in lockstep with
+    # ``BRIEFING_EVENT_KINDS_NOISE`` if the set grows.
+    noise = tuple(sorted(BRIEFING_EVENT_KINDS_NOISE))
+    if noise:
+        placeholders = ",".join("?" * len(noise))
+        rows = conn.execute(
+            f"""
+            SELECT id, occurred_at, actor, kind, payload_json
+            FROM events
+            WHERE kind NOT IN ({placeholders})
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (*noise, limit),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """
+            SELECT id, occurred_at, actor, kind, payload_json
+            FROM events
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    return [
+        {
             "id": r["id"],
             "occurred_at": r["occurred_at"],
             "actor": r["actor"],
-            "kind": kind,
-            "fields": _extract_briefing_payload(kind, r["payload_json"]),
-        })
-        if len(out) >= limit:
-            break
-    return out
+            "kind": r["kind"],
+            "fields": _extract_briefing_payload(r["kind"], r["payload_json"]),
+        }
+        for r in rows
+    ]
 
 
 def format_session_brief(
@@ -644,7 +676,7 @@ def format_last_suspend_summary(
     return {
         "occurred_at": suspend_row.get("occurred_at"),
         "actor": suspend_row.get("actor"),
-        "reason": _truncate(reason) if isinstance(reason, str) else reason,
+        "reason": _briefing_value(reason) if reason is not None else None,
         "active_workers_count": _count("active_workers"),
         "pending_items_count": _count("pending_items"),
     }

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -30,6 +30,7 @@ the central correctness fact:
 """
 from __future__ import annotations
 
+import json
 import sqlite3
 from typing import Any, Optional
 
@@ -330,6 +331,14 @@ def get_resume_briefing(conn: sqlite3.Connection) -> dict[str, Any]:
     Reflects the state needed to greet the human after a SUSPEND: which runs
     are still live, when the org was last suspended, and what happened in the
     journal recently.
+
+    .. note::
+       Heavyweight by design — returns raw ``payload_json`` and the full
+       ``resume_instructions`` body. /org-resume Phase 1 should call
+       :func:`get_resume_briefing_light` instead so a fresh secretary
+       session does not pay 6–8k tokens of context just to render the
+       opening summary (Issue #412). This API is retained for callers
+       that genuinely need the raw blobs (rare).
     """
     suspend_row = conn.execute(
         """
@@ -359,18 +368,354 @@ def get_resume_briefing(conn: sqlite3.Connection) -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Lightweight briefing API for /org-resume Phase 1 (Issue #412)
+# ---------------------------------------------------------------------------
+#
+# The heavyweight :func:`get_resume_briefing` returns raw ``payload_json``
+# blobs, the full ``resume_instructions`` body, and a 30-event tail. On a
+# busy org that bill comes due *every secretary session* during the Phase 1
+# briefing — empirically 6–8k tokens of context just to render the opening
+# summary. The light API trims that bill to roughly constant by:
+#
+# * compressing each event to a per-kind allowlist of fields (or a
+#   kind/actor/occurred_at fallback for unknown kinds — see
+#   ``docs/journal-events.md`` for the typical-fields catalog),
+# * dropping ``resume_instructions`` raw text in favour of a short
+#   ``resume_summary``,
+# * scoping briefing worker_dirs to ``runs.status`` membership rather
+#   than ``worker_dirs.lifecycle``: state-semantics-contract I7 pins
+#   that the two predicates can disagree (an ``active`` lifecycle dir
+#   may correspond to a completed run), and the briefing wants the
+#   runs-current set,
+# * returning a compressed ``last_suspend_summary`` (counts and the
+#   reason string) rather than the raw suspend payload, which can carry
+#   tens of KB of pending_items / active_workers for a busy session.
+#
+# The dashboard / converter path (``get_org_state_summary``) is
+# deliberately untouched — its callers depend on the existing shape.
+
+# Briefing-only event-stream noise list. These kinds get emitted often
+# enough to crowd out signal in a 5-event window without ever helping the
+# secretary's opening summary. Anything not on this list is considered
+# signal and may appear in :func:`list_recent_events_for_briefing`.
+BRIEFING_EVENT_KINDS_NOISE: frozenset[str] = frozenset({
+    # Observability churn from the dispatcher rate-limiter.
+    "events_dropped",
+    # /org-start re-asserts secretary identity on every cold boot; not
+    # interesting in a "what happened recently" briefing.
+    "secretary_identity_restored",
+})
+
+
+# Per-kind allowlist for ``event_summary`` payload extraction. The keys
+# match the event names in ``docs/journal-events.md``; the value tuple is
+# the subset of payload fields worth keeping in a one-line briefing
+# summary. Long-form fields (``summary``, ``note``) are intentionally
+# omitted — the briefing answers "what kind of thing happened" not "what
+# did the worker say verbatim". Unknown kinds fall back to
+# ``{kind, actor, occurred_at}``.
+_BRIEFING_PAYLOAD_FIELDS: dict[str, tuple[str, ...]] = {
+    # worker lifecycle
+    "worker_spawned":          ("worker", "task"),
+    "worker_completed":        ("worker", "task"),
+    "worker_reported":         ("worker", "task"),
+    "worker_closed":           ("worker", "pane_id"),
+    "worker_review":           ("worker", "task", "outcome"),
+    "worker_report_forwarded": ("worker", "task", "recipient"),
+    "worktree_removed":        ("path", "task"),
+    "retro_deferred":          ("worker", "reason"),
+    # delegate flow
+    "delegate_sent":           ("task", "worker"),
+    "delegate_resume":         ("task", "worker"),
+    "delegate_resume_r2":      ("task", "worker", "round"),
+    # plan / design
+    "plan_delivered":          ("task", "worker"),
+    "plan_approved":           ("task",),
+    "plan_approved_and_prep_dispatched": ("task", "prep_worker"),
+    "prep_delivered":          ("task", "worker"),
+    "design_approved":         ("task", "pr"),
+    "drift_reaudit":           ("task", "reason"),
+    # PR / push
+    "fix_pushed":              ("task", "branch", "commit"),
+    "pr_opened":               ("task", "pr"),
+    "prs_opened":              ("count",),
+    "pr_merged":               ("pr", "task"),
+    "prs_merged":              ("count",),
+    "prs_pushed":              ("count",),
+    # history / phase
+    "pre_history_reset_snapshot": ("path",),
+    "phase_d_snapshot":        ("path",),
+    "phase_d_complete":        ("task",),
+    "phase_d_force_push":      ("branch",),
+    "pane_closed":             ("pane_id", "worker"),
+    # issues
+    "issue_filed":             ("issue", "title"),
+    "issues_filed":            ("count",),
+    "issues_swept":            ("count",),
+    "issue_closed":            ("issue",),
+    # observability
+    "anomaly_observed":        ("worker", "kind", "confidence"),
+    "notify_sent":             ("recipient", "kind"),
+    # CI
+    "ci_completed":            ("pr", "status"),
+    # session lifecycle
+    "suspend":                 ("reason",),
+    "resume":                  (),
+    "task_completed":          ("task",),
+}
+
+# Cap any extracted string value at this length to keep a runaway field
+# (an unexpectedly long worker id, a multi-line title) from re-inflating
+# the briefing. Picked to fit a one-line terminal render.
+_BRIEFING_FIELD_MAX_LEN = 120
+
+
+def _truncate(value: Any) -> Any:
+    if isinstance(value, str) and len(value) > _BRIEFING_FIELD_MAX_LEN:
+        return value[:_BRIEFING_FIELD_MAX_LEN] + "…"
+    return value
+
+
+def _extract_briefing_payload(
+    kind: str, payload_json: Optional[str]
+) -> dict[str, Any]:
+    fields = _BRIEFING_PAYLOAD_FIELDS.get(kind)
+    if fields is None or not payload_json:
+        return {}
+    try:
+        payload = json.loads(payload_json)
+    except (TypeError, ValueError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return {f: _truncate(payload[f]) for f in fields if f in payload}
+
+
+def list_recent_events_for_briefing(
+    conn: sqlite3.Connection, limit: int = 5
+) -> list[dict[str, Any]]:
+    """Briefing-only recent events — short, allowlisted, noise-filtered.
+
+    Differs from :func:`list_recent_events` on three axes:
+
+    * default ``limit`` is 5 (vs. 50): the briefing renders a short
+      headline list, not the full activity tail.
+    * ``BRIEFING_EVENT_KINDS_NOISE`` rows are excluded.
+    * each row is the ``event_summary`` shape — ``id, occurred_at, actor,
+      kind, fields`` — where ``fields`` is the per-kind payload allowlist
+      extraction (see ``_BRIEFING_PAYLOAD_FIELDS``). Raw ``payload_json``
+      is never returned. Unknown kinds get an empty ``fields`` map and
+      fall back to ``{kind, actor, occurred_at}`` for identification.
+
+    The query over-fetches before noise filtering so a window of five
+    interesting events is still returned even if a recent suspend was
+    preceded by, say, four ``events_dropped`` rows.
+    """
+    if limit <= 0:
+        return []
+    # Over-fetch ×4 (capped at 200) so the noise filter still has room
+    # to deliver ``limit`` signal rows on a noisy tail.
+    fetch_limit = min(limit * 4 + len(BRIEFING_EVENT_KINDS_NOISE), 200)
+    rows = conn.execute(
+        """
+        SELECT id, occurred_at, actor, kind, payload_json
+        FROM events
+        ORDER BY id DESC
+        LIMIT ?
+        """,
+        (fetch_limit,),
+    ).fetchall()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        kind = r["kind"]
+        if kind in BRIEFING_EVENT_KINDS_NOISE:
+            continue
+        out.append({
+            "id": r["id"],
+            "occurred_at": r["occurred_at"],
+            "actor": r["actor"],
+            "kind": kind,
+            "fields": _extract_briefing_payload(kind, r["payload_json"]),
+        })
+        if len(out) >= limit:
+            break
+    return out
+
+
+def format_session_brief(
+    session: Optional[dict[str, Any]]
+) -> Optional[dict[str, Any]]:
+    """Compress an ``org_sessions`` row into the briefing-safe subset.
+
+    Drops ``resume_instructions`` raw body (often multi-KB after a long
+    suspend) in favour of a short ``resume_summary`` excerpt, and drops
+    pane/peer ids the briefing doesn't surface. Returning ``None`` for an
+    absent row mirrors :func:`get_session`.
+    """
+    if not session:
+        return None
+    raw = session.get("resume_instructions") or ""
+    if raw:
+        flat = raw.strip().splitlines()[0] if raw.strip() else ""
+        if len(flat) > _BRIEFING_FIELD_MAX_LEN:
+            resume_summary: Optional[str] = (
+                flat[:_BRIEFING_FIELD_MAX_LEN] + "…"
+            )
+        else:
+            resume_summary = flat or None
+    else:
+        resume_summary = None
+    return {
+        "status": session.get("status"),
+        "objective": session.get("objective"),
+        "started_at": session.get("started_at"),
+        "updated_at": session.get("updated_at"),
+        "suspended_at": session.get("suspended_at"),
+        "resumed_at": session.get("resumed_at"),
+        "resume_summary": resume_summary,
+        "has_resume_instructions": bool(raw),
+    }
+
+
+def list_briefing_worker_dirs(
+    conn: sqlite3.Connection,
+) -> list[dict[str, Any]]:
+    """Worker dirs scoped to live runs, not to ``worker_dirs.lifecycle``.
+
+    State-semantics-contract I7 pins that ``worker_dirs.lifecycle`` and
+    ``runs.status`` are independent predicates: an ``active`` lifecycle
+    directory may belong to a completed run (the inventory scrubber has
+    not yet flipped it to ``archived``), and a stale ``archived`` row
+    might still be referenced by a live ``in_use`` run if a previous
+    cleanup raced. The briefing wants the *runs-current* set — every
+    worker_dir reachable from a queued / in_use / review run — so it
+    joins through ``runs.worker_dir_id`` rather than filtering on
+    ``lifecycle = 'active'``.
+
+    The result is named ``active_inventory_dirs`` in
+    :func:`get_resume_briefing_light` so callers don't conflate it with
+    the dashboard's ``active_worker_dirs`` (lifecycle-scoped, used by
+    the inventory UI).
+    """
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT
+            d.id, d.abs_path, d.layout, d.lifecycle, d.current_branch
+        FROM worker_dirs d
+        JOIN runs r ON r.worker_dir_id = d.id
+        WHERE r.status IN ({','.join('?' * len(ACTIVE_RESERVATION_STATUSES))})
+        ORDER BY d.abs_path
+        """,
+        ACTIVE_RESERVATION_STATUSES,
+    ).fetchall()
+    return _rows_to_dicts(rows)
+
+
+def format_last_suspend_summary(
+    suspend_row: Optional[dict[str, Any]],
+) -> Optional[dict[str, Any]]:
+    """Compress the latest ``suspend`` event row into briefing-safe shape.
+
+    The raw ``suspend`` payload can carry tens of KB
+    (``active_workers[]``, ``pending_items[]``) on a busy org. The
+    briefing only needs scalar headlines (when, who, why, and the two
+    list lengths); a caller that needs the full payload should query the
+    events table directly or use the heavyweight
+    :func:`get_resume_briefing`.
+    """
+    if not suspend_row:
+        return None
+    raw = suspend_row.get("payload_json")
+    payload: dict[str, Any] = {}
+    if raw:
+        try:
+            decoded = json.loads(raw)
+            if isinstance(decoded, dict):
+                payload = decoded
+        except (TypeError, ValueError):
+            payload = {}
+
+    def _count(name: str) -> Optional[int]:
+        v = payload.get(name)
+        return len(v) if isinstance(v, list) else None
+
+    reason = payload.get("reason")
+    return {
+        "occurred_at": suspend_row.get("occurred_at"),
+        "actor": suspend_row.get("actor"),
+        "reason": _truncate(reason) if isinstance(reason, str) else reason,
+        "active_workers_count": _count("active_workers"),
+        "pending_items_count": _count("pending_items"),
+    }
+
+
+def get_resume_briefing_light(
+    conn: sqlite3.Connection,
+) -> dict[str, Any]:
+    """Lightweight Phase-1 briefing payload (Issue #412).
+
+    Sister to :func:`get_resume_briefing`, but explicitly bounded:
+
+    * ``session`` is replaced by :func:`format_session_brief` (no raw
+      ``resume_instructions`` body).
+    * ``recent_events`` is the 5-row event-summary stream from
+      :func:`list_recent_events_for_briefing` (no raw ``payload_json``,
+      noise kinds filtered out).
+    * ``active_inventory_dirs`` is :func:`list_briefing_worker_dirs`'
+      runs-scoped view (not ``worker_dirs.lifecycle='active'``).
+    * the latest ``suspend`` is reduced to :func:`format_last_suspend_summary`
+      (no raw payload).
+
+    The /org-resume Phase 1 query path uses this API so a fresh secretary
+    session pays roughly constant context cost regardless of how busy the
+    org has been.
+    """
+    last_row = conn.execute(
+        "SELECT occurred_at, kind FROM events ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    suspend_row = conn.execute(
+        """
+        SELECT occurred_at, actor, payload_json
+        FROM events
+        WHERE kind = 'suspend'
+        ORDER BY id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    return {
+        "session": format_session_brief(get_session(conn)),
+        "active_runs": list_active_runs(conn),
+        "reserved_runs": list_reserved_runs(conn),
+        "active_inventory_dirs": list_briefing_worker_dirs(conn),
+        "recent_events": list_recent_events_for_briefing(conn, limit=5),
+        "run_status_counts": _run_status_counts(conn),
+        "last_event_at": last_row["occurred_at"] if last_row else None,
+        "last_event_kind": last_row["kind"] if last_row else None,
+        "last_suspend_summary": format_last_suspend_summary(
+            _row_to_dict(suspend_row)
+        ),
+    }
+
+
 __all__ = [
     "ACTIVE_RESERVATION_STATUSES",
     "USER_VISIBLE_STATUSES",
     "ACTIVE_EXECUTION_STATUSES",
     "TERMINAL_STATUSES",
+    "BRIEFING_EVENT_KINDS_NOISE",
     "list_active_runs",
     "list_reserved_runs",
     "list_runs_with_dirs",
     "get_run_by_task_id",
     "list_worker_dirs",
     "list_recent_events",
+    "list_recent_events_for_briefing",
+    "list_briefing_worker_dirs",
+    "format_session_brief",
+    "format_last_suspend_summary",
     "get_session",
     "get_org_state_summary",
     "get_resume_briefing",
+    "get_resume_briefing_light",
 ]

--- a/tools/state_db/test_queries.py
+++ b/tools/state_db/test_queries.py
@@ -1,4 +1,4 @@
-"""Unit tests for the M1 read-only query layer.
+"""Unit tests for the M4 state-DB query layer.
 
 Run with:
     python -m unittest discover -s tools/state_db -p 'test_*.py'
@@ -8,6 +8,14 @@ that test_importer.py uses, so we exercise the real markdown → DB pipeline
 that dashboard / org-* skills will read from in production. A couple of
 tests bypass the importer to seed exact rows and pin down edge cases
 (suspend lookup, lifecycle filter, null workstream).
+
+Briefing-light coverage (``TestBriefingLight``) seeds intentionally heavy
+rows — long ``resume_instructions``, multi-KB ``payload_json`` blobs,
+both runs-attached and runs-orphaned ``archived``/``delete_pending``
+worker_dirs — and asserts the light briefing API returns *none* of those
+raw blobs. The size assertion locks in Issue #412's intent so a future
+refactor that re-introduces a raw payload to the briefing fails loudly
+instead of silently regressing the secretary's startup context cost.
 """
 from __future__ import annotations
 
@@ -20,13 +28,19 @@ from tools.state_db import apply_schema, connect
 from tools.state_db.importer import import_full_rebuild
 from tools.state_db.queries import (
     ACTIVE_RESERVATION_STATUSES,
+    BRIEFING_EVENT_KINDS_NOISE,
     TERMINAL_STATUSES,
     USER_VISIBLE_STATUSES,
+    format_last_suspend_summary,
+    format_session_brief,
     get_org_state_summary,
     get_resume_briefing,
+    get_resume_briefing_light,
     get_run_by_task_id,
     list_active_runs,
+    list_briefing_worker_dirs,
     list_recent_events,
+    list_recent_events_for_briefing,
     list_reserved_runs,
     list_worker_dirs,
 )
@@ -82,6 +96,18 @@ class TestEmptyDB(unittest.TestCase):
         self.assertEqual(b["active_runs"], [])
         self.assertIsNone(b["last_event_at"])
         self.assertIsNone(b["last_suspend_at"])
+
+    def test_get_resume_briefing_light_empty(self):
+        b = get_resume_briefing_light(self.conn)
+        self.assertIsNone(b["session"])
+        self.assertEqual(b["active_runs"], [])
+        self.assertEqual(b["reserved_runs"], [])
+        self.assertEqual(b["active_inventory_dirs"], [])
+        self.assertEqual(b["recent_events"], [])
+        self.assertEqual(b["run_status_counts"], {})
+        self.assertIsNone(b["last_event_at"])
+        self.assertIsNone(b["last_event_kind"])
+        self.assertIsNone(b["last_suspend_summary"])
 
 
 # ---------------------------------------------------------------------------
@@ -255,6 +281,301 @@ class TestEdgeCases(unittest.TestCase):
     def test_recent_events_negative_limit_is_safe(self):
         # Defensive: a caller passing limit=-1 should not blow up.
         self.assertEqual(list_recent_events(self.conn, limit=-1), [])
+
+
+# ---------------------------------------------------------------------------
+# Briefing-light shape & weight (Issue #412)
+# ---------------------------------------------------------------------------
+
+
+# Sentinel substrings the briefing-light path MUST NOT echo back. The
+# tail-padding length (320 chars) is chosen to comfortably exceed the
+# briefing's per-field truncation cap (~120 chars) so a value that gets
+# trimmed instead of dropped still fails the ``assertNotIn`` substring
+# check. Picked to be unlikely to occur naturally so an inadvertent
+# ``payload_json`` re-leak shows up as a single ``in`` hit.
+_HUGE_PAYLOAD_SENTINEL = "RAW_PAYLOAD_SHOULD_NOT_LEAK_" + "X" * 320
+_HUGE_INSTRUCTIONS_SENTINEL = (
+    "RAW_RESUME_INSTRUCTIONS_SHOULD_NOT_LEAK_" + "Y" * 320
+)
+
+
+class TestBriefingLight(unittest.TestCase):
+    """Pin Issue #412's invariants: no raw blobs, runs-scoped dirs, short tail."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.addCleanup(self._td.cleanup)
+        self.db_path = Path(self._td.name) / "briefing.db"
+        self.conn = connect(self.db_path)
+        apply_schema(self.conn)
+
+        # ---- session row with a multi-KB resume_instructions body ----
+        long_resume_instructions = (
+            "Resume guidance line 1\n"
+            + (_HUGE_INSTRUCTIONS_SENTINEL + " " * 16) * 50
+        )
+        self.conn.execute(
+            "INSERT INTO org_sessions "
+            "(id, status, started_at, updated_at, suspended_at, resumed_at, "
+            " objective, resume_instructions, last_writer_at) "
+            "VALUES (1, 'SUSPENDED', '2026-05-01T00:00:00Z', "
+            "'2026-05-09T00:00:00Z', '2026-05-09T00:00:00Z', NULL, "
+            "'Ship the briefing-context-trim work', ?, "
+            "'2026-05-09T00:00:00Z')",
+            (long_resume_instructions,),
+        )
+
+        # ---- one project + four worker_dirs across lifecycles ----
+        self.conn.execute(
+            "INSERT INTO projects (id, slug, display_name) "
+            "VALUES (1, 'pj', 'pj')"
+        )
+        self.conn.execute(
+            "INSERT INTO worker_dirs (id, abs_path, layout, lifecycle) "
+            "VALUES (10, '/w/active-with-run', 'flat', 'active')"
+        )
+        self.conn.execute(
+            "INSERT INTO worker_dirs (id, abs_path, layout, lifecycle) "
+            "VALUES (11, '/w/active-orphan', 'flat', 'active')"
+        )
+        self.conn.execute(
+            "INSERT INTO worker_dirs (id, abs_path, layout, lifecycle) "
+            "VALUES (12, '/w/archived-with-completed-run', 'flat', "
+            "'archived')"
+        )
+        self.conn.execute(
+            "INSERT INTO worker_dirs (id, abs_path, layout, lifecycle) "
+            "VALUES (13, '/w/delete-pending-with-run', 'flat', "
+            "'delete_pending')"
+        )
+
+        # ---- runs spanning the live + terminal status set ----
+        # run 1 → in_use, dir=10 (active). Should appear in
+        # active_inventory_dirs.
+        self.conn.execute(
+            "INSERT INTO runs (id, task_id, project_id, pattern, title, "
+            "status, worker_dir_id, dispatched_at) "
+            "VALUES (1, 't-live', 1, 'B', 't-live', 'in_use', 10, "
+            "'2026-05-09T01:00:00Z')"
+        )
+        # run 2 → completed, dir=12 (archived). Even though dir is
+        # archived, the join is gated by runs.status NOT IN
+        # ACTIVE_RESERVATION → must NOT appear in active_inventory_dirs.
+        self.conn.execute(
+            "INSERT INTO runs (id, task_id, project_id, pattern, title, "
+            "status, worker_dir_id, dispatched_at) "
+            "VALUES (2, 't-done', 1, 'A', 't-done', 'completed', 12, "
+            "'2026-05-08T00:00:00Z')"
+        )
+        # run 3 → queued (reservation), dir=13 (delete_pending).
+        # state-semantics-contract I7: lifecycle != runs.status — the
+        # run is live so the dir MUST appear in active_inventory_dirs
+        # despite delete_pending lifecycle.
+        self.conn.execute(
+            "INSERT INTO runs (id, task_id, project_id, pattern, title, "
+            "status, worker_dir_id, dispatched_at) "
+            "VALUES (3, 't-queued', 1, 'A', 't-queued', 'queued', 13, "
+            "'2026-05-09T02:00:00Z')"
+        )
+        # dir 11 has no run pointing to it → should be excluded by the
+        # runs-scoped briefing query (and the ``lifecycle='active'``
+        # filter would have wrongly included it).
+
+        # ---- ten heavy payload events (each ~3-4 KB of payload_json) ----
+        big_summary = _HUGE_PAYLOAD_SENTINEL + ("Z" * 4096)
+        for i in range(10):
+            payload = json.dumps({
+                "worker": f"worker-{i}",
+                "task": f"t-{i}",
+                "summary": big_summary,
+            })
+            self.conn.execute(
+                "INSERT INTO events (occurred_at, actor, kind, payload_json) "
+                "VALUES (?, 'secretary', 'worker_reported', ?)",
+                (f"2026-05-09T00:00:{i:02d}Z", payload),
+            )
+        # noise event right before suspend → must be filtered out of the
+        # briefing tail even though it would otherwise win on recency.
+        self.conn.execute(
+            "INSERT INTO events (occurred_at, actor, kind, payload_json) "
+            "VALUES ('2026-05-09T00:00:50Z', 'dispatcher', "
+            "'events_dropped', '{\"count\":12}')"
+        )
+        # latest suspend with a payload that names ~50 active workers
+        # and ~80 pending items so we can assert counts pass through but
+        # the raw lists do not.
+        suspend_payload = json.dumps({
+            "reason": _HUGE_PAYLOAD_SENTINEL + " end of day",
+            "active_workers": [
+                {"id": f"w-{i}", "task": f"t-{i}"} for i in range(50)
+            ],
+            "pending_items": [
+                {"id": f"p-{i}", "note": "x" * 200} for i in range(80)
+            ],
+        })
+        self.conn.execute(
+            "INSERT INTO events (occurred_at, actor, kind, payload_json) "
+            "VALUES ('2026-05-09T01:00:00Z', 'secretary', 'suspend', ?)",
+            (suspend_payload,),
+        )
+        self.conn.commit()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+
+    # ---- raw-blob suppression -------------------------------------------------
+
+    def test_briefing_light_excludes_raw_payload_and_resume_instructions(self):
+        b = get_resume_briefing_light(self.conn)
+        serialized = json.dumps(b, ensure_ascii=False, default=str)
+        self.assertNotIn(_HUGE_PAYLOAD_SENTINEL, serialized)
+        self.assertNotIn(_HUGE_INSTRUCTIONS_SENTINEL, serialized)
+        # And the heavyweight API still does leak them — the contrast
+        # documents *why* /org-resume Phase 1 picks the light variant.
+        heavy_serialized = json.dumps(
+            get_resume_briefing(self.conn), ensure_ascii=False, default=str
+        )
+        self.assertIn(_HUGE_PAYLOAD_SENTINEL, heavy_serialized)
+        self.assertIn(_HUGE_INSTRUCTIONS_SENTINEL, heavy_serialized)
+
+    def test_briefing_light_serialized_size_below_budget(self):
+        # Sanity ceiling — not a token count, but a strong proxy. With 10
+        # events at ~4 KB raw payload each + a ~5 KB resume_instructions
+        # blob, the heavy payload is well over 50 KB. The light path must
+        # come in under 8 KB even on this fixture.
+        size = len(json.dumps(
+            get_resume_briefing_light(self.conn),
+            ensure_ascii=False, default=str,
+        ))
+        self.assertLess(size, 8_000)
+
+    # ---- session_brief shape --------------------------------------------------
+
+    def test_session_brief_omits_raw_resume_instructions(self):
+        sb = format_session_brief({
+            "status": "SUSPENDED",
+            "objective": "ship it",
+            "started_at": "2026-05-01T00:00:00Z",
+            "updated_at": "2026-05-09T00:00:00Z",
+            "suspended_at": "2026-05-09T00:00:00Z",
+            "resumed_at": None,
+            "resume_instructions": _HUGE_INSTRUCTIONS_SENTINEL * 10,
+            "dispatcher_pane_id": "%1.0",
+        })
+        self.assertNotIn("resume_instructions", sb)
+        self.assertNotIn("dispatcher_pane_id", sb)
+        self.assertEqual(sb["status"], "SUSPENDED")
+        self.assertEqual(sb["objective"], "ship it")
+        self.assertTrue(sb["has_resume_instructions"])
+        self.assertNotIn(_HUGE_INSTRUCTIONS_SENTINEL, sb["resume_summary"])
+
+    def test_session_brief_none_passthrough(self):
+        self.assertIsNone(format_session_brief(None))
+        self.assertIsNone(format_session_brief({}))
+
+    # ---- runs-scoped worker_dirs ---------------------------------------------
+
+    def test_active_inventory_dirs_uses_runs_status_not_lifecycle(self):
+        dirs = list_briefing_worker_dirs(self.conn)
+        paths = sorted(d["abs_path"] for d in dirs)
+        # live in_use run + queued run → both included regardless of
+        # lifecycle (delete_pending pinned by I7).
+        self.assertEqual(
+            paths,
+            ["/w/active-with-run", "/w/delete-pending-with-run"],
+        )
+        # Importantly, the lifecycle='active' shortcut would have
+        # returned the orphan dir AND skipped the delete_pending live
+        # one — which is exactly the bug Codex Major #4 flags.
+        lifecycle_view = sorted(
+            d["abs_path"]
+            for d in list_worker_dirs(self.conn, lifecycle="active")
+        )
+        self.assertEqual(
+            lifecycle_view,
+            ["/w/active-orphan", "/w/active-with-run"],
+        )
+
+    # ---- recent_events tail ---------------------------------------------------
+
+    def test_recent_events_for_briefing_filters_noise_and_caps_limit(self):
+        events = list_recent_events_for_briefing(self.conn, limit=5)
+        self.assertEqual(len(events), 5)
+        kinds = {e["kind"] for e in events}
+        self.assertNotIn("events_dropped", kinds)
+        # Each row is event_summary shape — never raw payload_json.
+        for e in events:
+            self.assertNotIn("payload_json", e)
+            self.assertIn("fields", e)
+            for v in e["fields"].values():
+                if isinstance(v, str):
+                    self.assertNotIn(_HUGE_PAYLOAD_SENTINEL, v)
+
+    def test_recent_events_for_briefing_unknown_kind_falls_back(self):
+        self.conn.execute(
+            "INSERT INTO events (occurred_at, actor, kind, payload_json) "
+            "VALUES ('2026-05-09T03:00:00Z', 'secretary', "
+            "'made_up_unknown_kind', '{\"foo\":\"bar\",\"big\":\"" + "x" * 4096
+            + "\"}')"
+        )
+        self.conn.commit()
+        events = list_recent_events_for_briefing(self.conn, limit=1)
+        self.assertEqual(events[0]["kind"], "made_up_unknown_kind")
+        # Fallback shape: kind/actor/occurred_at present, fields empty —
+        # no raw blob accidentally extracted.
+        self.assertEqual(events[0]["fields"], {})
+        self.assertEqual(events[0]["actor"], "secretary")
+
+    def test_recent_events_for_briefing_zero_limit_returns_empty(self):
+        self.assertEqual(
+            list_recent_events_for_briefing(self.conn, limit=0), []
+        )
+        self.assertEqual(
+            list_recent_events_for_briefing(self.conn, limit=-3), []
+        )
+
+    # ---- last_suspend_summary -------------------------------------------------
+
+    def test_last_suspend_summary_compresses_lists_to_counts(self):
+        b = get_resume_briefing_light(self.conn)
+        s = b["last_suspend_summary"]
+        self.assertEqual(s["actor"], "secretary")
+        self.assertEqual(s["active_workers_count"], 50)
+        self.assertEqual(s["pending_items_count"], 80)
+        # Reason is truncated, not a raw multi-KB blob.
+        self.assertNotIn(_HUGE_PAYLOAD_SENTINEL, s["reason"])
+
+    def test_format_last_suspend_summary_handles_missing_payload(self):
+        s = format_last_suspend_summary({
+            "occurred_at": "2026-05-09T01:00:00Z",
+            "actor": "secretary",
+            "payload_json": None,
+        })
+        self.assertEqual(s["occurred_at"], "2026-05-09T01:00:00Z")
+        self.assertIsNone(s["reason"])
+        self.assertIsNone(s["active_workers_count"])
+        self.assertIsNone(s["pending_items_count"])
+
+    def test_format_last_suspend_summary_handles_malformed_payload(self):
+        s = format_last_suspend_summary({
+            "occurred_at": "2026-05-09T01:00:00Z",
+            "actor": "secretary",
+            "payload_json": "{not valid json",
+        })
+        self.assertIsNone(s["reason"])
+        self.assertIsNone(s["active_workers_count"])
+
+    # ---- briefing-noise allowlist constant ------------------------------------
+
+    def test_briefing_noise_constant_pins_known_noise_kinds(self):
+        # Lock in the current noise list — silently extending it changes
+        # what the secretary sees on cold-start, so a future drift should
+        # land in this test as a deliberate diff.
+        self.assertEqual(
+            BRIEFING_EVENT_KINDS_NOISE,
+            frozenset({"events_dropped", "secretary_identity_restored"}),
+        )
 
 
 if __name__ == "__main__":

--- a/tools/state_db/test_queries.py
+++ b/tools/state_db/test_queries.py
@@ -512,6 +512,53 @@ class TestBriefingLight(unittest.TestCase):
                 if isinstance(v, str):
                     self.assertNotIn(_HUGE_PAYLOAD_SENTINEL, v)
 
+    def test_recent_events_for_briefing_drops_nested_payload_blobs(self):
+        # Codex round 1 Major: ``_briefing_value`` must not pass through
+        # nested list/dict in an allowlisted field, otherwise a single
+        # ``summary`` field carrying a 30 KB list re-inflates the
+        # briefing past Issue #412's budget. Seed an allowlisted-key
+        # event whose value is a 200-element list of 200-char strings;
+        # the briefing must replace it with a length marker.
+        big_list = [_HUGE_PAYLOAD_SENTINEL[:64] + str(i) for i in range(200)]
+        big_dict = {f"k{i}": _HUGE_PAYLOAD_SENTINEL[:64] for i in range(200)}
+        self.conn.execute(
+            "INSERT INTO events (occurred_at, actor, kind, payload_json) "
+            "VALUES ('2026-05-09T04:00:00Z', 'secretary', 'plan_delivered', ?)",
+            (json.dumps({
+                "task": big_list,    # allowlisted key, nested value
+                "worker": big_dict,  # allowlisted key, nested value
+            }),),
+        )
+        self.conn.commit()
+        events = list_recent_events_for_briefing(self.conn, limit=1)
+        # The two values must come back as length markers, not raw lists.
+        self.assertEqual(
+            events[0]["fields"]["task"], {"_type": "list", "_len": 200}
+        )
+        self.assertEqual(
+            events[0]["fields"]["worker"], {"_type": "dict", "_keys": 200}
+        )
+        size = len(json.dumps(events[0], ensure_ascii=False, default=str))
+        # Without the scalar coercion this row alone would be > 30 KB.
+        self.assertLess(size, 500)
+
+    def test_recent_events_for_briefing_filters_noise_in_sql(self):
+        # Codex round 1 Minor: noise filtering must happen in SQL so a
+        # busy tail of noise rows never crowds out signal. Seed 30 noise
+        # rows on top of the existing 10 signal events; ``limit=5`` must
+        # still return 5 signal rows.
+        for i in range(30):
+            self.conn.execute(
+                "INSERT INTO events (occurred_at, actor, kind, payload_json) "
+                "VALUES (?, 'dispatcher', 'events_dropped', '{\"count\":1}')",
+                (f"2026-05-09T05:00:{i:02d}Z",),
+            )
+        self.conn.commit()
+        events = list_recent_events_for_briefing(self.conn, limit=5)
+        self.assertEqual(len(events), 5)
+        for e in events:
+            self.assertNotIn(e["kind"], BRIEFING_EVENT_KINDS_NOISE)
+
     def test_recent_events_for_briefing_unknown_kind_falls_back(self):
         self.conn.execute(
             "INSERT INTO events (occurred_at, actor, kind, payload_json) "


### PR DESCRIPTION
## Summary

Adds dedicated lightweight briefing APIs alongside the existing query layer so Secretary's `/org-resume` Phase 1 no longer pulls 6-8k tokens of raw `recent_events` payload, full `resume_instructions`, and lifecycle-based worker dirs into context at session start. The dashboard-facing `get_org_state_summary` keeps its shape unchanged for backward compatibility (Codex Major 1).

## New APIs (`tools/state_db/queries.py`)

- `get_resume_briefing_light(conn)` — briefing entry point
- `list_recent_events_for_briefing(conn, limit=5)` — SQL `WHERE NOT IN` filter for noise kinds + per-kind allowlist payload extraction (unknown kinds fall back to `kind/actor/occurred_at`)
- `list_briefing_worker_dirs(conn)` — derived from `runs.worker_dir_id` (per `state-semantics-contract` I7), not from `worker_dirs.lifecycle`
- `format_session_brief(session)` — drops raw `resume_instructions`, returns `{status, objective, suspended_at, resumed_at, resume_summary}`
- `format_last_suspend_summary(row)` — counts + reason only, raw payload elided
- `_briefing_value(value)` — scalar-only helper, list/dict replaced with length markers (Codex round-1 Major)

## Skill change

`.claude/skills/org-resume/SKILL.md` Phase 1 step 1 switches the documented query from `get_org_state_summary` (dashboard) to the new `get_resume_briefing_light`.

## Verification

- `python -m unittest tools.state_db.test_queries` → **33/33 OK**
- `python -m unittest tools.state_db.* tests.test_state_db_fallback` → **150/150 OK** (skipped=1)
- Lightness assertion: a fixture seeded with 10 huge payloads + 5KB `resume_instructions` + suspend lists 50/80 returns briefing JSON < 8KB
- Nested list/dict are replaced with length markers (round-1 Major)
- Noise filter SQL: 30 noise + 10 signal seed → `limit=5` always returns 5 signal events (round-1 Minor)
- `get_org_state_summary` shape assertion: dashboard-facing surface unchanged

## Compat

`get_org_state_summary` and `list_recent_events` are untouched. dashboard (`dashboard/org_state_converter.py` / `dashboard/server.py`) continues to consume the existing shape with zero migration.

## Codex review

- Pre-design (Blocker 1 / Major 5 / Minor 2 / Nit 1): all resolved in initial implementation
- Self-review round 1: Major (nested payload weak guarantee) + Minor (noise filter to SQL) → fixed in `937ec97`
- Self-review round 2: clean

## Refs

Closes #412