### PR TITLE
docs(readme): drop internal Phase 5 jargon, add venv activation to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ claude-org-ja が動かそうとしているのは、その「誰がオーケス
 
 ## 4 層アーキテクチャ（要約）
 
-claude-org-ja は 4 層スタックの **Layer 4** に位置するリファレンス配布物です。Layer 3（`renga`）と Layer 2（`claude-org-runtime`）に依存し、Layer 2 はさらに Layer 1（`core-harness`）に依存します。Phase 5 完了時点で Layer 1〜3 はいずれも独立 OSS パッケージとして公開済みで、claude-org-ja (Layer 4) は consumer として取り込む thin shim です。
+claude-org-ja は 4 層スタックの **Layer 4** に位置するリファレンス配布物です。Layer 3（`renga`）と Layer 2（`claude-org-runtime`）に依存し、Layer 2 はさらに Layer 1（`core-harness`）に依存します。Layer 1〜3 はそれぞれ独立 OSS パッケージとして公開済みで、claude-org-ja (Layer 4) は consumer として取り込む thin shim です。
 
 各層の責務・mermaid 図・パッケージ詳細は [`docs/overview-technical.md`](docs/overview-technical.md) を参照。
 
@@ -81,6 +81,7 @@ iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/sc
 
 ```bash
 cd claude-org-ja
+source .venv/bin/activate                                # Linux / macOS のみ。Windows native は scripts/install.ps1 が pip install --user 経路のため不要
 bash scripts/install-hooks.sh                            # コミット直前の秘密情報スキャナを有効化
 python tools/org_setup_prune.py --user-common-sandbox    # main pull 後に 1 回必須 (Issue #429 Task B/C + Issue #433 denyWrite)
 renga --layout ops                                       # 窓口（Secretary）ペインを起動


### PR DESCRIPTION
## Summary

Two small README onboarding fixes surfaced while reviewing the freshly merged Agent View refactor:

- **Drop \"Phase 5\" jargon from the 4-layer architecture section.** "Phase 5 完了時点で" is an internal release-plan term that does not parse for a first-time reader. Rewritten as the equivalent self-contained statement ("Layer 1〜3 はそれぞれ独立 OSS パッケージとして公開済みで、…") so the meaning stands on its own.
- **Add venv activation to the quickstart command block.** The Linux / macOS installer (`scripts/install.sh`) creates `\$TARGET_DIR/.venv` and editable-installs into it, but the post-install command sequence jumped straight from `cd claude-org-ja` to `python tools/org_setup_prune.py …` without `source .venv/bin/activate`. New first line tells the reader to activate the venv, with an inline comment noting that Windows native takes the `pip install --user` path and does not need activation.

No code changes. Single-file diff (README.md, +2 / -1).

## Test plan

- [ ] Visual sanity check on rendered README on GitHub (4 層アーキテクチャ + quickstart)
- [ ] Confirm the quickstart still reads coherently on first run for Linux / macOS users
- [ ] No-op for CI; docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)