### PR TITLE
feat(claude): extend --user-common-sandbox to denyWrite (Closes #433)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,9 +80,6 @@
         ".env.*",
         "**/credentials*",
         "**/*.pem"
-      ],
-      "denyWrite": [
-        "~/.claude/settings.json"
       ]
     }
   }

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -56,13 +56,13 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 
 **注意**: `renga-peers` MCP ツール 14 種は `renga mcp install` を一度実行して user-scope に MCP サーバーを登録した後に利用可能になる。登録手順は README「インストール」セクションを参照。
 
-### ユーザー共通の sandbox denyRead 補強（`--user-common-sandbox`、Issue #429 Task B）
+### ユーザー共通の sandbox denyRead / denyWrite 補強（`--user-common-sandbox`、Issue #429 Task B + Issue #433）
 
-> **⚠️ main pull 後の 1 回必須**: 本リポジトリを clone / pull した後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行する**。未実行だと共有 `.claude/settings.json` から除去された `~/.ssh` / `~/.aws` / `~/.config/gh` 等の sandbox denyRead が補完されず、**sandbox 防御が一時的に弱くなる**。
+> **⚠️ main pull 後の 1 回必須**: 本リポジトリを clone / pull した後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行する**。未実行だと共有 `.claude/settings.json` から除去された `~/.ssh` / `~/.aws` / `~/.config/gh` 等の sandbox denyRead **および** `~/.claude/settings.json` の sandbox denyWrite が補完されず、**sandbox 防御が一時的に弱くなる**。
 
-`tools/org_setup_prune.py --user-common-sandbox` は `~/.claude/settings.json` の `sandbox.filesystem.denyRead` に対して、機密 credential ディレクトリ群を **idempotent に union-merge** する専用モード。共有 (= リポジトリ) 側の `.claude/settings.json` から個人 path を除去（Issue #429 Task C）した分の defense-in-depth を、個人環境ごとに directory-level の bwrap deny として復元する。
+`tools/org_setup_prune.py --user-common-sandbox` は `~/.claude/settings.json` の `sandbox.filesystem.denyRead` / `denyWrite` 双方に対し、対象エントリを **idempotent に union-merge** する専用モード。共有 (= リポジトリ) 側の `.claude/settings.json` から個人 path を除去（Issue #429 Task C で denyRead 群、Issue #433 で denyWrite の `~/.claude/settings.json`）した分の defense-in-depth を、個人環境ごとに復元する。**単一フラグで denyRead + denyWrite の両方を処理する**（`--user-common-sandbox-write` のような別フラグは設けない、UX 簡素化方針）。
 
-**対象ディレクトリ（候補）**: `~`-prefixed の literal で保存され、ユーザー間で共有されても portable:
+**denyRead 対象ディレクトリ（候補）**: `~`-prefixed の literal で保存され、ユーザー間で共有されても portable:
 
 - `~/.ssh`
 - `~/.aws`
@@ -72,17 +72,26 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 - `~/.docker`
 - `~/.config/aws-vault`
 
-**フィルタ規則**:
+**denyRead フィルタ規則**:
 
 - **存在しないディレクトリは skip**。`~/.docker` が無い環境では entry を追加しない（bwrap launcher の case A 扱いを先回り）。
 - **realpath が HOME を escape する symlink は skip**。WSL2 + DriveFS で `~/.aws → /mnt/c/Users/<name>/.aws` のようになっている場合、bwrap の bootstrap mount が失敗する（`bwrap: Can't create file at /home/<user>/.aws/config: No such file or directory`）。これは claude-org-runtime の Layer 3 generator (`role_configs_schema.json#$comment_sandbox_anchor` の `suppressOnSymlinkEscape=True`) と同じ判定を user_common 側でも先回りする。
 
-**動作（idempotent / additive-only）**:
+**denyWrite 対象ファイル（候補）**: `~`-prefixed の *file* literal:
+
+- `~/.claude/settings.json`
+
+**denyWrite フィルタ規則（denyRead と非対称、Issue #433）**:
+
+- **存在チェック無し**: ファイルが未作成でも entry を merge する。書込防御は **ファイル未作成時点で意味があり**（fresh install では `~/.claude/settings.json` が Claude Code の初回起動時に作成される）、deny を先に置くことで初回作成時から bwrap subprocess の書き込みを構造的に止める。
+- **symlink-escape skip も適用しない**: denyWrite の対象は単一ファイル literal で、bwrap が write 先 path を解釈する際に存在しない path を case A で skip するため bootstrap 失敗の risk が無い。symmetric directory denyWrite (`~/.ssh` 等) は **Issue #433 のスコープ外**として deferred（`ssh-keygen` / `aws configure` 等の正規 write を巻き込む副作用が大きく、明確な threat model も無いため）。
+
+**動作（idempotent / additive-only、denyRead/denyWrite 共通）**:
 
 - 既存の top-level key (`theme`, `env`, `permissions`, etc.) は無触。
-- 既存の `sandbox` / `sandbox.filesystem` siblings (`enabled`, `failIfUnavailable`, `denyWrite`, `additionalDirectories`) は保持。
-- `denyRead` の既存順序を保ちつつ、未追加の candidate のみを後ろに append。重複は skip。
-- malformed shape（`sandbox` が object でない、`denyRead` が array でない、entry が string でない、等）は **書込前に `ValueError` で abort**。ユーザーデータの黙示的破壊を防ぐ。
+- 既存の `sandbox` / `sandbox.filesystem` siblings (`enabled`, `failIfUnavailable`, `additionalDirectories`, および merge 対象でない側の deny list) は保持。
+- `denyRead` / `denyWrite` の既存順序を保ちつつ、未追加の candidate のみを後ろに append。重複は skip。
+- malformed shape（`sandbox` が object でない、`denyRead` / `denyWrite` が array でない、entry が string でない、等）は **書込前に `ValueError` で abort**。ユーザーデータの黙示的破壊を防ぐ。denyRead 側で先に shape error が出れば denyWrite merge は実行されない（その逆も同様）。
 
 **使用方法**:
 
