### PR TITLE
feat(secretary): add handover/resume skills for context refresh

### DIFF
--- a/.claude/skills/secretary-handover/SKILL.md
+++ b/.claude/skills/secretary-handover/SKILL.md
@@ -39,17 +39,24 @@ description: >
 
 ## Step 2: state.db から構造化情報を取得する
 
-handover に参考情報として埋め込む。
+handover に参考情報として埋め込む。書き出し先は sandbox で write 可能な `$TMPDIR`
+（未設定なら `/tmp` フォールバック）に置く:
 
 ```bash
-python -c "
+python3 -c "
 from tools.state_db import connect
 from tools.state_db.queries import get_org_state_summary
-import json
+import json, os
 conn = connect('.state/state.db')
-print(json.dumps(get_org_state_summary(conn), ensure_ascii=False, indent=2, default=str))
-" > /tmp/secretary-handover-state.json
+out_path = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'secretary-handover-state.json')
+with open(out_path, 'w') as f:
+    json.dump(get_org_state_summary(conn), f, ensure_ascii=False, indent=2, default=str)
+print(out_path)
+"
 ```
+
+シェルリダイレクトで `> /tmp/...` を使うと、sandbox 環境では `/tmp` が read-only で
+書き込み失敗する。Python 側で `TMPDIR` を解決してから `open(..., 'w')` する形が安全。
 
 ここから以下を取り出す:
 - `session.status` / `session.objective`

--- a/.claude/skills/secretary-handover/SKILL.md
+++ b/.claude/skills/secretary-handover/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: secretary-handover
+description: >
+  窓口のコンテキストを圧迫したまま session を続けるのを避けるため、
+  直近のやり取り・進行中ワーク・組織状態を handover ファイルに書き出し、
+  /clear → /secretary-resume で新しい窓口セッションを開始する準備をする。
+  「リフレッシュ」「窓口を引き継ぎたい」「コンテキスト整理」と言われたとき、
+  または窓口自身が context が長くなったと判断したときに使う。
+---
+
+# secretary-handover: 窓口の引き継ぎ
+
+窓口セッションを長期化させずに、組織員としての自覚と直近やり取りを次セッションへ
+受け渡すための引き継ぎファイルを作る。書き出した後にユーザーへ `/clear` →
+`/secretary-resume` の流れを案内する。
+
+> **重要な前提**:
+> - ディスパッチャー / キュレーター / ワーカーのペインは生かしたまま残す。
+>   `/clear` は窓口の Claude コンテキストだけをリセットするので、state.db と
+>   handover ファイルから復帰できれば組織は途切れない。
+> - state DB (`.state/state.db`) は唯一の SoT。ペイン identity やワーク状態は
+>   そちらから引ける。handover はあくまで「会話の温度感」「人間との合意」「進行中の判断」など、
+>   構造化データに収まらない部分を残すために使う。
+
+## Step 1: handover 対象を整理する
+
+書き出す前に、窓口（自分）の context から以下を抽出する:
+
+1. **直近の人間との合意・判断**
+   - 採用した方針、却下した選択肢、保留中の検討事項
+2. **進行中のワーク**
+   - 派遣中のワーカー、その task_id、最新の進捗ステータス
+3. **Pending Decisions（人間に投げて未回答）**
+   - `.state/pending_decisions.json` があれば併読し、register と context の差分を残す
+4. **次のアクション（窓口視点）**
+   - 次に自分が何をすべきか、誰の返答を待っているか
+5. **直近の重要なやり取り抜粋**
+   - ユーザーが言った決定的な一言、自分が提案して合意された案など、3〜6 項目程度
+
+## Step 2: state.db から構造化情報を取得する
+
+handover に参考情報として埋め込む。
+
+```bash
+python -c "
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json
+conn = connect('.state/state.db')
+print(json.dumps(get_org_state_summary(conn), ensure_ascii=False, indent=2, default=str))
+" > /tmp/secretary-handover-state.json
+```
+
+ここから以下を取り出す:
+- `session.status` / `session.objective`
+- `session.dispatcher_pane_id` / `session.dispatcher_peer_id`
+- `session.curator_pane_id` / `session.curator_peer_id`
+- `active_runs[]`（進行中タスク）
+- `active_worker_dirs[]`（生きているワーカーディレクトリ）
+- 直近の `recent_events` 上位 3〜5 件
+
+## Step 3: handover ファイルを書き出す
+
+書き出し先: `.state/secretary-handover.md`
+
+既存ファイルがあれば `.state/secretary-handover.prev.md` にバックアップしてから上書きする:
+
+```bash
+[ -f .state/secretary-handover.md ] && cp .state/secretary-handover.md .state/secretary-handover.prev.md
+```
+
+フォーマット（YAML frontmatter + markdown）:
+
+```markdown
+---
+created_at: <UTC ISO8601>
+session_status: <ACTIVE | IDLE | SUSPENDED>
+session_objective: <一行サマリー or null>
+dispatcher_pane: <pane_id> / peer=<peer_id>
+curator_pane: <pane_id> / peer=<peer_id>
+---
+
+# Secretary Handover
+
+## 直近の人間との合意・判断
+- ...
+
+## 進行中のワーク
+- worker-<task_id> (<worker_dir>): <最新の状態 / 待ち事項>
+- ...
+
+## Pending Decisions（人間に投げて未回答）
+- ...
+（無ければ「なし」と明記する。空にしない）
+
+## 次のアクション（窓口視点）
+- ...
+
+## 直近の重要なやり取り抜粋
+- user: 「...」
+- 窓口: 「...」
+- ...
+
+## 参考: state.db スナップショット
+（Step 2 で取得した active_runs / recent_events を簡潔に転記。
+ 全文は `.state/state.db` に残っているので最小限でよい）
+```
+
+**書き方の注意**:
+- 「過去ログ」ではなく「次の自分への申し送り」として書く。たとえば
+  「ユーザーは B 案で進めたい意向」「ワーカーからの retro gate ack 待ち」のような形。
+- 機密情報・トークン・パスワードは絶対に書かない。
+- ファイルは人間も読むことを想定する。
+
+## Step 4: イベントを記録する
+
+```bash
+py -3 tools/journal_append.py secretary_handover \
+    --json '{"reason": "context_compaction", "active_workers": [...]}' 2>/dev/null \
+    || echo "(journal_append unavailable; skipping)"
+```
+
+## Step 5: ユーザーへ案内する
+
+以下のメッセージで完了報告する:
+
+```
+窓口の handover を `.state/secretary-handover.md` に書き出しました。
+このまま /clear で context をリセットしてください。
+新しい窓口セッションが始まったら /secretary-resume を実行すると、
+handover を読み込んで現状把握した状態で再開できます。
+
+ディスパッチャー・キュレーター・ワーカーペインはそのまま稼働を続けるので、
+組織は中断されません。
+```
+
+**窓口がやってはいけないこと**:
+- `/clear` を自分で打とうとしない（Claude Code 側のコマンド、ユーザーが入力する）
+- ディスパッチャーやキュレーターに SHUTDOWN を送らない（/org-suspend ではないので、
+  ペインは生かしたまま残す）

