### PR TITLE
fix(claude): drop ~/.config/gh from sandbox denyRead candidates

### DIFF
--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -76,10 +76,13 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 - **存在しないディレクトリは skip**。`~/.docker` が無い環境では entry を追加しない（bwrap launcher の case A 扱いを先回り）。
 - **realpath が HOME を escape する symlink は skip**。WSL2 + DriveFS で `~/.aws → /mnt/c/Users/<name>/.aws` のようになっている場合、bwrap の bootstrap mount が失敗する（`bwrap: Can't create file at /home/<user>/.aws/config: No such file or directory`）。これは claude-org-runtime の Layer 3 generator (`role_configs_schema.json#$comment_sandbox_anchor` の `suppressOnSymlinkEscape=True`) と同じ判定を user_common 側でも先回りする。
 
-**denyRead 候補から意図的に除外しているもの**:
+**候補リストから恒久的に除外しているもの**（候補定数 `USER_COMMON_SANDBOX_DENYREAD_CANDIDATES` 自体に含めない）:
 
-- `~/.aws` の HOME-escape symlink ケース（WSL2 + DriveFS）: 上記「realpath が HOME を escape する symlink は skip」に従い実行時に自動 skip される（候補リスト自体には残る）。
-- `~/.config/gh`: gh CLI は窓口（Secretary）の業務動線（push / PR 作成 / CI 監視 / review feedback ループ / merge cleanup）で必須のため deny しない。Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436) で defense-in-depth と運用継続性のトレードオフを評価し、**後者を優先**することにした。`~/.config/gh` は `USER_COMMON_SANDBOX_DENYREAD_REMOVE` の retire リストに登録されており、過去に `--user-common-sandbox` を実行して個人 `~/.claude/settings.json` の `sandbox.filesystem.denyRead` に当該 entry が残っているユーザーの環境では、次回 `--user-common-sandbox` 実行時に **黙って除去** される（additive + prune セマンティクス）。ユーザーが手で追加した他の entry は touch しない。
+- `~/.config/gh`: gh CLI は窓口（Secretary）の業務動線（push / PR 作成 / CI 監視 / review feedback ループ / merge cleanup）で必須のため deny しない。Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436) で defense-in-depth と運用継続性のトレードオフを評価し、**後者を優先**することにした。`~/.config/gh` は `USER_COMMON_SANDBOX_DENYREAD_REMOVE` の retire リストに登録されており、過去に `--user-common-sandbox` を実行して個人 `~/.claude/settings.json` の `sandbox.filesystem.denyRead` に当該 entry が残っているユーザーの環境では、次回 `--user-common-sandbox` 実行時に **自動的に除去** される（自動的な additive + prune セマンティクス）。ユーザーが手で追加した他の entry は touch しない。
+
+**候補リストには残るが実行時に skip されるケース**（候補定数には残るが merge 時に弾かれる）:
+
+- `~/.aws` の HOME-escape symlink ケース（WSL2 + DriveFS）: 上記「realpath が HOME を escape する symlink は skip」に従い実行時に自動 skip される。候補リストからは除外しないため、symlink を解消すれば次回実行で deny が効くようになる。
 
 **denyWrite 対象ファイル（候補）**: `~`-prefixed の *file* literal:
 
@@ -95,7 +98,7 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 - 既存の top-level key (`theme`, `env`, `permissions`, etc.) は無触。
 - 既存の `sandbox` / `sandbox.filesystem` siblings (`enabled`, `failIfUnavailable`, `additionalDirectories`, および merge 対象でない側の deny list) は保持。
 - `denyRead` / `denyWrite` の既存順序を保ちつつ、未追加の candidate のみを後ろに append。重複は skip。
-- **denyRead のみ additive + prune** (Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436)): 上記の「retire リスト」(`USER_COMMON_SANDBOX_DENYREAD_REMOVE`) に列挙された entry が既存 `denyRead` に残っていれば、毎回の実行で **黙って除去** する。retire 対象が現行候補リストにも入っている場合は除去せず保持（再追加ループを避けるため）。retire リストに無いユーザー追加 entry は一切 touch しない。denyWrite 側には retire リストを設けていない（現状 retire 対象が無いため）。
+- **denyRead のみ additive + prune** (Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436)): 上記の「retire リスト」(`USER_COMMON_SANDBOX_DENYREAD_REMOVE`) に列挙された entry が既存 `denyRead` に残っていれば、毎回の実行で **自動的に除去** する。retire 対象が現行候補リストにも入っている場合は除去せず保持（再追加ループを避けるため）。retire リストに無いユーザー追加 entry は一切 touch しない。denyWrite 側には retire リストを設けていない（現状 retire 対象が無いため）。
 - malformed shape（`sandbox` が object でない、`denyRead` / `denyWrite` が array でない、entry が string でない、等）は **書込前に `ValueError` で abort**。ユーザーデータの黙示的破壊を防ぐ。denyRead 側で先に shape error が出れば denyWrite merge は実行されない（その逆も同様）。
 
 **使用方法**:

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -66,7 +66,6 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 
 - `~/.ssh`
 - `~/.aws`
-- `~/.config/gh`
 - `~/.kube`
 - `~/.gnupg`
 - `~/.docker`
@@ -77,6 +76,11 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 - **存在しないディレクトリは skip**。`~/.docker` が無い環境では entry を追加しない（bwrap launcher の case A 扱いを先回り）。
 - **realpath が HOME を escape する symlink は skip**。WSL2 + DriveFS で `~/.aws → /mnt/c/Users/<name>/.aws` のようになっている場合、bwrap の bootstrap mount が失敗する（`bwrap: Can't create file at /home/<user>/.aws/config: No such file or directory`）。これは claude-org-runtime の Layer 3 generator (`role_configs_schema.json#$comment_sandbox_anchor` の `suppressOnSymlinkEscape=True`) と同じ判定を user_common 側でも先回りする。
 
