### PR TITLE
fix(hooks): make block-workers-delete.sh cwd-independent (Closes #426)

### DIFF
--- a/.hooks/block-workers-delete.sh
+++ b/.hooks/block-workers-delete.sh
@@ -55,8 +55,9 @@ if echo "$COMMAND" | grep -qE '(^|[|&;[:space:]])renga[[:space:]]'; then
 fi
 
 # workers ディレクトリのパスを org-config.md から読み取って解決する
-# Hook はプロジェクトルート (claude-org/) から実行される前提
-WORKERS_REL=$(grep 'workers_dir:' registry/org-config.md 2>/dev/null | sed 's/.*workers_dir:[[:space:]]*//' | tr -d '[:space:]')
+# CLAUDE_ORG_PATH 未設定時は cwd を使う（Secretary は cwd がプロジェクトルートなので fallback で動作）
+ORG_CONFIG="${CLAUDE_ORG_PATH:-$(pwd)}/registry/org-config.md"
+WORKERS_REL=$(grep 'workers_dir:' "$ORG_CONFIG" 2>/dev/null | sed 's/.*workers_dir:[[:space:]]*//' | tr -d '[:space:]' || true)
 if [[ -z "$WORKERS_REL" ]]; then
   # org-config.md が読めない場合はスキップ（Hook の責務外）
   exit 0

--- a/.hooks/block-workers-delete.sh
+++ b/.hooks/block-workers-delete.sh
@@ -55,14 +55,21 @@ if echo "$COMMAND" | grep -qE '(^|[|&;[:space:]])renga[[:space:]]'; then
 fi
 
 # workers ディレクトリのパスを org-config.md から読み取って解決する
-# CLAUDE_ORG_PATH 未設定時は cwd を使う（Secretary は cwd がプロジェクトルートなので fallback で動作）
-ORG_CONFIG="${CLAUDE_ORG_PATH:-$(pwd)}/registry/org-config.md"
+# org-config.md の workers_dir はリポジトリルート起点の相対パスなので、
+# config の読み込みも workers パスの正規化も ORG_ROOT 起点で行う
+# （CLAUDE_ORG_PATH 未設定時は cwd を fallback。Secretary は cwd がプロジェクトルートなので動作する）
+ORG_ROOT="${CLAUDE_ORG_PATH:-$(pwd)}"
+ORG_CONFIG="$ORG_ROOT/registry/org-config.md"
 WORKERS_REL=$(grep 'workers_dir:' "$ORG_CONFIG" 2>/dev/null | sed 's/.*workers_dir:[[:space:]]*//' | tr -d '[:space:]' || true)
 if [[ -z "$WORKERS_REL" ]]; then
   # org-config.md が読めない場合はスキップ（Hook の責務外）
   exit 0
 fi
-WORKERS_CANONICAL=$(portable_realpath "$WORKERS_REL")
+case "$WORKERS_REL" in
+  /*) WORKERS_ABS="$WORKERS_REL" ;;
+  *)  WORKERS_ABS="$ORG_ROOT/$WORKERS_REL" ;;
+esac
+WORKERS_CANONICAL=$(portable_realpath "$WORKERS_ABS")
 
 # 判定ロジック: 「再帰削除コマンドが含まれる」AND「workers パスが含まれる」
 # 引数パースではなく文字列マッチで判定する（for ループ等の回避パターンにも対応）

--- a/.hooks/test-block-workers-delete.sh
+++ b/.hooks/test-block-workers-delete.sh
@@ -7,7 +7,10 @@ set -euo pipefail
 HOOK=".hooks/block-workers-delete.sh"
 PASS=0
 FAIL=0
-WORKERS_DIR=$(realpath -m "../workers")
+# hook と同じ流儀で workers パスを解決する（registry/org-config.md の workers_dir は
+# ORG_ROOT 起点の相対パスとして定義されているため、CLAUDE_ORG_PATH があれば優先する）
+TEST_ORG_ROOT="${CLAUDE_ORG_PATH:-$(pwd)}"
+WORKERS_DIR=$(realpath -m "$TEST_ORG_ROOT/../workers")
 
 run_test() {
   local description="$1"
@@ -136,6 +139,58 @@ run_test "Edit ツール (Bash ではない)" \
 run_test "空コマンド" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"\"}}" \
   0
+
+echo ""
+
+# --- cwd 非依存性のテスト ---
+# 回帰: hook が registry/org-config.md を cwd 相対で読んでいた頃、Dispatcher cwd=.dispatcher/
+# では grep が exit 2 を返し set -euo pipefail で全 Bash がブロックされていた。
+# また、WORKERS_REL の正規化を cwd 起点で行うと絶対パス指定の workers 削除を検知できない。
+# CLAUDE_ORG_PATH 起点で config / workers パスを解決していることを担保する。
+echo "[cwd 非依存性 (CLAUDE_ORG_PATH 起点解決)]"
+
+HOOK_ABS="$(realpath "$HOOK")"
+# .dispatcher 配下を擬似 cwd として使う。ORG_ROOT は TEST_ORG_ROOT に揃える
+# （WORKERS_DIR と整合した workers パス解決を hook 側で起こすため）
+ALT_CWD="$(pwd)/.dispatcher"
+
+if [[ ! -d "$ALT_CWD" ]]; then
+  echo "  SKIP: .dispatcher ディレクトリが無いため cwd 非依存テストを省略"
+else
+  run_test_cwd() {
+    local description="$1"
+    local cwd="$2"
+    local org_path="$3"
+    local input_json="$4"
+    local expected_exit="$5"
+
+    actual_exit=0
+    ( cd "$cwd" && CLAUDE_ORG_PATH="$org_path" bash "$HOOK_ABS" ) <<< "$input_json" >/dev/null 2>&1 || actual_exit=$?
+
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+      echo "  PASS: $description"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: $description (expected exit $expected_exit, got $actual_exit)"
+      FAIL=$((FAIL + 1))
+    fi
+  }
+
+  run_test_cwd "Dispatcher cwd + 良性コマンド (回帰: 全 Bash ブロック)" \
+    "$ALT_CWD" "$TEST_ORG_ROOT" \
+    '{"tool_name":"Bash","tool_input":{"command":"ls"}}' \
+    0
+
+  run_test_cwd "Dispatcher cwd + workers 絶対パスの rm -rf (Blocker 回帰)" \
+    "$ALT_CWD" "$TEST_ORG_ROOT" \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm -rf ${WORKERS_DIR}/dummy-task\"}}" \
+    2
+
+  run_test_cwd "Dispatcher cwd + CLAUDE_ORG_PATH 未設定 + 良性コマンド (config 不在 fallback)" \
+    "$ALT_CWD" "" \
+    '{"tool_name":"Bash","tool_input":{"command":"ls"}}' \
+    0
+fi
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## Summary
- Fix a regression where the PreToolUse hook `.hooks/block-workers-delete.sh` blocked every Bash invocation from any pane whose cwd was not the repo root (e.g. the Dispatcher at `.dispatcher/`).
- Root cause: L59 read `registry/org-config.md` with a relative path; under `set -euo pipefail` the `grep` exited 2 (file not found), `pipefail` propagated it, `set -e` exited the hook with 2, which the PreToolUse contract reads as "deny".
- Resolve `registry/org-config.md` from `${CLAUDE_ORG_PATH:-$(pwd)}` so the hook works regardless of cwd. `CLAUDE_ORG_PATH` is already exported in `.dispatcher/.claude/settings.local.json`; the Secretary falls back to `pwd` because it always runs at the repo root.
- Fix a second defect Codex flagged in Round 1: `WORKERS_REL` was being normalized via `realpath` relative to the current cwd, which let absolute-path delete commands like `rm -rf /abs/path/to/workers/foo` slip past the matcher. Normalize `WORKERS_REL` against the resolved repo root instead.
- Extend `.hooks/test-block-workers-delete.sh` with three regression cases that exercise the dispatcher-cwd path and the absolute-path bypass.

Closes #426.

## Verification
- `bash .hooks/test-block-workers-delete.sh`: **27 passed / 0 failed** (including the three new regressions)
- Manual hook invocation (stdin-fed JSON) under several cwd / env combinations:
  1. Secretary cwd (repo root) — benign command → exit 0
  2. Dispatcher cwd (`.dispatcher/`) + `CLAUDE_ORG_PATH` set — benign command → exit 0
  3. Dispatcher cwd + `CLAUDE_ORG_PATH` unset (fallback path) — benign command → exit 0
  4. `rm -rf <workers_dir>/foo` (relative and absolute forms) → exit 2 (blocked)
  5. Non-recursive `rm`, `renga` invocations, `rm -rf` outside workers — exit 0 (no false positives)
- Codex full self-review, 2 rounds: Round 1 raised one Blocker (`WORKERS_REL` cwd-relative realpath bug, fixed in 7bf6af9); Round 2 had no Blocker / Major. Two Minor / Nit items remain intentionally out of scope (the test uses a fixed `../workers` literal instead of grepping `org-config.md`; the legacy unused variable `WORKERS_REL_CANONICAL` is still cwd-relative but unused).

## Test plan
- [x] `bash .hooks/test-block-workers-delete.sh` locally
- [x] Manual hook invocations across cwds (Secretary, Dispatcher with/without `CLAUDE_ORG_PATH`)
- [x] Manual checks that absolute-path workers deletes are still blocked
- [ ] CI (whatever workflow covers `.hooks/*` and `block-workers-delete` tests)