--- a/.claude/skills/secretary-resume/SKILL.md
+++ b/.claude/skills/secretary-resume/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: secretary-resume
+description: >
+  /secretary-handover で書き出した handover ファイルを読み込み、
+  窓口を新しいセッションで復帰させる。/clear 直後の最初のターンで使う。
+  「窓口を復帰」「resume」「引き継ぎから再開」と言われたときに使う。
+  /org-start ではない（ディスパッチャー・キュレーターは既に生きている前提）。
+---
+
+# secretary-resume: 窓口の復帰
+
+`/secretary-handover` で書き出した `.state/secretary-handover.md` を読み込み、
+窓口として最低限の自覚（組織員としての立ち位置・直近の人間とのやり取り・進行中ワーク）
+を復元する。
+
+> **前提**:
+> - ディスパッチャー / キュレーター / ワーカーのペインは前セッションから生きたまま
+>   残っている。新たに spawn しない（/org-start ではない）。
+> - state DB (`.state/state.db`) はそのまま使う。ペイン identity の再記録も不要。
+> - handover ファイルが存在しないか古すぎる場合は、/org-start もしくは
+>   /org-resume の使用を案内する。
+
+## Step 0: 自分の identity を確認する
+
+1. `mcp__renga-peers__set_summary` で「Secretary: 窓口（resumed）」をセット
+2. `mcp__renga-peers__list_panes` でフォーカスペインの name/role を確認:
+   - 期待値: `name == "secretary"` かつ `role == "secretary"`
+   - 不一致なら `mcp__renga-peers__set_pane_identity(target="focused", name="secretary", role="secretary")` で修復
+
+## Step 1: handover ファイルを読み込む
+
+1. `.state/secretary-handover.md` が存在するか確認:
+   ```bash
+   ls -la .state/secretary-handover.md 2>&1
+   ```
+   - 存在しない → ユーザーに案内して停止:
+     「handover ファイルがありません。/org-start で組織を起動するか、
+     /org-resume で suspend 状態から再開してください。」
+2. フロントマター `created_at` を見て鮮度を判定:
+   - 24 時間以内 → そのまま採用
+   - 24 時間超〜7 日以内 → ユーザーに警告（「handover が古いです、続行しますか？」）
+   - 7 日超 → 採用せず、`/org-start` への切り替えを推奨する
+3. ファイル本文を Read で取り込む。**書かれている内容は次セッションの自分にとっての
+   「事実」として扱う**（後の Step 3 で state.db と照合する）。
+
+## Step 2: state.db で現状を再取得する
+
+```bash
+python -c "
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json
+conn = connect('.state/state.db')
+print(json.dumps(get_org_state_summary(conn), ensure_ascii=False, indent=2, default=str))
+"
+```
+
+確認項目:
+- `session.status` が handover フロントマターと一致するか
+- `dispatcher_pane_id` / `curator_pane_id` が handover に書いた値と一致するか
+- `active_runs[]` が handover の「進行中のワーク」セクションと整合するか
+
+## Step 3: ペイン生存確認
+
+```
+mcp__renga-peers__list_peers
+```
+
+- ディスパッチャー / キュレーターの name が見えること
+- handover に記載のワーカーが現存するか（消えていれば後述）
+
+**差分があれば人間に報告する**（例:「handover ではワーカー X が進行中とありますが、
+現在のペインリストには見当たりません」）。勝手に再 spawn しない。
+
+## Step 4: ブリーフィングを人間に返す
+
+handover の情報と state.db の現状を統合した上で、以下の構造で簡潔に報告:
+
+```
+窓口を復帰しました。
+
+【セッション】
+- 目的: <session.objective>
+- 状態: <session.status>
+
+【ペイン構成】
+- dispatcher (pane=N, peer=M)
+- curator (pane=N, peer=M)
+- workers: <task_id list>
+
+【直近の合意・判断】
+- ...
+
+【Pending Decisions】
+- ...（無ければ「なし」）
+
+【次のアクション】
+- ...
+
+ご指示をお願いします。
+```
+
+## Step 5: handover ファイルを保持する
+
+- 削除しない（次回トラブル時の参照用に残す）
+- `.state/secretary-handover.prev.md` は前回のもの。読み込み済みであっても消さない
+
+## イベント記録
+
+```bash
+py -3 tools/journal_append.py secretary_resumed \
+    --json '{"handover_age_hours": <数値>}' 2>/dev/null \
+    || echo "(journal_append unavailable; skipping)"
+```
+
+## やってはいけないこと
+
+- 新規にディスパッチャー / キュレーターを spawn する（既に生きている）
+- ワーカーに勝手に SUSPEND / SHUTDOWN を送る
+- handover の内容と state.db の現状が食い違うときに、勝手にどちらかへ寄せる
+  （必ず人間に報告して判断を仰ぐ）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@
   - [`/org-delegate`](./.claude/skills/org-delegate/SKILL.md) — 作業委託（ワーカーへの指示組み立て・ディスパッチャー経由の派遣）
   - [`/org-escalation`](./.claude/skills/org-escalation/SKILL.md) — 判断仰ぎを人間にエスカレーションする正準フロー（pending-decisions register 更新を含む）
   - [`/org-pull-request`](./.claude/skills/org-pull-request/SKILL.md) — ユーザー承認後の push / PR 作成 / CI 監視 / レビュー指摘ループ / マージ後クローズ