+**denyRead 候補から意図的に除外しているもの**:
+
+- `~/.aws` の HOME-escape symlink ケース（WSL2 + DriveFS）: 上記「realpath が HOME を escape する symlink は skip」に従い実行時に自動 skip される（候補リスト自体には残る）。
+- `~/.config/gh`: gh CLI は窓口（Secretary）の業務動線（push / PR 作成 / CI 監視 / review feedback ループ / merge cleanup）で必須のため deny しない。Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436) で defense-in-depth と運用継続性のトレードオフを評価し、**後者を優先**することにした。`~/.config/gh` は `USER_COMMON_SANDBOX_DENYREAD_REMOVE` の retire リストに登録されており、過去に `--user-common-sandbox` を実行して個人 `~/.claude/settings.json` の `sandbox.filesystem.denyRead` に当該 entry が残っているユーザーの環境では、次回 `--user-common-sandbox` 実行時に **黙って除去** される（additive + prune セマンティクス）。ユーザーが手で追加した他の entry は touch しない。
+
 **denyWrite 対象ファイル（候補）**: `~`-prefixed の *file* literal:
 
 - `~/.claude/settings.json`
@@ -86,11 +90,12 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 - **存在チェック無し**: ファイルが未作成でも entry を merge する。書込防御は **ファイル未作成時点で意味があり**（fresh install では `~/.claude/settings.json` が Claude Code の初回起動時に作成される）、deny を先に置くことで初回作成時から bwrap subprocess の書き込みを構造的に止める。
 - **symlink-escape skip も適用しない**: denyWrite の対象は単一ファイル literal で、bwrap が write 先 path を解釈する際に存在しない path を case A で skip するため bootstrap 失敗の risk が無い。symmetric directory denyWrite (`~/.ssh` 等) は **Issue #433 のスコープ外**として deferred（`ssh-keygen` / `aws configure` 等の正規 write を巻き込む副作用が大きく、明確な threat model も無いため）。
 
-**動作（idempotent / additive-only、denyRead/denyWrite 共通）**:
+**動作（idempotent、denyRead/denyWrite 共通）**:
 
 - 既存の top-level key (`theme`, `env`, `permissions`, etc.) は無触。
 - 既存の `sandbox` / `sandbox.filesystem` siblings (`enabled`, `failIfUnavailable`, `additionalDirectories`, および merge 対象でない側の deny list) は保持。
 - `denyRead` / `denyWrite` の既存順序を保ちつつ、未追加の candidate のみを後ろに append。重複は skip。
+- **denyRead のみ additive + prune** (Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436)): 上記の「retire リスト」(`USER_COMMON_SANDBOX_DENYREAD_REMOVE`) に列挙された entry が既存 `denyRead` に残っていれば、毎回の実行で **黙って除去** する。retire 対象が現行候補リストにも入っている場合は除去せず保持（再追加ループを避けるため）。retire リストに無いユーザー追加 entry は一切 touch しない。denyWrite 側には retire リストを設けていない（現状 retire 対象が無いため）。
 - malformed shape（`sandbox` が object でない、`denyRead` / `denyWrite` が array でない、entry が string でない、等）は **書込前に `ValueError` で abort**。ユーザーデータの黙示的破壊を防ぐ。denyRead 側で先に shape error が出れば denyWrite merge は実行されない（その逆も同様）。
 
 **使用方法**:

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -58,7 +58,7 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 
 ### ユーザー共通の sandbox denyRead / denyWrite 補強（`--user-common-sandbox`、Issue #429 Task B + Issue #433）
 
-> **⚠️ main pull 後の 1 回必須**: 本リポジトリを clone / pull した後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行する**。未実行だと共有 `.claude/settings.json` から除去された `~/.ssh` / `~/.aws` / `~/.config/gh` 等の sandbox denyRead **および** `~/.claude/settings.json` の sandbox denyWrite が補完されず、**sandbox 防御が一時的に弱くなる**。
+> **⚠️ main pull 後の 1 回必須**: 本リポジトリを clone / pull した後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行する**。未実行だと共有 `.claude/settings.json` から除去された `~/.ssh` / `~/.aws` 等の sandbox denyRead **および** `~/.claude/settings.json` の sandbox denyWrite が補完されず、**sandbox 防御が一時的に弱くなる**。
 
 `tools/org_setup_prune.py --user-common-sandbox` は `~/.claude/settings.json` の `sandbox.filesystem.denyRead` / `denyWrite` 双方に対し、対象エントリを **idempotent に union-merge** する専用モード。共有 (= リポジトリ) 側の `.claude/settings.json` から個人 path を除去（Issue #429 Task C で denyRead 群、Issue #433 で denyWrite の `~/.claude/settings.json`）した分の defense-in-depth を、個人環境ごとに復元する。**単一フラグで denyRead + denyWrite の両方を処理する**（`--user-common-sandbox-write` のような別フラグは設けない、UX 簡素化方針）。
 

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -78,7 +78,7 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 
 **候補リストから恒久的に除外しているもの**（候補定数 `USER_COMMON_SANDBOX_DENYREAD_CANDIDATES` 自体に含めない）:
 
-- `~/.config/gh`: gh CLI は窓口（Secretary）の業務動線（push / PR 作成 / CI 監視 / review feedback ループ / merge cleanup）で必須のため deny しない。Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436) で defense-in-depth と運用継続性のトレードオフを評価し、**後者を優先**することにした。`~/.config/gh` は `USER_COMMON_SANDBOX_DENYREAD_REMOVE` の retire リストに登録されており、過去に `--user-common-sandbox` を実行して個人 `~/.claude/settings.json` の `sandbox.filesystem.denyRead` に当該 entry が残っているユーザーの環境では、次回 `--user-common-sandbox` 実行時に **自動的に除去** される（自動的な additive + prune セマンティクス）。ユーザーが手で追加した他の entry は touch しない。
+- `~/.config/gh`: gh CLI は窓口（Secretary）の業務動線（push / PR 作成 / CI 監視 / review feedback ループ / merge cleanup）で必須のため deny しない。defense-in-depth と運用継続性のトレードオフを評価し、後者を優先する判断とした。`~/.config/gh` は `USER_COMMON_SANDBOX_DENYREAD_REMOVE` の retire リストに登録されており、過去に `--user-common-sandbox` を実行して個人 `~/.claude/settings.json` の `sandbox.filesystem.denyRead` に当該 entry が残っているユーザーの環境では、次回 `--user-common-sandbox` 実行時に **自動的に除去** される（自動的な additive + prune セマンティクス）。ユーザーが手で追加した他の entry は touch しない。
 
 **候補リストには残るが実行時に skip されるケース**（候補定数には残るが merge 時に弾かれる）:
 
@@ -98,7 +98,7 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 - 既存の top-level key (`theme`, `env`, `permissions`, etc.) は無触。
 - 既存の `sandbox` / `sandbox.filesystem` siblings (`enabled`, `failIfUnavailable`, `additionalDirectories`, および merge 対象でない側の deny list) は保持。
 - `denyRead` / `denyWrite` の既存順序を保ちつつ、未追加の candidate のみを後ろに append。重複は skip。
