### PR TITLE
feat(claude): add dispatcher handover/resume protocol (Closes #464)

### DIFF
--- a/.claude/skills/dispatcher-handover/SKILL.md
+++ b/.claude/skills/dispatcher-handover/SKILL.md
@@ -14,6 +14,8 @@ allowed-tools:
   - Edit
   - Bash(py -3 ../tools/journal_append.py:*)
   - Bash(bash ../tools/journal_append.sh:*)
+  - Bash(python3 -c:*)
+  - Bash(py -3 -c:*)
   - Bash(ls:*)
   - Bash(cp:*)
   - mcp__renga-peers__send_message

--- a/.claude/skills/dispatcher-handover/SKILL.md
+++ b/.claude/skills/dispatcher-handover/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: dispatcher-handover
+description: >
+  ディスパッチャーのコンテキストを圧迫したまま session を続けるのを避けるため、
+  monitoring 状態（active workers / 直近 polling cursor / pending escalations）を
+  handover ファイルに書き出し、secretary の指示で /clear → /dispatcher-resume の
+  流れで新しいディスパッチャー session を開始する準備をする。
+  Secretary から DISPATCHER_HANDOVER peer message を受領したとき、または
+  ディスパッチャー自身が context が長くなったと判断したときに使う。
+effort: low
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(py -3 ../tools/journal_append.py:*)
+  - Bash(bash ../tools/journal_append.sh:*)
+  - Bash(ls:*)
+  - Bash(cp:*)
+  - mcp__renga-peers__send_message
+---
+
+# dispatcher-handover: ディスパッチャーの引き継ぎ
+
+ディスパッチャー session を長期化させずに、現在の monitoring 状態と組織員としての
+立ち位置を次 session へ受け渡すための handover ファイルを作る。書き出した後、
+secretary に「ack を受けたら send_keys で /clear → /dispatcher-resume を打って
+ほしい」と通知する。
+
+> **重要な前提**:
+> - 本 skill は **ディスパッチャー自身**（`.dispatcher/` cwd）が実行する。
+>   secretary から直接呼ぶものではない。
+> - ワーカー / 窓口 / キュレーターのペインは生かしたまま残す。`/clear` は
+>   ディスパッチャー Claude のコンテキストだけをリセットするので、state.db と
+>   handover ファイルから復帰できれば monitoring は途切れない。
+> - ディスパッチャーペイン (name=`dispatcher`) も生かしたまま残す。ペイン自体を
+>   閉じると pane_id / peer_id が変わり、`/loop 3m` の hook 再登録が必要になる。
+>   secretary は `mcp__renga-peers__send_keys(target="dispatcher", ...)` で `/clear`
+>   と `/dispatcher-resume` を打鍵するだけで pane を維持する canonical 経路を取る。
+> - state DB (`.state/state.db`) は唯一の SoT。pane/peer identity は handover に
+>   参考値として書くが、resume 時の真値は `list_panes` / `list_peers` の現観測。
+> - 監視ループに gap を生まないために、以下のファイルは **絶対に削除・編集しない**:
+>   - `.state/dispatcher-event-cursor.txt`（次サイクルの poll_events cursor）
+>   - `.state/dispatcher/worker-idle-state.json`（stall 検出の idle streak）
+>   - `.state/pending_decisions.json`（判断仰ぎ register）
+>   - `.state/workers/worker-*.md`（各ワーカー run state）
+>   handover ファイルは上記の **追加**コンテキスト（人間とのやり取りの温度感は無いが、
+>   進行中の派遣事情・直近の anomaly 観測）に絞る。
+
+## Step 1: handover 対象を整理する
+
+書き出す前に、ディスパッチャー自身の context から以下を抽出する:
+
+1. **直近の派遣事情**
+   - DELEGATE 受信 → spawn 成否、escalate 経路に乗ったタスクの ID
+2. **進行中のワーカー監視**
+   - `.state/workers/worker-*.md` の Status が `active` なペイン名と最新の Progress Log 抜粋
+3. **直近 anomaly 観測の要約**
+   - 過去 1 サイクル分で `journal_append` した `anomaly_observed` / `notify_sent` のうち
+     未解消のもの
+4. **未配送 / 失敗した送信**
+   - `[pane_not_found]` / `[split_refused]` 等で secretary に escalate 済み or
+     再試行待ちのもの
+5. **次のアクション（ディスパッチャー視点）**
+   - 次サイクルで優先的に確認すべき worker / 中継待ちの判断
+
+## Step 2: state.db から構造化情報を取得する
+
+handover に参考情報として埋め込む。書き出し先は sandbox で write 可能な `$TMPDIR`
+（未設定なら `/tmp` フォールバック）に置く:
+
+```bash
+python3 -c "
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json, os
+conn = connect('.state/state.db')
+out_path = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'dispatcher-handover-state.json')
+with open(out_path, 'w') as f:
+    json.dump(get_org_state_summary(conn), f, ensure_ascii=False, indent=2, default=str)
+print(out_path)
+"
+```
+
+ここから以下を取り出す:
+- `session.dispatcher_pane_id` / `session.dispatcher_peer_id`（現在の identity）
+- `active_runs[]`（進行中タスク）
+- `active_worker_dirs[]`（生きているワーカーディレクトリ）
+- 直近の `recent_events` のうち `worker_spawned` / `worker_reported` / `worker_escalation`
+  上位 5 件程度
+
+ディスパッチャーの cwd は `.dispatcher/` なので相対パスは 1 階層上に解決する:
+
+```bash
+# .dispatcher/ から実行する場合
+python3 -c "
+import sys, os
+sys.path.insert(0, os.path.abspath('..'))
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json
+conn = connect('../.state/state.db')
+out_path = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'dispatcher-handover-state.json')
+with open(out_path, 'w') as f:
+    json.dump(get_org_state_summary(conn), f, ensure_ascii=False, indent=2, default=str)
+print(out_path)
+"
+```
+
+## Step 3: handover ファイルを書き出す
+
+書き出し先: `.state/dispatcher-handover.md`（リポジトリルート起点。ディスパッチャー
+cwd `.dispatcher/` からは `../.state/dispatcher-handover.md`）。
+
+既存ファイルがあれば `.prev.md` にバックアップしてから上書きする:
+
+```bash
+[ -f ../.state/dispatcher-handover.md ] && \
+  cp ../.state/dispatcher-handover.md ../.state/dispatcher-handover.prev.md
+```
+
+フォーマット（YAML frontmatter + markdown）:
+
+```markdown
+---
+created_at: <UTC ISO8601>
+dispatcher_pane: <pane_id> / peer=<peer_id>
+active_worker_count: <int>
+event_cursor_present: <true | false>
+idle_state_present: <true | false>
+pending_decisions_count: <int>
+---
+
+# Dispatcher Handover
+
+## 監視対象のワーカー
+- worker-<task_id> (<worker_dir>): Status=<active|...>、直近 Progress Log 1 行抜粋
+- ...
+
+## 直近 anomaly / notify_sent サマリー
+- worker-<task_id>: kind=<approval_blocked|stall_suspected|relay_gap_suspected> ...
+（無ければ「なし」と明記する）
+
+## 未配送 / 失敗した送信
+- ...
+（無ければ「なし」）
+
+## 次のアクション（ディスパッチャー視点）
+- 次サイクルで再確認: worker-<task_id> の <理由>
+- ...
+
+## 監視 gap を埋める参照ファイル（read-only、本 skill は触らない）
+- `.state/dispatcher-event-cursor.txt`: poll_events 次 cursor（resume 後そのまま使う）
+- `.state/dispatcher/worker-idle-state.json`: stall 検出の idle streak
+- `.state/pending_decisions.json`: 判断仰ぎ register
+- `.state/workers/worker-*.md`: 各ワーカー run state
+
+## 参考: state.db スナップショット
+（Step 2 で取得した session / active_runs / recent_events を簡潔に転記）
+```
+
+**書き方の注意**:
+- 「過去ログ」ではなく「次の自分への申し送り」として書く。
+- 機密情報・トークン・パスワードは絶対に書かない。
+- ファイルは secretary / 人間も読むことを想定する。
+
+## Step 4: イベントを記録する
+
+ディスパッチャーの cwd は `.dispatcher/` なので 1 階層上を呼ぶ:
+
+```bash
+bash ../tools/journal_append.sh dispatcher_handover \
+    active_workers=<int> pending_decisions=<int> \
+    note=context_compaction
+```
+
+## Step 5: secretary に通知する
+
+`mcp__renga-peers__send_message(to_id="secretary", message=...)` で以下を伝える:
+
+```
+DISPATCHER_HANDOVER_READY: ../.state/dispatcher-handover.md に書き出しました。
+ack を返したら mcp__renga-peers__send_keys(target="dispatcher") で
+/clear → /dispatcher-resume を順に打鍵してください。
+ペインは閉じないでください（pane_id 維持で監視 gap を最小化）。
+active workers: <count>, pending decisions: <count>。
+```
+
+secretary はこの message を受領して、人間にエスカレーションせず（routine handover
+は判断仰ぎではない）、`send_keys` で /clear と /dispatcher-resume を打鍵する。
+ack が secretary から戻った後、本 skill は完了。次に何もしない（/clear で context
+がリセットされる前提）。
+
+**ディスパッチャーがやってはいけないこと**:
+- `/clear` を自分で打とうとしない（外部から send_keys で受ける側）
+- ワーカーやキュレーターに SHUTDOWN を送らない（pane は生かしたまま）
+- `.state/dispatcher-event-cursor.txt` / `worker-idle-state.json` /
+  `pending_decisions.json` を編集 / 削除しない（resume 時の連続性が壊れる）
+- `/loop 3m` を自分で停止しない（resume 後に再開する設計だが、現サイクルは継続）

--- a/.claude/skills/dispatcher-resume/SKILL.md
+++ b/.claude/skills/dispatcher-resume/SKILL.md
@@ -12,7 +12,10 @@ allowed-tools:
   - Read
   - Bash(py -3 ../tools/journal_append.py:*)
   - Bash(bash ../tools/journal_append.sh:*)
+  - Bash(python3 -c:*)
+  - Bash(py -3 -c:*)
   - Bash(ls:*)
+  - Bash(mv:*)
   - mcp__renga-peers__set_summary
   - mcp__renga-peers__list_panes
   - mcp__renga-peers__set_pane_identity
@@ -162,10 +165,19 @@ DISPATCHER_RESUMED: ディスパッチャー復帰完了。
 - 監視ループ: /loop 3m 再開 (or idle)
 ```
 
-## Step 7: handover ファイルを保持する
+## Step 7: handover ファイルを consumed 状態に切り替える
 
-- 削除しない（次回トラブル時の参照用に残す）
-- `.state/dispatcher-handover.prev.md` も読み込み済みでも消さない
+resume が成功したら、`.state/dispatcher-handover.md` を `.state/dispatcher-handover.consumed.md` に **rename する**。これにより:
+
+- `.dispatcher/CLAUDE.md` 起動時の自動分岐（handover ファイルが直近 7 日以内に存在すれば resume）が「次の `/org-start` cold-start 時にも誤って resume に分岐する」事故を防ぐ
+- 直近 1 件のみ参照用に `.consumed.md` 形式で残る（次の `/dispatcher-handover` が新たに `.md` を書いた時点で `.prev.md` バックアップに置き換わる、または上書きされる）
+
+```bash
+mv ../.state/dispatcher-handover.md ../.state/dispatcher-handover.consumed.md
+```
+
+- 既に `.consumed.md` があれば上書きで構わない（直近 1 件のみ保持）
+- `.state/dispatcher-handover.prev.md` は前回の `/dispatcher-handover` で書かれたバックアップ。読み込み済みでも消さない
 
 ## イベント記録
 

--- a/.claude/skills/dispatcher-resume/SKILL.md
+++ b/.claude/skills/dispatcher-resume/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: dispatcher-resume
+description: >
+  /dispatcher-handover で書き出した handover ファイルを読み込み、
+  ディスパッチャーを新しい session で復帰させる。/clear 直後の最初のターンで使う。
+  state.db の dispatcher_pane_id / dispatcher_peer_id を atomic に更新し、
+  worker monitoring の /loop 3m を再開する。
+  「ディスパッチャー復帰」「resume」「引き継ぎから再開」と secretary から指示された
+  ときに使う。/org-start ではない（ワーカー・窓口・キュレーターは生きている前提）。
+effort: low
+allowed-tools:
+  - Read
+  - Bash(py -3 ../tools/journal_append.py:*)
+  - Bash(bash ../tools/journal_append.sh:*)
+  - Bash(ls:*)
+  - mcp__renga-peers__set_summary
+  - mcp__renga-peers__list_panes
+  - mcp__renga-peers__set_pane_identity
+  - mcp__renga-peers__list_peers
+  - mcp__renga-peers__check_messages
+  - mcp__renga-peers__send_message
+---
+
+# dispatcher-resume: ディスパッチャーの復帰
+
+`/dispatcher-handover` で書き出した `.state/dispatcher-handover.md` を読み込み、
+ディスパッチャーとして最低限の自覚（組織員としての立ち位置・進行中の派遣・監視
+対象ワーカー）を復元し、`/loop 3m` の worker monitoring を再開する。
+
+> **前提**:
+> - ワーカー / 窓口 / キュレーターのペインは前 session から生きたまま残っている。
+>   新たに spawn しない（/org-start ではない）。
+> - 自ペイン（name=`dispatcher`）も生きている。secretary が `send_keys` で
+>   `/clear` → `/dispatcher-resume` を打鍵した直後の状態。pane_id / peer_id は
+>   変わっていないはずだが、必ず観測して state.db を **atomic 更新する**。
+> - state DB (`.state/state.db`) はそのまま使う。
+> - 監視 gap を埋める内部状態ファイル（`.state/dispatcher-event-cursor.txt` /
+>   `.state/dispatcher/worker-idle-state.json` / `.state/pending_decisions.json`）は
+>   前 session から残っている。新規作成・初期化しない（既存値からそのまま継続）。
+> - handover ファイルが存在しないか古すぎる場合は、`/org-start` を案内して停止する。
+
+## Step 0: 自分の identity を確認する
+
+1. `mcp__renga-peers__set_summary` で「Dispatcher: 監視（resumed）」をセット
+2. `mcp__renga-peers__list_panes` でフォーカスペインの name/role を確認:
+   - 期待値: `name == "dispatcher"` かつ `role == "dispatcher"`
+   - 不一致なら `mcp__renga-peers__set_pane_identity(target="focused", name="dispatcher", role="dispatcher")` で修復
+3. 自分の `pane_id` を `list_panes` から取得（`focused: true` の id）
+4. `mcp__renga-peers__list_peers` で `name == "dispatcher"` の `peer_id` を取得
+
+## Step 1: handover ファイルを読み込む
+
+ディスパッチャーの cwd は `.dispatcher/` なので、リポジトリ root のパスを 1 階層上に解決する。
+
+1. `.state/dispatcher-handover.md` が存在するか確認:
+   ```bash
+   ls -la ../.state/dispatcher-handover.md 2>&1
+   ```
+   - 存在しない → secretary に通知して停止:
+     ```
+     DISPATCHER_RESUME_FAILED: handover ファイルがありません。
+     /org-start でディスパッチャーを cold start してください。
+     ```
+2. フロントマター `created_at` を見て鮮度を判定:
+   - 24 時間以内 → そのまま採用
+   - 24 時間超〜7 日以内 → secretary に警告（「handover が古い、続行する旨」）
+   - 7 日超 → 採用せず `/org-start` への切り替えを推奨し停止
+3. ファイル本文を Read で取り込む。書かれている内容は次 session の自分にとっての
+   「事実」として扱う（後の Step 3 で state.db と照合する）。
+
+## Step 2: state.db の dispatcher identity を atomic 更新する
+
+Step 0 で観測した `pane_id` / `peer_id` を `StateWriter.transaction()` 経由で
+**1 トランザクションで** 書く（post-commit hook が `.state/org-state.md` を再生成
+してくれる）。これが acceptance の「state.db identity が atomic 更新」要件の本体。
+
+```bash
+python3 -c "
+import sys, os
+sys.path.insert(0, os.path.abspath('..'))
+from pathlib import Path
+from tools.state_db import connect
+from tools.state_db.writer import StateWriter
+conn = connect('../.state/state.db')
+with StateWriter(conn, claude_org_root=Path('..')).transaction() as w:
+    w.update_session(
+        dispatcher_pane_id='<observed_pane_id>',
+        dispatcher_peer_id='<observed_peer_id>',
+    )
+"
+```
+
+- `dispatcher_pane_id` / `dispatcher_peer_id` は **文字列**で書く（schema は TEXT、
+  既存 `/org-start` も文字列を入れているので型を揃える）
+- `transaction()` 内なので片方だけ書いて失敗しても DB は半端な状態にならない
+- 観測値が handover frontmatter と異なっても、現観測（list_panes / list_peers）を
+  真値として優先する。差分があった旨を secretary 宛 message に含める
+
+## Step 3: state.db で現状を再取得し handover と照合する
+
+```bash
+python3 -c "
+import sys, os
+sys.path.insert(0, os.path.abspath('..'))
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json
+conn = connect('../.state/state.db')
+print(json.dumps(get_org_state_summary(conn), ensure_ascii=False, indent=2, default=str))
+"
+```
+
+確認項目:
+- `active_runs[]` が handover の「監視対象のワーカー」セクションと整合するか
+- `active_worker_dirs[]` のワーカーディレクトリ存在
+
+handover には書かれていないが state.db に `active` で残っている worker、または
+handover には書かれているが state.db / list_panes で消えている worker があれば、
+secretary に **報告して** 判断を仰ぐ（勝手に再 spawn / status 変更しない）。
+
+## Step 4: ペイン生存確認
+
+`mcp__renga-peers__list_peers` を再度呼び、handover に記載のワーカー名が現存するか
+確認する。消えていれば secretary に `WORKER_PANE_EXITED: worker-{task_id} (resume
+時点で不存在)` を通知（reconcile は窓口の責務）。
+
+## Step 5: 監視ループの再開
+
+handover の `active_worker_count > 0` または state.db の active worker dirs が
+非空ならば `/loop 3m` で worker monitoring を再開する:
+
+```
+/loop 3m
+```
+
+- 監視ループの 1 サイクル目で `mcp__renga-peers__poll_events` は
+  `.state/dispatcher-event-cursor.txt` の前 cursor（前 session 終了時点）から resume
+  する。これで「pane が閉じている間に来た pane_exited は次回 poll で必ず拾える」
+  semantics が維持される（renga 0.5.7+ の cursor 仕様）
+- `mcp__renga-peers__check_messages` の 1 サイクル目で前 session 中にキューに溜まった
+  worker → dispatcher peer message を drain する
+- `.state/dispatcher/worker-idle-state.json` は前 session の `idle_streak_cycles` を
+  保持しているので stall 検出の連続性も維持される
+
+監視対象が 0 件（active worker dir も 0、active_runs も 0）の場合は `/loop` を
+始動せず、idle 状態を secretary に通知して待機する:
+
+```
+DISPATCHER_RESUMED_IDLE: 監視対象なしで resume 完了。DELEGATE 待機。
+```
+
+## Step 6: secretary にブリーフィングを返す
+
+handover + state.db の現状を統合した上で、secretary に簡潔に報告:
+
+```
+DISPATCHER_RESUMED: ディスパッチャー復帰完了。
+- pane=<observed_pane_id> / peer=<observed_peer_id> (state.db 更新済)
+- 監視対象ワーカー: <task_id list>
+- pending decisions: <count>
+- handover との差分: <あれば 1 行、無ければ「なし」>
+- 監視ループ: /loop 3m 再開 (or idle)
+```
+
+## Step 7: handover ファイルを保持する
+
+- 削除しない（次回トラブル時の参照用に残す）
+- `.state/dispatcher-handover.prev.md` も読み込み済みでも消さない
+
+## イベント記録
+
+ディスパッチャーの cwd は `.dispatcher/` なので 1 階層上を呼ぶ:
+
+```bash
+bash ../tools/journal_append.sh dispatcher_resumed \
+    pane_id=<observed_pane_id> peer_id=<observed_peer_id> \
+    active_workers=<count> note=resumed_from_handover
+```
+
+## やってはいけないこと
+
+- 新規にディスパッチャー / キュレーターを spawn する（既に生きている）
+- ワーカーに勝手に SUSPEND / SHUTDOWN を送る
+- `.state/dispatcher-event-cursor.txt` / `worker-idle-state.json` /
+  `pending_decisions.json` を初期化 / 削除する（前 session からの監視連続性が壊れる）
+- handover の内容と state.db の現状が食い違うときに、勝手にどちらかへ寄せる
+  （必ず secretary に報告して判断を仰ぐ）
+- atomic 更新を分割して書く（必ず `StateWriter.transaction()` 1 ブロックで完結させる）

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -136,6 +136,31 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 - 監視対象のペイン名は `.state/workers/worker-{peer_id}.md` の Pane Name から取得する
 
 
+## handover / resume（context 圧迫時の引き継ぎ）
+
+長時間稼働でディスパッチャー session の context が長くなった場合、または secretary から `DISPATCHER_HANDOVER` peer message を受領した場合は、以下の経路でディスパッチャーの Claude session だけを `/clear` して引き継ぐ。**ペイン自体・ワーカー・キュレーター・窓口は閉じない**ので、`/loop 3m` の worker monitoring に gap は出ない。
+
+- 書き出し: [`/dispatcher-handover`](../.claude/skills/dispatcher-handover/SKILL.md) — `.state/dispatcher-handover.md` を生成し、secretary に `DISPATCHER_HANDOVER_READY` を返す
+- 復帰: [`/dispatcher-resume`](../.claude/skills/dispatcher-resume/SKILL.md) — `/clear` 直後の最初のターンで実行する。handover を読み込み、state.db の `dispatcher_pane_id` / `dispatcher_peer_id` を `StateWriter.transaction()` 経由で atomic 更新し、`/loop 3m` を再開する
+
+### 起動時の分岐（cold-start vs resume）
+
+ディスパッチャー Claude session が起動した直後（`/org-start` 由来 / secretary の `send_keys` 由来 / 手動起動を問わず）は、まず以下を確認する:
+
+1. `../.state/dispatcher-handover.md` が存在し、かつ frontmatter `created_at` が 7 日以内 → **`/dispatcher-resume` を実行する**（cold-start ではない）
+2. 上記に該当しない → 従来通り cold-start（`/org-start` の Step は窓口側スキルが完了済み、本ファイル上記の DELEGATE 受信待ちから始める）
+
+この分岐により `/org-start` の起動シーケンス（dispatcher pane を新規 spawn → cold-start）と、handover/resume 経路（既存 pane で `/clear` → resume）が衝突しない。`/org-start` 直後は handover ファイルが古い（または存在しない）ので自然に cold-start に落ちる。
+
+### 監視 gap を埋める内部状態ファイル（handover/resume で触らない）
+
+resume 時に「監視に gap が出ない」ことの根拠はこれらが前 session から残り続けることに依存する。**handover / resume / `/clear` のいずれでも編集 / 削除しない**:
+
+- `../.state/dispatcher-event-cursor.txt` — `mcp__renga-peers__poll_events` の next_since cursor。resume 後の 1 サイクル目で前 cursor から再開する
+- `../.state/dispatcher/worker-idle-state.json` — stall 検出の per-worker `idle_streak_cycles` / `last_content_change_ts`
+- `../.state/pending_decisions.json` — 判断仰ぎ register。SECRETARY_RELAY_GAP_SUSPECTED の primary lookup source
+- `../.state/workers/worker-*.md` — 各ワーカー run state
+
 ## ペインクローズ（CLOSE_PANE 受信時）
 
 詳細手順（retro 完了報告ゲート / secretary unreachable fallback / 知見記録 / `close_pane` 呼び出し / 窓口への RETRO_RECORDED 報告）は [`.dispatcher/references/pane-close.md`](references/pane-close.md) を参照。

--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -150,7 +150,7 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 1. `../.state/dispatcher-handover.md` が存在し、かつ frontmatter `created_at` が 7 日以内 → **`/dispatcher-resume` を実行する**（cold-start ではない）
 2. 上記に該当しない → 従来通り cold-start（`/org-start` の Step は窓口側スキルが完了済み、本ファイル上記の DELEGATE 受信待ちから始める）
 
-この分岐により `/org-start` の起動シーケンス（dispatcher pane を新規 spawn → cold-start）と、handover/resume 経路（既存 pane で `/clear` → resume）が衝突しない。`/org-start` 直後は handover ファイルが古い（または存在しない）ので自然に cold-start に落ちる。
+この分岐により `/org-start` の起動シーケンス（dispatcher pane を新規 spawn → cold-start）と、handover/resume 経路（既存 pane で `/clear` → resume）が衝突しない。`/dispatcher-resume` は完了時に `.state/dispatcher-handover.md` を `.state/dispatcher-handover.consumed.md` に rename する（Step 7）ので、resume を 1 回消化した後の `/org-start` は `.md` 不在で自然に cold-start に落ちる。古い `.consumed.md` は分岐条件に **影響しない**（live `.md` のみを判定対象とする）。
 
 ### 監視 gap を埋める内部状態ファイル（handover/resume で触らない）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,10 @@
   - [`/secretary-resume`](./.claude/skills/secretary-resume/SKILL.md) — `/clear` 後の最初のターンで handover を読み込んで窓口復帰
 - ディスパッチャー session の context が長くなったら窓口から発火する canonical 経路 (Issue #464):
   1. `mcp__renga-peers__send_message(to_id="dispatcher", message="DISPATCHER_HANDOVER: context refresh をお願いします。/dispatcher-handover を実行してください。")` で起点を送る
-  2. ディスパッチャーから `DISPATCHER_HANDOVER_READY` の peer message を受領
-  3. `mcp__renga-peers__send_keys(target="dispatcher", text="/clear", enter=true)` → 数秒後に `mcp__renga-peers__send_keys(target="dispatcher", text="/dispatcher-resume", enter=true)` を打鍵
-  4. ディスパッチャーから `DISPATCHER_RESUMED` を受領して引き継ぎ完了。`/loop 3m` 監視は resume 内で再開済み
+  2. ディスパッチャーから `DISPATCHER_HANDOVER_READY` の peer message を受領（ここまで取りこぼしなく到達した時点で handover ファイル書き出しは完了している）
+  3. `mcp__renga-peers__send_keys(target="dispatcher", text="/clear", enter=true)` を発行。**直後に固定 sleep を置かず、`mcp__renga-peers__inspect_pane(target="dispatcher", lines=10)` で `/` プロンプトが空 (welcome screen / empty input) になるまで 1 秒間隔で poll する**（最大 15 秒）。プロンプト不確認のまま次の打鍵に進むと no-op で取りこぼし監視 gap になる
+  4. プロンプト確認後、`mcp__renga-peers__send_keys(target="dispatcher", text="/dispatcher-resume", enter=true)` を発行。送信後 `mcp__renga-peers__check_messages` を 30 秒以内 poll し `DISPATCHER_RESUMED` または `DISPATCHER_RESUME_FAILED` を待つ。タイムアウト時は `inspect_pane` でペイン状態を観測し、必要なら `/dispatcher-resume` を再送する（idempotent: resume の Step 7 で handover ファイルが `.consumed.md` に rename されているので、2 回目以降の起動分岐は cold-start 側に落ちる前に check_messages 再 drain で済む）
+  5. ディスパッチャーから `DISPATCHER_RESUMED` を受領して引き継ぎ完了。`/loop 3m` 監視は resume 内で再開済み
   - ペインは閉じない（pane_id 維持で監視 gap を最小化）。`/org-suspend` ではなく、ディスパッチャー Claude の context だけをリセットする操作
   - 詳細は [`/dispatcher-handover`](./.claude/skills/dispatcher-handover/SKILL.md) と [`/dispatcher-resume`](./.claude/skills/dispatcher-resume/SKILL.md) を参照
 - 実作業は全てワーカーに委譲する（コード編集、デバッグ、テスト、ビルド、git commit、環境構築等）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,13 @@
 - 窓口セッションの context が長くなったら以下で引き継ぎ:
   - [`/secretary-handover`](./.claude/skills/secretary-handover/SKILL.md) — 直近やり取り・組織状態を `.state/secretary-handover.md` に書き出す（ペインは生かしたまま）
   - [`/secretary-resume`](./.claude/skills/secretary-resume/SKILL.md) — `/clear` 後の最初のターンで handover を読み込んで窓口復帰
+- ディスパッチャー session の context が長くなったら窓口から発火する canonical 経路 (Issue #464):
+  1. `mcp__renga-peers__send_message(to_id="dispatcher", message="DISPATCHER_HANDOVER: context refresh をお願いします。/dispatcher-handover を実行してください。")` で起点を送る
+  2. ディスパッチャーから `DISPATCHER_HANDOVER_READY` の peer message を受領
+  3. `mcp__renga-peers__send_keys(target="dispatcher", text="/clear", enter=true)` → 数秒後に `mcp__renga-peers__send_keys(target="dispatcher", text="/dispatcher-resume", enter=true)` を打鍵
+  4. ディスパッチャーから `DISPATCHER_RESUMED` を受領して引き継ぎ完了。`/loop 3m` 監視は resume 内で再開済み
+  - ペインは閉じない（pane_id 維持で監視 gap を最小化）。`/org-suspend` ではなく、ディスパッチャー Claude の context だけをリセットする操作
+  - 詳細は [`/dispatcher-handover`](./.claude/skills/dispatcher-handover/SKILL.md) と [`/dispatcher-resume`](./.claude/skills/dispatcher-resume/SKILL.md) を参照
 - 実作業は全てワーカーに委譲する（コード編集、デバッグ、テスト、ビルド、git commit、環境構築等）
 - 問題が報告されたら、自分で調査せずワーカーに投げる
 

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -198,6 +198,8 @@ itself errored — see the fallback rules in `tools/pr_watch.py`);
 | `resume`                       | `restored_workers[]`, `note`            | secretary | secretary  | —            |
 | `task_completed`               | `task`                                  | secretary | secretary  | —            |
 | `secretary_identity_restored`  | `note`                                  | org-start | secretary  | —            |
+| `dispatcher_handover`          | `active_workers`, `pending_decisions`, `note` | dispatcher | dispatcher | —      |
+| `dispatcher_resumed`           | `pane_id`, `peer_id`, `active_workers`, `note` | dispatcher | dispatcher | —     |
 
 ## Adding a new event type
 


### PR DESCRIPTION
## Summary
- Adds `/dispatcher-handover` and `/dispatcher-resume` skills so the dispatcher Claude session can be refreshed without losing monitoring continuity (mirrors secretary-handover/resume).
- Secretary fires the canonical refresh path: `DISPATCHER_HANDOVER` → `send_keys /clear` → `send_keys /dispatcher-resume` → wait for `DISPATCHER_RESUMED` (readiness handshake instead of fixed sleep).
- Resume re-binds `dispatcher_pane_id` / `dispatcher_peer_id` atomically via `StateWriter.transaction()`, restarts `/loop 3m`, and renames the handover file to `.consumed.md` to avoid cold-start collision.
- Pane is preserved (pane_id stable); monitoring gap is bounded by the handshake.

## Acceptance (Issue #464)
- 再起動で worker 監視に gap が生じない: handshake + non-touched cursor/idle-state files
- state.db identity の atomic 更新: `StateWriter.transaction()` で `dispatcher_pane_id` / `dispatcher_peer_id` を更新
- 既存の `.dispatcher/CLAUDE.md` 起動シーケンスと衝突しない: 起動分岐で live handover ファイル (≤7 days) のみ resume 経路、それ以外は cold-start

## Files
- `.claude/skills/dispatcher-handover/SKILL.md` (new)
- `.claude/skills/dispatcher-resume/SKILL.md` (new)
- `.dispatcher/CLAUDE.md` (startup branch + monitoring-gap state file contract)
- `CLAUDE.md` (secretary-side canonical firing path)
- `docs/journal-events.md` (`dispatcher_handover` / `dispatcher_resumed` event kinds)

## Test plan
- [ ] CI green
- [ ] Manual E2E on next dispatcher context refresh (this PR is prose-mostly; runtime validation happens at first operational use, monitored via the readiness handshake)

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)