### PR TITLE
Add /org-attention-start and /org-attention-stop skills

### DIFF
--- a/.claude/skills/org-attention-start/SKILL.md
+++ b/.claude/skills/org-attention-start/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: org-attention-start
+description: >
+  attention notification watcher（承認待ち / 判断待ち / CI 失敗等を OS 通知 + 音で能動通知）を
+  dispatcher ペインの右側に split で常駐起動する。`.state/attention.json` が未配置なら
+  ja 既定テンプレートを `tools/templates/attention.example.json` から自動コピーする。
+  起動後のペイン id は `.state/attention_pane.json` に記録し、`/org-attention-stop` から参照する。
+  「attention 起動」「通知監視を始めて」「watcher を立てて」等で発動。
+  `/org-start` からの auto-start はしない（明示起動推奨ポリシー）。
+effort: low
+allowed-tools:
+  - Read
+  - Write
+  - Bash(mkdir:*)
+  - Bash(cp:*)
+  - Bash(copy:*)
+  - Bash(test:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - mcp__renga-peers__list_panes
+  - mcp__renga-peers__spawn_pane
+---
+
+# org-attention-start: attention watcher の常駐起動
+
+`claude-org-runtime attention watch` を dispatcher ペインの右側に split で常駐起動し、
+pane_id を `.state/attention_pane.json` に sidecar として記録する。停止は
+[`/org-attention-stop`](../org-attention-stop/SKILL.md) を使う。
+
+> **前提**: この skill は窓口（Secretary）の cwd（= claude-org-ja リポジトリ root）から呼ばれる。
+> attention watcher 自体は `claude-org-runtime` の console_scripts entrypoint で、`--state-dir .state` /
+> `--config .state/attention.json` の相対パスが repo root から resolve される必要がある。
+> dispatcher ペインの cwd は `.dispatcher` なので、spawn_pane では `cwd="."` を明示して
+> Secretary 側の cwd（= repo root）にバインドする。
+>
+> **設計判断 (sidecar)**: pane_id 記録は `.state/state.db` の schema 拡張ではなく
+> sidecar JSON (`.state/attention_pane.json`) を採用する。`.state/dashboard.pid` /
+> `.state/attention_notified.json` と同じ「補助プロセス追跡」パターンに揃え、
+> importer / writer / snapshotter / converter / drift_check への波及を回避するため。
+> attention watcher は OS subprocess であり Claude peer ではないため peer_id は持たず、
+> ダッシュボードへの状況表示も現状不要（人間判断、2026-05-17）。
+
+## Step 1: 二重起動チェック
+
+1. `.state/attention_pane.json` が存在するか確認:
+   ```bash
+   test -f .state/attention_pane.json && echo exists || echo absent
+   ```
+2. **存在する場合**: `mcp__renga-peers__list_panes` を呼び、sidecar に書かれた `pane_id` が
+   現在のタブに生存しているか照合する:
+   - **生存している** → 既に起動中。ユーザーに「attention watcher は既に pane id={N} で稼働中です。
+     再起動したい場合は `/org-attention-stop` を先に実行してください」と報告して **abort**
+   - **生存していない** (sidecar に stale な id) → 旧 sidecar を削除して Step 2 へ進む:
+     ```bash
+     rm .state/attention_pane.json
+     ```
+3. **存在しない場合**: Step 2 へ進む
+
+## Step 2: 設定ファイルの配置（未配置時のみ）
+
+1. `.state/attention.json` の有無を確認:
+   ```bash
+   test -f .state/attention.json && echo exists || echo absent
+   ```
+2. **未配置の場合**: ja 既定テンプレートを copy する（`.state/` は gitignored、fresh clone
+   直後だと未作成のことがあるので mkdir も同時に走らせる）:
+   ```bash
+   mkdir -p .state
+   cp tools/templates/attention.example.json .state/attention.json
+   ```
+   Windows native (PowerShell) で実行する場合は `copy` コマンドでも可:
+   ```powershell
+   if (!(Test-Path .state)) { mkdir .state }
+   copy tools\templates\attention.example.json .state\attention.json
+   ```
+3. **既に配置されている場合**: 上書きしない（ユーザーの個別調整を尊重する）。Step 3 へ進む
+
+## Step 3: dispatcher を split して watcher を起動
+
+dispatcher ペインの右半分（vertical split）に attention watcher 用の pane を作る:
+
+```
+mcp__renga-peers__spawn_pane(
+  target="dispatcher",
+  direction="vertical",
+  role="attention",
+  name="attention",
+  cwd=".",
+  command="claude-org-runtime attention watch --state-dir .state --config .state/attention.json"
+)
+```
+
+- `target="dispatcher"`: org-start Block A-1 で確立した安定名で解決
+- `direction="vertical"`: dispatcher ペイン = 左、attention ペイン = 右
+- `cwd="."`: Secretary の cwd（= repo root）基点で相対 resolve され、`.state/` パスが正しく当たる。
+  省略すると dispatcher の cwd (`.dispatcher`) を継承して `.state` が `.dispatcher/.state` に解決され
+  watcher が空の state を見ることになる
+- `name="attention"`: 後続の `/org-attention-stop` で `close_pane(target="attention")` または記録した
+  pane_id で参照する
+- 戻り値: `"Spawned pane id=N."` テキスト。N が attention watcher の pane_id
+
+**失敗時の分岐**:
+- `[split_refused]`: dispatcher pane が分割下限 (MIN_PANE_WIDTH=20) を下回っている。
+  ユーザーに「dispatcher ペインが分割不能サイズです。secretary 側を縮めるか、ターミナル幅を
+  広げてから再実行してください」と報告して abort
+- `[pane_not_found]`: dispatcher pane が存在しない（org-start 未実行 or dispatcher 落ち）。
+  ユーザーに「dispatcher pane が見つかりません。`/org-start` を先に実行してください」と
+  報告して abort
+- その他 `[<code>]`: [`renga-error-codes.md`](../org-delegate/references/renga-error-codes.md) を参照
+
+## Step 4: pane_id を sidecar に記録
+
+返り値からパースした pane_id を `.state/attention_pane.json` に書き出す:
+
+```json
+{
+  "pane_id": "<N>",
+  "name": "attention",
+  "started_at": "<ISO8601 UTC>",
+  "config_path": ".state/attention.json"
+}
+```
+
+`Write` ツールで上書き保存する（既存ファイルは Step 1 で削除済み）。
+
+journal event を 1 行追記する:
+
+```bash
+bash tools/journal_append.sh attention_watch_started pane_id=<N> config=.state/attention.json
+```
+
+Windows native では `py -3 tools/journal_append.py attention_watch_started pane_id=<N> config=.state/attention.json`。
+
+## Step 5: 報告
+
+```
+attention watcher を起動しました（pane id={N}、dispatcher の右側）。
+設定: .state/attention.json
+停止するときは /org-attention-stop を実行してください。
+```
+
+WSL の Windows 通知センター連携 (`wsl-notify-send.exe`) や OS 別の backend 挙動、トラブル
+シューティングは [`docs/operations/attention-watch.md`](../../../docs/operations/attention-watch.md)
+を参照。

--- a/.claude/skills/org-attention-start/SKILL.md
+++ b/.claude/skills/org-attention-start/SKILL.md
@@ -19,10 +19,7 @@ allowed-tools:
   - Bash(del:*)
   - Bash(bash tools/journal_append.sh:*)
   - Bash(py -3 tools/journal_append.py:*)
-  - mcp__renga-peers__list_panes
-  - mcp__renga-peers__spawn_pane
-  - mcp__renga-peers__close_pane
-  - mcp__renga-peers__inspect_pane
+  - mcp__renga-peers__*
 ---
 
 # org-attention-start: attention watcher の常駐起動

--- a/.claude/skills/org-attention-start/SKILL.md
+++ b/.claude/skills/org-attention-start/SKILL.md
@@ -125,37 +125,45 @@ mcp__renga-peers__spawn_pane(
   ください」と報告して abort
 - その他 `[<code>]`: [`renga-error-codes.md`](../org-delegate/references/renga-error-codes.md) を参照
 
-## Step 4: 起動 health check（即時クラッシュ検出）
+## Step 4: 起動 health check（即時クラッシュの negative-signal 検出のみ）
 
 `spawn_pane` の成功は「shell が立ち上がって command を発火した」までしか保証しない。
-`claude-org-runtime` 未導入 / 設定不正 / import error 等で watcher 本体が即時終了すると、
-sidecar に stale pane_id が記録されて以後の `/org-attention-start` / `/org-attention-stop`
-判定を壊す。Step 5 に進む前に **最低 2 秒待ってから** `inspect_pane` でペイン内容を観測し、
-watcher が生きているかを確認する:
+`claude-org-runtime` 未導入 / 設定不正 / import error で watcher 本体が即時終了すると、
+sidecar に stale pane_id が記録されて以後の判定を壊す。一方、watcher が **正常起動時に
+何を出力するか** は `claude-org-runtime` 側の契約で固定されておらず（polling loop に入って
+静かに待機する実装もあり得る）、「起動バナーが見えるまで待つ」「無出力なら fail」と扱うと
+**正常な quiet start を誤って kill する**経路になる。よって本 skill は **明示的な失敗
+シグナルだけを fail と判定**し、それ以外（空出力 / 不明な出力）は「起動成功扱い」とする:
 
 ```
-mcp__renga-peers__inspect_pane(target="attention", format="text", lines=40)
+mcp__renga-peers__inspect_pane(target="attention", format="text", lines=60)
 ```
 
-判定基準（いずれかに該当したら **起動失敗** として扱う）:
-- 出力末尾に shell prompt（`PS C:\...>` / `$ ` / `% ` 等）が露出している → command が即時終了して
-  shell に戻った
-- 出力に `command not found` / `is not recognized` / `ModuleNotFoundError` / `ImportError` /
-  `Traceback` / `[error]` / `[ERROR]` が含まれる
-- 出力が完全に空 → spawn 自体が wedged。10 秒猶予して再 inspect、それでも空なら失敗扱い
+inspect 自体のラウンドトリップ（数百 ms）で shell が即時終了するケースは pty buffer に
+残った prompt や error が cap される。**以下のいずれかに該当した場合のみ「起動失敗」**:
+
+- 出力末尾に shell prompt が露出している（`PS C:\...> ` / `$ ` / `% ` / `> ` の末尾露出）
+  → command が即時終了して shell に戻った
+- 出力に以下のいずれかの文字列を含む:
+  - `command not found` / `is not recognized` / `not recognized as an internal or external command`
+  - `ModuleNotFoundError` / `ImportError` / `Traceback (most recent call last)`
+  - `[error]` / `[ERROR]` / `FATAL` / `fatal:`
+
+**上記いずれも検出されない場合**（空出力 / 起動バナー / polling 待機 / 不明な行のみ等）
+→ **起動成功扱い** で Step 5 に進む。固定 sleep を入れて再 inspect する経路は持たない
+（quiet な健全起動を誤殺する経路を作らないため）。
 
 **起動失敗時**:
 1. `mcp__renga-peers__close_pane(target="<spawn 返り値の pane_id>")` で死んだペインを掃除
 2. sidecar は **書き込まない**
-3. journal に `attention_watch_start_failed pane_id=<N> reason="<inspect 抜粋>"` を記録:
+3. journal に `attention_watch_start_failed` を記録:
    ```bash
    bash tools/journal_append.sh attention_watch_start_failed pane_id=<N> reason=immediate_exit
    ```
-4. ユーザーに「watcher が起動直後に終了しました（出力: ...）。`claude-org-runtime` の導入確認
-   (`claude-org-runtime --version`) と `.state/attention.json` の構文確認を行ってください」と
-   報告して abort
-
-**起動成功時**（出力に watcher の起動ログ / polling 待機が見える）: Step 5 へ進む。
+4. ユーザーに「watcher が起動直後に終了しました（出力: <inspect 抜粋>）。
+   `claude-org-runtime --version` で導入を確認し、`.state/attention.json` の構文も
+   `claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json`
+   で検査してください」と報告して abort
 
 ## Step 5: pane_id を sidecar に記録
 

--- a/.claude/skills/org-attention-start/SKILL.md
+++ b/.claude/skills/org-attention-start/SKILL.md
@@ -15,10 +15,14 @@ allowed-tools:
   - Bash(cp:*)
   - Bash(copy:*)
   - Bash(test:*)
+  - Bash(rm:*)
+  - Bash(del:*)
   - Bash(bash tools/journal_append.sh:*)
   - Bash(py -3 tools/journal_append.py:*)
   - mcp__renga-peers__list_panes
   - mcp__renga-peers__spawn_pane
+  - mcp__renga-peers__close_pane
+  - mcp__renga-peers__inspect_pane
 ---
 
 # org-attention-start: attention watcher の常駐起動
@@ -42,19 +46,29 @@ pane_id を `.state/attention_pane.json` に sidecar として記録する。停
 
 ## Step 1: 二重起動チェック
 
-1. `.state/attention_pane.json` が存在するか確認:
+二重起動の判定は **sidecar の有無と live pane の両方** を見る必要がある（sidecar 不在でも
+過去の手動 spawn / クラッシュ後の孤児 `name="attention"` ペインが live で残るケースがあり、
+sidecar だけ見ると Step 3 の `spawn_pane(..., name="attention")` が `[name_in_use]` で失敗する）。
+
+1. `mcp__renga-peers__list_panes` を呼び、`name="attention"` / `role="attention"` の pane が
+   live で存在するか確認する
+2. `.state/attention_pane.json` が存在するか確認:
    ```bash
    test -f .state/attention_pane.json && echo exists || echo absent
    ```
-2. **存在する場合**: `mcp__renga-peers__list_panes` を呼び、sidecar に書かれた `pane_id` が
-   現在のタブに生存しているか照合する:
-   - **生存している** → 既に起動中。ユーザーに「attention watcher は既に pane id={N} で稼働中です。
-     再起動したい場合は `/org-attention-stop` を先に実行してください」と報告して **abort**
-   - **生存していない** (sidecar に stale な id) → 旧 sidecar を削除して Step 2 へ進む:
+3. 分岐:
+   - **live pane あり + sidecar あり + sidecar の pane_id が live pane と一致** → 正常に稼働中。
+     「attention watcher は既に pane id={N} で稼働中です。再起動したい場合は
+     `/org-attention-stop` を先に実行してください」と報告して **abort**
+   - **live pane あり + sidecar 無し / pane_id 不一致** → 孤児ペインまたは sidecar drift。
+     ユーザーに状況を報告し「`/org-attention-stop` で孤児 pane を掃除してから再実行してください」
+     と案内して **abort**（自動 close はしない。孤児ペインに何が動いているか不明なため）
+   - **live pane 無し + sidecar あり** → stale sidecar。削除して Step 2 へ進む:
      ```bash
      rm .state/attention_pane.json
      ```
-3. **存在しない場合**: Step 2 へ進む
+     Windows native: `del .state\attention_pane.json`
+   - **live pane 無し + sidecar 無し** → クリーン状態。Step 2 へ進む
 
 ## Step 2: 設定ファイルの配置（未配置時のみ）
 
@@ -106,9 +120,44 @@ mcp__renga-peers__spawn_pane(
 - `[pane_not_found]`: dispatcher pane が存在しない（org-start 未実行 or dispatcher 落ち）。
   ユーザーに「dispatcher pane が見つかりません。`/org-start` を先に実行してください」と
   報告して abort
+- `[name_in_use]`: Step 1 の二重起動チェックが取りこぼした live pane が直前に再出現した race。
+  ユーザーに「attention pane が並走で先に立ち上がりました。`/org-attention-stop` で掃除して
+  ください」と報告して abort
 - その他 `[<code>]`: [`renga-error-codes.md`](../org-delegate/references/renga-error-codes.md) を参照
 
-## Step 4: pane_id を sidecar に記録
+## Step 4: 起動 health check（即時クラッシュ検出）
+
+`spawn_pane` の成功は「shell が立ち上がって command を発火した」までしか保証しない。
+`claude-org-runtime` 未導入 / 設定不正 / import error 等で watcher 本体が即時終了すると、
+sidecar に stale pane_id が記録されて以後の `/org-attention-start` / `/org-attention-stop`
+判定を壊す。Step 5 に進む前に **最低 2 秒待ってから** `inspect_pane` でペイン内容を観測し、
+watcher が生きているかを確認する:
+
+```
+mcp__renga-peers__inspect_pane(target="attention", format="text", lines=40)
+```
+
+判定基準（いずれかに該当したら **起動失敗** として扱う）:
+- 出力末尾に shell prompt（`PS C:\...>` / `$ ` / `% ` 等）が露出している → command が即時終了して
+  shell に戻った
+- 出力に `command not found` / `is not recognized` / `ModuleNotFoundError` / `ImportError` /
+  `Traceback` / `[error]` / `[ERROR]` が含まれる
+- 出力が完全に空 → spawn 自体が wedged。10 秒猶予して再 inspect、それでも空なら失敗扱い
+
+**起動失敗時**:
+1. `mcp__renga-peers__close_pane(target="<spawn 返り値の pane_id>")` で死んだペインを掃除
+2. sidecar は **書き込まない**
+3. journal に `attention_watch_start_failed pane_id=<N> reason="<inspect 抜粋>"` を記録:
+   ```bash
+   bash tools/journal_append.sh attention_watch_start_failed pane_id=<N> reason=immediate_exit
+   ```
+4. ユーザーに「watcher が起動直後に終了しました（出力: ...）。`claude-org-runtime` の導入確認
+   (`claude-org-runtime --version`) と `.state/attention.json` の構文確認を行ってください」と
+   報告して abort
+
+**起動成功時**（出力に watcher の起動ログ / polling 待機が見える）: Step 5 へ進む。
+
+## Step 5: pane_id を sidecar に記録
 
 返り値からパースした pane_id を `.state/attention_pane.json` に書き出す:
 
@@ -131,7 +180,7 @@ bash tools/journal_append.sh attention_watch_started pane_id=<N> config=.state/a
 
 Windows native では `py -3 tools/journal_append.py attention_watch_started pane_id=<N> config=.state/attention.json`。
 
-## Step 5: 報告
+## Step 6: 報告
 
 ```
 attention watcher を起動しました（pane id={N}、dispatcher の右側）。

--- a/.claude/skills/org-attention-stop/SKILL.md
+++ b/.claude/skills/org-attention-stop/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: org-attention-stop
+description: >
+  `/org-attention-start` で起動した attention watcher ペインを停止する。
+  `.state/attention_pane.json` に記録された pane_id を参照して
+  `mcp__renga-peers__close_pane` で破棄し、sidecar を削除する。
+  「attention 止めて」「通知監視を停止」「watcher 落として」等で発動。
+effort: low
+allowed-tools:
+  - Read
+  - Bash(rm:*)
+  - Bash(del:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - mcp__renga-peers__list_panes
+  - mcp__renga-peers__close_pane
+---
+
+# org-attention-stop: attention watcher の停止
+
+[`/org-attention-start`](../org-attention-start/SKILL.md) で起動した watcher ペインを閉じ、
+sidecar (`.state/attention_pane.json`) をクリアする。
+
+## Step 1: sidecar 読み込み
+
+1. `.state/attention_pane.json` を `Read` で開く
+2. **存在しない場合**: ユーザーに「attention watcher は起動していません（sidecar が無い）」と
+   報告して終了。念のため `mcp__renga-peers__list_panes` で `name="attention"` / `role="attention"`
+   のペインが残っていないか確認し、見つかれば Step 2-b に進む（人為的に手動起動された孤児ペインの掃除）
+3. `pane_id` フィールドを読み取る
+
+## Step 2: ペインを閉じる
+
+### 2-a: 記録された pane_id で close
+
+```
+mcp__renga-peers__close_pane(target="<pane_id>")
+```
+
+- 成功時: `"Closed pane id=N."` テキストが返る
+- `[pane_not_found]` / `[pane_vanished]`: 既に閉じている。sidecar が stale。Step 3 へ進む
+- `[last_pane]`: タブの唯一のペインが attention だった（通常発生しない、dispatcher / secretary が残っているはず）。
+  状況をユーザーに報告して abort（手動対応に委ねる）
+
+### 2-b: sidecar 不在で孤児ペインのみある場合
+
+Step 1 で sidecar 不在だが `list_panes` に `name="attention"` ペインが残っていた場合:
+
+```
+mcp__renga-peers__close_pane(target="attention")
+```
+
+同じく `[pane_not_found]` / `[pane_vanished]` は skip 扱い。
+
+## Step 3: sidecar の削除
+
+```bash
+rm -f .state/attention_pane.json
+```
+
+Windows native: `del .state\attention_pane.json` （既に削除済みでも無害化のため `2>nul` 等で抑制）。
+
+journal event を 1 行追記する:
+
+```bash
+bash tools/journal_append.sh attention_watch_stopped pane_id=<N>
+```
+
+Windows native では `py -3 tools/journal_append.py attention_watch_stopped pane_id=<N>`。
+
+## Step 4: 報告
+
+```
+attention watcher を停止しました（pane id={N}）。
+再開するときは /org-attention-start を実行してください。
+```
+
+sidecar が無く孤児ペインも無かった場合は:
+
+```
+attention watcher は既に停止しています。
+```

--- a/.claude/skills/org-attention-stop/SKILL.md
+++ b/.claude/skills/org-attention-stop/SKILL.md
@@ -21,36 +21,44 @@ allowed-tools:
 [`/org-attention-start`](../org-attention-start/SKILL.md) で起動した watcher ペインを閉じ、
 sidecar (`.state/attention_pane.json`) をクリアする。
 
-## Step 1: sidecar 読み込み
+## Step 1: sidecar と live pane の状態確認
 
-1. `.state/attention_pane.json` を `Read` で開く
-2. **存在しない場合**: ユーザーに「attention watcher は起動していません（sidecar が無い）」と
-   報告して終了。念のため `mcp__renga-peers__list_panes` で `name="attention"` / `role="attention"`
-   のペインが残っていないか確認し、見つかれば Step 2-b に進む（人為的に手動起動された孤児ペインの掃除）
-3. `pane_id` フィールドを読み取る
+1. `mcp__renga-peers__list_panes` を呼び、`name="attention"` または `role="attention"` の
+   live pane があれば pane_id を控える（**name と role の両方を見る**: 手動起動の孤児ペインは
+   name を付けずに role だけ持っている可能性がある）
+2. `.state/attention_pane.json` を `Read` で開けたら `pane_id` を読み取る。存在しなければ skip
+3. 分岐:
+   - **sidecar あり** → 2-a へ
+   - **sidecar 無し + 孤児 pane 検出** → 2-b へ
+   - **sidecar 無し + 孤児 pane 無し** → 「attention watcher は既に停止しています」と報告して終了
 
 ## Step 2: ペインを閉じる
 
 ### 2-a: 記録された pane_id で close
 
 ```
-mcp__renga-peers__close_pane(target="<pane_id>")
+mcp__renga-peers__close_pane(target="<sidecar の pane_id>")
 ```
 
 - 成功時: `"Closed pane id=N."` テキストが返る
 - `[pane_not_found]` / `[pane_vanished]`: 既に閉じている。sidecar が stale。Step 3 へ進む
-- `[last_pane]`: タブの唯一のペインが attention だった（通常発生しない、dispatcher / secretary が残っているはず）。
-  状況をユーザーに報告して abort（手動対応に委ねる）
+- `[last_pane]`: タブの唯一のペインが attention だった（通常発生しない、dispatcher / secretary が
+  残っているはず）。状況をユーザーに報告して abort（手動対応に委ねる）
 
-### 2-b: sidecar 不在で孤児ペインのみある場合
+Step 1 で得た「list_panes 上の attention ペイン」と sidecar の pane_id が一致しない場合は、
+**sidecar の id を優先して close した後**、`list_panes` を再取得して残っていれば 2-b に進む
+（drift / orphan の追加掃除）。
 
-Step 1 で sidecar 不在だが `list_panes` に `name="attention"` ペインが残っていた場合:
+### 2-b: sidecar 無し / drift で孤児ペインを掃除する場合
+
+Step 1 で `list_panes` から得た **pane_id（name ではなく数値 id）** で close する:
 
 ```
-mcp__renga-peers__close_pane(target="attention")
+mcp__renga-peers__close_pane(target="<list_panes から取得した数値 pane_id>")
 ```
 
-同じく `[pane_not_found]` / `[pane_vanished]` は skip 扱い。
+`target="attention"` のような name 指定は、role だけ持って name を持たない孤児ペインに当たらない
+ため使用しない。`[pane_not_found]` / `[pane_vanished]` は skip 扱い。
 
 ## Step 3: sidecar の削除
 

--- a/.claude/skills/org-attention-stop/SKILL.md
+++ b/.claude/skills/org-attention-stop/SKILL.md
@@ -12,8 +12,7 @@ allowed-tools:
   - Bash(del:*)
   - Bash(bash tools/journal_append.sh:*)
   - Bash(py -3 tools/journal_append.py:*)
-  - mcp__renga-peers__list_panes
-  - mcp__renga-peers__close_pane
+  - mcp__renga-peers__*
 ---
 
 # org-attention-stop: attention watcher の停止

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -140,18 +140,13 @@ Block A の spawn 発火と並列。ダッシュボード server は別プロセ
 >
 > 承認待ち / 判断待ち / CI 失敗 / silent stop / PR merged 等を OS notification + 音 + terminal bell で能動的に通知する watcher を別途常駐させられる。**`/org-start` からの自動起動はしない**（OS 通知 backend は環境依存が強く、勝手に音が鳴ると不快になりやすいため。設計 [`docs/design/attention-notification.md`](../../../docs/design/attention-notification.md) §11 Q1）。
 >
-> 有効化したいユーザーには Step 4 の起動完了報告と合わせて以下を案内する:
+> 有効化したいユーザーには Step 4 の起動完了報告と合わせて [`/org-attention-start`](../org-attention-start/SKILL.md) の実行を案内する。skill が以下を一括で行う:
 >
-> ```bash
-> # 初回のみ ja 既定テンプレートを .state/ にコピー（.state/ は gitignored、fresh clone 直後は未作成）
-> mkdir -p .state
-> cp tools/templates/attention.example.json .state/attention.json
+> - `.state/attention.json` 未配置時は `tools/templates/attention.example.json` から自動コピー
+> - dispatcher ペインの右側を vertical split し `claude-org-runtime attention watch ...` を常駐起動
+> - pane_id を `.state/attention_pane.json` sidecar に記録（停止は [`/org-attention-stop`](../org-attention-stop/SKILL.md) で参照）
 >
-> # 別ターミナル or バックグラウンドで常駐
-> claude-org-runtime attention watch --state-dir .state --config .state/attention.json
-> ```
->
-> 1 回限りの動作確認は `claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json`（`--config` を外すと runtime 中立の英語 default が出るので、ja テンプレートの導通確認には必ず付ける）。OS 別 backend 挙動・トラブルシューティングは [`docs/operations/attention-watch.md`](../../../docs/operations/attention-watch.md) を参照。
+> 1 回限りの動作確認は `claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json`（`--config` を外すと runtime 中立の英語 default が出るので、ja テンプレートの導通確認には必ず付ける）。OS 別 backend 挙動・トラブルシューティング・別ターミナルからの素 CLI 起動手順は [`docs/operations/attention-watch.md`](../../../docs/operations/attention-watch.md) を参照。
 
 ### Block D: 両ペインの合流 (Enter / list_peers poll / 挨拶 / DB write / snapshot)
 

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -17,9 +17,22 @@
 
 ## 2. 有効化 / 無効化
 
-### 2.1 設定ファイルの配置
+### 2.1 推奨: skill 経由の起動 / 停止
 
-`tools/templates/attention.example.json` は ja 既定のテンプレート集を含む tracked example。実運用では `.state/attention.json` にコピーする（`.state/` は gitignored、fresh clone や `/org-start` 前だと未作成）:
+renga タブ内（窓口セッション）からは、設定ファイルの自動配置・dispatcher ペインへの split 起動・pane_id 記録までを一括で扱う **2 つのスキル**を使うのが推奨経路:
+
+| 操作 | スキル | 副作用 |
+|---|---|---|
+| 起動 | [`/org-attention-start`](../../.claude/skills/org-attention-start/SKILL.md) | `.state/attention.json` 未配置時は `tools/templates/attention.example.json` から自動コピー → dispatcher ペインの右側を vertical split → `claude-org-runtime attention watch ...` を常駐起動 → pane_id を `.state/attention_pane.json` sidecar に記録 |
+| 停止 | [`/org-attention-stop`](../../.claude/skills/org-attention-stop/SKILL.md) | sidecar を読んで `mcp__renga-peers__close_pane` でペイン破棄 → sidecar 削除 |
+
+`/org-start` からの自動起動はしない（OS 通知 backend は環境依存が強く、勝手に音が鳴ると不快になりやすいため。設計 [`docs/design/attention-notification.md`](../design/attention-notification.md) §11 Q1）。`/org-start` 完了後に明示的に `/org-attention-start` を発火するか、必要なときだけ手動配置（§2.2）する。
+
+sidecar (`.state/attention_pane.json`) は `.state/dashboard.pid` / `.state/attention_notified.json` と同じ「補助プロセス追跡」パターンで、`.state/state.db` schema は拡張しない（importer / writer / snapshotter / converter / drift_check への波及を避けるため）。`.state/` が gitignored なので sidecar も commit には乗らない。
+
+### 2.2 手動配置（renga 外 / 別ターミナルから起動したい場合）
+
+`tools/templates/attention.example.json` は ja 既定のテンプレート集を含む tracked example。renga タブを使わず別ターミナルから常駐させたい場合や、テンプレートを手動編集してから配置したい場合は次の通り:
 
 ```bash
 mkdir -p .state
@@ -28,7 +41,7 @@ cp tools/templates/attention.example.json .state/attention.json
 
 OS 通知や音の挙動を変えたい場合は `.state/attention.json` を編集する（template strings の上書き、`sound` の切替、`cooldown_sec` の調整など）。テンプレートの placeholder allowlist は `{task_id}` / `{worker}` / `{kind}` / `{status}` / `{pr}` / `{summary}` の 6 種で、未知 placeholder は literal のまま残るか runtime の fallback template で補われる（設計 §6 参照）。
 
-### 2.2 1 回限りの動作確認 (`scan`)
+### 2.3 1 回限りの動作確認 (`scan`)
 
 `watch` を常駐させる前に、現状の `.state/` から想定どおりに attention event が抽出されるか確認する:
 
@@ -38,17 +51,19 @@ claude-org-runtime attention scan --state-dir .state --config .state/attention.j
 
 `--config .state/attention.json` を必ず付ける（外すと runtime 中立の英語 default が title/body に出てしまい、ja テンプレートが効いているかの確認にならない）。`--dry-run` は OS notification subprocess を呼ばないので、CI 環境や音を鳴らしたくない時間帯でも安全。出力は `{ "events": [{ "key": ..., "kind": ..., "severity": ..., "title": ..., "body": ...}, ...] }` 形式（詳細は [`docs/verification.md` の attention scan 検証ブロック](../verification.md) を参照）。
 
-### 2.3 常駐 (`watch`)
+### 2.4 常駐 (`watch`) — 手動起動
+
+renga タブの外（別ターミナル / バックグラウンド）から直接 watcher を起動したい場合の素の CLI:
 
 ```bash
 claude-org-runtime attention watch --state-dir .state --config .state/attention.json
 ```
 
-別ターミナル or バックグラウンドで起動する。`/org-start` から自動起動はしない（環境依存が強いため明示起動が推奨。設計 §11 Q1 / §7 "org-start guidance"）。停止は通常通り Ctrl-C（dedup state の書き込みは atomic replace で行われるため、強制終了でも次回起動時に復旧可能。§5 参照）。
+通常運用では §2.1 の `/org-attention-start` を使う（pane_id 記録・sidecar 管理・二重起動チェックを skill が担当）。停止は Ctrl-C（dedup state の書き込みは atomic replace で行われるため、強制終了でも次回起動時に復旧可能。§5 参照）。
 
-### 2.4 無効化
+### 2.5 無効化
 
-恒久的に止める場合は単に `watch` プロセスを終了するだけでよい。設定ファイル（`.state/attention.json`）の削除は不要。一時的に通知を抑えたい場合は `.state/attention.json` で `"desktop": false` / `"sound": "off"` に切り替えるか、個別 kind の severity を `"urgent"` → `"normal"` に下げる（`notify.<kind>` に取れる値は `"urgent"` / `"normal"` の 2 値のみで、kind 単位の `off` は無い。完全に止めたい場合は全体 `desktop: false` を使う）。
+renga タブ内から起動した場合は [`/org-attention-stop`](../../.claude/skills/org-attention-stop/SKILL.md) で sidecar とペインを一括クリーンアップする。手動起動した watcher は Ctrl-C で終了するだけでよい。設定ファイル（`.state/attention.json`）の削除は不要。一時的に通知を抑えたい場合は `.state/attention.json` で `"desktop": false` / `"sound": "off"` に切り替えるか、個別 kind の severity を `"urgent"` → `"normal"` に下げる（`notify.<kind>` に取れる値は `"urgent"` / `"normal"` の 2 値のみで、kind 単位の `off` は無い。完全に止めたい場合は全体 `desktop: false` を使う）。
 
 ## 3. OS 別の notification backend 挙動
 


### PR DESCRIPTION
## Summary
Turns the attention notification watcher into a pair of org-* skills so it can be enabled from inside Claude Code instead of requiring the user to copy the config template and launch `claude-org-runtime attention watch` manually.

- `/org-attention-start` — copies `tools/templates/attention.example.json` to `.state/attention.json` if missing, splits the dispatcher pane via `mcp__renga-peers__spawn_pane`, launches the watcher in that pane, and records the pane id to `.state/attention_pane.json`.
- `/org-attention-stop` — reads the sidecar, closes the watcher pane via `mcp__renga-peers__close_pane`, and deletes the sidecar.
- Health check is negative-signal only (shell prompt / Traceback / ModuleNotFoundError) so a quiet, healthy watcher is not killed by overzealous probing.
- Duplicate-launch handling branches on a 4-quadrant matrix of `sidecar exists x pane alive`, so both stale sidecars and orphan panes are detected.
- `/org-start` does not auto-start the watcher — the Sidebar in `org-start/SKILL.md` is rewritten to point at the new skill, preserving the opt-in policy.
- `docs/operations/attention-watch.md` Section 2 is reworked around the skill flow; the manual `claude-org-runtime attention watch` invocation is kept as the fallback for non-renga environments.
- pane-id persistence stays in a sidecar JSON (`.state/attention_pane.json`) rather than state.db; matches the existing `.state/dashboard.pid` / `.state/attention_notified.json` pattern, no schema changes.

## Files
- new: `.claude/skills/org-attention-start/SKILL.md`
- new: `.claude/skills/org-attention-stop/SKILL.md`
- update: `.claude/skills/org-start/SKILL.md` (Sidebar rewrite)
- update: `docs/operations/attention-watch.md` (Section 2 rewrite)

## Verification
- Codex self-review through round 3: Blocker / Major / Minor / Nit — none.
- `tools/audit_link_paths.py`: existing 22 violations + 2 new (existing slash-form skill references; all targets resolve).
- End-to-end pane launch / close requires renga at runtime; not reachable from inside the worker pane and is part of the human review for this PR.

## Test plan
- [ ] In a fresh renga session, `/org-attention-start` copies the template (when absent), splits the dispatcher pane, launches the watcher, and writes `.state/attention_pane.json`.
- [ ] Re-running `/org-attention-start` with a live pane is a no-op (4-quadrant check).
- [ ] `/org-attention-stop` closes the pane and deletes the sidecar.
- [ ] After a manual pane close, re-running `/org-attention-start` recovers (orphan detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)