@@ -97,11 +106,11 @@ python tools/org_setup_prune.py --user-common-sandbox
 python tools/org_setup_prune.py --user-common-sandbox  # → "no changes"
 ```
 
-**前提（Issue #429 Task A 調査結論を踏まえた含意）**: Claude Code は `permissions.deny` の `Read(...)` を `sandbox.filesystem.denyRead` に **merge する** ([公式 docs](https://code.claude.com/docs/en/settings))。したがって `permissions.deny Read(~/.aws/*)` を共有 / 個人 settings いずれかに書くと、symlink-escape 環境では bwrap bootstrap 失敗が起きうる。本モードが directory-level deny を採用し symlink-escape を skip するのは、Layer 2 (`Read(...)`) と Layer 3 (`sandbox.filesystem.denyRead`) のどちらに書いても同じ failure を踏むためで、Layer 3 側で realpath ベースに前さばきして root-cause を構造的に避ける設計。
+**前提 1（Issue #429 Task A 調査結論を踏まえた含意）**: Claude Code は `permissions.deny` の `Read(...)` を `sandbox.filesystem.denyRead` に **merge する** ([公式 docs](https://code.claude.com/docs/en/settings))。したがって `permissions.deny Read(~/.aws/*)` を共有 / 個人 settings いずれかに書くと、symlink-escape 環境では bwrap bootstrap 失敗が起きうる。本モードが directory-level deny を採用し symlink-escape を skip するのは、Layer 2 (`Read(...)`) と Layer 3 (`sandbox.filesystem.denyRead`) のどちらに書いても同じ failure を踏むためで、Layer 3 側で realpath ベースに前さばきして root-cause を構造的に避ける設計。
 
-**スコープ外（本モード）**: `sandbox.filesystem.denyWrite` は **本モードの対象外**。共有 `.claude/settings.json` の `denyWrite: ["~/.claude/settings.json"]` は Issue #429 Task C 時点では残置している。理由: (i) Task B PR #430 が `denyRead` 限定で `denyWrite` 拡張を持たない、(ii) 削除すると defense-in-depth が失われる（`~/.claude/settings.json` への意図しない上書きを止める唯一の Layer 3 mechanism）、(iii) 単一 file 名のため username 漏洩の影響は globbed entry より軽微、の 3 点に基づく判断。`denyWrite` も個人 settings 側へ移管するための Task B 拡張 (`tools/org_setup_prune.py` に `--user-common-sandbox-write` 相当を追加し、`~/.claude/settings.json` を candidate として merge する) は別 Issue を起票して扱う方針。本判断は本ファイル内に閉じる（旧版で参照していた共有 `.claude/settings.json` の inline コメントは JSON 仕様上設置できないため誤りだった）。
+**前提 2（denyWrite の merge セマンティクス、Issue #433 で確認）**: 公式 docs の `sandbox.filesystem.denyWrite` 説明にも「Arrays are merged across all settings scopes. Also merged with paths from `Edit(...)` deny permission rules.」と明記されており、denyRead と同じく Layer 2 (`Edit(...)`) と Layer 3 (`sandbox.filesystem.denyWrite`) が effective set として合流する。本モードが Layer 3 側に直接書く理由は、共有 `.claude/settings.json` の `permissions.deny Edit(~/.claude/settings.json)` 経由でも同じ effective deny を作れるが、共有 settings に書くと repo を pull する全ユーザーの home path に対して deny が適用される副作用（個人ごとの opt-out が不可能）が出るため。個人 settings 側に書くと個人環境ごとに撤回可能で、また「個人の `~/.claude/settings.json` を守る」という意図と保管場所が一致する。
 
-**詳細**: 実装は `tools/org_setup_prune.py` の `merge_user_common_sandbox_denyread` / `filter_existing_user_dirs` / `process_user_common_sandbox`、テストは `tools/test_org_setup_prune.py` の `MergeUserCommonSandboxDenyread` / `ProcessUserCommonSandboxCli` クラス群。
+**詳細**: 実装は `tools/org_setup_prune.py` の `merge_user_common_sandbox_denyread` / `merge_user_common_sandbox_denywrite` / `filter_existing_user_dirs` / `process_user_common_sandbox`（denyRead/denyWrite の merge は共通の `_merge_sandbox_deny` ヘルパー経由）、テストは `tools/test_org_setup_prune.py` の `MergeUserCommonSandboxTests` / `MergeUserCommonSandboxDenywriteTests` / `UserCommonSandboxEndToEndTests` クラス群。
 
 ## 窓口 (`<repo>/.claude/settings.local.json`)
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ pip install -e .
 # 5. renga の MCP サーバーを Claude Code に登録（初回のみ）
 renga mcp install
 
-# 6. pre-commit secret scanner と個人 sandbox 補強（main pull 後に 1 回必須、Issue #429 Task B/C）
+# 6. pre-commit secret scanner と個人 sandbox 補強（main pull 後に 1 回必須、Issue #429 Task B/C + Issue #433 denyWrite）
 bash scripts/install-hooks.sh
 python tools/org_setup_prune.py --user-common-sandbox
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/sc
 ```bash
 cd claude-org-ja
 bash scripts/install-hooks.sh                            # コミット直前の秘密情報スキャナを有効化
-python tools/org_setup_prune.py --user-common-sandbox    # main pull 後に 1 回必須 (Issue #429 Task B/C)
+python tools/org_setup_prune.py --user-common-sandbox    # main pull 後に 1 回必須 (Issue #429 Task B/C + Issue #433 denyWrite)
 renga --layout ops                                       # 窓口（Secretary）ペインを起動
 ```
 
@@ -316,12 +316,13 @@ claude-org-ja は **4 層防御**（`permissions.deny` / PreToolUse フック / 
 | `git push --force` / `git reset --hard` / `git branch -D`（窓口・キュレーター） | ✅ | ✅ (`block-dangerous-git.sh`) | — | — |
 | `cat .env` / 認証情報読み取り（Bash 経由） | — | — | ⚠️ macOS (Seatbelt) / Linux / WSL2 (`bubblewrap`+`socat`) のみ。**Windows native は Claude Code 側未実装で素通り**（[docs/verification.md §10.1](docs/verification.md)） | — |
 | `cat ~/.ssh/<key>` / `cat ~/.aws/credentials`（Bash subprocess 経由のホーム dotfile 読み取り） | — (Issue #429 Task C で共有 settings から除去) | — | ⚠️ 個人 `~/.claude/settings.json` で `python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行すると `sandbox.filesystem.denyRead` に directory-level deny がマージされる（symlink-escape は自動 skip。Issue #429 Task B）。**Bash subprocess (sandboxed commands) のみ防御**: `sandbox.filesystem.denyRead` は sandbox 経由 syscall を止めるが Read tool 自体は止めない | — |
+| `echo x >> ~/.claude/settings.json`（Bash subprocess 経由の個人 Claude 設定上書き） | — (Issue #433 で共有 settings の `denyWrite` から除去・個人 settings 側へ移管) | — | ⚠️ 個人 `~/.claude/settings.json` で `python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行すると `sandbox.filesystem.denyWrite` に `~/.claude/settings.json` がマージされる（preventive deny、ファイル未作成でも適用。Issue #433）。**Bash subprocess (sandboxed commands) のみ防御**: Read tool 経由の `Edit(...)` は別 layer (`permissions.deny`) で抑止する | — |
 | `Read tool` 経由のホーム dotfile 読み取り（`Read(~/.ssh/<key>)` 等） | — (Issue #429 Task C で共有 settings から除去) | — | — (`sandbox.filesystem.denyRead` は Read tool に逆方向 merge されない。Claude Code 公式 docs は `Read(...)` deny → `denyRead` の一方向 merge のみ規定) | — |
 | ステージ差分への秘密情報混入 | — | — | — | ✅ ([.githooks/pre-commit](.githooks/pre-commit)) |
 | シェル関数経由の bypass（`f(){ git commit --no-verify; }; f`） | — | ➖ 関数定義の静的解析は非対応 | — | — |
 
 **残存リスク (residual risk)**:
-- **シェル関数定義経由のルーティング**: 関数本体内に隠された禁止コマンドは PreToolUse フックの静的解析では検出できません（Phase 2c で検討した shell-layer 静的解析は誤検知率と保守コストの観点から廃案）。sandbox の `denyWrite` も対象が `~/.claude/settings.json` 等の限定リストで、`git commit` などのリポジトリ副作用は止めません（ホーム dotfile `~/.ssh` / `~/.aws` の defense-in-depth は [Issue #429](https://github.com/suisya-systems/claude-org-ja/issues/429) Task B/C で **個人 `~/.claude/settings.json` 側に移管** されています。共有 settings からは個人 path entry を除去し、`python tools/org_setup_prune.py --user-common-sandbox` で個人環境ごとに directory-level の `sandbox.filesystem.denyRead` をマージする方式に変更されました。**この補強は sandboxed Bash サブプロセス経由の read のみを止め、Read tool 経由の `Read(~/.aws/<file>)` は止めません**（Claude Code 公式 docs の merge は `Read(...)` deny → `denyRead` の一方向）。Read tool 経由は Claude Code 組込の credential 保護層と、worker_role schema (`tools/org_extension_schema.json` の `worker_roles.*`) が emit する `permissions.deny` で受ける残存リスクとして整理されています。WSL2 + DriveFS で `~/.aws` が `/mnt/c/...` への symlink になっている環境は自動 skip され、bwrap bootstrap 失敗を構造的に避けます。なお WSL 環境では `claude-org-runtime` が、realpath がサンドボックスの可視範囲から外れる Layer 3 `denyRead` / `denyWrite` エントリを出力時に抑止し、抑止対象を `$comment` フィールドに列挙して出力します）。本ベクトルは現状ロール契約による自主規律と上記 user-level sandbox deny の併用で担保されます。
+- **シェル関数定義経由のルーティング**: 関数本体内に隠された禁止コマンドは PreToolUse フックの静的解析では検出できません（Phase 2c で検討した shell-layer 静的解析は誤検知率と保守コストの観点から廃案）。sandbox の `denyWrite` も `git commit` などのリポジトリ副作用は止めません。ホーム dotfile の defense-in-depth は [Issue #429](https://github.com/suisya-systems/claude-org-ja/issues/429) Task B/C（`denyRead` 系候補）および [Issue #433](https://github.com/suisya-systems/claude-org-ja/issues/433)（`denyWrite` の `~/.claude/settings.json`）で **共有 `.claude/settings.json` から個人 `~/.claude/settings.json` 側へ移管** されています。`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行することで、個人環境ごとに directory-level の `sandbox.filesystem.denyRead`（symlink-escape は自動 skip）と file-level の `sandbox.filesystem.denyWrite`（preventive、ファイル未作成でも適用）が同時にマージされます。**この補強は sandboxed Bash サブプロセス経由の read / write のみを止め、Read tool 経由の `Read(~/.aws/<file>)` や Edit tool 経由の `Edit(~/.claude/settings.json)` は止めません**（Claude Code 公式 docs の merge は `Read(...)` deny → `denyRead` / `Edit(...)` deny → `denyWrite` の一方向のみ）。Read / Edit tool 経由は Claude Code 組込の credential 保護層と、worker_role schema (`tools/org_extension_schema.json` の `worker_roles.*`) が emit する `permissions.deny` で受ける残存リスクとして整理されています。WSL2 + DriveFS で `~/.aws` が `/mnt/c/...` への symlink になっている環境では denyRead 側が自動 skip され、bwrap bootstrap 失敗を構造的に避けます（denyWrite は単一ファイル literal のため symlink-escape の影響を受けません）。なお WSL 環境では `claude-org-runtime` が、realpath がサンドボックスの可視範囲から外れる Layer 3 `denyRead` / `denyWrite` エントリを出力時に抑止し、抑止対象を `$comment` フィールドに列挙して出力します。本ベクトルは現状ロール契約による自主規律と上記 user-level sandbox deny の併用で担保されます。
 - **Windows native の sandbox 不在**: 上記表のとおり `cat .env` 等は Windows native では素通りします。ワーカー実行環境としては macOS / Linux / WSL2 を推奨し、Windows native では別経路（OS 側のファイル権限・GitHub Secret Scanning 等）で補完してください。
 
 詳細と段階導入の意思決定は [Issue #79](https://github.com/suisya-systems/claude-org-ja/issues/79) と [docs/verification.md §10](docs/verification.md) を参照。
@@ -335,9 +336,13 @@ python tools/org_setup_prune.py --user-common-sandbox  # 後述「個人 sandbox
 
 これで `core.hooksPath` が `.githooks/` に設定され、コミット直前の秘密情報スキャナが有効になります。
 
-### 個人 sandbox の補強（main pull 後に 1 回必須、Issue #429 Task B / C）
+### 個人 sandbox の補強（main pull 後に 1 回必須、Issue #429 Task B / C + Issue #433）
 
-> **⚠️ 移行 pre-condition**: 共有 `.claude/settings.json` から個人パスエントリ (`~/.config/gh/hosts.yml` / `Read(~/.ssh/*)` / `Read(~/.aws/*)`) を除去 ([Issue #429](https://github.com/suisya-systems/claude-org-ja/issues/429) Task C) しました。**本 PR を pull した後、`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行しないと、個人環境の sandbox 防御が一時的に弱くなります**（共有 settings の defense-in-depth 分が個人側で補完されないため）。
+> **⚠️ 移行 pre-condition**: 共有 `.claude/settings.json` から個人パスエントリを除去しました:
+> - `~/.config/gh/hosts.yml` / `Read(~/.ssh/*)` / `Read(~/.aws/*)` ([Issue #429](https://github.com/suisya-systems/claude-org-ja/issues/429) Task C, denyRead 系)
+> - `sandbox.filesystem.denyWrite: ["~/.claude/settings.json"]` ([Issue #433](https://github.com/suisya-systems/claude-org-ja/issues/433), denyWrite 系)
+>
+> **本 PR を pull した後、`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行しないと、個人環境の sandbox 防御（denyRead / denyWrite 両系統）が一時的に弱くなります**（共有 settings の defense-in-depth 分が個人側で補完されないため）。
 
 ```bash
 # diff プレビュー（書き込まない）
@@ -347,9 +352,11 @@ python tools/org_setup_prune.py --user-common-sandbox --dry-run
 python tools/org_setup_prune.py --user-common-sandbox
 ```
 
-`~/.claude/settings.json` の `sandbox.filesystem.denyRead` に対し、機密 credential ディレクトリ群（`~/.ssh` / `~/.aws` / `~/.config/gh` / `~/.kube` / `~/.gnupg` / `~/.docker` / `~/.config/aws-vault`）を idempotent に union-merge します。**実在しないもの・realpath が HOME を escape する symlink（WSL2 + DriveFS で `~/.aws → /mnt/c/...` のケース等）は自動 skip** されます。他のキー (`theme`, `env`, `permissions` 等) は無触。
+`~/.claude/settings.json` の `sandbox.filesystem.denyRead` に対し、機密 credential ディレクトリ群（`~/.ssh` / `~/.aws` / `~/.config/gh` / `~/.kube` / `~/.gnupg` / `~/.docker` / `~/.config/aws-vault`）を idempotent に union-merge します。**実在しないもの・realpath が HOME を escape する symlink（WSL2 + DriveFS で `~/.aws → /mnt/c/...` のケース等）は自動 skip** されます。
 
-実装 / 仕様の詳細は [`.claude/skills/org-setup/references/permissions.md`](.claude/skills/org-setup/references/permissions.md) の「ユーザー共通の sandbox denyRead 補強」節と Task A 調査結論 ([docs/verification.md §10.1 Addendum](docs/verification.md)) を参照。
+同じフラグで `sandbox.filesystem.denyWrite` に `~/.claude/settings.json` も union-merge します（Issue #433）。denyWrite は **preventive deny** で扱い、対象ファイルが未作成でも entry を追加します（書込防御は fresh install で `~/.claude/settings.json` が Claude Code により初回作成される瞬間から有効にする意図）。他のキー (`theme`, `env`, `permissions` 等) は無触。
+
+実装 / 仕様の詳細は [`.claude/skills/org-setup/references/permissions.md`](.claude/skills/org-setup/references/permissions.md) の「ユーザー共通の sandbox denyRead / denyWrite 補強」節と Task A 調査結論 ([docs/verification.md §10.1 Addendum](docs/verification.md)) を参照。
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ claude-orgの使い方ガイド。
 curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.sh | bash
 cd claude-org-ja
 bash scripts/install-hooks.sh
-python tools/org_setup_prune.py --user-common-sandbox   # main pull 後に 1 回必須 (Issue #429 Task B/C)
+python tools/org_setup_prune.py --user-common-sandbox   # main pull 後に 1 回必須 (Issue #429 Task B/C + Issue #433 denyWrite)
 renga --layout ops
 ```
 
@@ -35,7 +35,7 @@ renga --layout ops
 iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.ps1 | iex
 cd claude-org-ja
 bash scripts/install-hooks.sh                            # Git Bash / WSL 上で実行
-py -3 tools/org_setup_prune.py --user-common-sandbox     # main pull 後に 1 回必須 (Issue #429 Task B/C)
+py -3 tools/org_setup_prune.py --user-common-sandbox     # main pull 後に 1 回必須 (Issue #429 Task B/C + Issue #433 denyWrite)
 renga --layout ops
 ```
 
@@ -62,7 +62,7 @@ git clone https://github.com/suisya-systems/claude-org-ja.git
 cd claude-org-ja
 renga mcp install                                            # 初回のみ。renga-peers MCP を user-scope 登録
 bash scripts/install-hooks.sh                                # pre-commit secret scanner を有効化
-python tools/org_setup_prune.py --user-common-sandbox        # main pull 後に 1 回必須 (Issue #429 Task B/C)
+python tools/org_setup_prune.py --user-common-sandbox        # main pull 後に 1 回必須 (Issue #429 Task B/C + Issue #433 denyWrite)
 renga --layout ops
 ```
 
@@ -74,7 +74,7 @@ renga --layout ops
 
 `/org-setup` は **additive-only**（不足分を追加するだけで既存を消さない）。drift を baseline に戻したい場合は [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) のロール別サンプル JSON で `settings.local.json` を手動置換する。
 
-> **⚠️ main pull 後の 1 回必須（Issue #429 Task B / C）**: 共有 `.claude/settings.json` から個人パスエントリ (`~/.config/gh/hosts.yml` / `Read(~/.ssh/*)` / `Read(~/.aws/*)`) を除去したため、初回 / pull 後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行**してください。未実行だと個人環境の sandbox 防御が一時的に弱くなります（[README §個人 sandbox の補強](../README.md) と [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) 参照）。
+> **⚠️ main pull 後の 1 回必須（Issue #429 Task B / C + Issue #433）**: 共有 `.claude/settings.json` から個人パスエントリを除去したため（denyRead 系: `~/.config/gh/hosts.yml` / `Read(~/.ssh/*)` / `Read(~/.aws/*)`、denyWrite 系: `~/.claude/settings.json`）、初回 / pull 後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行**してください（単一フラグで denyRead + denyWrite 両系統を補完）。未実行だと個人環境の sandbox 防御が一時的に弱くなります（[README §個人 sandbox の補強](../README.md) と [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) 参照）。
 >
 > ```bash
 > # diff プレビュー

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -477,6 +477,26 @@ claude-org-ja 本体は Issue #429 Task C（本 addendum と同 PR）で共有 `
 
 調査ログ全文は [Issue #429 のコメント](https://github.com/suisya-systems/claude-org-ja/issues/429#issuecomment-4419741705) を参照。
 
+#### Addendum 2: denyWrite の merge セマンティクス確認と移管（Issue #433）
+
+**前提確認**: Claude Code 公式 docs <https://code.claude.com/docs/en/settings> の `sandbox.filesystem.denyWrite` 説明（2026-05 時点）:
+
+> Paths where sandboxed commands cannot write. Arrays are merged across all settings scopes. **Also merged with paths from `Edit(...)` deny permission rules.**
+
+つまり denyWrite も denyRead と対称に、(a) 複数 settings scope（user / shared / project）の array が merge される、(b) Layer 2 (`permissions.deny` の `Edit(...)`) のパスが effective set に追加される。「`Edit(...)` のみで `Write(...)` には言及されていない」点に注意 — `Write(...)` も新規ファイル書き込み tool だが、公式 docs では明示的に挙げられていない（実機での `Write(...)` → `denyWrite` merge 検証は本 PR スコープ外、現状は doc 通り `Edit(...)` のみが Layer 3 へ自動 mirror すると解釈する）。
+
+**移管の決定**: Issue #429 Task C と Issue #433 で **`~/.claude/settings.json` への denyWrite も共有 `.claude/settings.json` から個人 `~/.claude/settings.json` 側へ移管** した（Task C の denyRead 移管と対称、Task B の `--user-common-sandbox` フラグを単一のまま denyRead + denyWrite 双方を扱うよう拡張）。理由:
+
+1. **個人ごとの opt-out 可能性**: 共有 settings に `denyWrite: ["~/.claude/settings.json"]` を置くと、repo を pull する全ユーザーの home path に対して deny が適用される。個人 settings 側へ移すと、各操作者が自分の `~/.claude/settings.json` を編集して撤回でき、ロール契約と個人運用の整合が取りやすい。
+2. **保管場所と意図の一致**: 「個人の `~/.claude/settings.json` を sandbox subprocess 経由の書き込みから守る」という意図と、deny 自身が記述される場所（個人 `~/.claude/settings.json`）が物理的に一致する。共有 settings 側にあると「誰が誰の home dir を守っているのか」が不透明になりやすい。
+3. **defense-in-depth の維持**: 公式 docs の merge ルールに従い、Layer 2 (`permissions.deny Edit(~/.claude/settings.json)`) と Layer 3 (`sandbox.filesystem.denyWrite`) は effective set で合流する。Layer 3 を個人側へ落としても、Layer 2 を共有 settings 側で必要に応じて宣言できるため、defense-in-depth は idempotent に再構成可能。
+
+**preventive deny（=ファイル不在でも merge）の判断**: `~/.claude/settings.json` は fresh install の Claude Code が初回起動時に作成する。`--user-common-sandbox` を **`~/.claude/settings.json` 作成前に**実行した場合に entry を skip すると、初回 Claude Code 起動と次の `--user-common-sandbox` 実行の間に bwrap subprocess の write が素通りする時間窓ができる。これを避けるため、denyWrite candidate は **存在チェックを行わず常に merge** する（denyRead が directory 単位かつ bwrap bootstrap 失敗 risk があるため existence-check を行うのとは非対称）。
+
+**残存検証 (実機)**: Issue #79 の §10.1 表に denyWrite 行が既に含まれており、共有 settings 移行後も `~/.claude/settings.json` の denyWrite で同等の挙動が出ることを各 OS 行で再測すること。本 addendum 時点で実機検証済みの環境は Phase 2a 計画と同じ（Windows / macOS / Linux / WSL2; 詳細結果記載は §10.1 の表本体を参照）。
+
+**実装**: `tools/org_setup_prune.py` の `merge_user_common_sandbox_denywrite` / `USER_COMMON_SANDBOX_DENYWRITE_CANDIDATES`、`tools/test_org_setup_prune.py` の `MergeUserCommonSandboxDenywriteTests` および `UserCommonSandboxEndToEndTests` の denyWrite 関連ケース群。
+
 ---
 
 ## 10.2. Phase 3 sandbox case E 実機検証 (WSL Layer 3 suppression, runtime 0.1.4+)

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -391,6 +391,7 @@ head -1 knowledge/raw/*.md  # <!-- curated --> マーカー確認
 - 本リポジトリを clone し Claude Code が起動できる状態
 - 検証対象リポジトリ直下にダミー `.env`（例: `FAKE_TOKEN=dummy-not-a-real-secret`）を用意（`.gitignore` 対象のため commit されない）
 - 既知バグ [anthropics/claude-code#32226](https://github.com/anthropics/claude-code/issues/32226) により denyRead が期待通り効かないケースが報告されているため、**必ず実機で挙動を確認**する
+- **個人 sandbox 補強の事前適用（Issue #429 Task B/C + Issue #433）**: 手順 3 の `~/.ssh/id_rsa` 読出と手順 4 の `~/.claude/settings.json` 書込はいずれも **個人 `~/.claude/settings.json` 側に移管された** deny を経由する。検証前に `python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行し、個人 `~/.claude/settings.json` の `sandbox.filesystem.denyRead` / `denyWrite` に当該 entry が merge 済みである状態にしてから手順 1〜4 を実施すること。実行しないまま手順 3 / 4 を確認すると、共有 settings 側に entry が無いため何も deny されず誤った "fail" 判定になる
 
 **手順**:
 1. 窓口 Claude に `cat .env` を実行するよう依頼する（Bash ツール経由）
@@ -399,8 +400,9 @@ head -1 knowledge/raw/*.md  # <!-- curated --> マーカー確認
 4. `~/.claude/settings.json` の書込を試みるコマンドを依頼する（例: `echo x >> ~/.claude/settings.json`）
 
 **期待結果**:
-- 手順 1〜3: sandbox により Bash サブプロセスで denied（`Permission denied` 相当のエラー）。Claude Code が結果を受け取っても内容は空 / エラーになる
-- 手順 4: denyWrite により write 失敗
+- 手順 1〜2: 共有 `.claude/settings.json` の `sandbox.filesystem.denyRead` (`.env` / `**/credentials*` 等) により Bash サブプロセスで denied（`Permission denied` 相当）
+- 手順 3: 個人 `~/.claude/settings.json` の `sandbox.filesystem.denyRead` (`~/.ssh` 等、上記前提で merge 済み) により Bash サブプロセスで denied。merge していない環境では Claude Code 組込の credential 保護層が拾うケースもあるが、ここでは Layer 3 (sandbox) の検証として individual 確認する
+- 手順 4: 個人 `~/.claude/settings.json` の `sandbox.filesystem.denyWrite` (`~/.claude/settings.json`、上記前提で merge 済み、Issue #433) により write 失敗
 
 **失敗パターンと対処**:
 - `.env` の内容が読めてしまう → Claude Code 側のバグの可能性。バージョンと `claude --version` を記録し Issue #32226 のステータスを確認。暫定対応として `permissions.deny` の `Read(./.env)` 追加（Claude Code の Read ツール経路を塞ぐ）
@@ -471,7 +473,7 @@ WSL2 などで `bubblewrap` 未導入時に sandbox init が silent no-op fallba
 1. **対象環境で当該 symlink を退避/削除し、real directory を `mkdir -p` で作り直す**。`mkdir -p` 単発では既存 symlink を real directory に置き換えないため、`rm <link> && mkdir -p <dir>` 等の明示的置換が必要。
 2. **当該環境では `Read(~/.aws/*)` / `Read(~/.ssh/*)` を共有・個人いずれの settings からも除外する**。bwrap の bootstrap 失敗を避けるための回避策。**ただしこの選択は意図的に Claude 側の credential read 防御を弱める残存リスクを含む**: (a) Claude Code は同一ユーザー権限で動くため OS のファイルパーミッションは Claude プロセス自身を止めない、(b) claude-org-runtime の WSL Layer 3 suppression (§10.2 Phase 3 case E) は escape する Layer 3 entry を **emit 段階で落とす** 動作で、deny を強化するわけではない、(c) `--user-common-sandbox` も同 candidate を skip する。残るのは Claude Code 組込の credential 保護層 (`~/.ssh/id_*` 等の特定 path に対するもの) と Layer 4 hook / role 契約のみで、`~/.aws/credentials` の `cat` を完全に止める保証は無い。symlink-escape 環境では選択肢 1 (real directory 化) が望ましく、選択肢 2 はそれが運用上不可能な場合の妥協策と位置付ける。
 
-claude-org-ja 本体は Issue #429 Task C（本 addendum と同 PR）で共有 `.claude/settings.json` から `Read(~/.ssh/*)` / `Read(~/.aws/*)` / `~/.config/gh/hosts.yml` を除去した（= 上記選択肢 2 を採用）。個人環境ごとに実在する（= symlink でない）機密ディレクトリを deny したい場合は、Issue #429 Task B で導入された `python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行することで `~/.claude/settings.json` の `sandbox.filesystem.denyRead` に directory-level deny がマージされる（symlink-escape candidate は自動 skip）。詳細は [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) の「ユーザー共通の sandbox denyRead 補強（`--user-common-sandbox`）」節を参照。
+claude-org-ja 本体は Issue #429 Task C（本 addendum と同 PR）で共有 `.claude/settings.json` から `Read(~/.ssh/*)` / `Read(~/.aws/*)` / `~/.config/gh/hosts.yml` を除去した（= 上記選択肢 2 を採用）。個人環境ごとに実在する（= symlink でない）機密ディレクトリを deny したい場合は、Issue #429 Task B で導入された `python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行することで `~/.claude/settings.json` の `sandbox.filesystem.denyRead` に directory-level deny がマージされる（symlink-escape candidate は自動 skip）。詳細は [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) の「ユーザー共通の sandbox denyRead / denyWrite 補強（`--user-common-sandbox`）」節を参照。
 
 **upstream への enhancement request（任意）**: 「`Read(...)` / `Edit(...)` の `permissions.deny` を `sandbox.filesystem.denyRead` に merge する際、realpath が `sandbox_read_roots` を escape する path は除外する」改善が Claude Code 側に入れば、本 portability 問題は構造的に解消する。本タスクのスコープ外。
 
@@ -493,7 +495,7 @@ claude-org-ja 本体は Issue #429 Task C（本 addendum と同 PR）で共有 `
 
 **preventive deny（=ファイル不在でも merge）の判断**: `~/.claude/settings.json` は fresh install の Claude Code が初回起動時に作成する。`--user-common-sandbox` を **`~/.claude/settings.json` 作成前に**実行した場合に entry を skip すると、初回 Claude Code 起動と次の `--user-common-sandbox` 実行の間に bwrap subprocess の write が素通りする時間窓ができる。これを避けるため、denyWrite candidate は **存在チェックを行わず常に merge** する（denyRead が directory 単位かつ bwrap bootstrap 失敗 risk があるため existence-check を行うのとは非対称）。
 
-**残存検証 (実機)**: Issue #79 の §10.1 表に denyWrite 行が既に含まれており、共有 settings 移行後も `~/.claude/settings.json` の denyWrite で同等の挙動が出ることを各 OS 行で再測すること。本 addendum 時点で実機検証済みの環境は Phase 2a 計画と同じ（Windows / macOS / Linux / WSL2; 詳細結果記載は §10.1 の表本体を参照）。
+**残存検証 (実機、未実施)**: §10.1 の現状表は Windows native（sandbox 未実装、`cat .env` 等が素通り）と WSL2 (`bubblewrap` 未導入で sandbox disabled) の 2 行のみで、macOS / Linux / WSL2 + bubblewrap 導入後の denyWrite 実機確認は本 PR 時点で **未実施**。Issue #433 の正常系（`echo x >> ~/.claude/settings.json` が、`--user-common-sandbox` 適用後の個人 `~/.claude/settings.json` の `denyWrite` で deny される）の確認は §10.1 手順 4 の人間タスクとして残し、結果を本節の表に追記すること。Windows native での deny 不発は §10.1 が既に記録しており、本 addendum でも追加検証は不要（sandbox 自体が未実装のため）。
 
 **実装**: `tools/org_setup_prune.py` の `merge_user_common_sandbox_denywrite` / `USER_COMMON_SANDBOX_DENYWRITE_CANDIDATES`、`tools/test_org_setup_prune.py` の `MergeUserCommonSandboxDenywriteTests` および `UserCommonSandboxEndToEndTests` の denyWrite 関連ケース群。
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -446,13 +446,15 @@ claude  # 警告が消えることを確認
 
 1. WSL2 内に本リポジトリを clone もしくは `\\wsl$\...` 経由で Windows 側 worktree を共有
 2. WSL 側で `claude` を起動（wsl 用 Claude Code または `npm install -g` で導入）
-3. 以下を依頼し、それぞれ deny を確認:
-   - `cat .env を実行して` → sandbox denyRead で Permission denied 相当
+3. **個人 sandbox 補強を適用** (Issue #429 Task B/C + Issue #433 で必須): `python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行し、個人 `~/.claude/settings.json` の `sandbox.filesystem.denyRead` / `denyWrite` に entry を merge する
+4. **個人 `~/.claude/settings.json` を退避** (deny が万一不発した場合の corruption 回避): `cp ~/.claude/settings.json ~/.claude/settings.json.preflight-backup`
+5. 以下を依頼し、それぞれ deny を確認:
+   - `cat .env を実行して` → 共有 settings の sandbox denyRead で Permission denied 相当
    - `grep -r FAKE_TOKEN . を実行して` → 同上
-   - `echo x >> ~/.claude/settings.json.sandbox-test` → denyWrite で書込失敗
-4. 実測結果を本セクションの表に追記（OS 行を増やす形）
+   - `echo x >> ~/.claude/settings.json` → 個人 settings の denyWrite で書込失敗（Issue #433 で追加された exact-match の denyWrite）。**deny が効かなかった場合** はファイル末尾に `x` が追記されるので、`cp ~/.claude/settings.json.preflight-backup ~/.claude/settings.json` で復元する
+6. 実測結果を本セクションの表に追記（OS 行を増やす形）
 
-WSL で deny されなければ、 (a) Claude Code のバージョンが sandbox 未対応、(b) 設定 syntax の解釈差異、(c) #32226 の別症状、のいずれか。バージョンと Issue #32226 ステータスを記録。
+WSL で deny されなければ、 (a) Claude Code のバージョンが sandbox 未対応、(b) 設定 syntax の解釈差異、(c) #32226 の別症状、(d) `--user-common-sandbox` の merge が反映されていない、のいずれか。バージョンと Issue #32226 ステータス、`~/.claude/settings.json` の `sandbox.filesystem.denyWrite` 内容を記録。
 
 ### Phase 2a portability fix ([Issue #83](https://github.com/suisya-systems/claude-org-ja/issues/83))
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -258,7 +258,7 @@ Done. Next steps:
 
   cd $Dir
   bash scripts/install-hooks.sh                                # enable pre-commit secret scanner (run from Git Bash / WSL)
-  py -3 tools/org_setup_prune.py --user-common-sandbox         # required after main pull (Issue #429 Task B/C)
+  py -3 tools/org_setup_prune.py --user-common-sandbox         # required after main pull (Issue #429 Task B/C + Issue #433 denyWrite)
   renga --layout ops                                           # launch the Secretary pane
 
 Inside the Secretary's Claude Code pane, run:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -465,7 +465,7 @@ Done. Next steps:
 
   cd $TARGET_DIR$VENV_HINT
   bash scripts/install-hooks.sh                                # enable pre-commit secret scanner
-  python tools/org_setup_prune.py --user-common-sandbox        # required after main pull (Issue #429 Task B/C)
+  python tools/org_setup_prune.py --user-common-sandbox        # required after main pull (Issue #429 Task B/C + Issue #433 denyWrite)
   renga --layout ops                                           # launch the Secretary pane
 
 Inside the Secretary's Claude Code pane, run:

--- a/tools/org_setup_prune.py
+++ b/tools/org_setup_prune.py
@@ -18,11 +18,18 @@ org-delegate -- out of scope here.)
 ``user_common`` (``~/.claude/settings.json``) lives in the user's home and is
 shared with non-org plugins, so the prune rewrite would clobber unrelated
 keys. Instead a dedicated mode -- ``--user-common-sandbox`` -- performs only
-a *targeted, idempotent union merge* of sensitive credential directories
-into ``sandbox.filesystem.denyRead`` (existence-checked, ``~``-prefixed
-literal entries preserved so the file remains portable across users). All
-other keys are passed through untouched. See Issue #429 for the migration
-that moves these entries out of the shared, checked-in ``.claude/settings.json``.
+a *targeted, idempotent union merge* into the user-level sandbox block:
+
+- ``sandbox.filesystem.denyRead`` for sensitive credential directories
+  (existence-checked + realpath-escape skipped on WSL; ``~``-prefixed
+  literal entries preserved so the file stays portable across users).
+- ``sandbox.filesystem.denyWrite`` for ``~/.claude/settings.json``
+  (file literal, NOT existence-checked -- preventive deny so the write
+  guard is in place before Claude Code first creates the file).
+
+All other keys are passed through untouched. See Issue #429 for the
+denyRead migration (Task B/C) and Issue #433 for the denyWrite migration
+out of the shared, checked-in ``.claude/settings.json``.
 
 Usage:
     py -3 tools/org_setup_prune.py --role secretary --dry-run
@@ -76,6 +83,28 @@ USER_COMMON_SANDBOX_DENYREAD_CANDIDATES: tuple[str, ...] = (
     "~/.gnupg",
     "~/.docker",
     "~/.config/aws-vault",
+)
+
+# Files (not directories) that should be added to user_common's
+# ``sandbox.filesystem.denyWrite`` so writes to user-level Claude
+# settings can never be made via Bash subprocess inside the bwrap
+# sandbox (Issue #433 -- previously lived as a project-shared entry
+# in ``.claude/settings.json`` until Task C migrated denyRead candidates
+# to user_common; denyWrite is now migrated symmetrically).
+#
+# Stored as ``~``-prefixed *file* literals (portable across users), and
+# **not existence-checked**: blocking a write is preventive and remains
+# meaningful even when the file has not been created yet (fresh
+# installs come in with ``~/.claude/settings.json`` absent, and we want
+# the deny in place before Claude Code first writes it).
+#
+# Note: symmetric directory denyWrite for ``~/.ssh`` / ``~/.aws`` / etc.
+# is intentionally **deferred** (Issue #433 scope) -- those would block
+# legitimate writes (e.g. ``ssh-keygen``, ``aws configure``) without a
+# clear threat model, and the denyRead candidates already mitigate the
+# read-exfiltration vector that motivated Task B/C.
+USER_COMMON_SANDBOX_DENYWRITE_CANDIDATES: tuple[str, ...] = (
+    "~/.claude/settings.json",
 )
 
 DEFAULT_USER_COMMON_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
@@ -332,18 +361,24 @@ def filter_existing_user_dirs(
     return out
 
 
-def merge_user_common_sandbox_denyread(
+def _merge_sandbox_deny(
     settings: dict,
     entries: list[str] | tuple[str, ...],
+    *,
+    key: str,
 ) -> dict:
-    """Pure: return a new settings dict with ``entries`` union-merged into
-    ``sandbox.filesystem.denyRead``.
+    """Shared pure merger for ``sandbox.filesystem.{key}`` -- the engine
+    behind both ``merge_user_common_sandbox_denyread`` and
+    ``merge_user_common_sandbox_denywrite``. ``key`` is ``"denyRead"`` or
+    ``"denyWrite"``.
+
+    Semantics (identical across the two keys):
 
     - Existing top-level keys (theme, env, permissions, etc.) are preserved.
     - Existing ``sandbox`` / ``sandbox.filesystem`` siblings (``enabled``,
-      ``failIfUnavailable``, ``denyWrite``, ``additionalDirectories``) are
-      preserved.
-    - Existing ``denyRead`` order and entries are preserved; new entries are
+      ``failIfUnavailable``, the *other* deny list, ``additionalDirectories``,
+      etc.) are preserved.
+    - Existing list order and entries are preserved; new entries are
       appended in input order, skipping any that already match an existing
       value verbatim. This makes the operation idempotent: re-running on a
       previously-merged file is a no-op.
@@ -351,12 +386,11 @@ def merge_user_common_sandbox_denyread(
       along the touched spine. Callers can compare ``id`` / ``==`` safely.
 
     Raises ``ValueError`` if an existing ``sandbox`` / ``sandbox.filesystem``
-    is not a JSON object, or an existing ``denyRead`` is not a JSON array.
-    The caller is expected to abort before touching the file rather than
-    silently coerce a malformed shape (which would destroy user data).
+    is not a JSON object, or the targeted deny list is not a JSON array of
+    strings. The caller is expected to abort before touching the file
+    rather than silently coerce a malformed shape (which would destroy
+    user data).
     """
-    # Validate existing shape first so a malformed file aborts with a clear
-    # error regardless of whether we end up writing.
     sandbox_val = settings.get("sandbox")
     if sandbox_val is not None and not isinstance(sandbox_val, dict):
         raise ValueError(
@@ -367,12 +401,12 @@ def merge_user_common_sandbox_denyread(
         raise ValueError(
             f"settings['sandbox']['filesystem'] must be an object or absent, got {type(fs_val).__name__}"
         )
-    dr_val = fs_val.get("denyRead") if isinstance(fs_val, dict) else None
-    if dr_val is not None and not isinstance(dr_val, list):
+    deny_val = fs_val.get(key) if isinstance(fs_val, dict) else None
+    if deny_val is not None and not isinstance(deny_val, list):
         raise ValueError(
-            f"settings['sandbox']['filesystem']['denyRead'] must be an array or absent, got {type(dr_val).__name__}"
+            f"settings['sandbox']['filesystem']['{key}'] must be an array or absent, got {type(deny_val).__name__}"
         )
-    existing_dr: list = list(dr_val) if isinstance(dr_val, list) else []
+    existing: list = list(deny_val) if isinstance(deny_val, list) else []
     # All existing entries must be strings: Claude Code's own bwrap launcher
     # consumes the raw-string form in ~/.claude/settings.json (the structured
     # ``{anchor: ..., path: ...}`` form is internal to claude-org-runtime's
@@ -381,40 +415,73 @@ def merge_user_common_sandbox_denyread(
     # diff operations on the rendered list never hit ``TypeError`` on an
     # unhashable element, and so the merge cannot accidentally legitimize an
     # entry shape the launcher would reject.
-    for i, existing in enumerate(existing_dr):
-        if not isinstance(existing, str):
+    for i, ex in enumerate(existing):
+        if not isinstance(ex, str):
             raise ValueError(
-                f"settings['sandbox']['filesystem']['denyRead'][{i}] must be a string, got {type(existing).__name__}"
+                f"settings['sandbox']['filesystem']['{key}'][{i}] must be a string, got {type(ex).__name__}"
             )
 
-    added = [e for e in entries if e not in existing_dr]
+    added = [e for e in entries if e not in existing]
     if not added:
         # No new entries to merge -- return the input unchanged. This keeps
-        # the operation a true no-op when none of the candidate directories
-        # exist on this system (or all of them are already present), instead
-        # of injecting an empty ``sandbox.filesystem.denyRead: []`` block
-        # that the user never had. Required so the non-dry-run path matches
-        # the dry-run "(no changes)" output (Codex round-2 review).
+        # the operation a true no-op when none of the candidates apply (or
+        # all of them are already present), instead of injecting an empty
+        # ``sandbox.filesystem.{key}: []`` block that the user never had.
+        # Required so the non-dry-run path matches the dry-run "(no
+        # changes)" output (Codex round-2 review, Issue #429 Task B).
         return dict(settings)
 
     result = dict(settings)
     sandbox = dict(sandbox_val) if isinstance(sandbox_val, dict) else {}
     filesystem = dict(fs_val) if isinstance(fs_val, dict) else {}
-    filesystem["denyRead"] = existing_dr + added
+    filesystem[key] = existing + added
     sandbox["filesystem"] = filesystem
     result["sandbox"] = sandbox
     return result
 
 
+def merge_user_common_sandbox_denyread(
+    settings: dict,
+    entries: list[str] | tuple[str, ...],
+) -> dict:
+    """Pure: union-merge ``entries`` into ``sandbox.filesystem.denyRead``.
+    See ``_merge_sandbox_deny`` for the shared semantics (idempotent,
+    additive-only, malformed shape raises ``ValueError``, input never
+    mutated)."""
+    return _merge_sandbox_deny(settings, entries, key="denyRead")
+
+
+def merge_user_common_sandbox_denywrite(
+    settings: dict,
+    entries: list[str] | tuple[str, ...],
+) -> dict:
+    """Pure: union-merge ``entries`` into ``sandbox.filesystem.denyWrite``.
+
+    Mirrors ``merge_user_common_sandbox_denyread`` -- denyWrite entries
+    are *file* literals (e.g. ``~/.claude/settings.json``) rather than
+    directories, and the caller is expected **not** to existence-filter
+    them: blocking a write is preventive and remains meaningful even
+    when the file has not yet been created. Shape validation and the
+    idempotent / additive semantics are identical to the denyRead helper.
+    """
+    return _merge_sandbox_deny(settings, entries, key="denyWrite")
+
+
 def process_user_common_sandbox(
     *,
     settings_path: Path,
-    candidates: tuple[str, ...] | list[str] = USER_COMMON_SANDBOX_DENYREAD_CANDIDATES,
+    denyread_candidates: tuple[str, ...] | list[str] = USER_COMMON_SANDBOX_DENYREAD_CANDIDATES,
+    denywrite_candidates: tuple[str, ...] | list[str] = USER_COMMON_SANDBOX_DENYWRITE_CANDIDATES,
     home: Path | None = None,
     dry_run: bool,
     no_backup: bool,
 ) -> int:
     """Drive a user_common sandbox merge against ``settings_path``.
+
+    Applies two idempotent merges in sequence: directory-level
+    ``sandbox.filesystem.denyRead`` candidates (existence + realpath-escape
+    filtered) followed by file-level ``sandbox.filesystem.denyWrite``
+    candidates (preventive deny -- no existence filter; Issue #433).
 
     Returns a process-style return code (0 on success / no-op; non-zero on
     malformed JSON). When ``settings_path`` does not exist the file is
@@ -439,9 +506,10 @@ def process_user_common_sandbox(
     else:
         current = {}
 
-    existing_entries = filter_existing_user_dirs(candidates, home=home)
+    existing_read_entries = filter_existing_user_dirs(denyread_candidates, home=home)
     try:
-        target = merge_user_common_sandbox_denyread(current, existing_entries)
+        target = merge_user_common_sandbox_denyread(current, existing_read_entries)
+        target = merge_user_common_sandbox_denywrite(target, denywrite_candidates)
     except ValueError as exc:
         print(
             f"[org_setup_prune] user_common: {settings_path} has malformed sandbox shape: {exc}; aborting.",
@@ -453,32 +521,62 @@ def process_user_common_sandbox(
         # In dry-run we always render the report, even on no-op, so the
         # operator can see which candidates were skipped (missing dir /
         # symlink-escape) and judge whether the result is correct.
-        print(render_user_common_diff(settings_path, current, target, candidates, existing_entries))
+        print(
+            render_user_common_diff(
+                settings_path,
+                current,
+                target,
+                denyread_candidates,
+                existing_read_entries,
+                denywrite_candidates,
+            )
+        )
         return 0
 
     if target == current:
-        msg = f"[org_setup_prune] user_common: {settings_path} already has all applicable sandbox.filesystem.denyRead entries; no changes."
+        msg = (
+            f"[org_setup_prune] user_common: {settings_path} already has all "
+            "applicable sandbox.filesystem.denyRead / denyWrite entries; no changes."
+        )
         print(msg)
         return 0
 
     bak = write_settings(settings_path, target, make_backup=not no_backup)
-    added = _added_in_append_order(_safe_deny_read(current), _safe_deny_read(target))
+    added_read = _added_in_append_order(_safe_deny_list(current, "denyRead"), _safe_deny_list(target, "denyRead"))
+    added_write = _added_in_append_order(_safe_deny_list(current, "denyWrite"), _safe_deny_list(target, "denyWrite"))
+    fragments: list[str] = []
+    if added_read:
+        fragments.append(f"denyRead {added_read}")
+    if added_write:
+        fragments.append(f"denyWrite {added_write}")
+    added_summary = "; added " + ", ".join(fragments) if fragments else ""
     print(
         f"[org_setup_prune] user_common: wrote {settings_path}"
         + (f" (backup: {bak.name})" if bak else "")
-        + (f"; added {added}" if added else "")
+        + added_summary
     )
     return 0
 
 
+def _safe_deny_list(settings: dict, key: str) -> list[str]:
+    """Return a copy of ``sandbox.filesystem.{key}`` from ``settings``,
+    defaulting to an empty list when any spine node is missing. ``key`` is
+    ``"denyRead"`` or ``"denyWrite"``."""
+    return list(((settings.get("sandbox") or {}).get("filesystem") or {}).get(key) or [])
+
+
 def _safe_deny_read(settings: dict) -> list[str]:
-    return list(((settings.get("sandbox") or {}).get("filesystem") or {}).get("denyRead") or [])
+    """Backwards-compatible shim around ``_safe_deny_list`` (Issue #429
+    Task B). Retained because external callers / tests may import the
+    symbol directly."""
+    return _safe_deny_list(settings, "denyRead")
 
 
 def _added_in_append_order(current: list[str], target: list[str]) -> list[str]:
-    """Return the suffix of ``target`` that ``merge_user_common_sandbox_denyread``
-    appended on top of ``current`` -- preserving the input-append order the
-    merger advertises (i.e., the order the user will see in the file)."""
+    """Return the suffix of ``target`` that the merger appended on top of
+    ``current`` -- preserving the input-append order the merger advertises
+    (i.e., the order the user will see in the file). Used for both
+    denyRead and denyWrite diffs."""
     cur_set = set(current)
     return [e for e in target if e not in cur_set]
 
@@ -487,23 +585,31 @@ def render_user_common_diff(
     settings_path: Path,
     current: dict,
     target: dict,
-    candidates: tuple[str, ...] | list[str],
-    existing_entries: list[str],
+    denyread_candidates: tuple[str, ...] | list[str],
+    existing_read_entries: list[str],
+    denywrite_candidates: tuple[str, ...] | list[str] = (),
 ) -> str:
-    added = _added_in_append_order(_safe_deny_read(current), _safe_deny_read(target))
-    skipped_missing = [c for c in candidates if c not in existing_entries]
+    added_read = _added_in_append_order(_safe_deny_list(current, "denyRead"), _safe_deny_list(target, "denyRead"))
+    added_write = _added_in_append_order(_safe_deny_list(current, "denyWrite"), _safe_deny_list(target, "denyWrite"))
+    skipped_missing = [c for c in denyread_candidates if c not in existing_read_entries]
     lines = [f"=== user_common: {settings_path} ==="]
-    if not added:
+    if not added_read and not added_write:
         lines.append("  (no changes)")
-    else:
+    if added_read:
         lines.append("  sandbox.filesystem.denyRead added:")
-        for it in added:
+        for it in added_read:
+            lines.append(f"    + {it}")
+    if added_write:
+        lines.append("  sandbox.filesystem.denyWrite added:")
+        for it in added_write:
             lines.append(f"    + {it}")
     if skipped_missing:
         # These include both non-existent directories AND symlink-escape
         # entries (the latter are common on WSL where ``~/.aws`` /
-        # ``~/.ssh`` may resolve to ``/mnt/c/...``).
-        lines.append("  skipped (directory missing or resolves outside HOME):")
+        # ``~/.ssh`` may resolve to ``/mnt/c/...``). denyWrite candidates
+        # are *not* existence-checked (preventive deny, Issue #433) so they
+        # never appear in this list.
+        lines.append("  skipped denyRead (directory missing or resolves outside HOME):")
         for it in skipped_missing:
             lines.append(f"    - {it}")
     return "\n".join(lines)
@@ -708,9 +814,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--user-common-sandbox",
         action="store_true",
-        help="Union-merge sensitive credential directory denyRead entries into the user-level "
-             "~/.claude/settings.json sandbox block (existence-checked, idempotent, ~-prefixed). "
-             "Does NOT rewrite other keys. See Issue #429.",
+        help="Union-merge sensitive credential directory denyRead entries AND a denyWrite entry "
+             "for ~/.claude/settings.json into the user-level ~/.claude/settings.json sandbox "
+             "block (idempotent, ~-prefixed; denyRead candidates existence-checked, denyWrite "
+             "candidates always merged as preventive deny). Does NOT rewrite other keys. "
+             "See Issue #429 (Task B/C, denyRead) and Issue #433 (denyWrite migration).",
     )
     parser.add_argument(
         "--user-common-settings-path",

--- a/tools/test_org_setup_prune.py
+++ b/tools/test_org_setup_prune.py
@@ -531,6 +531,93 @@ class MergeUserCommonSandboxTests(unittest.TestCase):
         self.assertEqual(out["sandbox"]["filesystem"]["denyRead"], ["~/.ssh", "~/.ssh/**"])
 
 
+class MergeUserCommonSandboxDenywriteTests(unittest.TestCase):
+    """``merge_user_common_sandbox_denywrite`` mirrors the denyRead helper
+    (idempotent, additive-only, malformed-shape rejection). denyWrite is
+    NOT existence-filtered by the caller -- the test set focuses on the
+    merger semantics; existence behavior is asserted at the process_*
+    layer (file-absent preventive deny). (Issue #433)"""
+
+    def test_creates_sandbox_block_when_missing(self) -> None:
+        out = p.merge_user_common_sandbox_denywrite({"theme": "dark"}, ["~/.claude/settings.json"])
+        self.assertEqual(out["theme"], "dark")
+        self.assertEqual(
+            out["sandbox"]["filesystem"]["denyWrite"],
+            ["~/.claude/settings.json"],
+        )
+
+    def test_preserves_existing_deny_write_entries_and_order(self) -> None:
+        base = {
+            "sandbox": {
+                "enabled": True,
+                "filesystem": {
+                    "denyRead": ["**/credentials*"],
+                    "denyWrite": ["~/.something/existing"],
+                },
+            },
+        }
+        out = p.merge_user_common_sandbox_denywrite(base, ["~/.claude/settings.json"])
+        self.assertEqual(
+            out["sandbox"]["filesystem"]["denyWrite"],
+            ["~/.something/existing", "~/.claude/settings.json"],
+        )
+        # Sibling sandbox keys + the denyRead list survive untouched.
+        self.assertTrue(out["sandbox"]["enabled"])
+        self.assertEqual(out["sandbox"]["filesystem"]["denyRead"], ["**/credentials*"])
+
+    def test_idempotent_on_repeat(self) -> None:
+        base = {"sandbox": {"filesystem": {"denyWrite": ["~/.claude/settings.json"]}}}
+        once = p.merge_user_common_sandbox_denywrite(base, ["~/.claude/settings.json"])
+        twice = p.merge_user_common_sandbox_denywrite(once, ["~/.claude/settings.json"])
+        self.assertEqual(once, twice)
+        self.assertEqual(twice["sandbox"]["filesystem"]["denyWrite"], ["~/.claude/settings.json"])
+
+    def test_empty_entries_is_noop(self) -> None:
+        # Symmetric with the denyRead helper: empty input must NOT inject
+        # a ``denyWrite: []`` block that the user never had.
+        out = p.merge_user_common_sandbox_denywrite({"theme": "dark"}, [])
+        self.assertEqual(out, {"theme": "dark"})
+        self.assertNotIn("sandbox", out)
+
+    def test_all_entries_already_present_is_noop(self) -> None:
+        base = {"sandbox": {"filesystem": {"denyWrite": ["~/.claude/settings.json"]}}}
+        out = p.merge_user_common_sandbox_denywrite(base, ["~/.claude/settings.json"])
+        self.assertEqual(out, base)
+
+    def test_input_is_not_mutated(self) -> None:
+        base = {"sandbox": {"filesystem": {"denyWrite": ["existing"]}}}
+        snapshot = json.loads(json.dumps(base))
+        p.merge_user_common_sandbox_denywrite(base, ["~/.claude/settings.json"])
+        self.assertEqual(base, snapshot)
+
+    def test_malformed_deny_write_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            p.merge_user_common_sandbox_denywrite(
+                {"sandbox": {"filesystem": {"denyWrite": "not-a-list"}}},
+                ["~/.claude/settings.json"],
+            )
+
+    def test_non_string_existing_deny_write_entry_raises(self) -> None:
+        # Same launcher contract as denyRead: only raw-string entries are
+        # accepted on the user-level surface.
+        with self.assertRaises(ValueError):
+            p.merge_user_common_sandbox_denywrite(
+                {"sandbox": {"filesystem": {"denyWrite": [{"anchor": "home", "path": ".claude/settings.json"}]}}},
+                ["~/.claude/settings.json"],
+            )
+
+    def test_denyread_sibling_is_preserved(self) -> None:
+        # Sequential application (denyRead then denyWrite) must not
+        # clobber the denyRead list the prior merge produced.
+        after_read = p.merge_user_common_sandbox_denyread({"theme": "dark"}, ["~/.ssh"])
+        after_both = p.merge_user_common_sandbox_denywrite(after_read, ["~/.claude/settings.json"])
+        self.assertEqual(after_both["sandbox"]["filesystem"]["denyRead"], ["~/.ssh"])
+        self.assertEqual(
+            after_both["sandbox"]["filesystem"]["denyWrite"],
+            ["~/.claude/settings.json"],
+        )
+
+
 class UserCommonSandboxEndToEndTests(unittest.TestCase):
     """CLI ``--user-common-sandbox`` end-to-end against an injected HOME."""
 
