### PR TITLE
test(claude): add attention watcher integration fixtures (Closes #445)

### DIFF
--- a/tests/fixtures/attention/expected_scan.json
+++ b/tests/fixtures/attention/expected_scan.json
@@ -1,0 +1,47 @@
+[
+  {
+    "key": "event:2",
+    "kind": "approval_blocked",
+    "severity": "urgent",
+    "title": "Worker approval required",
+    "body": "worker-T-approval is waiting for approval.",
+    "source": "state.db.events",
+    "task_id": "T-approval",
+    "worker": "worker-T-approval",
+    "created_at": "2026-05-01T01:00:00Z"
+  },
+  {
+    "key": "event:4",
+    "kind": "ci_failed",
+    "severity": "urgent",
+    "title": "CI failed",
+    "body": "PR #42 finished with failed.",
+    "source": "state.db.events",
+    "task_id": "T-ci-fail",
+    "pr": 42,
+    "status": "failed",
+    "created_at": "2026-05-01T03:00:00Z"
+  },
+  {
+    "key": "pending:T-pending-stale:pending_decision",
+    "kind": "pending_decision",
+    "severity": "urgent",
+    "title": "Pending decision",
+    "body": "T-pending-stale is waiting for human judgment.",
+    "source": "pending_decisions",
+    "task_id": "T-pending-stale",
+    "summary": "Need approval to expand scope to migration cleanup.",
+    "created_at": "2026-01-01T00:00:00Z"
+  },
+  {
+    "key": "pending:T-relay-gap:user_reply_not_forwarded",
+    "kind": "user_reply_not_forwarded",
+    "severity": "urgent",
+    "title": "User reply not forwarded",
+    "body": "T-relay-gap: user reply has not been relayed to the worker.",
+    "source": "pending_decisions",
+    "task_id": "T-relay-gap",
+    "summary": "Codex review round 3 done; OK to merge?",
+    "created_at": "2026-01-02T00:00:00Z"
+  }
+]

--- a/tests/fixtures/attention/expected_scan.json
+++ b/tests/fixtures/attention/expected_scan.json
@@ -12,6 +12,28 @@
   },
   {
     "key": "event:4",
+    "kind": "relay_gap_suspected",
+    "severity": "urgent",
+    "title": "Secretary relay gap suspected",
+    "body": "Relay gap detected for T-relay-suspected.",
+    "source": "state.db.events",
+    "task_id": "T-relay-suspected",
+    "worker": "worker-T-relay-suspected",
+    "created_at": "2026-05-01T02:30:00Z"
+  },
+  {
+    "key": "event:5",
+    "kind": "silent_worker_output",
+    "severity": "urgent",
+    "title": "Silent worker output",
+    "body": "worker-T-silent produced output without a peer message.",
+    "source": "state.db.events",
+    "task_id": "T-silent",
+    "worker": "worker-T-silent",
+    "created_at": "2026-05-01T02:45:00Z"
+  },
+  {
+    "key": "event:6",
     "kind": "ci_failed",
     "severity": "urgent",
     "title": "CI failed",

--- a/tests/fixtures/attention/pending_decisions.json
+++ b/tests/fixtures/attention/pending_decisions.json
@@ -13,9 +13,9 @@
     "user_replied_at": "2026-01-02T00:00:00Z"
   },
   {
-    "task_id": "T-fresh",
+    "task_id": "T-future-dated",
     "received_at": "2099-01-01T00:00:00Z",
-    "raw_message": "Just asked, no urgency.",
+    "raw_message": "Below threshold (received_at far in the future so _minutes_since stays negative regardless of wall clock).",
     "status": "pending"
   }
 ]

--- a/tests/fixtures/attention/pending_decisions.json
+++ b/tests/fixtures/attention/pending_decisions.json
@@ -1,0 +1,21 @@
+[
+  {
+    "task_id": "T-pending-stale",
+    "received_at": "2026-01-01T00:00:00Z",
+    "raw_message": "Need approval to expand scope to migration cleanup.",
+    "status": "pending"
+  },
+  {
+    "task_id": "T-relay-gap",
+    "received_at": "2026-01-01T00:30:00Z",
+    "raw_message": "Codex review round 3 done; OK to merge?",
+    "status": "escalated",
+    "user_replied_at": "2026-01-02T00:00:00Z"
+  },
+  {
+    "task_id": "T-fresh",
+    "received_at": "2099-01-01T00:00:00Z",
+    "raw_message": "Just asked, no urgency.",
+    "status": "pending"
+  }
+]

