### PR TITLE
docs(claude): add release-class pre-fetch step to org-delegate skill (curator proposal #1)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -83,6 +83,35 @@ description: >
 
 work-skill の手順をそのままコピーしない。参考情報として提示し、ワーカーが判断する。
 
+## Step 0.6: release-class タスクの pre-fetch（窓口が実行）
+
+`release/*` ブランチを切るタスクは worker が **対象プロジェクトの最新 `main`** から branch することを前提とする。Phase 2 worker git guardrails 以降、worker 側 `.claude/settings.json` の `permissions.deny` に `Bash(git fetch)` / `Bash(git pull)` / `Bash(git remote update)` が含まれており、ローカル `origin/main` が古いまま worker をディスパッチすると着手 5 分以内に「git fetch deny」BLOCKER が発火し、窓口往復で 10 分以上のロスになる（claude-org-runtime v0.1.10 事例）。
+
+このため **release-class タスクに限り**、`gen_delegate_payload.py preview` / `apply` の前に窓口側で fetch を代行する:
+
+```bash
+# 対象プロジェクト（release を切るリポジトリ）のローカルルート
+cd <target project root>
+
+# 最新 origin/main を取り込んで local main を ff 更新
+git fetch origin
+git pull --ff-only origin main
+```
+
+### 適用条件
+
+以下のいずれかに該当する場合のみ発動:
+
+- task description / commit-prefix / planned branch に `release`, `release/`, `vX.Y.Z` 等のリリース昇格を示す語が含まれる
+- 対象ファイルに `CHANGELOG.md` の昇格、`__about__.__version__` / `pyproject.toml` の `version` bump 等のリリース昇格作業が含まれる
+- task_id に `release` を含む（例: `runtime-0-1-10-release`）
+
+通常の feature / fix / docs タスクでは実行しない。worker permissions deny は「worker は本流履歴を引き寄せず sandbox 内で完結する」意図的設計であり、release だけが「最新 main からの branch」を必須とする例外フローである。
+
+### 背景・経緯
+
+詳細な経緯（worker 5 分以内 BLOCKER → 10 分追加ロスの実測、4 つの対応選択肢の比較、permissions 側根本原因）は [`knowledge/curated/release-process.md`](../../../knowledge/curated/release-process.md) の「release ブランチ作成時は窓口側で `git fetch` を代行する」節を参照。
+
 ## Step 0.7 / 1 / 1.5 / 2: 1 コマンドで派遣ペイロードを生成（Issue #283）
 
 Step 0.7 (gitignore 事前チェック) / Step 1 (Pattern 判定) / Step 1.5 (ワーカーディレクトリ準備 + role 決定 + settings 生成) / Step 2 (DELEGATE 本文組み立て) は **`tools/gen_delegate_payload.py` が一括で行う**。窓口の責務はタスク特定 (Step 0)・work-skill 検索 (Step 0.5)・対象ファイルの抽出・depth 判断のみ。


### PR DESCRIPTION
## Summary

Adds an explicit pre-dispatch step to `.claude/skills/org-delegate/SKILL.md` requiring Secretary to run `git fetch origin && git pull --ff-only origin main` on the target project directory before delegating any release-class task. Implements curator's improvement proposal #1 from the 2026-05-13 `/org-curate` cycle.

## Background

During runtime `v0.1.10` release dispatch (this session), the release worker hit a BLOCKER on its first iteration because the worker's `.claude/settings` denied `Bash(git fetch)` (pre-PR #24 runtime defaults), and the local `origin/main` ref was stale. ~10 minutes were lost to the escalation/recovery roundtrip. PR #24 (runtime side, shipped in v0.1.11) widened worker permissions to allow `Bash(git fetch:*)`, but the underlying root cause — release worker branches from a stale local main — would still cause confusion (missed CHANGELOG entries from concurrent merges, missed version bumps, etc.) even with the permission unblock.

Curator's curated note `knowledge/curated/release-process.md` captures the in-depth rationale.

## Changes

- `.claude/skills/org-delegate/SKILL.md`: insert Step 0.6 (release-class pre-fetch) between Step 0.5 (work-skill 検索) and Step 0.7 (gitignore pre-check). Documents:
  - applicability conditions (release / vX.Y.Z / task_id contains release)
  - the canonical pre-dispatch commands
  - the historical incident reference (v0.1.10 release dispatch BLOCKER)

Tool / hook layer unchanged. Pure skill-doc addition.

## Test plan

- [ ] \`bash tools/check_markdown_link_conventions.sh\`
- [ ] Skill renders correctly in next release-class dispatch

## Out of scope

- Other delegation workflows — Step 0.6 applies to release-class tasks only.
- Automating the fetch in \`gen_delegate_payload.py\` — Secretary keeps the human-in-the-loop step for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)