@@ -553,6 +640,11 @@ class UserCommonSandboxEndToEndTests(unittest.TestCase):
         self.assertNotIn("~/.kube", deny_read)
         self.assertNotIn("~/.gnupg", deny_read)
 
+    def _denywrite_default_present(self, deny_write: list[str]) -> None:
+        # Issue #433: every default run merges ``~/.claude/settings.json``
+        # into denyWrite (preventive deny, no existence check).
+        self.assertIn("~/.claude/settings.json", deny_write)
+
     def test_creates_settings_when_missing(self) -> None:
         # File deliberately absent; the merge should create it with only
         # the sandbox block populated.
@@ -569,6 +661,7 @@ class UserCommonSandboxEndToEndTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         loaded = json.loads(self.settings_path.read_text(encoding="utf-8"))
         self._candidates_match(loaded["sandbox"]["filesystem"]["denyRead"])
+        self._denywrite_default_present(loaded["sandbox"]["filesystem"]["denyWrite"])
         # No spurious extra keys.
         self.assertEqual(set(loaded.keys()), {"sandbox"})
 
@@ -591,6 +684,7 @@ class UserCommonSandboxEndToEndTests(unittest.TestCase):
         self.assertEqual(loaded["permissions"]["allow"], ["Bash(echo)"])
         self.assertEqual(loaded["env"]["FOO"], "1")
         self._candidates_match(loaded["sandbox"]["filesystem"]["denyRead"])
