### PR TITLE
chore(claude): cleanup Session #16 residue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,13 @@ Thumbs.db
 # M4 (Issue #267): journal.jsonl decommissioned — events table is the SoT.
 # Local files lingering from pre-M4 runs are no longer authoritative.
 .state/journal.jsonl
+
+# Local Python venv (Secretary main working tree only)
+.venv/
+
+# Ad-hoc scratch / log artifacts
+tmp/
+err.log
+
+# Dispatcher pane snapshot scratch (machine-local)
+.dispatcher/panes-snapshot-tmp.json

--- a/knowledge/curated/codex.md
+++ b/knowledge/curated/codex.md
@@ -1,0 +1,26 @@
+# codex CLI 利用の運用知見
+
+codex CLI（セルフレビュー用）でハマりがちなハング挙動と対処。
+
+## codex exec は長文日本語プロンプトで数十分ハングし得る → 出力 0 bytes ベースで kill タイムアウトを設ける
+
+`codex exec --skip-git-repo-check "<長文プロンプト>"` は、4000 文字超 / 多数の指示観点 / 階層的分類指示などプロンプトが大きいと、応答開始までに数十分かかるか、永遠に応答しないことがある（codex-cli 0.129.0 で観測）。
+
+観測例（renga `feat/spawn-claude-pane-soft-validation` ワーカー、2026-05-10）:
+
+- プロセス自体は alive（`STAT=Sl`）
+- stdout output ファイルは 0 bytes のまま 165 分（`etimes=9935s`）経過
+- 既知の `codex:rescue` skill ハング（CLAUDE.md 記載: 18 分超）と異なり、`codex exec` 直打ちでも長時間ハングが発生
+
+これは codex の thinking phase が stdout 沈黙する設計に起因する。`/proc/<pid>/cmdline` で日本語が正しく届いていることは確認できるが、それと応答時間は別問題。
+
+運用ルール:
+
+1. 出力 0 bytes が **5–10 分継続したら kill** を作業手順に明記する。`wc -l <output_file>` で 0 が続いている間は何も来ていないと判定してよい
+2. ハング検知時は `kill -9` で codex プロセスツリー全体（`zsh -c …` / `node …` / `codex` 本体）を落とす
+3. レビュー観点はもっと絞る（1–2 観点 + 「指摘がなければなしでよい」）。Blocker-Major-Minor-Nit 4 段階分類 × 5 観点のような重い指示は避ける
+4. codex 未導入環境および kill 後は **skip 扱いとして完了報告に進んでよい**（renga の CLAUDE.md でも codex セルフレビュー skip は許容されている）
+
+関連: renga の CLAUDE.md（検証深度 full の codex セルフレビュー手順）、過去の `codex:rescue` skill 18 分超ハング事例（renga CLAUDE.md 記載）。
+
+出典: `2026-05-10-codex-exec-hang-on-long-japanese-prompt.md`

