### PR TITLE
docs(claude): README §304 / §318 / §320 drift fix for Phase 2 hooks + Phase 3 case E

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ claude-org-ja は **4 層防御**（`permissions.deny` / PreToolUse フック / 
 
 ### 攻撃ベクトル × 防御層マトリクス
 
-本リポジトリ自身の `.claude/settings.json`（窓口・キュレーター用、`auto` モード）と `.githooks/pre-commit` を基準にした、主要な攻撃ベクトルと各層の対応表です（✅ ブロック / ⚠️ 部分・条件付き / — 対象外 / ➖ 未配備）。**ワーカーロール用テンプレート（`.claude/skills/org-setup/references/permissions.md`）は `permissions.deny` が `git push` 系と `rm -r` / `rm -rf` のみで、PreToolUse フックは `check-worker-boundary.sh` / `block-org-structure.sh` / `block-git-push.sh` が配備されます**（`block-no-verify.sh` / `block-dangerous-git.sh` はワーカー側には未配備）。`--no-verify` / `git reset --hard` / `git branch -D` 系の直接遮断は本リポジトリ側の窓口・キュレーターのみが該当します。ワーカーは `git push` 自体を `block-git-push.sh` で全面遮断するため、`--force` を含む push 系は副次的に止まりますが、ローカルでの `git commit --no-verify` や `git reset --hard` はロール契約による自主規律で担保される設計です（ディスパッチャーは `.dispatcher/` 用の独立した hook 群で別途管理）。
+本リポジトリ自身の `.claude/settings.json`（窓口・キュレーター用、`auto` モード）と `.githooks/pre-commit` を基準にした、主要な攻撃ベクトルと各層の対応表です（✅ ブロック / ⚠️ 部分・条件付き / — 対象外 / ➖ 未配備）。**ワーカーロール用テンプレート（[`tools/org_extension_schema.json`](tools/org_extension_schema.json) の `worker_roles.{default,claude-org-self-edit}` が SoT。`.claude/skills/org-setup/references/permissions.md` は同 SoT の参照ドキュメント）にも `check-worker-boundary.sh` / `block-org-structure.sh` / `block-git-push.sh` に加えて `block-no-verify.sh` / `block-dangerous-git.sh` が配備済みです**。`permissions.deny` も `git push` 系と `rm -r` / `rm -rf` に加えて `git fetch` / `git pull` / `git remote add|set-url|remove` / `git submodule` / `git lfs` / `git gc` / `git filter-branch` / `git filter-repo` / `git replace` / `git update-ref` / `git config --global|--local|--worktree` / `git reflog expire|delete` / `git worktree*` を `-C` バリアント込みで拒否します。`--no-verify` / `git reset --hard` / `git branch -D` 系の直接遮断は窓口・キュレーターに加えてワーカー側でも有効になりました（ディスパッチャーは `.dispatcher/` 用の独立した hook 群で別途管理）。
 
 | 攻撃ベクトル | `permissions.deny` | PreToolUse フック | sandbox | pre-commit |
 |---|---|---|---|---|
@@ -315,9 +315,8 @@ claude-org-ja は **4 層防御**（`permissions.deny` / PreToolUse フック / 
 | シェル関数経由の bypass（`f(){ git commit --no-verify; }; f`） | — | ➖ 関数定義の静的解析は非対応 | — | — |
 
 **残存リスク (residual risk)**:
-- **シェル関数定義経由のルーティング**: 関数本体内に隠された禁止コマンドは PreToolUse フックの静的解析では検出できません（Phase 2c で検討した shell-layer 静的解析は誤検知率と保守コストの観点から廃案）。sandbox の `denyWrite` も対象が `~/.claude/settings.json` 等の限定リストで、`git commit` などのリポジトリ副作用は止めません（ホーム dotfile `~/.ssh` / `~/.aws` は WSL2 での sandbox init 失敗を避けるため `permissions.deny` の Read 側で防御する方針へ移行、[Issue #83](https://github.com/suisya-systems/claude-org-ja/issues/83)）。本ベクトルは現状ロール契約による自主規律のみで担保されます。
+- **シェル関数定義経由のルーティング**: 関数本体内に隠された禁止コマンドは PreToolUse フックの静的解析では検出できません（Phase 2c で検討した shell-layer 静的解析は誤検知率と保守コストの観点から廃案）。sandbox の `denyWrite` も対象が `~/.claude/settings.json` 等の限定リストで、`git commit` などのリポジトリ副作用は止めません（ホーム dotfile `~/.ssh` / `~/.aws` は WSL2 での sandbox init 失敗を避けるため `permissions.deny` の Read 側で防御する方針へ移行、[Issue #83](https://github.com/suisya-systems/claude-org-ja/issues/83)。なお WSL 環境では `claude-org-runtime` が、realpath がサンドボックスの可視範囲から外れる Layer 3 `denyRead` / `denyWrite` エントリ（例: `~/.aws` が `/mnt/c/...` 経由のリンク先になっているケース）を出力時に抑止し、抑止対象を `$comment` フィールドに列挙して出力します。Layer 2 `permissions.deny` の `Read(...)` / `Write(...)` 側が引き続き一次防御です）。本ベクトルは現状ロール契約による自主規律のみで担保されます。
 - **Windows native の sandbox 不在**: 上記表のとおり `cat .env` 等は Windows native では素通りします。ワーカー実行環境としては macOS / Linux / WSL2 を推奨し、Windows native では別経路（OS 側のファイル権限・GitHub Secret Scanning 等）で補完してください。
-- **ワーカーロールの薄い deny**: ワーカー用テンプレートの `permissions.deny` は意図的に小さく保たれており、ローカルでの `git commit --no-verify` / `git reset --hard` の直接遮断は配備されません（`git push` 自体は hook で全面遮断されるため `--force` は副次的に止まります）。残るリスクはロール契約と窓口側 CI の保護に依存します。
 
 詳細と段階導入の意思決定は [Issue #79](https://github.com/suisya-systems/claude-org-ja/issues/79) と [docs/verification.md §10](docs/verification.md) を参照。
 


### PR DESCRIPTION
## Summary
Catch-up to README sections that drifted after PR #420 (Phase 2 worker git guardrails) + `claude-org-runtime` v0.1.8 / v0.1.9 (Phase 3 case E + schema sync) landed in this session.

- §304-308 area: removed the claim that workers lack `block-no-verify.sh` / `block-dangerous-git.sh` and rely on role-contract self-discipline. After PR #420 both hooks are attached to `worker_roles.{default,claude-org-self-edit}` and `permissions.deny` includes the fetch / pull / remote / submodule / lfs / gc / filter-branch / replace / update-ref / config write / reflog mutation / `git worktree*` family (with `-C` variants).
- §318: added a short clause that on WSL the runtime now suppresses Layer 3 `denyRead` / `denyWrite` entries whose `realpath` escapes the sandbox view (e.g. `~/.aws` via `/mnt/c/`) and emits a `\$comment` listing the suppressed entries. Layer 2 `permissions.deny` remains the primary defense.
- §320: dropped a stale "thin deny" bullet that contradicted the post-PR-#420 worker policy.

## Test plan
- [x] Visual diff review (no logic / no tests, verification depth minimal)
- [ ] CI passes

Refs #376 #379 #392 #420