+        self._denywrite_default_present(loaded["sandbox"]["filesystem"]["denyWrite"])
 
     def test_existing_deny_read_entries_are_preserved(self) -> None:
         # Operator already added their own credential entry; the merge
@@ -622,9 +716,41 @@ class UserCommonSandboxEndToEndTests(unittest.TestCase):
         self.assertEqual(loaded["sandbox"]["filesystem"]["denyWrite"], ["~/.claude/settings.json"])
 
     def test_no_existing_candidates_does_not_write_empty_sandbox(self) -> None:
-        # HOME with none of the candidate directories present: the merge
-        # must be a true no-op -- not "write an empty sandbox block".
+        # HOME with none of the candidate directories present AND empty
+        # denyWrite candidates: the merge must be a true no-op -- not
+        # "write an empty sandbox block". (Issue #433: denyWrite defaults
+        # to ``~/.claude/settings.json`` and would otherwise always inject
+        # a sandbox block; pass ``denywrite_candidates=()`` to exercise
+        # the all-empty case.)
         bare_home = Path(tempfile.mkdtemp(prefix="user_common_bare_"))
+        try:
+            (bare_home / ".claude").mkdir()
+            bare_settings = bare_home / ".claude" / "settings.json"
+            bare_settings.write_text(json.dumps({"theme": "dark"}), encoding="utf-8")
+            rc = p.process_user_common_sandbox(
+                settings_path=bare_settings,
+                home=bare_home,
+                denywrite_candidates=(),
+                dry_run=False,
+                no_backup=True,
+            )
+            self.assertEqual(rc, 0)
+            loaded = json.loads(bare_settings.read_text(encoding="utf-8"))
+            self.assertEqual(loaded, {"theme": "dark"})
+            # No spurious .bak either: when target == current we skip the
+            # writer altogether, so the file was never overwritten.
+            baks = list(bare_settings.parent.glob("settings.json.bak.*"))
+            self.assertEqual(baks, [])
+        finally:
+            import shutil
+            shutil.rmtree(bare_home, ignore_errors=True)
+
+    def test_default_denywrite_inserted_even_when_denyread_empty(self) -> None:
+        # Counterpart to test_no_existing_candidates_does_not_write_empty_sandbox:
+        # with the DEFAULT denywrite_candidates the bare-home scenario is
+        # NOT a no-op -- the preventive denyWrite for ~/.claude/settings.json
+        # must be merged even though no denyRead directories exist. (Issue #433)
+        bare_home = Path(tempfile.mkdtemp(prefix="user_common_default_dw_"))
         try:
             (bare_home / ".claude").mkdir()
             bare_settings = bare_home / ".claude" / "settings.json"