--- a/knowledge/curated/delegation.md
+++ b/knowledge/curated/delegation.md
@@ -1,0 +1,120 @@
+# 委譲（delegation）の運用知見
+
+委譲フロー（dispatcher delegate-plan / worker による実作業）で発生した、運用時に踏みやすい制約と回避策。
+
+## ディスパッチャーで sandbox が有効なときは delegate-plan helper が落ちる
+
+`/sandbox`（auto-allow）を有効化したディスパッチャーペインで `claude-org-runtime dispatcher delegate-plan` を実行すると、helper が `.state/workers/worker-{task_id}.md` や `.state/dispatcher/outbox/{task_id}-instruction.md` を書こうとした時点で「read-only file system」エラーになる。bubblewrap サンドボックスは Bash の `auto-allow` に関係なく `/tmp` とプロジェクト外ディレクトリへの書き込みを遮断するため。
+
+対処は以下のいずれか:
+
+- **本筋**: probe セッション後に `/sandbox` を無効化してから DELEGATE を処理する。dispatcher の通常運用と sandbox は競合する設計と捉える。
+- **緊急回避**: `claude_org_runtime.dispatcher.runner.choose_split(panes)` を Python ライブラリとして直接呼び target/direction を取得し、state ファイルは Bash でなく Claude の **Write ツール** で作成する（Write は sandbox 制約の対象外）。`tools/journal_append.sh` の DB 書き込みは sandbox 下で失敗するが、state ファイルが正しく更新されていれば worker-monitoring 側のクローズには影響しない。
+
+教訓: sandbox は調査用ツールという位置づけで、dispatcher の常時運用と両立しない。Write ツール経由の作成は「Bash がブロックされても書ける」回避口として覚えておく価値がある。
+
+出典: `2026-05-09-delegation-dispatcher-sandbox-fallback.md`
+
+## auto permission mode で pip install がブロックされたときの代替
+
+ワーカーが `pip install --user shellcheck-py` を試みたところ "bash denied by auto mode" でブロックされた。当該タスク (`install-sh-wsl2-fix`) では以下の二段で対応した:
+
+1. **stub 方式での検証**: `claude` / `renga` / `gh` をダミースクリプトで模倣する stub ディレクトリを作り、`PATH="$stubs:/usr/bin:/bin" bash scripts/install.sh --dry-run` で install スクリプトの動作だけ検証。外部ツールの実インストール無しに install フローを通せる。
+2. **permission の恒久改善**: `pip install --user` を `/org-setup` または `settings.json` の `permissions.allow` に追加すれば、同種ブロックは将来分も含めて消せる。
+
+委譲指示テンプレ側で「外部 CLI が必要な検証は stub 方式も検討」と明示しておくと、ワーカーが同じ壁にぶつかった時の試行回数を減らせる。
+
+副次観察: 当該タスクの Codex セルフレビューは Round 1 で Major 指摘（`--dry-run` 下でも Windows pip probe が実行される）を出し、Round 2 で修正確認、Round 3 でクリーンに収束。検証深度 `full` の効果が実測できた事例。
+
+出典: `2026-05-09-delegation-pip-install-auto-mode-block.md`
+
+## DELEGATE 指示文中の flag-like text を `spawn_claude_pane` の `args[]` に直訳しない
+
+DELEGATE 指示文 / worker brief 本文中に `--skip-settings`, `--mode audit` といった「フラグ風」のテキストが含まれていても、ディスパッチャーは `spawn_claude_pane` の `args[]` にそれをそのまま渡してはならない。`args[]` は **Claude Code CLI の実フラグ専用**フィールド（例: `--resume`, `--continue`）で、それ以外を渡すと `error: unknown option '--xxx'` で Claude Code が即時 exit する。
+
+実例:
+
+- `dispatcher-skip-settings-fix` (2026-05-09): DELEGATE 文中の `gen_delegate_payload.py --skip-settings` を CLI 引数と誤認 → `args=["--skip-settings"]` で起動 → 即時 exit。
+- `sandbox-probe-iter-b-round-3` (2026-05-09): 「`--skip-settings` で起動」という指示記述を args に直訳 → pane id=11 即時 exit → 再 spawn (id=12) で対応。worker への遅延 2〜3 分。
+
+教訓:
+
+- DELEGATE 文中の `--xxx` 形式テキストは **作業説明 / ツール側オプション説明 / コンテキスト情報** であって CLI 引数ではない。「`--skip-settings` で起動」と書いてあっても、それは「settings.local.json が既に worktree に配置済み」というコンテキスト情報であり、Claude Code は普通に起動するだけでよい。
+- `spawn_claude_pane` の `args[]` は通常空（省略）にする。
+- `.dispatcher/CLAUDE.md` に `args[]` 取り扱い注意セクションが追加済み（PR #391）。
+
+出典: `2026-05-09-delegation-dispatcher-args-passthrough.md`, `2026-05-09-delegation-skip-settings-wrong-cli-arg.md`
+
+## check-worker-boundary hook の commit メッセージ誤検知 → `git commit -F` で回避
+
+ワーカーが `git commit -m "... git reset --hard ..."` のようにメッセージ本文に hook の検出キーワード（`git reset --hard` 等）を含めると、`check-worker-boundary.sh` が誤検知して Write をブロックする。本来の hook はファイルパスをチェックする設計だが、commit メッセージ本文中のパターンも引っかかる。
+
+回避策: `git commit -F <file>` を使い、メッセージをファイル経由で渡す。
+
+```bash
+# NG（hook に誤検知される）
+git commit -m "docs: 検証結果記録 (git reset --hard パターン含む)"
+
+# OK
+echo "docs: 検証結果記録 (git reset --hard パターン含む)" > commit_msg.txt
+git commit -F commit_msg.txt
+```
+
+将来のワーカーがテスト結果や観測結果を commit メッセージに書く場合、hook トリガーワードを含むと同様の問題が起きる。hook の false-positive が疑われたら `-F` を試す。当該事例（`sandbox-probe-iter-b-round-2`, 2026-05-09）はワーカー自己解決で外部エスカレーションなし。
+
+出典: `2026-05-09-delegation-hook-commit-message-false-positive.md`
+
+## iteration A B1-1 委譲プロセスで露呈した 4 つの落とし穴
+
+Issue #376 sandbox-probe iteration A B1-1 を 3 ワーカー連で進めて出た、再現性のある delegation 設計上の罠。
+
+### 1. dispatcher proxy 経由で credential を扱う設計は組まない
+
+ワーカーが auto-mode classifier に阻まれる動作（`spawn_claude_pane` / 機微 read 等）を「dispatcher の bypassPermissions に肩代わりさせる」誘惑が出ても NO。dispatcher は DELEGATE / CLOSE_PANE のみを期待する設計で、worker からそれ以外（probe 実行依頼）を送られると **拒否することが正しい防御反応**。Secretary が「正規 probe」と pre-notify しても、その pre-notify 自体が peer message 経由なので signal として効かない（OS-level credential アクセス + ユーザー明示承認なし + peer message 経由の権威付け、への警戒）。設計レイヤで proxy 経路を組まない。
+
+実例: B1-1 で当初「dispatcher pane に send_message で probe コマンドを実行依頼する」設計だったが、dispatcher が 2 回連続で拒否（正しい挙動）。設計を「ユーザーが dispatcher pane で対話的に probe → worker は書き起こしのみ」に組み替えて成立。
+
+### 2. incorporation 系 task の指示で「sha256 一致」を primitive にしない
+
+「ソース commit を取り込み先に sha256 一致でコピーする」という primitive は、取り込み元 commit と取り込み先 main の独立進化（特に Codex iterative review fix / hot-fix / format change）を無視する。selective merge を初手から提示する。
+
+実例: Pre-Phase 0 spike (PR #383) の incorporation を sha256 一致で片付けたあと、destination 側に Codex iterative review (round1/2/3) で 3 commit の修正が積まれた。次の incorporation 指示で sha256 一致と書くと、round3 fix（credential 露出対策の Blocker fix）を機械的に上書きする。worker が `git diff vs origin/main` で物理差分を取り判断仰ぎ → ユーザー判断 → selective merge (+5/-5 のみ手動転記) で対応。指示テンプレに「ソース commit が destination の現状と乖離している場合の selective merge 手順」を初手から組み込む。
+
+### 3. audit-mode で「初期状態と完全一致」型の仮説評価には実機反証実験を最低 1 つ要求する
+
+audit-only mode は「コード変更なし」を保証するが、実機反証実験の禁止までは含意しない。**reproduction is part of audit**。観察 shape が複数経路で説明できる場合、最低 1 つを実機反証実験で除外させる。
+
+実例: `db-mystery-iter-a-audit` で「sandbox shadow FS が真因」と結論したが、Secretary が同現象を再観測して真因が **`tools/state_db/__init__.py` の `connect()` が cwd 相対**で worktree 内に別 DB を生成していただけと判明。worker は `find . -name state.db` を当該 worktree 内のみで実行して棄却したため、`.worktrees/*/state/state.db` パターンの shadow DB を見落とした。`--mode audit` の delegation guidance に「観察 shape が複数経路で説明できる場合、最低 1 つを実機反証実験で除外せよ」を明示する。
+
+### 4. probe 系 task の事前指示に testbed credential 切替手順を含める
+
+`~/.config/`, `~/.aws/`, `~/.ssh/`, `~/.netrc`, `~/.npmrc` 等の本番 credential に触れる可能性がある probe 系 / 検証系 / fuzzing 系 task では、事前に testbed credential への切替手順を CLAUDE.local.md に必須セクション化する（`gh auth login --with-token < testbed.txt` で probe 専用 token に切替、終了後 `gh auth refresh` で本番に戻すか、testbed token をローテーション）。
+
+実例: iteration A B1-1 checklist 1.1 はもともと `cat ~/.config/gh/hosts.yml` を「sandbox denyRead が効くか」の試行として設計。実機実行で sandbox auto-allow + denyRead 列空 → 通過し、実 oauth_token が dispatcher stdout に表示。事後的にユーザーへ `gh auth refresh` のローテーション推奨を伝達したが、本番 token を晒した状態で完了。
+
+出典: `2026-05-09-delegation-iteration-a-b1-1-process.md`
+
+## Pattern A で外部 GitHub repo を worker_dir に割り当てるときは spawn 前に clone 状態をチェックする
+
+Pattern A（プロジェクトディレクトリ）で worker_dir が外部 GitHub repo を指すケース（例: `claude-org-runtime`）では、worker_dir に CLAUDE.md / `.claude/` のみが配置済みでも、git repo 本体が clone 済みとは限らない。dispatcher が spawn した直後にワーカーが「リポジトリが clone されていない」とブロックを上げ、secretary → dispatcher へ clone 依頼が逆流する事故が発生した。
+
+dispatcher 側の予防チェック:
+
+```bash
+git -C {worker_dir} rev-parse --git-dir 2>/dev/null
+```
+
+このコマンドが失敗（`.git` 不在）したら、spawn 前に secretary に clone 完了を確認させる。
+
+dispatcher が緊急で clone する場合の手順（org 固有ファイルの退避が必要）:
+
+1. CLAUDE.md / `.claude/` / `send_plan.json` を `/tmp` にバックアップ
+2. `git clone <url> /tmp/clone-xxx`
+3. `mv /tmp/clone-xxx/.git {worker_dir}/.git`
+4. `git -C {worker_dir} checkout -- .` で tracked ファイルを展開
+5. バックアップから CLAUDE.md / `.claude/` を復元（repo 同梱の CLAUDE.md を org 用で上書き）
+6. `git -C {worker_dir} checkout -b {branch_name}`
+
+本筋は secretary 側の `gen_delegate_payload.py apply` 段階で clone まで完了させる設計。dispatcher の `.git` 存在チェックは早期検出のセーフティネットという位置づけ。
+
+出典: `2026-05-09-delegation-pattern-a-external-repo-clone-check.md`

--- a/knowledge/curated/dispatcher-monitoring.md
+++ b/knowledge/curated/dispatcher-monitoring.md
@@ -1,0 +1,59 @@
+# ディスパッチャー worker-monitoring 設計知見
+
+`.dispatcher/references/worker-monitoring.md` の検知ロジック設計時に出てきた、再現性のある落とし穴。
+
+## 同一監視サイクル内での時刻順序を明示的にモデル化する（PANE_OUTPUT_WITHOUT_PEER_MSG）
+
+worker-monitoring の 1 サイクルは Step 1 (poll_events) → Step 2 (check_messages) → Step 3 (list_panes) → Step 4 (inspect_pane) → Step 5 / 5.1 / 5.2 評価、の順で**直列に実行される**。Step 2 で worker→secretary peer-msg を受信すると、secretary はその時点で events table に `occurred_at = T_msg` で永続化する。Step 4 の `inspect_pane` で初めて画面変化を検知して `last_content_change_ts` を更新する設計だと、現サイクルの inspect 時刻 (= `now`) は必ず `T_msg` より後 (`T_msg < T_inspect`) になる。
+
+このとき (c)(ii) の `WHERE occurred_at >= last_content_change_ts` クエリで、正当な peer-msg `T_msg` が cutoff に弾かれてしまう。後続サイクルで `last_content_change_ts` 以降に worker→secretary 痕跡なしと判定 → fire という誤発火が起きる。
+
+### 解法: 「前サイクルの `last_check_ts`」を `last_content_change_ts` に採用
+
+idle→active 遷移時、`last_content_change_ts` を **現サイクルの inspect 時刻**ではなく **前サイクルの `last_check_ts`** にする。前サイクルの `last_check_ts` は「最後に画面が idle と確認できていた時刻」で、現サイクルで届く peer-msg より必然的に古い。これで (c)(ii) の cutoff は peer-msg より古くなり、acked と正しく判定される。
+
+active 継続中（出力が複数サイクルにわたって連続）は `last_content_change_ts` を **据え置く**（active 期間の START 時刻を保持）。active 期間中に届いた進捗 peer-msg を全て acked 経路に乗せるため。
+
+### 一般化できる教訓
+
+監視ループが直列実行されるとき、**同サイクル内で発生する複数イベントの時刻順序は明示的にモデル化する**。「イベント A の永続化時刻 vs イベント B の観測時刻」のような場面で、cutoff を「観測時刻」(= `now`) に置くと cutoff が後発イベントを除外する race を生む。
+
+cutoff の正しい起点は「直前まで対象状態が継続していた時刻の上限」(= 前サイクルの末尾時刻)。Step 5 (stall) と Step 5.1 (relay gap) は「window 内に痕跡があるか」の存在判定で時間順序を厳密に要求しなかったため race が顕在化していなかったが、新しい検知パターンを追加する際は同サイクル race の有無を desk-check すべき。
+
+## Codex iterative review はラウンドごとに別の抽象レベルを露呈する
+
+PANE_OUTPUT_WITHOUT_PEER_MSG の 3 ラウンドレビューで指摘されたバグは、それぞれ独立した抽象レベルで露呈した:
+
+- **Round 1 Blocker**: 時間 window のスコープが誤っていた（15 分窓 vs `last_content_change_ts` 起点）
+- **Round 1 Major**: 検知粒度の精度が緩かった（idle ≥ 1 vs ≥ 2）
+- **Round 2 Major**: 記述同士の整合性 — (b)(5) と (c)(ii) の論理矛盾（Round 1 修正の副作用）
+- **Round 3 Major**: 同サイクル race — Round 1+2 の正しい論理を仮定しても残るタイミングバグ
+
+各ラウンドは前のラウンドで露呈した粒度の問題を解いた後でなければ見えない。1 回のレビューで「全部出しきる」のは構造的に難しく、3 ラウンド上限の運用契約は妥当（Blocker/Major が連続して出続けるなら設計やり直し signal、出ない/Minor 化したら収束 signal、と読める）。
+
+出典: `2026-05-09-pane-output-without-peer-msg-race.md`
+
+## dispatcher_retro_gate と channel 通知の不整合
+
+`tools/dispatcher_retro_gate.py --attempt N` は内部で `check_messages` をポーリングして secretary の ack を検出する設計。しかし secretary が `send_message(to_id="dispatcher", ...)` ではなく **renga-peers の channel broadcast 形式**（dispatcher の system-reminder として届く形式）で返答した場合、gate は `check_messages` キューに何も入らないため検出できず、`status: "polling"` のまま全 10 attempt を消費する。
+
+### 実例
+
+`phase3-doc-fix-issue-ref` のクローズ時 (2026-05-09): secretary の YES ack が channel 通知で届いたため gate が検出できず timeout。実際には ack 確認済みとして手動でペインクローズを続行（retro_deferred は書かなかった）。
+
+### 影響
+
+- gate が ack を拾えず timeout → 本来は不要な retro_deferred 記録または手動判断が必要になる。
+
+### 暫定回避（運用側）
+
+channel 通知で secretary ack が届いた場合、dispatcher が直接「ack 受領済み」と判断して retro 手順を続行する。retro_deferred は書かない。
+
+### 根本対策（要設計）
+
+1. retro gate に `inspect_pane` ベースのフォールバックを追加し、secretary ペインの画面を見て YES/NO パターンをスキャンする経路を持たせる、または
+2. secretary 側で retro gate ack は必ず `send_message(to_id="dispatcher")` で返す規約を明文化する。
+
+両受信経路（`check_messages` キュー / channel broadcast）を retro gate が考慮していないのが構造的な原因。
+
+出典: `2026-05-09-retro-gate-channel-notification-gap.md`

--- a/knowledge/curated/release-process.md
+++ b/knowledge/curated/release-process.md
@@ -1,0 +1,37 @@
+# リリース運用
+
+リリース昇格コミット時に踏みやすい慣行・落とし穴。
+
+## Keep a Changelog: リリース時に空の `## [Unreleased]` を残す
+
+Keep a Changelog 形式の `CHANGELOG.md` をリリース昇格するとき、`## [Unreleased]` 見出しを `## [X.Y.Z] — YYYY-MM-DD` に「置換」してはならない。**空の `## [Unreleased]` プレースホルダを新リリース見出しの上にそのまま残す**。
+
+正:
+
+```
+## [Unreleased]
+
+## [1.1.3] — 2026-05-09
+...
+```
+
+誤（リリース後に Unreleased 受け皿が消える）:
+
+```
+## [1.1.3] — 2026-05-09
+...
+```
+
+### なぜ非自明か
+
+- Keep a Changelog の例だけ見ると `[Unreleased]` は「次リリースまでの作業中エントリ溜め場」なので、リリース時に `[X.Y.Z]` に書き換えるのが直感的。
+- 置換すると次リリース向けの受け皿セクションが消え、次の PR で「[Unreleased] に追記」する worker が見出しを毎回再生成する手間 / 漏れリスクを負う。
+- Keep a Changelog 公式 spec はどちらの運用も明示しないので、リポジトリの過去タグを `git show vX.Y.Z:CHANGELOG.md` で確認するのが正解の決め手。
+
+### 適用範囲
+
+- Keep a Changelog 形式の `CHANGELOG.md` を採用しているリポジトリ全般のリリース昇格コミット。
+- リリース直前 / 直後の git diff 確認時、空 `[Unreleased]` が残っているかをチェックリスト項目にする。
+- renga リポジトリでは v1.1.0 / v1.1.1 / v1.1.2 すべて、リリース後タグ時点で空の `## [Unreleased]` を残してある（`git show v1.1.2:CHANGELOG.md` で確認可能）。v1.1.3 リリース worker はこの慣行を見落として置換してしまい、Codex セルフレビューで Minor 指摘を受けた。
+
+出典: `2026-05-09-keepachangelog-empty-unreleased-placeholder.md`

--- a/knowledge/curated/schema-validation.md
+++ b/knowledge/curated/schema-validation.md
@@ -1,0 +1,46 @@
+# スキーマ検証の運用知見
+
+YAML / JSON authoring と byte-level schema 比較で踏みがちな silent failure と、その防御パターン。
+
+## 「キーが存在するか」と「値が truthy か」は別物として扱う
+
+スキーマ validation で「絶対に書いてはならないキー」を reject する際、`raw_role.get(key) is None` ではなく `key in raw_role`（キー存在ベース）で判定する。`get()` は YAML/JSON で値を `null` にした authoring エラーを silent に許してしまう。
+
+実例（claude-org-runtime#13、Codex review round 1/2）: `worker_roles` に `sandbox_by_pattern: {A?, B?, C?}` を追加し、worker role では `sandbox` / `sandbox_by_pattern` を mutual exclusive、org role では `sandbox_by_pattern` を reject する仕様を入れた。最初の実装は `raw_role.get("sandbox_by_pattern") is None` で「未宣言」を判定していたが、これは `sandbox_by_pattern: null`（キーは存在するが値が None）のとき、
+
+- worker role: `sandbox` と `sandbox_by_pattern: null` が併存しても通る → silent fallthrough
+- org role: `sandbox_by_pattern: null` が通る → reject されない
+
+という silent misconfig を許してしまう。Codex review で指摘されて `"sandbox_by_pattern" in raw_role` に切り替えた。
+
+教訓: `_VALID_ANCHORS` 系の閉じた集合 validation でも同じく「null 値 = 未指定ではない」を意識する。role × pattern × sandbox の cross-product schema や Phase 1 sandbox / Phase 2 hooks のような将来追加でも同じ罠が起きやすい。
+
+出典: `2026-05-10-key-presence-vs-value-truthiness-in-schema-routing.md`
+
+## best-effort 文字列置換には「未展開 placeholder 残存ガード」を必ず併設する
+
+`_substitute()` が「mapping にあるキーだけ置換し、無いキーは untouched で残す」挙動を取るなら、render の最終段で「downstream consumer が literal として扱う部分に未展開 placeholder が残っていないか」を walk して reject する guard を必ず併設する。特に security boundary を表現する struct（sandbox / permissions）では必須。
+
+実例（claude-org-runtime#13）: Pattern B sandbox は `{base_clone}/.git/worktrees/{task_id}` を含むが、CLI 呼び出しで `--base-clone` が渡されないと、rendered `settings.local.json` に literal `"{base_clone}/..."` が残る。bwrap launcher は `additionalDirectories` を concrete path として消費するので、未展開 placeholder がそのまま流れると sandbox の境界が静かに壊れる（Layer 3 が無効化されるか、起動時に意味不明なエラー）。
+
+実装パターン: `_reject_unresolved_pattern_b_placeholders()` のように対象 dict を visit し、`{base_clone}` / `{task_id}` / `{branch_ref}` を含む string が残っていれば、不足している flag 名（`--base-clone` 等）を含む usable error を投げる。「足りない flag が何か」を error message に書くと operator がすぐ直せる。
+
+出典: `2026-05-10-key-presence-vs-value-truthiness-in-schema-routing.md`
+
+## ja-only Layer 2 credential mirror は drift checker で strip してから byte 比較する
+
+`tools/check_runtime_schema_drift.py` の byte 比較は、ja 側 `worker_roles` の `permissions.deny` に含まれる ja 固有 Layer 2 home credential mirror（`~/.netrc`, `~/.npmrc`, `~/.config/gh/` 等）が runtime bundled schema には存在せず、byte drift として fail する問題がある。
+
+理由: runtime bundled schema は汎用ベースラインで ja 固有 credential deny を含まない。ja 側 PR3（secretary/curator）は `required_deny` / `required_allow` 経由で対称に管理しているが、`worker_roles` の `permissions.deny` には ja-only の Layer 2 エントリが直接入る → byte 比較が非対称を検出して fail。
+
+解決パターン: `_strip_ja_only_sandbox_bodies` 関数の `worker_roles` 処理パス内で、`_JA_ONLY_LAYER2_CREDENTIAL_DENIES`（Layer 2 credential mirror の既知エントリセット）に含まれるエントリを `permissions.deny` から除去してから byte 比較に渡す。
+
+PR #416（commit 15c235, `ja-phase1-pr4-worker-roles-bodies`）で実装。
+
+付記: 大型 1-PR では「事前 Codex design review + post-impl Codex self-review の二段構え」が有効。PR #416 では Codex round 1–3 で以下が検出・修正された:
+
+- ja-only Layer 2 credential mirror の strip（このパターン）
+- packed-refs B2 surface の追加
+- doc-audit Pattern B read surface mirror の調整
+
+出典: `2026-05-10-ja-only-layer2-credential-mirror-drift-strip.md`

--- a/knowledge/curated/testing.md
+++ b/knowledge/curated/testing.md
@@ -1,0 +1,22 @@
+# テスト記述の運用知見
+
+クロスプラットフォーム / CI で踏みやすいテスト失敗の回避策。
+
+## Python テストでパス完全一致のアサーションは `os.path.join` を使う
+
+POSIX ハードコード（`f"{base}/.git/config"` のような文字列結合）は Windows CI で失敗する。`os.path.join` はプラットフォームに応じて区切り文字（POSIX なら `/`、Windows なら `\`）を返すので、テスト側もそれに合わせる必要がある。
+
+```python
+# NG: POSIX ハードコード（Windows CI で fail）
+assert any(p == f"{base_clone}/.git/config" for p in captured)
+
+# OK: プラットフォーム非依存
+expected_joined = os.path.join(base_clone, ".git/config")
+assert any(p == expected_joined for p in captured)
+```
+
+`claude-org-runtime` の `test_settings_generator.py` で `base_clone` anchor のテストアサーション追加時に、Windows CI で実際に発火した。同テストファイル内の `home_anchor` 系テストは既にこのパターンで書かれていたため、コード内慣例としても確立済み。新規アサーション追加時は周辺コードのスタイルを踏襲する。
+
+適用範囲: Python テストでパスの完全一致アサーションを書く全ケース（OS 依存の git/HOME パス、`additionalDirectories` 検証、bwrap arg 検証など）。
+
+出典: `2026-05-10-delegation-windows-path-separator-in-tests.md`

--- a/knowledge/curated/wsl-tui.md
+++ b/knowledge/curated/wsl-tui.md
@@ -1,0 +1,45 @@
+# WSL2 / Windows Terminal の TUI 実装知見
+
+WSL2 + Windows Terminal でターミナル UI を作るときに踏みやすい入力イベントの差異。
+
+## Ctrl+Enter は crossterm では Ctrl+J として届く
+
+TUI アプリで「WSL2 / Windows Terminal でも Ctrl+Enter を commit キーとして使いたい」場合、kitty keyboard protocol を有効化しなくても `KeyCode::Char('j') + CONTROL`（= Ctrl+J）を受け付ければよい。WSL / Windows Terminal は extended-key reporting 無効時に Ctrl+Enter を素の LF バイト (0x0A) として送ってくる。crossterm の raw-mode parser はこれを Ctrl+J に decode する。
+
+### なぜ非自明か
+
+- 一般的な認識は「Ctrl+Enter は kitty / modifyOtherKeys / Win32 input mode が有効でないと distinct event にならない」。
+- 実際には WSL / Windows Terminal はデフォルトで Ctrl+Enter に対し LF バイトを送出している。
+- crossterm 0.29 (`src/event/sys/unix/parse.rs:107` 付近) には以下のロジックがある:
+
+  ```rust
+  c @ b'\x01'..=b'\x1A' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+      KeyCode::Char((c - 0x1 + b'a') as char),
+      KeyModifiers::CONTROL,
+  ))))),
+  ```
+
+  これにより 0x0A (LF) → `Char('j') + CONTROL`（= Ctrl+J）。
+- 0x0D (CR) は `b'\r' => KeyCode::Enter` の別分岐（Ctrl+M ではなく Enter）。
+- raw mode 限定。raw mode 無効時は LF も Enter として処理されるので、TUI アプリに限り通用するルート。
+
+### 設計上の含意（renga issue #226）
+
+`is_overlay_commit_key` で `Char('j') + CONTROL` を accept すれば、kitty protocol を有効化せずに WSL でも Ctrl+Enter で commit できる。kitty protocol の全面有効化は Esc 処理や他キーのレポート方法を変えてしまうため、IME overlay のような modal UI に局所適用する方が副作用が少ない。
+
+ただし「modifier が完全一致 CONTROL」に絞ること。`.contains(CONTROL)` だと `Ctrl+Shift+J` / `Ctrl+Alt+J` も commit してしまい、extended-key reporting が有効なホストで誤動作する。
+
+### 再現方法
+
+- 環境: WSL2 + Windows Terminal (default settings)
+- アプリ側で `crossterm::event::read()` を loop し、KeyEvent を debug dump
+- Ctrl+Enter を押す → `KeyEvent { code: Char('j'), modifiers: CONTROL, ... }` が出る
+- 比較: 純 Linux gnome-terminal は modifyOtherKeys を有効化しない限り Ctrl+Enter で何も distinct イベントを送らない（Enter と同じ 0x0D）
+
+### 関連リンク
+
+- crossterm Issue #371（`\n` vs `\r` vs Ctrl+J の扱い）
+- Windows Terminal Issue #879（Ctrl+Enter sends `\n` by default）
+- renga PR (Issue #226 修正)
+
+出典: `2026-05-09-wsl-ctrl-enter-arrives-as-ctrl-j.md`

--- a/registry/projects.md
+++ b/registry/projects.md
@@ -18,3 +18,5 @@ claude-org-ja 自身（self-edit）は本レジストリに載せない。`tools
 |---|---|---|---|---|
 | 時計アプリ | clock-app | - | Webブラウザで動くデジタル時計 | デザイン変更、機能追加 |
 | renga | renga | https://github.com/suisya-systems/renga | Rust 製の Claude Code 用ターミナルマルチプレクサ（TUI） | 機能追加、バグ修正、Issue 対応 |
+| サンドボックス検証 | sandbox-probe | - | Issue #376 / #377 用の sandbox profile / hook / settings 配備の実測検証エリア。candidate profile を handcraft して probe を回し allow/deny matrix を作る | Pre-Phase 0 spike、probe 反復、profile validation |
+| ランタイム | claude-org-runtime | https://github.com/suisya-systems/claude-org-runtime | Layer 2 = org-runtime: claude-org-ja から抽出された Python runtime (dispatcher / state schema / reference role prompts)。ja は pin で参照する | role_configs_schema.json 同期、release 駆動、dispatcher / settings.generator のメンテ |


### PR DESCRIPTION
## Summary
- Add `registry/projects.md` entries for `sandbox-probe` and `claude-org-runtime` (already in use during session #16)
- Commit 7 curator output files under `knowledge/curated/` (codex, delegation, dispatcher-monitoring, release-process, schema-validation, testing, wsl-tui)
- Add `.venv/`, `tmp/`, `err.log`, `.dispatcher/panes-snapshot-tmp.json` to `.gitignore`

Pure janitorial cleanup — no behavioral change. 9 files / +367 / verification depth: minimal.

## Test plan
- [ ] CI passes