### PR TITLE
chore(registry): add token-tracking project

### DIFF
--- a/registry/projects.md
+++ b/registry/projects.md
@@ -20,3 +20,4 @@ claude-org-ja 自身（self-edit）は本レジストリに載せない。`tools
 | renga | renga | https://github.com/suisya-systems/renga | Rust 製の Claude Code 用ターミナルマルチプレクサ（TUI） | 機能追加、バグ修正、Issue 対応 |
 | サンドボックス検証 | sandbox-probe | - | Issue #376 / #377 用の sandbox profile / hook / settings 配備の実測検証エリア。candidate profile を handcraft して probe を回し allow/deny matrix を作る | Pre-Phase 0 spike、probe 反復、profile validation |
 | ランタイム | claude-org-runtime | https://github.com/suisya-systems/claude-org-runtime | Layer 2 = org-runtime: claude-org-ja から抽出された Python runtime (dispatcher / state schema / reference role prompts)。ja は pin で参照する | role_configs_schema.json 同期、release 駆動、dispatcher / settings.generator のメンテ |
+| token-tracking | token-tracking | https://github.com/aainc/token-tracking | Claude Code OTel ローカル監視スタック (otel-collector + Prometheus + Grafana)。個人 (Pro/Max) ローカル構成 + Team plan スケール拡張ガイド付き | dashboard 改修、collector / Grafana 設定更新、export スクリプト機能追加、Team 化作業 |


### PR DESCRIPTION
## Summary
- aainc/token-tracking を registry/projects.md に追加
- Claude Code OTel ローカル監視スタック (otel-collector + Prometheus + Grafana) を Pro/Max 個人ローカル向け + Team plan スケール拡張ガイド付きで配布するリポジトリ
- 次回以降の delegation は Pattern A/B で派遣可能になる

## Test plan
- [ ] dashboard が `_parse_projects` で正しく token-tracking 行をパースできるか (Markdown 表記の整合性)
- [ ] 次回 token-tracking 関連 task を `gen_delegate_payload preview --project-slug token-tracking` で派遣して Pattern A 判定になることを確認