@@ -637,11 +763,13 @@ class UserCommonSandboxEndToEndTests(unittest.TestCase):
             )
             self.assertEqual(rc, 0)
             loaded = json.loads(bare_settings.read_text(encoding="utf-8"))
-            self.assertEqual(loaded, {"theme": "dark"})
-            # No spurious .bak either: when target == current we skip the
-            # writer altogether, so the file was never overwritten.
-            baks = list(bare_settings.parent.glob("settings.json.bak.*"))
-            self.assertEqual(baks, [])
+            self.assertEqual(loaded["theme"], "dark")
+            self.assertEqual(
+                loaded["sandbox"]["filesystem"]["denyWrite"],
+                ["~/.claude/settings.json"],
+            )
+            # denyRead absent (nothing to merge there).
+            self.assertNotIn("denyRead", loaded["sandbox"]["filesystem"])
         finally:
             import shutil
             shutil.rmtree(bare_home, ignore_errors=True)
@@ -727,10 +855,16 @@ class UserCommonSandboxEndToEndTests(unittest.TestCase):
         ])
         self.assertEqual(rc, 0)
         loaded = json.loads(self.settings_path.read_text(encoding="utf-8"))
-        deny = loaded["sandbox"]["filesystem"]["denyRead"]
-        self.assertIn("~/.ssh", deny)
-        self.assertIn("~/.aws", deny)
-        self.assertNotIn("~/.kube", deny)
+        deny_read = loaded["sandbox"]["filesystem"]["denyRead"]
+        self.assertIn("~/.ssh", deny_read)
+        self.assertIn("~/.aws", deny_read)
+        self.assertNotIn("~/.kube", deny_read)
+        # Issue #433: denyWrite is part of the single --user-common-sandbox
+        # flag and must be applied alongside denyRead.
+        self.assertEqual(
+            loaded["sandbox"]["filesystem"]["denyWrite"],
+            ["~/.claude/settings.json"],
+        )
 
     def test_cli_home_override_takes_precedence(self) -> None:
         # When both --user-common-settings-path and --user-common-home are
