### PR TITLE
feat(claude): instrument secretary awaiting_user emission at 3 gates (Refs #28)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -317,6 +317,11 @@ worker → Secretary peer message
   ```
 - DB の events テーブルにイベント追記 (`bash tools/journal_append.sh ...`)
 - **dogfood pass 完了時の register 更新（Issue #338）**: 完了したタスクが `registry/dogfood_pending.md` の `dogfood_run_task_id` 列に earmark されていた場合、該当行の `status` を `open → consumed` に遷移する。defect は paired follow-up issue (`dogfood_issue` 列) に既に集約されている前提（dogfood pass worker の brief で format 指定済）。protocol 全体は本 SKILL Step 1.8 を SoT
+- **awaiting_user 通知の emit（Issue #28）**: 人間への報告 → 承認待ち停止に入る直前で、attention watcher に「Secretary が user の判断待ちで停止する」ことを知らせる:
+  ```bash
+  bash tools/journal_append.sh notify_sent kind=awaiting_user task_id=<task_id> gate=worker_completed note="<PR/Issue 等の短い文脈>"
+  ```
+  並走 runtime PR の classifier がこの 1 行を `secretary_awaiting_user` (default severity `urgent`) として拾い、画面前にユーザーが居ない場合でもビープで気付ける。CLAUDE.md「secretary が user の判断を待っている状態を通知する」節を参照
 - 結果を人間に報告し、**ペインを閉じず承認待ちで停止**。承認なしで push/PR を発行すると worker / user 双方への protocol 違反
 
 #### 2b / 2c. ユーザー承認後・レビュー指摘・マージ後クローズ

--- a/.claude/skills/org-escalation/SKILL.md
+++ b/.claude/skills/org-escalation/SKILL.md
@@ -51,6 +51,12 @@ description: >
    ```
    escalated entry が無ければ no-op、既に設定済みでも idempotent。これにより [`../../../.dispatcher/references/worker-monitoring.md` Step 5.1 (a-2)](../../../.dispatcher/references/worker-monitoring.md#step-5-1) で「ユーザー返答済みなのに Secretary が転送忘れ」を deterministic に検知できる
 
+4.5. **awaiting_user 通知の emit（Issue #28）**: `mark-user-replied` → `resolve --kind to_worker` の境界で、attention watcher に「ユーザー返答が secretary 側に着き、worker へ転送する間の secretary 側 user-driven 動作」を知らせる 1 行を emit する:
+   ```bash
+   bash tools/journal_append.sh notify_sent kind=awaiting_user task_id={task_id} gate=escalation_reply_forward note="<decision の短い要約>"
+   ```
+   並走 runtime PR の classifier が `secretary_awaiting_user` (default severity `urgent`) として拾う。CLAUDE.md「secretary が user の判断を待っている状態を通知する」節を参照。本 emit は escalated entry の有無に依らず副作用を残さない（journal 1 行追記のみ、register / pending_decisions は触らない）
+
 5. **ワーカーに人間判断を転送する** (`to_id="worker-{task_id}"` で `send_message`)。伝達直後に register を `resolved` に更新:
    ```bash
    python tools/pending_decisions.py resolve --task-id {task_id} --kind to_worker

--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -33,6 +33,11 @@ description: >
 - DB の events テーブルにイベント追記 (push / PR open など、`bash tools/journal_append.sh ...`)
 - PR 番号が確定したら `tools/pr-watch.ps1 <PR>` (Windows) / `tools/pr-watch.sh <PR>` (POSIX) で CI を監視する。完了時に `ci_completed` が自動で events に記録される。CI 完了で pr-watch は **return** する（review feedback loop 2c や手動 close 2b-ii に進めるよう同期占有しない）
 - **renga 環境では pr-watch が CI 完了 / merge 検出 / 24h タイムアウトの瞬間に Secretary へ peer message を送る** (Issue #326)。窓口は events テーブルをポーリングせず、`<channel source="renga-peers"> CI_COMPLETED: PR #<n> ...` (および `PR_MERGED: PR #<n>` / `PR_MERGE_WATCH_TIMEOUT: PR #<n>` / `PR_MERGED_NO_RUN: PR #<n>`) の到着で次のステップへ進める。`CI_COMPLETED` 受信 → ユーザーに merge 承認を仰ぐ → ユーザー承認 → `PR_MERGED` 受信で 2b-ii の post-merge cleanup へ。`PR_MERGED_NO_RUN` は merge は観測したが対応 run 行が見つからなかった失敗系（`tools/run_complete_on_merge.py` の `no_run` 終端）で、post-merge cleanup には進めず人間判断で対処する。RENGA_SOCKET 未設定の plain shell / CI では peer-send は silent noop となり、従来どおり events テーブルのポーリングにフォールバックする
+- **CI_COMPLETED 受信 → ユーザーに merge 承認を仰ぐ直前で awaiting_user 通知を emit する（Issue #28）**: attention watcher にユーザーが merge 承認待ちで stop していることを知らせる:
+  ```bash
+  bash tools/journal_append.sh notify_sent kind=awaiting_user task_id=<task_id> gate=ci_green_merge_gate note="PR #<PR> CI green, awaiting merge approval"
+  ```
+  並走 runtime PR の classifier が `secretary_awaiting_user` (default severity `urgent`) として拾う。CLAUDE.md「secretary が user の判断を待っている状態を通知する」節を参照。`PR_MERGE_WATCH_TIMEOUT` 等の失敗系は対象外（awaiting_user ではなく別経路で人間判断）
 - **merge を待ち合わせたい時のみ** `-MergeWatch` (PowerShell) / `--merge-watch` (POSIX) を付ける。CI 通過後に `gh pr view --json mergedAt` を 24h ポーリングし、初回の merge で `tools/run_complete_on_merge.py` を呼ぶ (Issue #317)。merge-watch 中も pr-watch プロセスは生きたまま、merge 観測時に `pr_merged` イベントを events に追記してから return する
 - run.status は **REVIEW のまま据え置く**（GitHub 側 PR レビュー指摘が来たら同ペインで対応するため。COMPLETED への遷移は 2b-ii で `update_run_status('<task_id>', 'completed')` を呼ぶ）。markdown 直接編集はしない
 - **ペインはまだ閉じない**: PR 作成直後に `CLOSE_PANE` を送らない。worktree 除去・Worker Directory Registry 更新も 2b-ii まで遅延する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,26 @@
 
 retro gate ack は必ず `mcp__renga-peers__send_message(to_id="dispatcher", ...)` で返す。channel broadcast 形式の ack は `dispatcher_retro_gate.py` が `check_messages` で検出できず timeout する。dispatcher 宛の direct send_message のみが retro gate を通過する経路である。
 
+## secretary が user の判断を待っている状態を通知する（Issue #28）
+
+Secretary が「次の一手はユーザーの返答待ち」で停止する gate では、attention watcher がユーザーに気付かせるための信号を 1 行 emit する。Secretary 側は claude-org-ja の本リポジトリで stop しているため、画面前にユーザーが居ない場合 awaiting_user の状態が長時間放置される。この emit を runtime classifier 側で `secretary_awaiting_user` (default severity `urgent`) にマップすることで、ビープ等で通知される。
+
+### 対象 gate（3 箇所）
+- **`worker_completed`**: ワーカーから完了報告を受領 → ack + DB の events テーブルへ review transition を追記 → ユーザーへ承認待ちで停止する直前。[`/org-delegate`](./.claude/skills/org-delegate/SKILL.md) Step 5 sub 2a。
+- **`ci_green_merge_gate`**: PR 作成後の CI 監視で `CI_COMPLETED` 受信（CI green）→ ユーザーへ merge 承認を仰ぐ直前。[`/org-pull-request`](./.claude/skills/org-pull-request/SKILL.md) 2b-i。
+- **`escalation_reply_forward`**: 判断仰ぎを人間に上げ、ユーザー返答を受け取り、ワーカーへ転送する直前。[`/org-escalation`](./.claude/skills/org-escalation/SKILL.md) の `mark-user-replied` → `resolve --kind to_worker` の境界。
+
+### Canonical emit 形
+```
+bash tools/journal_append.sh notify_sent kind=awaiting_user task_id=TASK gate=GATE note=SHORT
+```
+- `task_id`: 対象ワーカー / PR / decision に対応する task_id（escalation_reply_forward の場合は decision に紐付く task_id）。
+- `gate`: `worker_completed` / `ci_green_merge_gate` / `escalation_reply_forward` のいずれか。
+- `note`: 1 行以下の短い文脈（PR 番号 / Issue 番号 / 要約等）。
+
+### 通知側の挙動
+並走の runtime PR が attention watcher classifier に `notify_sent` payload の `kind=awaiting_user` を `secretary_awaiting_user` subkind として認識する mapping を追加する。default severity は `urgent`（即時ビープ）。
+
 ## ワーカーからの判断仰ぎは人間にエスカレーションする
 
 ワーカーから renga-peers で以下のメッセージが来たら、Secretary は **必ず人間に上げる**。一次承認・自己解釈で返答しない:


### PR DESCRIPTION
## Summary

Refs #28 (ja side). Pairs with runtime PR https://github.com/suisya-systems/claude-org-runtime/pull/_NEXT_ which adds the `awaiting_user` `notify_sent` subkind to the attention classifier. Together these close Issue #28 — the attention watcher's gap where secretary-initiated user prompts (push approval, merge approval, escalation reply forward) produced no audible signal because no urgent severity event was being emitted at those moments.

## Approach

Instrument the secretary's existing canonical gates with a single-line `notify_sent` emission. The runtime classifier (paired PR) maps the new subkind to `secretary_awaiting_user` severity `urgent`. Users hear a beep precisely when the secretary is waiting on their input — not before, not after.

## Changes (4 files, +36 lines insertion-only)

1. **`CLAUDE.md`** — new top-level section "secretary が user の判断を待っている状態を通知する (Issue #28)" placed between the retro-gate-ack section and the worker-escalation section. Documents:
   - 3 canonical gates and their gate labels
   - Canonical emit form: `bash tools/journal_append.sh notify_sent kind=awaiting_user task_id=<task> gate=<gate> note=<short>`
   - Runtime classifier default severity is urgent (paired PR adds this)
2. **`.claude/skills/org-delegate/SKILL.md`** Step 5 sub 2a — insert an `awaiting_user` emit bullet (gate=worker_completed) between the events table append and the "結果を人間に報告し承認待ちで停止" line.
3. **`.claude/skills/org-pull-request/SKILL.md`** §2b-i — insert `awaiting_user` emit (gate=ci_green_merge_gate) immediately after the renga peer-message `CI_COMPLETED` notification paragraph, right at the point where secretary asks user for merge approval.
4. **`.claude/skills/org-escalation/SKILL.md`** — insert Step 4.5 (gate=escalation_reply_forward) between `mark-user-replied` and `resolve --kind to_worker`, capturing the "user has replied, secretary is about to forward" gate.

## Verified

- `tools/journal_append.sh` / `.py` accept the freeform `notify_sent` event with `kind=` and arbitrary `k=v` payload already (verified by reading `tools/journal_append.py:76-127`). No tool changes needed.
- `.state/attention.json` local override (`worker_completed`: `urgent`) and runtime classifier defaults are not touched — those are separate concerns. After the paired runtime PR lands and users `pip install -U claude-org-runtime`, the local override becomes redundant and can be reverted manually.

## Out of scope

- Runtime classifier changes (paired PR).
- Auto-resolution of the local `.state/attention.json` override after Issue #28 lands (user-initiated, no automation).

## Test plan

- [ ] `bash tools/check_markdown_link_conventions.sh`
- [ ] Cross-link to runtime PR resolves once that PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)