-- **denyRead のみ additive + prune** (Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436)): 上記の「retire リスト」(`USER_COMMON_SANDBOX_DENYREAD_REMOVE`) に列挙された entry が既存 `denyRead` に残っていれば、毎回の実行で **自動的に除去** する。retire 対象が現行候補リストにも入っている場合は除去せず保持（再追加ループを避けるため）。retire リストに無いユーザー追加 entry は一切 touch しない。denyWrite 側には retire リストを設けていない（現状 retire 対象が無いため）。
+- **denyRead のみ additive + prune**: 上記の「retire リスト」(`USER_COMMON_SANDBOX_DENYREAD_REMOVE`) に列挙された entry が既存 `denyRead` に残っていれば、毎回の実行で **自動的に除去** する。retire 対象が現行候補リストにも入っている場合は除去せず保持（再追加ループを避けるため）。retire リストに無いユーザー追加 entry は一切 touch しない。denyWrite 側には retire リストを設けていない（現状 retire 対象が無いため）。
 - malformed shape（`sandbox` が object でない、`denyRead` / `denyWrite` が array でない、entry が string でない、等）は **書込前に `ValueError` で abort**。ユーザーデータの黙示的破壊を防ぐ。denyRead 側で先に shape error が出れば denyWrite merge は実行されない（その逆も同様）。
 
 **使用方法**:

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ bash scripts/install-hooks.sh                          # core.hooksPath を .git
 python tools/org_setup_prune.py --user-common-sandbox  # 個人 ~/.claude/settings.json の sandbox denyRead / denyWrite を補強
 ```
 
-`--user-common-sandbox` は idempotent で、`~/.claude/settings.json` の `sandbox.filesystem.denyRead` に機密 credential ディレクトリ群（`~/.ssh` / `~/.aws` / `~/.config/gh` / `~/.kube` / `~/.gnupg` / `~/.docker` / `~/.config/aws-vault`）を、`denyWrite` に `~/.claude/settings.json` 自身を idempotent に union-merge します（実在しないもの・symlink-escape は自動 skip。詳細は [`docs/getting-started.md`](docs/getting-started.md) と [`.claude/skills/org-setup/references/permissions.md`](.claude/skills/org-setup/references/permissions.md)）。
+`--user-common-sandbox` は idempotent で、`~/.claude/settings.json` の `sandbox.filesystem.denyRead` に機密 credential ディレクトリ群（`~/.ssh` / `~/.aws` / `~/.kube` / `~/.gnupg` / `~/.docker` / `~/.config/aws-vault`）を、`denyWrite` に `~/.claude/settings.json` 自身を idempotent に union-merge します（実在しないもの・symlink-escape は自動 skip。詳細は [`docs/getting-started.md`](docs/getting-started.md) と [`.claude/skills/org-setup/references/permissions.md`](.claude/skills/org-setup/references/permissions.md)）。`~/.config/gh` は gh CLI が窓口の業務動線（push / PR 作成 / CI 監視 / review feedback ループ / merge cleanup）で必須のため候補から意図的に除外しており、過去のリビジョンで個人 settings.json に残っていれば次回実行時に自動的に prune されます。
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,7 @@ renga --layout ops
 
 `/org-setup` は **additive-only**（不足分を追加するだけで既存を消さない）。drift を baseline に戻したい場合は [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) のロール別サンプル JSON で `settings.local.json` を手動置換する。
 
-> **⚠️ main pull 後の 1 回必須（Issue #429 Task B / C + Issue #433 + Issue #436）**: 共有 `.claude/settings.json` から個人パスエントリを除去したため（denyRead 系: `Read(~/.ssh/*)` / `Read(~/.aws/*)` 等、denyWrite 系: `~/.claude/settings.json`）、初回 / pull 後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行**してください（単一フラグで denyRead + denyWrite 両系統を補完）。未実行だと個人環境の sandbox 防御が一時的に弱くなります（[README §個人 sandbox の補強](../README.md) と [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) 参照）。なお `~/.config/gh` は gh CLI が窓口業務動線で必須のため Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436) で候補から除外しており、過去のリビジョンで個人 settings.json に残っていれば次回実行時に自動的に prune されます。
+> **⚠️ main pull 後の 1 回必須（Issue #429 Task B / C + Issue #433）**: 共有 `.claude/settings.json` から個人パスエントリを除去したため（denyRead 系: `Read(~/.ssh/*)` / `Read(~/.aws/*)` 等、denyWrite 系: `~/.claude/settings.json`）、初回 / pull 後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行**してください（単一フラグで denyRead + denyWrite 両系統を補完）。未実行だと個人環境の sandbox 防御が一時的に弱くなります（[README §個人 sandbox の補強](../README.md) と [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) 参照）。なお `~/.config/gh` は gh CLI が窓口業務動線で必須のため候補から除外しており、過去のリビジョンで個人 settings.json に残っていれば次回実行時に自動的に prune されます。
 >
 > ```bash
 > # diff プレビュー

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,7 @@ renga --layout ops
 
 `/org-setup` は **additive-only**（不足分を追加するだけで既存を消さない）。drift を baseline に戻したい場合は [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) のロール別サンプル JSON で `settings.local.json` を手動置換する。
 
-> **⚠️ main pull 後の 1 回必須（Issue #429 Task B / C + Issue #433）**: 共有 `.claude/settings.json` から個人パスエントリを除去したため（denyRead 系: `~/.config/gh/hosts.yml` / `Read(~/.ssh/*)` / `Read(~/.aws/*)`、denyWrite 系: `~/.claude/settings.json`）、初回 / pull 後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行**してください（単一フラグで denyRead + denyWrite 両系統を補完）。未実行だと個人環境の sandbox 防御が一時的に弱くなります（[README §個人 sandbox の補強](../README.md) と [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) 参照）。
+> **⚠️ main pull 後の 1 回必須（Issue #429 Task B / C + Issue #433 + Issue #436）**: 共有 `.claude/settings.json` から個人パスエントリを除去したため（denyRead 系: `Read(~/.ssh/*)` / `Read(~/.aws/*)` 等、denyWrite 系: `~/.claude/settings.json`）、初回 / pull 後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行**してください（単一フラグで denyRead + denyWrite 両系統を補完）。未実行だと個人環境の sandbox 防御が一時的に弱くなります（[README §個人 sandbox の補強](../README.md) と [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) 参照）。なお `~/.config/gh` は gh CLI が窓口業務動線で必須のため Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436) で候補から除外しており、過去のリビジョンで個人 settings.json に残っていれば次回実行時に黙って prune されます。
 >
 > ```bash
 > # diff プレビュー

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,7 @@ renga --layout ops
 
 `/org-setup` は **additive-only**（不足分を追加するだけで既存を消さない）。drift を baseline に戻したい場合は [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) のロール別サンプル JSON で `settings.local.json` を手動置換する。
 
-> **⚠️ main pull 後の 1 回必須（Issue #429 Task B / C + Issue #433 + Issue #436）**: 共有 `.claude/settings.json` から個人パスエントリを除去したため（denyRead 系: `Read(~/.ssh/*)` / `Read(~/.aws/*)` 等、denyWrite 系: `~/.claude/settings.json`）、初回 / pull 後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行**してください（単一フラグで denyRead + denyWrite 両系統を補完）。未実行だと個人環境の sandbox 防御が一時的に弱くなります（[README §個人 sandbox の補強](../README.md) と [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) 参照）。なお `~/.config/gh` は gh CLI が窓口業務動線で必須のため Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436) で候補から除外しており、過去のリビジョンで個人 settings.json に残っていれば次回実行時に黙って prune されます。
+> **⚠️ main pull 後の 1 回必須（Issue #429 Task B / C + Issue #433 + Issue #436）**: 共有 `.claude/settings.json` から個人パスエントリを除去したため（denyRead 系: `Read(~/.ssh/*)` / `Read(~/.aws/*)` 等、denyWrite 系: `~/.claude/settings.json`）、初回 / pull 後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行**してください（単一フラグで denyRead + denyWrite 両系統を補完）。未実行だと個人環境の sandbox 防御が一時的に弱くなります（[README §個人 sandbox の補強](../README.md) と [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) 参照）。なお `~/.config/gh` は gh CLI が窓口業務動線で必須のため Issue [#436](https://github.com/suisya-systems/claude-org-ja/issues/436) で候補から除外しており、過去のリビジョンで個人 settings.json に残っていれば次回実行時に自動的に prune されます。
 >
 > ```bash
 > # diff プレビュー

--- a/tools/org_setup_prune.py
+++ b/tools/org_setup_prune.py
@@ -78,11 +78,31 @@ PRUNABLE_ROLES = ("secretary", "dispatcher", "curator")
 USER_COMMON_SANDBOX_DENYREAD_CANDIDATES: tuple[str, ...] = (
     "~/.ssh",
     "~/.aws",
-    "~/.config/gh",
     "~/.kube",
     "~/.gnupg",
     "~/.docker",
     "~/.config/aws-vault",
+)
+
+# Entries that **were** in the candidate set in older revisions but have
+# since been retired. Listing them here lets ``--user-common-sandbox``
+# silently strip them on every run so the user does not have to hand-edit
+# their personal ``~/.claude/settings.json`` after a pull (Issue #436).
+#
+# Each entry is removed from an existing ``sandbox.filesystem.denyRead``
+# **only when it is not also present in the current candidate set** -- a
+# path cannot simultaneously be a retiree and an active candidate. Other
+# existing entries (operator-added literals, glob patterns, etc.) are
+# never touched.
+#
+# Membership rationale:
+#   ``~/.config/gh``: gh CLI is on the Secretary critical path
+#       (push / PR create / CI watch / review feedback loop / merge
+#       cleanup). Deny-by-directory at the bwrap layer broke that loop
+#       in practice (Issue #436); the defense-in-depth trade-off was
+#       resolved in favour of operational continuity.
+USER_COMMON_SANDBOX_DENYREAD_REMOVE: tuple[str, ...] = (
+    "~/.config/gh",
 )
 
 # Files (not directories) that should be added to user_common's
@@ -366,6 +386,7 @@ def _merge_sandbox_deny(
     entries: list[str] | tuple[str, ...],
     *,
     key: str,
+    remove: list[str] | tuple[str, ...] = (),
 ) -> dict:
     """Shared pure merger for ``sandbox.filesystem.{key}`` -- the engine
     behind both ``merge_user_common_sandbox_denyread`` and
@@ -384,6 +405,13 @@ def _merge_sandbox_deny(
       previously-merged file is a no-op.
     - The input is never mutated; nested dicts/lists are shallow-copied
       along the touched spine. Callers can compare ``id`` / ``==`` safely.
+
+    Optional ``remove`` lists retired candidates that must be stripped
+    from the existing deny list (Issue #436). An entry is removed only
+    when it is present in ``existing`` AND not also present in
+    ``entries`` -- a path cannot simultaneously be retired and an active
+    candidate. Operator-added entries that aren't in ``remove`` are
+    untouched.
 
     Raises ``ValueError`` if an existing ``sandbox`` / ``sandbox.filesystem``
     is not a JSON object, or the targeted deny list is not a JSON array of
@@ -421,20 +449,29 @@ def _merge_sandbox_deny(
                 f"settings['sandbox']['filesystem']['{key}'][{i}] must be a string, got {type(ex).__name__}"
             )
 
-    added = [e for e in entries if e not in existing]
-    if not added:
-        # No new entries to merge -- return the input unchanged. This keeps
-        # the operation a true no-op when none of the candidates apply (or
-        # all of them are already present), instead of injecting an empty
-        # ``sandbox.filesystem.{key}: []`` block that the user never had.
-        # Required so the non-dry-run path matches the dry-run "(no
-        # changes)" output (Codex round-2 review, Issue #429 Task B).
+    entries_set = set(entries)
+    removed = [r for r in remove if r in existing and r not in entries_set]
+    if removed:
+        removed_set = set(removed)
+        pruned = [e for e in existing if e not in removed_set]
+    else:
+        pruned = existing
+
+    added = [e for e in entries if e not in pruned]
+    if not added and not removed:
+        # No new entries to merge AND nothing to prune -- return the input
+        # unchanged. This keeps the operation a true no-op when none of
+        # the candidates apply (or all of them are already present),
+        # instead of injecting an empty ``sandbox.filesystem.{key}: []``
+        # block that the user never had. Required so the non-dry-run path
+        # matches the dry-run "(no changes)" output (Codex round-2 review,
+        # Issue #429 Task B).
         return dict(settings)
 
     result = dict(settings)
     sandbox = dict(sandbox_val) if isinstance(sandbox_val, dict) else {}
     filesystem = dict(fs_val) if isinstance(fs_val, dict) else {}
-    filesystem[key] = existing + added
+    filesystem[key] = pruned + added
     sandbox["filesystem"] = filesystem
     result["sandbox"] = sandbox
     return result
@@ -443,12 +480,20 @@ def _merge_sandbox_deny(
 def merge_user_common_sandbox_denyread(
     settings: dict,
     entries: list[str] | tuple[str, ...],
+    *,
+    remove: list[str] | tuple[str, ...] = (),
 ) -> dict:
     """Pure: union-merge ``entries`` into ``sandbox.filesystem.denyRead``.
     See ``_merge_sandbox_deny`` for the shared semantics (idempotent,
-    additive-only, malformed shape raises ``ValueError``, input never
-    mutated)."""
-    return _merge_sandbox_deny(settings, entries, key="denyRead")
+    malformed shape raises ``ValueError``, input never mutated).
+
+    Optional ``remove`` lists retired candidates (e.g. ``~/.config/gh``
+    after Issue #436) that must be silently stripped from the existing
+    deny list so users do not have to hand-edit their personal
+    ``~/.claude/settings.json`` after a pull. An entry is dropped only
+    when it is currently present AND not also a member of ``entries``.
+    """
+    return _merge_sandbox_deny(settings, entries, key="denyRead", remove=remove)
 
 
 def merge_user_common_sandbox_denywrite(
@@ -472,6 +517,7 @@ def process_user_common_sandbox(
     settings_path: Path,
     denyread_candidates: tuple[str, ...] | list[str] = USER_COMMON_SANDBOX_DENYREAD_CANDIDATES,
     denywrite_candidates: tuple[str, ...] | list[str] = USER_COMMON_SANDBOX_DENYWRITE_CANDIDATES,
+    denyread_remove: tuple[str, ...] | list[str] = USER_COMMON_SANDBOX_DENYREAD_REMOVE,
     home: Path | None = None,
     dry_run: bool,
     no_backup: bool,
@@ -482,6 +528,12 @@ def process_user_common_sandbox(
     ``sandbox.filesystem.denyRead`` candidates (existence + realpath-escape
     filtered) followed by file-level ``sandbox.filesystem.denyWrite``
     candidates (preventive deny -- no existence filter; Issue #433).
+
+    ``denyread_remove`` lists retired denyRead candidates that must be
+    silently stripped from an existing settings.json on every run
+    (Issue #436): defense-in-depth retirements that the operator should
+    not need to apply by hand. Operator-added entries that aren't in this
+    list are left untouched.
 
     Returns a process-style return code (0 on success / no-op; non-zero on
     malformed JSON). When ``settings_path`` does not exist the file is
@@ -508,7 +560,9 @@ def process_user_common_sandbox(
 
     existing_read_entries = filter_existing_user_dirs(denyread_candidates, home=home)
     try:
-        target = merge_user_common_sandbox_denyread(current, existing_read_entries)
+        target = merge_user_common_sandbox_denyread(
+            current, existing_read_entries, remove=denyread_remove,
+        )
         target = merge_user_common_sandbox_denywrite(target, denywrite_candidates)
     except ValueError as exc:
         print(
@@ -542,18 +596,23 @@ def process_user_common_sandbox(
         return 0
 
     bak = write_settings(settings_path, target, make_backup=not no_backup)
-    added_read = _added_in_append_order(_safe_deny_list(current, "denyRead"), _safe_deny_list(target, "denyRead"))
+    cur_read = _safe_deny_list(current, "denyRead")
+    tgt_read = _safe_deny_list(target, "denyRead")
+    added_read = _added_in_append_order(cur_read, tgt_read)
+    removed_read = _removed_from_input(cur_read, tgt_read)
     added_write = _added_in_append_order(_safe_deny_list(current, "denyWrite"), _safe_deny_list(target, "denyWrite"))
     fragments: list[str] = []
     if added_read:
-        fragments.append(f"denyRead {added_read}")
+        fragments.append(f"denyRead added {added_read}")
+    if removed_read:
+        fragments.append(f"denyRead removed {removed_read}")
     if added_write:
-        fragments.append(f"denyWrite {added_write}")
-    added_summary = "; added " + ", ".join(fragments) if fragments else ""
+        fragments.append(f"denyWrite added {added_write}")
+    summary = "; " + ", ".join(fragments) if fragments else ""
     print(
         f"[org_setup_prune] user_common: wrote {settings_path}"
         + (f" (backup: {bak.name})" if bak else "")
-        + added_summary
+        + summary
     )
     return 0
 
@@ -581,6 +640,15 @@ def _added_in_append_order(current: list[str], target: list[str]) -> list[str]:
     return [e for e in target if e not in cur_set]
 
 
+def _removed_from_input(current: list[str], target: list[str]) -> list[str]:
+    """Counterpart of ``_added_in_append_order`` for the retire path
+    (Issue #436): entries present in ``current`` but absent from
+    ``target``, in their original input order so the diff stays
+    deterministic."""
+    tgt_set = set(target)
+    return [e for e in current if e not in tgt_set]
+
+
 def render_user_common_diff(
     settings_path: Path,
     current: dict,
@@ -589,16 +657,26 @@ def render_user_common_diff(
     existing_read_entries: list[str],
     denywrite_candidates: tuple[str, ...] | list[str] = (),
 ) -> str:
-    added_read = _added_in_append_order(_safe_deny_list(current, "denyRead"), _safe_deny_list(target, "denyRead"))
+    cur_read = _safe_deny_list(current, "denyRead")
+    tgt_read = _safe_deny_list(target, "denyRead")
+    added_read = _added_in_append_order(cur_read, tgt_read)
+    removed_read = _removed_from_input(cur_read, tgt_read)
     added_write = _added_in_append_order(_safe_deny_list(current, "denyWrite"), _safe_deny_list(target, "denyWrite"))
     skipped_missing = [c for c in denyread_candidates if c not in existing_read_entries]
     lines = [f"=== user_common: {settings_path} ==="]
-    if not added_read and not added_write:
+    if not added_read and not added_write and not removed_read:
         lines.append("  (no changes)")
     if added_read:
         lines.append("  sandbox.filesystem.denyRead added:")
         for it in added_read:
             lines.append(f"    + {it}")
+    if removed_read:
+        # Retired denyRead candidates (Issue #436): silently stripped on
+        # every run so the operator does not have to hand-edit their
+        # personal settings.json after a pull.
+        lines.append("  sandbox.filesystem.denyRead removed (retired candidate):")
+        for it in removed_read:
+            lines.append(f"    - {it}")
     if added_write:
         lines.append("  sandbox.filesystem.denyWrite added:")
         for it in added_write:

--- a/tools/org_setup_prune.py
+++ b/tools/org_setup_prune.py
@@ -86,8 +86,8 @@ USER_COMMON_SANDBOX_DENYREAD_CANDIDATES: tuple[str, ...] = (
 
 # Entries that **were** in the candidate set in older revisions but have
 # since been retired. Listing them here lets ``--user-common-sandbox``
-# silently strip them on every run so the user does not have to hand-edit
-# their personal ``~/.claude/settings.json`` after a pull (Issue #436).
+# strip them automatically on every run so the user does not have to
+# hand-edit their personal ``~/.claude/settings.json`` after a pull.
 #
 # Each entry is removed from an existing ``sandbox.filesystem.denyRead``
 # **only when it is not also present in the current candidate set** -- a
@@ -99,8 +99,8 @@ USER_COMMON_SANDBOX_DENYREAD_CANDIDATES: tuple[str, ...] = (
 #   ``~/.config/gh``: gh CLI is on the Secretary critical path
 #       (push / PR create / CI watch / review feedback loop / merge
 #       cleanup). Deny-by-directory at the bwrap layer broke that loop
-#       in practice (Issue #436); the defense-in-depth trade-off was
-#       resolved in favour of operational continuity.
+#       in practice; the defense-in-depth trade-off was resolved in
+#       favour of operational continuity.
 USER_COMMON_SANDBOX_DENYREAD_REMOVE: tuple[str, ...] = (
     "~/.config/gh",
 )
@@ -407,11 +407,10 @@ def _merge_sandbox_deny(
       along the touched spine. Callers can compare ``id`` / ``==`` safely.
 
     Optional ``remove`` lists retired candidates that must be stripped
-    from the existing deny list (Issue #436). An entry is removed only
-    when it is present in ``existing`` AND not also present in
-    ``entries`` -- a path cannot simultaneously be retired and an active
-    candidate. Operator-added entries that aren't in ``remove`` are
-    untouched.
+    from the existing deny list. An entry is removed only when it is
+    present in ``existing`` AND not also present in ``entries`` -- a
+    path cannot simultaneously be retired and an active candidate.
+    Operator-added entries that aren't in ``remove`` are untouched.
 
     Raises ``ValueError`` if an existing ``sandbox`` / ``sandbox.filesystem``
     is not a JSON object, or the targeted deny list is not a JSON array of
@@ -487,9 +486,9 @@ def merge_user_common_sandbox_denyread(
     See ``_merge_sandbox_deny`` for the shared semantics (idempotent,
     malformed shape raises ``ValueError``, input never mutated).
 
-    Optional ``remove`` lists retired candidates (e.g. ``~/.config/gh``
-    after Issue #436) that must be silently stripped from the existing
-    deny list so users do not have to hand-edit their personal
+    Optional ``remove`` lists retired candidates (e.g. ``~/.config/gh``)
+    that must be stripped automatically from the existing deny list so
+    users do not have to hand-edit their personal
     ``~/.claude/settings.json`` after a pull. An entry is dropped only
     when it is currently present AND not also a member of ``entries``.
     """
@@ -530,10 +529,10 @@ def process_user_common_sandbox(
     candidates (preventive deny -- no existence filter; Issue #433).
 
     ``denyread_remove`` lists retired denyRead candidates that must be
-    silently stripped from an existing settings.json on every run
-    (Issue #436): defense-in-depth retirements that the operator should
-    not need to apply by hand. Operator-added entries that aren't in this
-    list are left untouched.
+    stripped automatically from an existing settings.json on every run:
+    defense-in-depth retirements that the operator should not need to
+    apply by hand. Operator-added entries that aren't in this list are
+    left untouched.
 
     Returns a process-style return code (0 on success / no-op; non-zero on
     malformed JSON). When ``settings_path`` does not exist the file is
@@ -641,10 +640,9 @@ def _added_in_append_order(current: list[str], target: list[str]) -> list[str]:
 
 
 def _removed_from_input(current: list[str], target: list[str]) -> list[str]:
-    """Counterpart of ``_added_in_append_order`` for the retire path
-    (Issue #436): entries present in ``current`` but absent from
-    ``target``, in their original input order so the diff stays
-    deterministic."""
+    """Counterpart of ``_added_in_append_order`` for the retire path:
+    entries present in ``current`` but absent from ``target``, in their
+    original input order so the diff stays deterministic."""
     tgt_set = set(target)
     return [e for e in current if e not in tgt_set]
 
@@ -671,9 +669,9 @@ def render_user_common_diff(
         for it in added_read:
             lines.append(f"    + {it}")
     if removed_read:
-        # Retired denyRead candidates (Issue #436): silently stripped on
-        # every run so the operator does not have to hand-edit their
-        # personal settings.json after a pull.
+        # Retired denyRead candidates: stripped automatically on every
+        # run so the operator does not have to hand-edit their personal
+        # settings.json after a pull.
         lines.append("  sandbox.filesystem.denyRead removed (retired candidate):")
         for it in removed_read:
             lines.append(f"    - {it}")

--- a/tools/test_org_setup_prune.py
+++ b/tools/test_org_setup_prune.py
@@ -357,10 +357,10 @@ class CheckerOverrideAwarenessTests(unittest.TestCase):
 
 
 class CandidateSetTests(unittest.TestCase):
-    """Issue #436: ``~/.config/gh`` was retired from the denyRead
-    candidate set (gh CLI is on the Secretary critical path) and moved to
-    the retire list so older personal settings.json files have it pruned
-    on the next ``--user-common-sandbox`` run."""
+    """``~/.config/gh`` was retired from the denyRead candidate set
+    (gh CLI is on the Secretary critical path) and moved to the retire
+    list so older personal settings.json files have it pruned on the
+    next ``--user-common-sandbox`` run."""
 
     def test_gh_not_in_active_candidates(self) -> None:
         self.assertNotIn("~/.config/gh", p.USER_COMMON_SANDBOX_DENYREAD_CANDIDATES)
@@ -551,8 +551,8 @@ class MergeUserCommonSandboxTests(unittest.TestCase):
         self.assertEqual(out["sandbox"]["filesystem"]["denyRead"], ["~/.ssh", "~/.ssh/**"])
 
     def test_remove_strips_legacy_entry_and_preserves_others(self) -> None:
-        # Issue #436: a retired candidate (``~/.config/gh``) lingering in
-        # an existing settings.json is silently pruned, while operator
+        # A retired candidate (``~/.config/gh``) lingering in an
+        # existing settings.json is pruned automatically, while operator
         # additions and the entries we are appending right now survive.
         base = {
             "sandbox": {
@@ -1057,10 +1057,10 @@ class UserCommonSandboxEndToEndTests(unittest.TestCase):
         self.assertEqual(baks, [])
 
     def test_legacy_gh_entry_silently_removed_on_merge(self) -> None:
-        # Issue #436: an existing personal settings.json that still has
+        # An existing personal settings.json that still has
         # ``~/.config/gh`` in denyRead (added by an older revision of
-        # --user-common-sandbox) must have it silently stripped on the
-        # next run, while operator-added entries are preserved.
+        # --user-common-sandbox) must have it stripped automatically on
+        # the next run, while operator-added entries are preserved.
         self.settings_path.write_text(json.dumps({
             "sandbox": {
                 "filesystem": {

--- a/tools/test_org_setup_prune.py
+++ b/tools/test_org_setup_prune.py
@@ -356,6 +356,26 @@ class CheckerOverrideAwarenessTests(unittest.TestCase):
         )
 
 
+class CandidateSetTests(unittest.TestCase):
+    """Issue #436: ``~/.config/gh`` was retired from the denyRead
+    candidate set (gh CLI is on the Secretary critical path) and moved to
+    the retire list so older personal settings.json files have it pruned
+    on the next ``--user-common-sandbox`` run."""
+
+    def test_gh_not_in_active_candidates(self) -> None:
+        self.assertNotIn("~/.config/gh", p.USER_COMMON_SANDBOX_DENYREAD_CANDIDATES)
+
+    def test_gh_in_retire_list(self) -> None:
+        self.assertIn("~/.config/gh", p.USER_COMMON_SANDBOX_DENYREAD_REMOVE)
+
+    def test_other_credential_dirs_still_active(self) -> None:
+        # Sentinel: removing gh must not have collaterally dropped any of
+        # the other credential candidates.
+        for entry in ("~/.ssh", "~/.aws", "~/.kube", "~/.gnupg",
+                      "~/.docker", "~/.config/aws-vault"):
+            self.assertIn(entry, p.USER_COMMON_SANDBOX_DENYREAD_CANDIDATES)
+
+
 class FilterExistingUserDirsTests(unittest.TestCase):
     """Existence check must stat against the injected HOME, return the
     original ``~``-prefixed literal (not the expanded path), and ignore
@@ -529,6 +549,57 @@ class MergeUserCommonSandboxTests(unittest.TestCase):
             {"sandbox": {"filesystem": {"denyRead": ["~/.ssh"]}}}, ["~/.ssh/**"],
         )
         self.assertEqual(out["sandbox"]["filesystem"]["denyRead"], ["~/.ssh", "~/.ssh/**"])
+
+    def test_remove_strips_legacy_entry_and_preserves_others(self) -> None:
+        # Issue #436: a retired candidate (``~/.config/gh``) lingering in
+        # an existing settings.json is silently pruned, while operator
+        # additions and the entries we are appending right now survive.
+        base = {
+            "sandbox": {
+                "filesystem": {
+                    "denyRead": [
+                        "**/*.pem",          # operator-added
+                        "~/.config/gh",      # retired candidate, must go
+                        "~/.ssh",            # active candidate, must stay
+                    ],
+                },
+            },
+        }
+        out = p.merge_user_common_sandbox_denyread(
+            base, ["~/.ssh", "~/.aws"], remove=("~/.config/gh",),
+        )
+        self.assertEqual(
+            out["sandbox"]["filesystem"]["denyRead"],
+            ["**/*.pem", "~/.ssh", "~/.aws"],
+        )
+
+    def test_remove_when_entry_absent_is_noop(self) -> None:
+        # Once the legacy entry is gone, subsequent runs must not modify
+        # the file (idempotency under the new prune semantics).
+        base = {"sandbox": {"filesystem": {"denyRead": ["~/.ssh"]}}}
+        out = p.merge_user_common_sandbox_denyread(
+            base, ["~/.ssh"], remove=("~/.config/gh",),
+        )
+        self.assertEqual(out, base)
+
+    def test_remove_does_not_drop_entry_also_in_active_candidates(self) -> None:
+        # Defensive: if a path is somehow in both the retire list AND the
+        # active candidate list, it must NOT be removed (otherwise the
+        # subsequent additive merge would just re-append it, producing a
+        # write loop with no semantic change).
+        base = {"sandbox": {"filesystem": {"denyRead": ["~/.config/gh"]}}}
+        out = p.merge_user_common_sandbox_denyread(
+            base, ["~/.config/gh"], remove=("~/.config/gh",),
+        )
+        self.assertEqual(out, base)
+
+    def test_remove_input_not_mutated(self) -> None:
+        base = {"sandbox": {"filesystem": {"denyRead": ["~/.config/gh"]}}}
+        snapshot = json.loads(json.dumps(base))
+        p.merge_user_common_sandbox_denyread(
+            base, [], remove=("~/.config/gh",),
+        )
+        self.assertEqual(base, snapshot)
 
 
 class MergeUserCommonSandboxDenywriteTests(unittest.TestCase):