@@ -746,15 +880,110 @@ class UserCommonSandboxEndToEndTests(unittest.TestCase):
             ])
             self.assertEqual(rc, 0)
             loaded = json.loads(self.settings_path.read_text(encoding="utf-8"))
-            deny = loaded["sandbox"]["filesystem"]["denyRead"]
+            deny_read = loaded["sandbox"]["filesystem"]["denyRead"]
             # Only the alt_home's directories should match -- self.home's
             # ``.ssh`` / ``.aws`` should NOT appear.
-            self.assertIn("~/.gnupg", deny)
-            self.assertNotIn("~/.ssh", deny)
-            self.assertNotIn("~/.aws", deny)
+            self.assertIn("~/.gnupg", deny_read)
+            self.assertNotIn("~/.ssh", deny_read)
+            self.assertNotIn("~/.aws", deny_read)
+            # denyWrite is HOME-independent (file literal, no existence
+            # check), so it appears regardless of which HOME is used.
+            self.assertEqual(
+                loaded["sandbox"]["filesystem"]["denyWrite"],
+                ["~/.claude/settings.json"],
+            )
         finally:
             import shutil
             shutil.rmtree(alt_home, ignore_errors=True)
+
+    def test_denywrite_added_when_settings_path_was_absent(self) -> None:
+        # The denyWrite candidate is ``~/.claude/settings.json``. The file
+        # may legitimately be absent on a fresh install (Claude Code
+        # writes it on first launch); the preventive-deny contract
+        # (Issue #433) says we still merge the entry so the guard is in
+        # place from the start.
+        absent_target = self.home / ".claude" / "settings.json.absent-target"
+        self.assertFalse(absent_target.exists())
+        rc = p.process_user_common_sandbox(
+            settings_path=self.settings_path,
+            denywrite_candidates=(str(absent_target),),
+            home=self.home,
+            dry_run=False,
+            no_backup=True,
+        )
+        self.assertEqual(rc, 0)
+        loaded = json.loads(self.settings_path.read_text(encoding="utf-8"))
+        self.assertIn(str(absent_target), loaded["sandbox"]["filesystem"]["denyWrite"])
+        # File still absent -- preventive deny does NOT create the target.
+        self.assertFalse(absent_target.exists())
+
+    def test_existing_denywrite_entry_preserved_alongside_default(self) -> None:
+        # Operator already pinned a custom denyWrite path; the merge must
+        # union, not replace.
+        self.settings_path.write_text(json.dumps({
+            "sandbox": {
+                "filesystem": {
+                    "denyWrite": ["~/.operator/custom"],
+                },
+            },
+        }), encoding="utf-8")
+        rc = p.process_user_common_sandbox(
+            settings_path=self.settings_path,
+            home=self.home,
+            dry_run=False,
+            no_backup=True,
+        )
+        self.assertEqual(rc, 0)
+        loaded = json.loads(self.settings_path.read_text(encoding="utf-8"))
+        deny_write = loaded["sandbox"]["filesystem"]["denyWrite"]
+        self.assertIn("~/.operator/custom", deny_write)
+        self.assertIn("~/.claude/settings.json", deny_write)
+        # Existing comes first (input order preservation).
+        self.assertEqual(deny_write[0], "~/.operator/custom")
+
+    def test_dry_run_reports_denywrite_added(self) -> None:
+        # Capture the dry-run report and confirm denyWrite shows up in
+        # the diff section (separately from denyRead).
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = p.process_user_common_sandbox(
+                settings_path=self.settings_path,
+                home=self.home,
+                dry_run=True,
+                no_backup=True,
+            )
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn("sandbox.filesystem.denyWrite added", out)
+        self.assertIn("~/.claude/settings.json", out)
+        # And denyRead is still rendered (composability check).
+        self.assertIn("sandbox.filesystem.denyRead added", out)
+
+    def test_malformed_denywrite_aborts_without_write(self) -> None:
+        # Existing ``denyWrite`` shape is malformed -> raise before any
+        # write happens. denyRead may be well-formed; the sequential
+        # merge must surface the denyWrite shape error.
+        original = json.dumps({
+            "sandbox": {
+                "filesystem": {
+                    "denyRead": ["~/.ssh"],
+                    "denyWrite": "off",
+                },
+            },
+        })
+        self.settings_path.write_text(original, encoding="utf-8")
+        rc = p.process_user_common_sandbox(
+            settings_path=self.settings_path,
+            home=self.home,
+            dry_run=False,
+            no_backup=True,
+        )
+        self.assertNotEqual(rc, 0)
+        self.assertEqual(self.settings_path.read_text(encoding="utf-8"), original)
+        baks = list(self.settings_path.parent.glob("settings.json.bak.*"))
+        self.assertEqual(baks, [])
 
     def test_dry_run_renders_skipped_even_on_noop(self) -> None:
         # First merge populates the file; then a second --dry-run is a