+- 窓口セッションの context が長くなったら以下で引き継ぎ:
+  - [`/secretary-handover`](./.claude/skills/secretary-handover/SKILL.md) — 直近やり取り・組織状態を `.state/secretary-handover.md` に書き出す（ペインは生かしたまま）
+  - [`/secretary-resume`](./.claude/skills/secretary-resume/SKILL.md) — `/clear` 後の最初のターンで handover を読み込んで窓口復帰
 - 実作業は全てワーカーに委譲する（コード編集、デバッグ、テスト、ビルド、git commit、環境構築等）
 - 問題が報告されたら、自分で調査せずワーカーに投げる
 


### PR DESCRIPTION
## Summary

- 窓口セッションの context が長くなったときに `/clear` で context をリセットしつつ、組織員としての自覚と直近の人間とのやり取りを次セッションへ渡すための 2 スキルを追加
- `/secretary-handover` で `.state/secretary-handover.md` に申し送りを書き出し、`/clear` 後に `/secretary-resume` で復帰する設計
- ディスパッチャー・キュレーター・ワーカーの各ペインは生かしたまま再利用するので、組織は途切れない

## 設計の前提

- `state.db` は唯一の SoT。ペイン identity / ワーク状態はそちらから引く
- handover.md は構造化データに収まらない「会話の温度感」「人間との合意」「進行中の判断」を残す用途
- 鮮度判定: 24h 以内そのまま採用 / 24h〜7d 警告 / 7d 超は `/org-start` を推奨

## Test plan

- [ ] `/secretary-handover` 発火確認（description trigger）
- [ ] `.state/secretary-handover.md` が想定フォーマットで書き出される
- [ ] `/clear` 後の `/secretary-resume` で handover が読み込まれ、現状把握まで到達できる
- [ ] handover が無い状態で `/secretary-resume` を叩いたとき、`/org-start` への切り替え案内が出る
- [ ] CLAUDE.md「役割の境界」セクションから両スキルへのリンクが解決する