--- a/tests/fixtures/attention/state_events.json
+++ b/tests/fixtures/attention/state_events.json
@@ -25,6 +25,26 @@
     }
   },
   {
+    "kind": "notify_sent",
+    "occurred_at": "2026-05-01T02:30:00Z",
+    "actor": null,
+    "payload": {
+      "kind": "relay_gap_suspected",
+      "task_id": "T-relay-suspected",
+      "worker": "worker-T-relay-suspected"
+    }
+  },
+  {
+    "kind": "notify_sent",
+    "occurred_at": "2026-05-01T02:45:00Z",
+    "actor": null,
+    "payload": {
+      "kind": "pane_output_without_peer_msg",
+      "task_id": "T-silent",
+      "worker": "worker-T-silent"
+    }
+  },
+  {
     "kind": "ci_completed",
     "occurred_at": "2026-05-01T03:00:00Z",
     "actor": null,

--- a/tests/fixtures/attention/state_events.json
+++ b/tests/fixtures/attention/state_events.json
@@ -1,0 +1,47 @@
+[
+  {
+    "kind": "heartbeat",
+    "occurred_at": "2026-05-01T00:00:00Z",
+    "actor": null,
+    "payload": {}
+  },
+  {
+    "kind": "notify_sent",
+    "occurred_at": "2026-05-01T01:00:00Z",
+    "actor": null,
+    "payload": {
+      "kind": "approval_blocked",
+      "task_id": "T-approval",
+      "worker": "worker-T-approval"
+    }
+  },
+  {
+    "kind": "notify_sent",
+    "occurred_at": "2026-05-01T02:00:00Z",
+    "actor": null,
+    "payload": {
+      "kind": "heartbeat_ping",
+      "task_id": "T-ignored"
+    }
+  },
+  {
+    "kind": "ci_completed",
+    "occurred_at": "2026-05-01T03:00:00Z",
+    "actor": null,
+    "payload": {
+      "status": "failed",
+      "pr": 42,
+      "task_id": "T-ci-fail"
+    }
+  },
+  {
+    "kind": "ci_completed",
+    "occurred_at": "2026-05-01T03:30:00Z",
+    "actor": null,
+    "payload": {
+      "status": "success",
+      "pr": 43,
+      "task_id": "T-ci-ok"
+    }
+  }
+]

--- a/tests/test_attention_runtime_integration.py
+++ b/tests/test_attention_runtime_integration.py
@@ -1,0 +1,249 @@
+"""Layer 4 integration test for ``claude-org-runtime attention scan``.
+
+Feeds a hand-curated fixture (``tests/fixtures/attention/``) into the
+runtime CLI and asserts that the ``--dry-run --json`` output matches a
+checked-in golden file. This is the drift-detection seam between ja's
+``.state`` shape and the runtime classifier: if the runtime adds or
+renames an urgent kind ja could plausibly emit, this test fails and
+forces a deliberate vocabulary reconciliation on the ja side.
+
+Design source: ``docs/design/attention-notification.md`` §8 (companion
+to runtime PRs #19 + #20 — attention scan/watch CLI and template
+overrides). The runtime CLI ships in ``claude-org-runtime>=0.1.10``;
+on older runtimes that don't expose the ``attention`` subcommand the
+test skips with a clear message instead of failing.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "attention"
+STATE_EVENTS_JSON = FIXTURE_DIR / "state_events.json"
+PENDING_JSON = FIXTURE_DIR / "pending_decisions.json"
+GOLDEN_JSON = FIXTURE_DIR / "expected_scan.json"
+
+# Mirrors the attention-relevant columns of tools/state_db/schema.sql.
+# Projecting only what the runtime reader touches keeps a non-attention
+# schema migration from breaking this test.
+_EVENTS_SCHEMA = """
+CREATE TABLE events (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  occurred_at  TEXT NOT NULL DEFAULT '2026-05-01T00:00:00Z',
+  actor        TEXT,
+  kind         TEXT NOT NULL,
+  payload_json TEXT NOT NULL DEFAULT '{}'
+);
+"""
+
+# Dispatch metadata depends on the host OS notification backend
+# (notify-send vs stdout vs PowerShell). The integration contract under
+# test is the classifier output, not the delivery channel, so these
+# fields are stripped before comparing against the golden.
+_DISPATCH_ONLY_KEYS = frozenset({
+    "desktop_dispatched", "bell_dispatched", "delivered",
+})
+
+# Drift canary: the set of urgent attention kinds the fixture is
+# expected to surface. If the runtime stops classifying any of these
+# as urgent, the assertion in
+# test_all_expected_urgent_kinds_are_recognized fails and points at
+# the gap.
+_EXPECTED_URGENT_KINDS = frozenset({
+    "approval_blocked",
+    "ci_failed",
+    "pending_decision",
+    "user_reply_not_forwarded",
+})
+
+
+def _build_state_db(db_path: Path, events: list[dict]) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(_EVENTS_SCHEMA)
+        for ev in events:
+            conn.execute(
+                "INSERT INTO events (occurred_at, actor, kind, payload_json)"
+                " VALUES (?, ?, ?, ?)",
+                (
+                    ev["occurred_at"],
+                    ev.get("actor"),
+                    ev["kind"],
+                    json.dumps(ev.get("payload", {})),
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _normalize(events: list[dict]) -> list[dict]:
+    """Strip env-dependent dispatch keys and sort by stable ``key``.
+
+    The CLI emits events in a deterministic order (DB events by id ASC,
+    then pending decisions in file order), but sorting both sides keeps
+    the assertion message readable when only one event drifts.
+    """
+    return sorted(
+        ({k: v for k, v in ev.items() if k not in _DISPATCH_ONLY_KEYS}
+         for ev in events),
+        key=lambda ev: ev["key"],
+    )
+
+
+def _runtime_has_attention() -> bool:
+    """Probe for the ``attention`` subcommand on the installed runtime."""
+    exe = shutil.which("claude-org-runtime")
+    if exe is None:
+        return False
+    proc = subprocess.run(
+        [exe, "attention", "--help"],
+        capture_output=True, text=True, timeout=10,
+    )
+    return proc.returncode == 0
+
+
+class AttentionRuntimeIntegrationTests(unittest.TestCase):
+    """End-to-end check: ja fixture → runtime CLI → golden output."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not _runtime_has_attention():
+            raise unittest.SkipTest(
+                "claude-org-runtime CLI without 'attention' subcommand; "
+                "install claude-org-runtime>=0.1.10 to run this test"
+            )
+        cls.events_spec = json.loads(
+            STATE_EVENTS_JSON.read_text(encoding="utf-8"),
+        )
+        cls.pending = json.loads(
+            PENDING_JSON.read_text(encoding="utf-8"),
+        )
+        cls.golden = json.loads(
+            GOLDEN_JSON.read_text(encoding="utf-8"),
+        )
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.state_dir = Path(self._tmpdir.name) / ".state"
+        self.state_dir.mkdir()
+        _build_state_db(self.state_dir / "state.db", self.events_spec)
+        (self.state_dir / "pending_decisions.json").write_text(
+            json.dumps(self.pending, indent=2), encoding="utf-8",
+        )
+
+    def _run_scan(self) -> list[dict]:
+        result = subprocess.run(
+            [
+                "claude-org-runtime", "attention", "scan",
+                "--state-dir", str(self.state_dir),
+                "--dry-run", "--json",
+            ],
+            check=False, capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"attention scan exited with {result.returncode}; "
+            f"stderr={result.stderr!r}",
+        )
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(
+                f"attention scan stdout was not JSON: {exc}; "
+                f"stdout={result.stdout!r}"
+            )
+
+    # ------------------------------------------------------------------
+    # (1) Whole-fixture comparison against the golden.
+    # ------------------------------------------------------------------
+    def test_scan_output_matches_golden(self) -> None:
+        events = self._run_scan()
+        self.assertEqual(_normalize(events), _normalize(self.golden))
+
+    # ------------------------------------------------------------------
+    # (2) Each individual acceptance case from design §8 is present.
+    # ------------------------------------------------------------------
+    def test_notify_sent_approval_blocked_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:2")
+        self.assertEqual(ev["kind"], "approval_blocked")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["task_id"], "T-approval")
+
+    def test_ci_completed_failed_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:4")
+        self.assertEqual(ev["kind"], "ci_failed")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["pr"], 42)
+        self.assertEqual(ev["status"], "failed")
+
+    def test_stale_pending_decision_is_urgent(self) -> None:
+        ev = self._find_event(
+            self._run_scan(),
+            key="pending:T-pending-stale:pending_decision",
+        )
+        self.assertEqual(ev["kind"], "pending_decision")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["task_id"], "T-pending-stale")
+
+    def test_user_reply_not_forwarded_is_urgent(self) -> None:
+        ev = self._find_event(
+            self._run_scan(),
+            key="pending:T-relay-gap:user_reply_not_forwarded",
+        )
+        self.assertEqual(ev["kind"], "user_reply_not_forwarded")
+        self.assertEqual(ev["severity"], "urgent")
+
+    # ------------------------------------------------------------------
+    # (3) Progress-only and below-threshold cases are dropped.
+    # ------------------------------------------------------------------
+    def test_progress_only_events_are_filtered(self) -> None:
+        keys = {ev["key"] for ev in self._run_scan()}
+        # heartbeat (filtered by reader)
+        self.assertNotIn("event:1", keys)
+        # notify_sent with unrecognized subkind (filtered by classifier)
+        self.assertNotIn("event:3", keys)
+        # ci_completed status=success (filtered by classifier)
+        self.assertNotIn("event:5", keys)
+        # pending decision still inside the freshness window
+        self.assertNotIn("pending:T-fresh:pending_decision", keys)
+
+    # ------------------------------------------------------------------
+    # (4) Drift canary — the runtime must still classify every kind the
+    # ja fixture is built around as urgent.
+    # ------------------------------------------------------------------
+    def test_all_expected_urgent_kinds_are_recognized(self) -> None:
+        urgent_kinds = {
+            ev["kind"] for ev in self._run_scan()
+            if ev.get("severity") == "urgent"
+        }
+        missing = _EXPECTED_URGENT_KINDS - urgent_kinds
+        self.assertEqual(
+            missing, set(),
+            "runtime is no longer classifying "
+            f"{sorted(missing)} as urgent; either the runtime vocabulary "
+            "drifted or the ja fixture is stale — reconcile before merging."
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers.
+    # ------------------------------------------------------------------
+    def _find_event(self, events: list[dict], *, key: str) -> dict:
+        for ev in events:
+            if ev.get("key") == key:
+                return ev
+        self.fail(
+            f"event with key={key!r} not found in scan output; "
+            f"got keys={[ev.get('key') for ev in events]!r}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_attention_runtime_integration.py
+++ b/tests/test_attention_runtime_integration.py
@@ -51,12 +51,15 @@ _DISPATCH_ONLY_KEYS = frozenset({
 })
 
 # Drift canary: the set of urgent attention kinds the fixture is
-# expected to surface. If the runtime stops classifying any of these
-# as urgent, the assertion in
+# expected to surface. Mirrors the urgent rows of
+# docs/design/attention-notification.md §5 — if the runtime stops
+# classifying any of these as urgent, the assertion in
 # test_all_expected_urgent_kinds_are_recognized fails and points at
 # the gap.
 _EXPECTED_URGENT_KINDS = frozenset({
     "approval_blocked",
+    "relay_gap_suspected",
+    "silent_worker_output",
     "ci_failed",
     "pending_decision",
     "user_reply_not_forwarded",
@@ -177,8 +180,18 @@ class AttentionRuntimeIntegrationTests(unittest.TestCase):
         self.assertEqual(ev["severity"], "urgent")
         self.assertEqual(ev["task_id"], "T-approval")
 
-    def test_ci_completed_failed_is_urgent(self) -> None:
+    def test_notify_sent_relay_gap_is_urgent(self) -> None:
         ev = self._find_event(self._run_scan(), key="event:4")
+        self.assertEqual(ev["kind"], "relay_gap_suspected")
+        self.assertEqual(ev["severity"], "urgent")
+
+    def test_notify_sent_silent_output_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:5")
+        self.assertEqual(ev["kind"], "silent_worker_output")
+        self.assertEqual(ev["severity"], "urgent")
+
+    def test_ci_completed_failed_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:6")
         self.assertEqual(ev["kind"], "ci_failed")
         self.assertEqual(ev["severity"], "urgent")
         self.assertEqual(ev["pr"], 42)
@@ -211,9 +224,14 @@ class AttentionRuntimeIntegrationTests(unittest.TestCase):
         # notify_sent with unrecognized subkind (filtered by classifier)
         self.assertNotIn("event:3", keys)
         # ci_completed status=success (filtered by classifier)
-        self.assertNotIn("event:5", keys)
-        # pending decision still inside the freshness window
-        self.assertNotIn("pending:T-fresh:pending_decision", keys)
+        self.assertNotIn("event:7", keys)
+        # pending decision whose received_at is far in the future —
+        # _minutes_since returns negative so the entry stays below the
+        # urgent threshold; this exercises the negative-delta branch
+        # of the staleness check.
+        self.assertNotIn(
+            "pending:T-future-dated:pending_decision", keys,
+        )
 
     # ------------------------------------------------------------------
     # (4) Drift canary — the runtime must still classify every kind the


### PR DESCRIPTION
## Summary

Add ja-side integration verification fixtures for the attention watcher feature thread. Tests subprocess `claude-org-runtime attention scan --dry-run --json` against a generated `state.db` + `pending_decisions.json` fixture and compares the JSON output to a checked-in golden. Serves as a drift canary for the ja event vocabulary against the runtime classifier.

Closes #445.

## Companion to

- `claude-org-runtime` PR #22 — runtime side of attention watcher (CLI + classifier + templates), merged
- `claude-org-ja` PR #452 — Layer 4 distribution (config + docs + README + org-start guidance), in flight

## What's added

| File | Type | Purpose |
|---|---|---|
| `tests/fixtures/attention/state_events.json` | NEW | Events spec materialized into a tmp `state.db` by the test helper (binary commit avoided per design §8) |
| `tests/fixtures/attention/pending_decisions.json` | NEW | Pending register fixture: stale pending decision, escalated-relay-gap, plus a future-dated entry that should NOT trigger |
| `tests/fixtures/attention/expected_scan.json` | NEW | Golden output enumerating the 6 urgent kinds the fixture should produce |
| `tests/test_attention_runtime_integration.py` | NEW | 9-test unittest module: builds the fixture in a tmp dir, invokes `claude-org-runtime attention scan --dry-run --json`, asserts golden match. Gracefully `skipUnless` if the installed runtime lacks the `attention` subcommand |

Diff stat: +424 lines across 4 new files.

## Drift canary semantics

The fixture exercises every urgent kind from design `docs/design/attention-notification.md` §5:

- `notify_sent kind=approval_blocked` → urgent `approval_blocked`
- `notify_sent kind=relay_gap_suspected` → urgent `relay_gap_suspected`
- `notify_sent kind=pane_output_without_peer_msg` → urgent `silent_worker_output`
- `ci_completed status=failed` → urgent `ci_failed`
- stale pending decision → urgent `pending_decision`
- user replied but not forwarded → urgent `user_reply_not_forwarded`
- progress-only event → ignored (asserted absent from output)
- future-dated pending → ignored (asserted absent from output)

If the runtime classifier ever drops or renames an urgent kind that ja `state.db` can emit, this test fails — the canary fires.

## Verification

- `python -m unittest tests.test_attention_runtime_integration -v` → 9 tests OK against an editable install of `claude-org-runtime` from the merged main
- `python -m unittest discover -s tests -v` → 282 tests OK (no existing-suite regressions)
- `python -m unittest discover -s tools -p 'test_*.py'` → 381 tests OK

## Codex self-review

2 rounds:

- R1: Major × 2, Minor × 1
  - Major: golden should exercise all 6 urgent kinds from §5 (not just 4 from the original brief) → expanded
  - Major: future-dated pending must be asserted absent (negative assertion) → added
  - Minor: test cleanup didn't remove tmp dir on failure → wrapped in try/finally
- R2: 1 Major + 1 Minor resolved, 1 Major remained → release coordination question (escalated to Secretary; resolution: Option A — land now, runtime 0.1.10 release later auto-activates canary via CI pip resolve)

## Release coordination

`claude-org-runtime` on PyPI is still 0.1.9 (pre-attention). The runtime PR that adds `attention` subcommand is merged on main but unreleased. With ja pin `>=0.1.9,<0.2`, CI installs the latest available — which is 0.1.9 today, so the 9 tests `skipUnless` to keep the suite green. Once `claude-org-runtime` 0.1.10 ships, CI auto-picks it up, the skip resolves, and the canary becomes active without further PR work. Approved approach per Secretary escalation 2026-05-12.

## Test plan

- [ ] CI green (tests skip gracefully on runtime 0.1.9; suite stays green)
- [ ] After `claude-org-runtime` 0.1.10 release: re-run CI on a fresh PR or on main → canary activates, 9 tests now exercised
- [ ] On merge: design `docs/design/attention-notification.md` §10 "全体 Acceptance Criteria" reaches full satisfaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