@@ -984,6 +1055,95 @@ class UserCommonSandboxEndToEndTests(unittest.TestCase):
         self.assertEqual(self.settings_path.read_text(encoding="utf-8"), original)
         baks = list(self.settings_path.parent.glob("settings.json.bak.*"))
         self.assertEqual(baks, [])
+
+    def test_legacy_gh_entry_silently_removed_on_merge(self) -> None:
+        # Issue #436: an existing personal settings.json that still has
+        # ``~/.config/gh`` in denyRead (added by an older revision of
+        # --user-common-sandbox) must have it silently stripped on the
+        # next run, while operator-added entries are preserved.
+        self.settings_path.write_text(json.dumps({
+            "sandbox": {
+                "filesystem": {
+                    "denyRead": [
+                        "**/*.pem",         # operator-added, must stay
+                        "~/.config/gh",     # retired candidate
+                        "~/.ssh",           # active candidate, must stay
+                    ],
+                },
+            },
+        }), encoding="utf-8")
+        rc = p.process_user_common_sandbox(
+            settings_path=self.settings_path,
+            home=self.home,
+            dry_run=False,
+            no_backup=True,
+        )
+        self.assertEqual(rc, 0)
+        loaded = json.loads(self.settings_path.read_text(encoding="utf-8"))
+        deny = loaded["sandbox"]["filesystem"]["denyRead"]
+        self.assertNotIn("~/.config/gh", deny)
+        self.assertIn("**/*.pem", deny)
+        self.assertIn("~/.ssh", deny)
+        self.assertIn("~/.aws", deny)
+        # denyWrite still gets the preventive deny (Issue #433).
+        self.assertEqual(
+            loaded["sandbox"]["filesystem"]["denyWrite"],
+            ["~/.claude/settings.json"],
+        )
+
+    def test_legacy_gh_entry_absent_is_idempotent_noop(self) -> None:
+        # When ``~/.config/gh`` was never in the file, a run with the
+        # default retire list must remain a no-op against an
+        # already-merged settings.json. (Sanity check: the prune branch
+        # must not flip a clean steady state into a new write.)
+        rc1 = p.process_user_common_sandbox(
+            settings_path=self.settings_path,
+            home=self.home,
+            dry_run=False,
+            no_backup=True,
+        )
+        self.assertEqual(rc1, 0)
+        first = self.settings_path.read_text(encoding="utf-8")
+        # Confirm setup landed without ``~/.config/gh`` (the .config/gh
+        # directory does not exist in this test's HOME).
+        loaded_first = json.loads(first)
+        self.assertNotIn(
+            "~/.config/gh", loaded_first["sandbox"]["filesystem"]["denyRead"],
+        )
+        rc2 = p.process_user_common_sandbox(
+            settings_path=self.settings_path,
+            home=self.home,
+            dry_run=False,
+            no_backup=True,
+        )
+        self.assertEqual(rc2, 0)
+        self.assertEqual(self.settings_path.read_text(encoding="utf-8"), first)
+
+    def test_dry_run_renders_removed_legacy_entry(self) -> None:
+        # Capture the dry-run report and confirm the retire branch
+        # surfaces the removal so the operator can audit the change.
+        self.settings_path.write_text(json.dumps({
+            "sandbox": {"filesystem": {"denyRead": ["~/.config/gh"]}},
+        }), encoding="utf-8")
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = p.process_user_common_sandbox(
+                settings_path=self.settings_path,
+                home=self.home,
+                dry_run=True,
+                no_backup=True,
+            )
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn("denyRead removed", out)
+        self.assertIn("~/.config/gh", out)
+        # File must remain untouched in dry-run.
+        self.assertEqual(
+            json.loads(self.settings_path.read_text(encoding="utf-8")),
+            {"sandbox": {"filesystem": {"denyRead": ["~/.config/gh"]}}},
+        )
 
     def test_dry_run_renders_skipped_even_on_noop(self) -> None:
         # First merge populates the file; then a second --dry-run is a


