### PR TITLE
fix(installer): jq fail-close + README/getting-started drift fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Phase 5 完了時点で **Layer 1 / 2 / 3 はいずれも独立 OSS パッケー
 
 ### ワンライナー（推奨）
 
-依存ツール（`git` / `claude` / `renga` / `gh`）が導入済みなら、以下のワンライナーでクローン + `renga mcp install` までを一気に実行できます。
+依存ツール（`git` / `claude` / `renga` / `gh` / `jq`）が導入済みなら、以下のワンライナーでクローン + `renga mcp install` までを一気に実行できます。
 
 **macOS / Linux（bash）**:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ## 前提ツール（Prerequisites）
 
-ワンライナー / 手動手順のいずれを使う場合も、以下のツールは事前に導入しておく必要があります。インストーラ（`scripts/install.sh` / `scripts/install.ps1`）は `git` / `claude` / `renga` / `gh` の 4 つを fail-close で検証し、Python は警告のみ、`jq` / Node.js は検証されません（自動インストールはしません）。表中の用途を満たすには 7 つすべての導入が必要です。
+ワンライナー / 手動手順のいずれを使う場合も、以下のツールは事前に導入しておく必要があります。インストーラ（`scripts/install.sh` / `scripts/install.ps1`）は `git` / `claude` / `renga` / `gh` / `jq` の 5 つを fail-close で検証し、Python は警告のみ、Node.js は Linux / macOS のみ検証します（自動インストールはしません）。表中の用途を満たすには 7 つすべての導入が必要です。
 
 | ツール | 最小バージョン | 用途 | 導入リンク |
 |---|---|---|---|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ claude-orgの使い方ガイド。
 
 ### インストール
 
-依存ツール（`git` / `claude` / `renga` / `gh`）が揃っていれば、ワンライナーでクローン + `renga mcp install` までを一括実行できる。
+依存ツール（`git` / `claude` / `renga` / `gh` / `jq`）が揃っていれば、ワンライナーでクローン + `renga mcp install` までを一括実行できる。
 
 **macOS / Linux（bash）**:
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4,7 +4,7 @@
 #   pwsh -NoProfile -File scripts/install.ps1 [-Dir <path>] [-DryRun] [-SkipMcp]
 #
 # This script:
-#   1. Checks for required commands (git, claude, renga, gh) and prints
+#   1. Checks for required commands (git, claude, renga, gh, jq) and prints
 #      installation hints when something is missing.
 #   2. Clones suisya-systems/claude-org-ja (asks before reusing an
 #      existing directory).
@@ -91,6 +91,7 @@ if (-not (Test-Prerequisite 'git'    'https://git-scm.com/downloads'))          
 if (-not (Test-Prerequisite 'claude' 'https://claude.ai/code (Claude Code CLI)'))               { $missing = $true }
 if (-not (Test-Prerequisite 'renga'  'npm install -g @suisya-systems/renga@0.18.0'))            { $missing = $true }
 if (-not (Test-Prerequisite 'gh'     'https://cli.github.com/'))                                { $missing = $true }
+if (-not (Test-Prerequisite 'jq'     'https://jqlang.org/download/'))                           { $missing = $true }
 Write-Host ''
 
 if ($missing) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@
 #   bash scripts/install.sh [--dir <path>] [--dry-run] [--skip-mcp]
 #
 # This script:
-#   1. Checks for required commands (git, claude, renga, gh) and prints
+#   1. Checks for required commands (git, claude, renga, gh, jq) and prints
 #      installation hints when something is missing.
 #   2. Clones suisya-systems/claude-org-ja (asks before reusing an
 #      existing directory).
@@ -237,6 +237,7 @@ if [[ "$IS_LINUX" == "1" || "$IS_MAC" == "1" ]]; then
 fi
 require_or_warn renga  "npm install -g @suisya-systems/renga@0.18.0" || missing=1
 require_or_warn gh     "https://cli.github.com/" || missing=1
+require_or_warn jq     "apt install jq / brew install jq / https://jqlang.org/download/" || missing=1
 # Capture the absolute path so the later `run renga mcp install` can
 # bypass bash's PATH-extension blind spot for `.cmd` shims (Git Bash
 # on Windows tries `.exe` but not `.cmd` / `.bat`, so a PATH-only


### PR DESCRIPTION
## Summary
- Add jq presence check to the one-liner installers (`scripts/install.sh` / `scripts/install.ps1`) using the existing `require_or_warn` / `Test-Prerequisite` patterns. jq is now part of the fail-close prerequisite set alongside git / claude / renga / gh.
- Re-align documentation that still described jq as "not validated":
  - `README.md` L40 — describe fail-close as the 5 commands (git / claude / renga / gh / jq), Python as warn-only, Node.js as Linux/macOS only.
  - `README.md` L86 — add jq to the quickstart prerequisites table.
  - `docs/getting-started.md` L20 — add jq to the deps list.
- Update the header comments in both installer scripts to reflect the new required-commands set.
- jq version validation is intentionally out of scope; the existing `require_or_warn` pattern only does "presence + hint" (renga 0.18.0+, gh, etc. are not version-parsed either). Minimal diff: 4 files / +7 -5.

## Verification
- `bash -n scripts/install.sh` — passes
- Dry-run with jq present — all prereqs report `[ok]`, exits 0
- Dry-run with jq absent (PATH masked) — emits `[miss] jq not found.` and exits 1 (fail-close behavior confirmed on the bash side)
- Codex full self-review, 3 rounds — no Blocker / Major. Two Minor / Nit items left intentionally (out of scope):
  - `docs/getting-started.md` L11 short prerequisite list does not list jq (mirrors the existing omission of git / python; full list is delegated to README)
  - `scripts/install.sh:8` header comment does not list node/npm (pre-existing drift unrelated to jq)

## Test plan
- [x] `bash -n scripts/install.sh`
- [x] Local dry-run with jq present
- [x] Local dry-run with jq absent (PATH masked)
- [ ] CI: `.github/workflows/install-scripts.yml` (shellcheck / pwsh) on this PR