### PR TITLE
docs(claude): add ja attention template for secretary_awaiting_user (Refs #28)

### DIFF
--- a/tools/templates/attention.example.json
+++ b/tools/templates/attention.example.json
@@ -76,6 +76,10 @@
     "pr_merged": {
       "title": "PR がマージされました",
       "body": "PR #{pr} がマージされました。"
+    },
+    "secretary_awaiting_user": {
+      "title": "窓口が判断待ちです",
+      "body": "{task_id} で窓口がユーザー入力を待っています。"
     }
   }
 }


### PR DESCRIPTION
## Summary

Refs #28. UX polish follow-up to the recently landed runtime PR https://github.com/suisya-systems/claude-org-runtime/pull/30 and ja PR #456. The runtime PR added a `secretary_awaiting_user` attention kind with English `_DEFAULT_TEMPLATES` ("Secretary awaiting user / {task_id} ..."). Without a ja override in `tools/templates/attention.example.json`, watcher output for this kind reads in English while every other surfaced kind has a ja template. This PR adds the missing ja entry.

## Changes

- `tools/templates/attention.example.json`: append one `templates.secretary_awaiting_user` entry:
  - title: `窓口が判断待ちです`
  - body: `{task_id} で窓口がユーザー入力を待っています。`

## Verification

- `python3 -c 'import json; json.load(open("tools/templates/attention.example.json"))'` — valid JSON.
- No changes to `notify` map, TTL config knobs, or any other template entries.

## Out of scope

- Other languages (English defaults remain in runtime; this is the ja repo's template only).
- Per-gate template differentiation (`worker_completed` vs `ci_green_merge_gate` vs `escalation_reply_forward` all share the same template currently — a future enhancement could vary the body per gate, but the runtime classifier surfaces only the kind not the gate so this would need a runtime change first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)