### PR DESCRIPTION
## Summary

Remove `~/.config/gh` from the sandbox `denyRead` candidate set so that the Secretary pane can use the `gh` CLI (push / `gh pr create` / `gh pr checks --watch` / `tools/pr-watch.*` / `tools/set_run_pr_open.py`) under the default sandbox without flipping every call to `dangerouslyDisableSandbox`. Existing users who already have the entry baked into their personal `~/.claude/settings.json` get it removed automatically by the next `--user-common-sandbox` run.

> Supersedes #437 (the original PR was rebased onto the freshly merged main of the README refactor, but the project's git-push hook blocks all `--force` family flags including `--force-with-lease` by current policy, so the rebased history is delivered on a fresh branch instead. Same commits, same diff.)

- **Drop from candidate set**: `tools/org_setup_prune.py` `USER_COMMON_SANDBOX_DENYREAD_CANDIDATES` no longer carries `~/.config/gh`. The other entries (`~/.ssh`, `~/.aws`, `~/.kube`, `~/.gnupg`, `~/.docker`, `~/.config/aws-vault`) stay; the Secretary does not touch those directories in its normal flow, so the defense-in-depth remains for credentials that are genuinely off-path.
- **Auto-prune existing entry**: new `USER_COMMON_SANDBOX_DENYREAD_REMOVE` retire list is consumed by `_merge_sandbox_deny(..., remove=...)`. Running `--user-common-sandbox` on a settings.json that still has `~/.config/gh` in `denyRead` removes that one entry while leaving every other deny untouched (defensive guard: if the same path were ever re-added to the candidate set in the future, the retire pass refuses to remove it). Both dry-run and write modes surface a `removed (retired candidate)` label so the operator sees what changed.
- **Docs alignment**: `permissions.md`, `README.md`, and `docs/getting-started.md` drop `~/.config/gh` from the candidate enumeration. The reason (gh CLI is required for the Secretary's operational path — push / PR creation / CI watch / review feedback loop / merge cleanup) is now stated as self-contained prose rather than as an Issue-trace pointer.
- **Tests**: `tools/test_org_setup_prune.py` adds 10 new cases — `CandidateSetTests` (3) for the candidate-set shape, `MergeUserCommonSandboxTests` (4) for the retire semantics + defensive guard, and `UserCommonSandboxEndToEndTests` (3) for end-to-end retire (existing entry pruned + idempotency + denyWrite unaffected). Full suite is 74 tests, all green.

## Test plan

- [ ] `python -m unittest tools.test_org_setup_prune` — 74 tests pass
- [ ] `python tools/org_setup_prune.py --user-common-sandbox --dry-run` against a `~/.claude/settings.json` that has `~/.config/gh` baked in — confirm `removed (retired candidate): - ~/.config/gh` appears and nothing else is touched
- [ ] `python tools/org_setup_prune.py --user-common-sandbox --dry-run` against a clean settings.json (no `~/.config/gh`) — confirm `no changes`
- [ ] `python tools/check_role_configs.py` — drift-free
- [ ] After this lands, Secretary pane can run `gh auth status` / `git push` / `gh pr create` / `tools/pr-watch.sh <PR>` under the default sandbox

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)