### PR TITLE
skills: add effort/allowed-tools frontmatter to all 14 SKILL.md

### DIFF
--- a/.claude/skills/org-curate/SKILL.md
+++ b/.claude/skills/org-curate/SKILL.md
@@ -4,6 +4,16 @@ description: >
   蓄積された生の学び（knowledge/raw/）を整理・統合する。
   キュレーターClaudeの /loop から定期呼び出しされる。
   手動で「知見を整理して」と言われたときにも使う。
+effort: medium
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(mkdir -p knowledge/raw/archive/)
+  - Bash(mv knowledge/raw/*)
+  - Bash(grep:*)
+  - Bash(find knowledge/*)
+  - mcp__renga-peers__send_message
 ---
 
 # org-curate: 知見整理

--- a/.claude/skills/org-dashboard/SKILL.md
+++ b/.claude/skills/org-dashboard/SKILL.md
@@ -4,6 +4,14 @@ description: >
   組織のダッシュボードを更新してブラウザで開く。
   「ダッシュボード見せて」「状況を可視化して」「プロジェクト一覧見たい」
   「全体像を見せて」等で発動。
+effort: low
+allowed-tools:
+  - Bash(cat .state/dashboard.pid)
+  - Bash(kill -0 *)
+  - Bash(python3 dashboard/server.py *)
+  - Bash(py -3 dashboard/server.py *)
+  - Bash(open http://localhost:8099)
+  - Bash(start http://localhost:8099)
 ---
 
 # org-dashboard: ダッシュボードを開く

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -5,6 +5,23 @@ description: >
   手を動かす実作業は原則としてワーカーに任せる。
   ユーザーから作業の依頼を受けたとき、ファイル編集・実装・調査等の
   実作業が発生する場合に発動する。
+effort: medium
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash(python tools/gen_delegate_payload.py:*)
+  - Bash(py -3 tools/gen_delegate_payload.py:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python -m tools.state_db.importer:*)
+  - Bash(git fetch:*)
+  - Bash(git log:*)
+  - Bash(gh issue create:*)
+  - mcp__renga-peers__send_message
+  - mcp__renga-peers__inspect_pane
+  - mcp__renga-peers__list_peers
+  - mcp__renga-peers__list_panes
 ---
 
 # org-delegate: ワーカー派遣

--- a/.claude/skills/org-escalation/SKILL.md
+++ b/.claude/skills/org-escalation/SKILL.md
@@ -7,6 +7,14 @@ description: >
   scope-expansion / blocker メッセージ受信時。
   通常の進捗 / 完了報告は org-delegate Step 5 (1) / (2a) で扱う。本スキルは
   「自己解釈で承認しないための register 更新を含む正準フロー」を担当する。
+effort: medium
+allowed-tools:
+  - Read
+  - Edit
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(python tools/pending_decisions.py:*)
+  - Bash(py -3 tools/pending_decisions.py:*)
+  - mcp__renga-peers__send_message
 ---
 
 # org-escalation: 判断仰ぎ・スコープ拡張・ブロッカーのエスカレーション

--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -7,6 +7,28 @@ description: >
   (2) GitHub PR にレビュー指摘 / CI 失敗が来てワーカーへ修正指示を送り直すとき、
   (3) PR がマージされ最終クローズ条件を満たしたとき。
   単に「ワーカーに作業を依頼する」初動は org-delegate であり本スキルではない。
+effort: medium
+allowed-tools:
+  - Read
+  - Bash(git push:*)
+  - Bash(git -C * worktree remove:*)
+  - Bash(git worktree remove:*)
+  - Bash(gh pr create:*)
+  - Bash(gh pr view:*)
+  - Bash(gh pr checks:*)
+  - Bash(gh issue create:*)
+  - Bash(gh issue edit:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python tools/set_run_pr_open.py:*)
+  - Bash(py -3 tools/set_run_pr_open.py:*)
+  - Bash(python tools/run_complete_on_merge.py:*)
+  - Bash(py -3 tools/run_complete_on_merge.py:*)
+  - Bash(bash tools/pr-watch.sh:*)
+  - Bash(pwsh tools/pr-watch.ps1:*)
+  - Bash(powershell tools/pr-watch.ps1:*)
+  - mcp__renga-peers__send_message
+  - mcp__renga-peers__check_messages
 ---
 
 # org-pull-request: PR 作成・レビュー・マージ後クローズ

--- a/.claude/skills/org-resume/SKILL.md
+++ b/.claude/skills/org-resume/SKILL.md
@@ -4,6 +4,16 @@ description: >
   中断された組織を再開する。.state/org-state.md が存在し Status: SUSPENDED のとき、
   「再開」「続きから」「前回どこまでやった？」と言われたときに使う。
   起動時の自動ブリーフィングにも対応。
+effort: low
+allowed-tools:
+  - Read
+  - Bash(git status)
+  - Bash(git log:*)
+  - Bash(py -3 tools/state_migrate.py)
+  - Bash(python3 tools/state_migrate.py)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(python -m tools.state_db.importer:*)
 ---
 
 # org-resume: 組織の再開

--- a/.claude/skills/org-retro/SKILL.md
+++ b/.claude/skills/org-retro/SKILL.md
@@ -5,6 +5,12 @@ description: >
   委譲の進め方自体を振り返り、プロセス改善の知見を記録する。
   さらに、完了タスクの作業パターンをwork-skillとして蓄積すべきか判断する。
   実作業の技術的な振り返りはワーカーが自動的に行うため、ここでは扱わない。
+effort: medium
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - mcp__renga-peers__send_message
 ---
 
 # org-retro: 委譲プロセスの振り返り

--- a/.claude/skills/org-setup/SKILL.md
+++ b/.claude/skills/org-setup/SKILL.md
@@ -5,6 +5,15 @@ description: |
   Claude Code の許可設定・環境変数を一括で配置・更新するスキル。
   「設定して」「許可設定を更新して」「セットアップして」
   「permissions設定」「org-setup」等で発動する。
+effort: low
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash(python tools/org_setup_prune.py:*)
+  - Bash(py -3 tools/org_setup_prune.py:*)
+  - Bash(python tools/check_role_configs.py:*)
+  - Bash(py -3 tools/check_role_configs.py:*)
 ---
 
 # org-setup: 組織の許可設定を一括配置

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -4,6 +4,15 @@ description: >
   組織を起動する。前回の状態を読み込んでブリーフィングし、
   ディスパッチャーとキュレーターペインを起動する。ClaudeCode起動直後に1回実行する。
   「起動して」「スタート」「始めて」等でも発動。
+effort: low
+allowed-tools:
+  - Read
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python -m tools.state_db.importer:*)
+  - Bash(py -3 dashboard/org_state_converter.py:*)
+  - Bash(python3 dashboard/org_state_converter.py:*)
+  - mcp__renga-peers__*
 ---
 
 # org-start: 組織の起動

--- a/.claude/skills/org-suspend/SKILL.md
+++ b/.claude/skills/org-suspend/SKILL.md
@@ -3,6 +3,13 @@ name: org-suspend
 description: >
   組織を中断し、全状態をディスクに保存する。「中断」「保存して終了」
   「閉じたい」「一旦やめる」「今日は終わり」と言われたときに使う。
+effort: low
+allowed-tools:
+  - Read
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python -m tools.state_db.importer:*)
+  - mcp__renga-peers__*
 ---
 
 # org-suspend: 組織の中断

--- a/.claude/skills/secretary-handover/SKILL.md
+++ b/.claude/skills/secretary-handover/SKILL.md
@@ -6,6 +6,13 @@ description: >
   /clear → /secretary-resume で新しい窓口セッションを開始する準備をする。
   「リフレッシュ」「窓口を引き継ぎたい」「コンテキスト整理」と言われたとき、
   または窓口自身が context が長くなったと判断したときに使う。
+effort: low
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(bash tools/journal_append.sh:*)
 ---
 
 # secretary-handover: 窓口の引き継ぎ

--- a/.claude/skills/secretary-resume/SKILL.md
+++ b/.claude/skills/secretary-resume/SKILL.md
@@ -5,6 +5,15 @@ description: >
   窓口を新しいセッションで復帰させる。/clear 直後の最初のターンで使う。
   「窓口を復帰」「resume」「引き継ぎから再開」と言われたときに使う。
   /org-start ではない（ディスパッチャー・キュレーターは既に生きている前提）。
+effort: low
+allowed-tools:
+  - Read
+  - Bash(py -3 tools/journal_append.py:*)
+  - mcp__renga-peers__set_summary
+  - mcp__renga-peers__list_panes
+  - mcp__renga-peers__set_pane_identity
+  - mcp__renga-peers__list_peers
+  - mcp__renga-peers__check_messages
 ---
 
 # secretary-resume: 窓口の復帰

--- a/.claude/skills/skill-audit/SKILL.md
+++ b/.claude/skills/skill-audit/SKILL.md
@@ -5,6 +5,13 @@ description: >
   状態ベースで発火する: 候補キュー knowledge/skill-candidates.md の pending が 5 件以上、
   または .claude/skills/ 配下の work-skill 数（org-* を除く）が 20 以上になった場合のみ実行。
   時間ベースの /loop では起動しない（変化の無い日に raw ログを汚す副作用を避けるため）。
+effort: medium
+allowed-tools:
+  - Read
+  - Bash(grep:*)
+  - Bash(find:*)
+  - Bash(wc:*)
+  - mcp__renga-peers__send_message
 ---
 
 # skill-audit: skill 棚卸し

--- a/.claude/skills/skill-eligibility-check/SKILL.md
+++ b/.claude/skills/skill-eligibility-check/SKILL.md
@@ -5,6 +5,11 @@ description: >
   「skill 化推奨 / 候補止まり / curated ノートのまま」の 3 値と根拠を返す。
   自動 skill 化はせず、推奨は knowledge/skill-candidates.md に追記し、
   窓口が候補キューが溜まった時点でバッチで人間に問い合わせる二段構え。
+effort: low
+allowed-tools:
+  - Read
+  - Edit
+  - Write
 ---
 
 # skill-eligibility-check: skill 化判定


### PR DESCRIPTION
## Summary
- Add `effort:` and `allowed-tools:` official frontmatter fields to all 14 SKILL.md files under `.claude/skills/`.
- Per Anthropic Claude Code Skills spec: https://code.claude.com/docs/en/skills#frontmatter-reference
- `effort:` overrides session effort while the skill is active.
- `allowed-tools:` is pre-approval (NOT a deny-list) — listed tools skip per-use approval; unlisted tools still work but go through normal permission flow.

Closes #461

## Test plan
- [x] All 14 SKILL.md frontmatter blocks parse as valid YAML (verified with PyYAML `safe_load`).
- [x] CI green.