### PR DESCRIPTION
## Summary

Extend `python tools/org_setup_prune.py --user-common-sandbox` from `denyRead`-only to **`denyRead` + `denyWrite`** under a single flag, and migrate `~/.claude/settings.json` out of the shared `sandbox.filesystem.denyWrite` into each user's personal `~/.claude/settings.json`. Single-flag UX, idempotent, preventive deny for files that don't yet exist.

Pairs with PR #430 (Task B, denyRead infrastructure) and PR #432 (Task C, shared denyRead cleanup). Closes the leak-mitigation arc started in Issue #429.

## Design decisions

| Decision | Choice | Rationale |
|---|---|---|
| Flag surface | Single `--user-common-sandbox` handles both | UX simplicity, follows PR #430's precedent |
| denyWrite candidates | `~/.claude/settings.json` only | Issue #433 explicit scope; symmetric directory denyWrite deferred |
| Symmetric `~/.ssh` / `~/.aws` denyWrite | **Deferred** | Would intercept legitimate `ssh-keygen` / `aws configure` writes with no clear threat model |
| `~/.claude/settings.json` existence check | **Preventive merge** (skip existence check) | File is created by Claude Code on first launch — deny must be in place before that |
| Layer-2 → Layer-3 docs | `Edit(...)` mirrors to `denyWrite` per official docs | Confirmed at https://code.claude.com/docs/en/settings; `Write(...)` not documented → out of scope |

## Changes

- `tools/org_setup_prune.py`:
  - Extracted `_merge_sandbox_deny` common helper to share between read / write paths
  - Added `merge_user_common_sandbox_denywrite(settings, entries)` and `USER_COMMON_SANDBOX_DENYWRITE_CANDIDATES`
  - `process_user_common_sandbox` now handles both lists; `render_user_common_diff` reports both
  - CLI help + module docstring updated
- `tools/test_org_setup_prune.py`: +14 new tests (preventive deny, existing-entry preserve, dry-run report, malformed-shape abort for denyWrite); fixtures updated to cover both lists
- `.claude/settings.json`: removed `sandbox.filesystem.denyWrite` block entirely
- `.claude/skills/org-setup/references/permissions.md`: restructured to "denyRead / denyWrite reinforcement" with preventive-deny rationale + deferred scope
- `README.md`: attack-vector matrix gains denyWrite row; migration pre-condition and personal-sandbox section updated for denyWrite
- `docs/getting-started.md`: synced one-time-required comment to Issue #433
- `docs/verification.md`: §10.1 pre-condition gains `--user-common-sandbox` step; new **Addendum 2 (denyWrite migration)** documenting the Layer 2 → Layer 3 mirror; WSL2 procedure switched to exact-match paths + backup step
- `scripts/install.{sh,ps1}`: migration warning synced

## Verification

- `python3 tools/test_org_setup_prune.py` → **64 tests OK** (50 existing + 14 new)
- `python3 tools/check_role_configs.py` → role_configs OK
- CLI smoke: `--user-common-sandbox` (real) and `--user-common-sandbox --dry-run` both merge `denyRead` and `denyWrite` correctly; idempotent on re-run
- `git grep -nE '(<operator>|<absolute-home-path>)'` → no new leaks in added content
- Codex self-review: 3 rounds, final round **Approve** (no Blocker, no Major)

## Migration

After this PR lands, each operator must re-run:

```bash
python tools/org_setup_prune.py --user-common-sandbox
```

This adds `~/.claude/settings.json` to the personal `sandbox.filesystem.denyWrite` (preventive — works even when the file is absent on a fresh install). Without this step, pulling main removes the shared protection without local replacement.

## Out of scope

Live-environment verification of `denyWrite` enforcement on macOS / Linux / WSL2 + bubblewrap is documented as a human checklist in `docs/verification.md` §10.1 step 4 + WSL2 procedure. Not executed in this PR.

## Closes

Closes #433.

## Test plan

- [ ] CI green
- [ ] After merge: re-run `--user-common-sandbox` on a clean checkout; confirm personal `~/.claude/settings.json` `sandbox.filesystem.denyWrite` gains `~/.claude/settings.json` entry, idempotent
- [ ] After merge: `git grep -F 'denyWrite' .claude/settings.json` → no match in shared settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)