### PR TITLE
feat(org-start): detect claude-org-runtime version drift at startup

### DIFF
--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -153,6 +153,7 @@ Block A の spawn 発火と並列。`claude-org-runtime` の installed バージ
 
 > 設計メモ:
 > - latest 取得は PyPI JSON API (`https://pypi.org/pypi/claude-org-runtime/json`) を urllib.request で叩く (timeout 3s)。`pip index versions` は experimental で stderr に warning を吐くため採用しない
+> - **pin window**: ja の `pyproject.toml` 依存に書かれた制約 (例 `>=0.1.9,<0.2`) を読み取り、PyPI releases から制約を満たす最新だけを latest として比較する。これにより `0.2.x` が PyPI にリリースされても窓外への upgrade を促さない（`packaging` モジュール利用）。`packaging` 未インストール環境では silent skip
 > - 「drift = 古い」も「drift = preview 入り (installed > latest の release channel ずれ)」も同じく 1 行で通知する。auto-upgrade はせず、対応はユーザー判断に委ねる
 > - スクリプト本体: [`tools/check_runtime_version.py`](../../../tools/check_runtime_version.py)
 
@@ -286,7 +287,7 @@ curator を再 spawn して復旧するか、curator 無しで暫定継続する
 ...
 何をしますか？
 
-[runtime drift] claude-org-runtime: installed=0.1.2 latest=0.1.11 -- `pip install --upgrade claude-org-runtime` で最新化できます
+[runtime drift] claude-org-runtime: installed=0.1.2 latest=0.1.11 -- ja の pin 内最新です。`python -m pip install --upgrade 'claude-org-runtime'` で更新できます
 ```
 
 ## Appendix: ClaudeCode 起動コマンド（役割別）

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -12,6 +12,8 @@ allowed-tools:
   - Bash(python -m tools.state_db.importer:*)
   - Bash(py -3 dashboard/org_state_converter.py:*)
   - Bash(python3 dashboard/org_state_converter.py:*)
+  - Bash(py -3 tools/check_runtime_version.py:*)
+  - Bash(python3 tools/check_runtime_version.py:*)
   - mcp__renga-peers__*
 ---
 
@@ -136,6 +138,24 @@ Block A の spawn 発火と並列。ダッシュボード server は別プロセ
 3. ユーザーに案内する:
    「ダッシュボードを起動しました → http://localhost:8099」
 
+### Block C2: claude-org-runtime バージョン drift 検出 (Issue #472)
+
+Block A の spawn 発火と並列。`claude-org-runtime` の installed バージョンと PyPI の latest を比較し、drift があれば Step 4 の起動完了報告に 1 行 warning を添える。auto-upgrade は行わず通知のみ。
+
+1. drift チェックを実行する:
+   ```bash
+   py -3 tools/check_runtime_version.py   # Windows
+   python3 tools/check_runtime_version.py # Mac/Linux
+   ```
+2. 出力分岐:
+   - stdout が空 (exit 0): INSTALLED == LATEST、未インストール、オフライン、PyPI レスポンス parse 失敗 のいずれか。**Step 4 報告に warning 行を出さない**（silent）
+   - stdout に `[runtime drift] ...` の 1 行: drift 検出。**この 1 行をそのまま Step 4 起動完了報告の末尾に warning として転記する**
+
+> 設計メモ:
+> - latest 取得は PyPI JSON API (`https://pypi.org/pypi/claude-org-runtime/json`) を urllib.request で叩く (timeout 3s)。`pip index versions` は experimental で stderr に warning を吐くため採用しない
+> - 「drift = 古い」も「drift = preview 入り (installed > latest の release channel ずれ)」も同じく 1 行で通知する。auto-upgrade はせず、対応はユーザー判断に委ねる
+> - スクリプト本体: [`tools/check_runtime_version.py`](../../../tools/check_runtime_version.py)
+
 > **Sidebar: attention watcher の起動案内（optional, 明示起動推奨）**
 >
 > 承認待ち / 判断待ち / CI 失敗 / silent stop / PR merged 等を OS notification + 音 + terminal bell で能動的に通知する watcher を別途常駐させられる。**`/org-start` からの自動起動はしない**（OS 通知 backend は環境依存が強く、勝手に音が鳴ると不快になりやすいため。設計 [`docs/design/attention-notification.md`](../../../docs/design/attention-notification.md) §11 Q1）。
@@ -234,7 +254,9 @@ Block A の spawn が両方成功した後、両ペインで Claude が並列に
 
 ## Step 4: 準備完了の報告
 
-人間に簡潔に報告する。Block D-5 の DB write 内容に応じて、起動済み role を正確に列挙する（curator 失敗時に「キュレーターを起動しました」と虚偽報告しないため）:
+人間に簡潔に報告する。Block D-5 の DB write 内容に応じて、起動済み role を正確に列挙する（curator 失敗時に「キュレーターを起動しました」と虚偽報告しないため）。
+
+**Block C2 の runtime drift 出力の扱い**: Block C2 で `tools/check_runtime_version.py` の stdout に `[runtime drift] ...` の 1 行が出ていれば、下記いずれのテンプレートでも **末尾に空行を 1 つ挟んだ上でその 1 行をそのまま転記する**。stdout が空であれば warning 行は付けない（INSTALLED == LATEST / 未インストール / オフライン / parse 失敗 はすべて silent）。
 
 **前回の状態がある場合 (両 role 成功)**:
 ```
@@ -257,6 +279,14 @@ Block A の spawn が両方成功した後、両ペインで Claude が並列に
 ディスパッチャーは稼働中ですが、キュレーター起動に失敗しました（理由: {[<code>] / peer 未登録 timeout 等}）。
 curator を再 spawn して復旧するか、curator 無しで暫定継続するかを選んでください。
 （curator 無しでもワーカー派遣・状態書き込みは可能ですが、知見の自動 curate (/loop 30m /org-curate) は停止します）
+```
+
+**drift 検出時の warning 添付例** (上記テンプレートの末尾に転記):
+```
+...
+何をしますか？
+
+[runtime drift] claude-org-runtime: installed=0.1.2 latest=0.1.11 -- `pip install --upgrade claude-org-runtime` で最新化できます
 ```
 
 ## Appendix: ClaudeCode 起動コマンド（役割別）

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -140,7 +140,7 @@ Block A の spawn 発火と並列。ダッシュボード server は別プロセ
 
 ### Block C2: claude-org-runtime バージョン drift 検出 (Issue #472)
 
-Block A の spawn 発火と並列。`claude-org-runtime` の installed バージョンと PyPI の latest を比較し、drift があれば Step 4 の起動完了報告に 1 行 warning を添える。auto-upgrade は行わず通知のみ。
+Block A の spawn 発火と並列。`claude-org-runtime` の installed バージョンと PyPI の latest を比較し、drift があれば Step 4 の起動完了報告に 1 行 warning を添える。auto-upgrade は行わず通知のみ。**バージョン番号は本ファイルにも script にも hard-code せず、すべて importlib.metadata と PyPI JSON API の動的取得値のみを使う**（runtime のリリースごとに記述が陳腐化することを避けるため）。
 
 1. drift チェックを実行する:
    ```bash
@@ -148,13 +148,15 @@ Block A の spawn 発火と並列。`claude-org-runtime` の installed バージ
    python3 tools/check_runtime_version.py # Mac/Linux
    ```
 2. 出力分岐:
-   - stdout が空 (exit 0): INSTALLED == LATEST、未インストール、オフライン、PyPI レスポンス parse 失敗 のいずれか。**Step 4 報告に warning 行を出さない**（silent）
+   - stdout が空 (exit 0): installed == latest、未インストール、オフライン、PyPI レスポンス parse 失敗、pin 解析失敗、pin 範囲内に release 無し のいずれか。**Step 4 報告に warning 行を出さない**（silent）
    - stdout に `[runtime drift] ...` の 1 行: drift 検出。**この 1 行をそのまま Step 4 起動完了報告の末尾に warning として転記する**
 
 > 設計メモ:
 > - latest 取得は PyPI JSON API (`https://pypi.org/pypi/claude-org-runtime/json`) を urllib.request で叩く (timeout 3s)。`pip index versions` は experimental で stderr に warning を吐くため採用しない
-> - **pin window**: ja の `pyproject.toml` 依存に書かれた制約 (例 `>=0.1.9,<0.2`) を読み取り、PyPI releases から制約を満たす最新だけを latest として比較する。これにより `0.2.x` が PyPI にリリースされても窓外への upgrade を促さない（`packaging` モジュール利用）。`packaging` 未インストール環境では silent skip
+> - **pin window**: ja の `pyproject.toml` の `claude-org-runtime` 依存制約を regex で動的に読み取り、PyPI releases からその制約を満たす最新のみを latest として比較する。これにより上位 major / 上位 minor が PyPI にリリースされても窓外への upgrade を促さない（`packaging.SpecifierSet` 利用）。`packaging` 未インストール環境では silent skip
+> - yanked release は候補から除外する（pip が通常選ばないバージョンを `latest` として表示しないため）
 > - 「drift = 古い」も「drift = preview 入り (installed > latest の release channel ずれ)」も同じく 1 行で通知する。auto-upgrade はせず、対応はユーザー判断に委ねる
+> - 警告コマンドには `pyproject.toml` から読み取った pin 制約をそのまま埋め込むので、ユーザーが警告コマンドをそのまま貼り付けても窓外への upgrade にはならない
 > - スクリプト本体: [`tools/check_runtime_version.py`](../../../tools/check_runtime_version.py)
 
 > **Sidebar: attention watcher の起動案内（optional, 明示起動推奨）**
@@ -257,7 +259,7 @@ Block A の spawn が両方成功した後、両ペインで Claude が並列に
 
 人間に簡潔に報告する。Block D-5 の DB write 内容に応じて、起動済み role を正確に列挙する（curator 失敗時に「キュレーターを起動しました」と虚偽報告しないため）。
 
-**Block C2 の runtime drift 出力の扱い**: Block C2 で `tools/check_runtime_version.py` の stdout に `[runtime drift] ...` の 1 行が出ていれば、下記いずれのテンプレートでも **末尾に空行を 1 つ挟んだ上でその 1 行をそのまま転記する**。stdout が空であれば warning 行は付けない（INSTALLED == LATEST / 未インストール / オフライン / parse 失敗 はすべて silent）。
+**Block C2 の runtime drift 出力の扱い**: Block C2 で `tools/check_runtime_version.py` の stdout に `[runtime drift] ...` の 1 行が出ていれば、下記いずれのテンプレートでも **末尾に空行を 1 つ挟んだ上でその 1 行をそのまま転記する**。stdout が空であれば warning 行は付けない（installed == latest / 未インストール / オフライン / parse 失敗 / pin 範囲内 release 無し はすべて silent）。
 
 **前回の状態がある場合 (両 role 成功)**:
 ```
@@ -282,12 +284,12 @@ curator を再 spawn して復旧するか、curator 無しで暫定継続する
 （curator 無しでもワーカー派遣・状態書き込みは可能ですが、知見の自動 curate (/loop 30m /org-curate) は停止します）
 ```
 
-**drift 検出時の warning 添付例** (上記テンプレートの末尾に転記):
+**drift 検出時の warning 添付例** (上記テンプレートの末尾に転記。`{installed}` / `{latest_in_window}` / `{pin}` は実行時にスクリプトが PyPI と `pyproject.toml` から動的に決定するもので、本ファイルには hard-code しない):
 ```
 ...
 何をしますか？
 
-[runtime drift] claude-org-runtime: installed=0.1.2 latest=0.1.11 -- `python -m pip install --upgrade 'claude-org-runtime>=0.1.9,<0.2'` で更新できます
+[runtime drift] claude-org-runtime: installed={installed} latest={latest_in_window} -- `python -m pip install --upgrade 'claude-org-runtime{pin}'` で更新できます
 ```
 
 ## Appendix: ClaudeCode 起動コマンド（役割別）

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -287,7 +287,7 @@ curator を再 spawn して復旧するか、curator 無しで暫定継続する
 ...
 何をしますか？
 
-[runtime drift] claude-org-runtime: installed=0.1.2 latest=0.1.11 -- ja の pin 内最新です。`python -m pip install --upgrade 'claude-org-runtime'` で更新できます
+[runtime drift] claude-org-runtime: installed=0.1.2 latest=0.1.11 -- `python -m pip install --upgrade 'claude-org-runtime>=0.1.9,<0.2'` で更新できます
 ```
 
 ## Appendix: ClaudeCode 起動コマンド（役割別）

--- a/tools/check_runtime_version.py
+++ b/tools/check_runtime_version.py
@@ -2,19 +2,22 @@
 """Runtime version drift check for /org-start (Issue #472).
 
 Compares the installed ``claude-org-runtime`` version against the
-latest release on PyPI that still satisfies ja's pin window (declared
-in ``pyproject.toml`` dependencies, e.g. ``>=0.1.9,<0.2``). If they
-differ, prints a single warning line to stdout so /org-start can
-splice it into its Step 4 readiness report. In all other cases —
-versions match, package not installed, PyPI unreachable, parse
-failure, no pin-compatible release found, ``packaging`` import
-failure — the script stays silent.
+latest release on PyPI that still satisfies ja's pin window
+(declared in ``pyproject.toml`` dependencies). If they differ,
+prints a single warning line to stdout so /org-start can splice it
+into its Step 4 readiness report. In all other cases — versions
+match, package not installed, PyPI unreachable, parse failure, no
+pin-compatible release found, ``packaging`` import failure — the
+script stays silent.
 
 The pin window matters because /org-start's warning must not steer
 users into an upgrade that breaks ja's compatibility contract: when
-ja pins ``<0.2`` and PyPI ships ``0.2.0``, we still want to bring
-users up to the latest in-window release (e.g. ``0.1.11``) but never
-recommend the out-of-window one.
+ja's upper bound is exclusive and PyPI ships a release past it, we
+still want to bring users up to the latest in-window release but
+never recommend the out-of-window one. No specific version is
+hard-coded anywhere — installed comes from ``importlib.metadata``,
+latest from the PyPI JSON API, and the pin spec from a regex over
+``pyproject.toml`` at read time.
 
 The script never auto-upgrades and never exits non-zero — drift is
 informational, and skipping silently is the correct behavior when the

--- a/tools/check_runtime_version.py
+++ b/tools/check_runtime_version.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Runtime version drift check for /org-start (Issue #472).
+
+Compares the installed ``claude-org-runtime`` version against the latest
+release on PyPI. If they differ, prints a single warning line to stdout
+so /org-start can splice it into its Step 4 readiness report. In all
+other cases (versions match, package not installed, PyPI unreachable,
+parse failure) the script stays silent.
+
+The script never auto-upgrades and never exits non-zero — drift is
+informational, and skipping silently is the correct behavior when the
+machine is offline or in a sandboxed CI lane.
+
+Used by ``.claude/skills/org-start/SKILL.md`` Block C2.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+# On Windows the default console codepage is cp932 / cp1252, which can't
+# encode the JP message body. Force UTF-8 on stdout so /org-start (which
+# reads this script's stdout via the Bash tool) gets a clean string.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+except (AttributeError, OSError):
+    pass
+
+PACKAGE = "claude-org-runtime"
+PYPI_JSON_URL = f"https://pypi.org/pypi/{PACKAGE}/json"
+TIMEOUT_SEC = 3.0
+
+
+def _installed_version() -> str | None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:
+        return None
+    try:
+        return version(PACKAGE)
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def _latest_version() -> str | None:
+    try:
+        req = urllib.request.Request(
+            PYPI_JSON_URL,
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+            payload = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, ConnectionError, OSError):
+        return None
+    except (json.JSONDecodeError, ValueError):
+        return None
+    except Exception:
+        return None
+    info = payload.get("info") if isinstance(payload, dict) else None
+    if not isinstance(info, dict):
+        return None
+    latest = info.get("version")
+    if not isinstance(latest, str) or not latest:
+        return None
+    return latest
+
+
+def main() -> int:
+    installed = _installed_version()
+    if installed is None:
+        return 0
+    latest = _latest_version()
+    if latest is None:
+        return 0
+    if installed == latest:
+        return 0
+    print(
+        f"[runtime drift] {PACKAGE}: installed={installed} latest={latest} "
+        f"-- `pip install --upgrade {PACKAGE}` で最新化できます"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_runtime_version.py
+++ b/tools/check_runtime_version.py
@@ -117,19 +117,27 @@ def _latest_version(pin=_AUTO_PIN) -> str | None:
             from packaging.version import InvalidVersion, Version
         except ImportError:
             return _fallback_info_version(payload, pin)
-        try:
-            spec = SpecifierSet(pin) if pin else SpecifierSet()
-        except InvalidSpecifier:
-            spec = SpecifierSet()
+        if pin:
+            try:
+                spec: SpecifierSet | None = SpecifierSet(pin)
+            except InvalidSpecifier:
+                # Pin parse failure: prefer silence over recommending an
+                # out-of-window upgrade (the docstring guarantees silent
+                # skip on parse failure).
+                return None
+        else:
+            spec = None
         candidates: list[Version] = []
-        for raw in releases.keys():
+        for raw, files in releases.items():
+            if _release_is_yanked(files):
+                continue
             try:
                 ver = Version(raw)
             except InvalidVersion:
                 continue
             if ver.is_prerelease or ver.is_devrelease:
                 continue
-            if spec and ver not in spec:
+            if spec is not None and ver not in spec:
                 continue
             candidates.append(ver)
         if candidates:
@@ -137,6 +145,21 @@ def _latest_version(pin=_AUTO_PIN) -> str | None:
         return None
 
     return _fallback_info_version(payload, pin)
+
+
+def _release_is_yanked(files) -> bool:
+    """A PyPI release version is considered yanked when every uploaded
+    file under it is marked yanked. Conservatively treat an empty file
+    list as "not yanked" so we don't drop legitimate releases that
+    simply lack file metadata in the JSON snapshot."""
+    if not isinstance(files, list) or not files:
+        return False
+    for entry in files:
+        if not isinstance(entry, dict):
+            return False
+        if not entry.get("yanked"):
+            return False
+    return True
 
 
 def _fallback_info_version(payload: dict, pin: str | None) -> str | None:
@@ -159,14 +182,21 @@ def main() -> int:
     installed = _installed_version()
     if installed is None:
         return 0
-    latest = _latest_version()
+    pin = _read_pin_spec()
+    latest = _latest_version(pin)
     if latest is None:
         return 0
     if installed == latest:
         return 0
+    # Bare ``pip install --upgrade claude-org-runtime`` would fetch the
+    # PyPI maximum, which may be out of ja's pin window. Bake the pin
+    # spec into the recommended command so the user never gets steered
+    # to an unsupported version.
+    spec_suffix = pin if pin else ""
+    upgrade_target = f"{PACKAGE}{spec_suffix}"
     print(
         f"[runtime drift] {PACKAGE}: installed={installed} latest={latest} "
-        f"-- ja の pin 内最新です。`python -m pip install --upgrade '{PACKAGE}'` で更新できます"
+        f"-- `python -m pip install --upgrade '{upgrade_target}'` で更新できます"
     )
     return 0
 

--- a/tools/check_runtime_version.py
+++ b/tools/check_runtime_version.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
 """Runtime version drift check for /org-start (Issue #472).
 
-Compares the installed ``claude-org-runtime`` version against the latest
-release on PyPI. If they differ, prints a single warning line to stdout
-so /org-start can splice it into its Step 4 readiness report. In all
-other cases (versions match, package not installed, PyPI unreachable,
-parse failure) the script stays silent.
+Compares the installed ``claude-org-runtime`` version against the
+latest release on PyPI that still satisfies ja's pin window (declared
+in ``pyproject.toml`` dependencies, e.g. ``>=0.1.9,<0.2``). If they
+differ, prints a single warning line to stdout so /org-start can
+splice it into its Step 4 readiness report. In all other cases —
+versions match, package not installed, PyPI unreachable, parse
+failure, no pin-compatible release found, ``packaging`` import
+failure — the script stays silent.
+
+The pin window matters because /org-start's warning must not steer
+users into an upgrade that breaks ja's compatibility contract: when
+ja pins ``<0.2`` and PyPI ships ``0.2.0``, we still want to bring
+users up to the latest in-window release (e.g. ``0.1.11``) but never
+recommend the out-of-window one.
 
 The script never auto-upgrades and never exits non-zero — drift is
 informational, and skipping silently is the correct behavior when the
@@ -17,13 +26,12 @@ Used by ``.claude/skills/org-start/SKILL.md`` Block C2.
 from __future__ import annotations
 
 import json
+import re
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
 
-# On Windows the default console codepage is cp932 / cp1252, which can't
-# encode the JP message body. Force UTF-8 on stdout so /org-start (which
-# reads this script's stdout via the Bash tool) gets a clean string.
 try:
     sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
 except (AttributeError, OSError):
@@ -32,6 +40,12 @@ except (AttributeError, OSError):
 PACKAGE = "claude-org-runtime"
 PYPI_JSON_URL = f"https://pypi.org/pypi/{PACKAGE}/json"
 TIMEOUT_SEC = 3.0
+PYPROJECT_PATH = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+# Sentinel so callers can pass ``pin=None`` to *opt out* of the pin
+# window, while leaving the default unspecified branch free to
+# auto-discover the pin from pyproject.toml.
+_AUTO_PIN = object()
 
 
 def _installed_version() -> str | None:
@@ -47,7 +61,27 @@ def _installed_version() -> str | None:
         return None
 
 
-def _latest_version() -> str | None:
+def _read_pin_spec() -> str | None:
+    """Return the version specifier string for PACKAGE from
+    pyproject.toml, or None when it can't be located. We grep with a
+    regex rather than parse TOML so the script keeps its
+    zero-runtime-dependency contract (Python 3.10 has no stdlib
+    tomllib)."""
+    try:
+        text = PYPROJECT_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(
+        rf'["\']{re.escape(PACKAGE)}\s*([^"\']*?)["\']',
+        text,
+    )
+    if not m:
+        return None
+    spec = m.group(1).strip()
+    return spec or None
+
+
+def _fetch_pypi_payload() -> dict | None:
     try:
         req = urllib.request.Request(
             PYPI_JSON_URL,
@@ -61,11 +95,62 @@ def _latest_version() -> str | None:
         return None
     except Exception:
         return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _latest_version(pin=_AUTO_PIN) -> str | None:
+    """Return the newest stable release of PACKAGE on PyPI that
+    satisfies ``pin``. Pass ``pin=None`` to disable the pin window;
+    omit the argument to auto-discover the pin from pyproject.toml.
+    Returns None on any failure path so the caller stays silent."""
+    payload = _fetch_pypi_payload()
+    if payload is None:
+        return None
+
+    if pin is _AUTO_PIN:
+        pin = _read_pin_spec()
+
+    releases = payload.get("releases")
+    if isinstance(releases, dict) and releases:
+        try:
+            from packaging.specifiers import InvalidSpecifier, SpecifierSet
+            from packaging.version import InvalidVersion, Version
+        except ImportError:
+            return _fallback_info_version(payload, pin)
+        try:
+            spec = SpecifierSet(pin) if pin else SpecifierSet()
+        except InvalidSpecifier:
+            spec = SpecifierSet()
+        candidates: list[Version] = []
+        for raw in releases.keys():
+            try:
+                ver = Version(raw)
+            except InvalidVersion:
+                continue
+            if ver.is_prerelease or ver.is_devrelease:
+                continue
+            if spec and ver not in spec:
+                continue
+            candidates.append(ver)
+        if candidates:
+            return str(max(candidates))
+        return None
+
+    return _fallback_info_version(payload, pin)
+
+
+def _fallback_info_version(payload: dict, pin: str | None) -> str | None:
+    """Last-resort path when releases dict is missing or packaging is
+    unavailable. Trusts info.version only when no pin window applies
+    — silent skip otherwise to avoid recommending an out-of-window
+    upgrade."""
     info = payload.get("info") if isinstance(payload, dict) else None
     if not isinstance(info, dict):
         return None
     latest = info.get("version")
     if not isinstance(latest, str) or not latest:
+        return None
+    if pin:
         return None
     return latest
 
@@ -81,7 +166,7 @@ def main() -> int:
         return 0
     print(
         f"[runtime drift] {PACKAGE}: installed={installed} latest={latest} "
-        f"-- `pip install --upgrade {PACKAGE}` で最新化できます"
+        f"-- ja の pin 内最新です。`python -m pip install --upgrade '{PACKAGE}'` で更新できます"
     )
     return 0
 

--- a/tools/test_check_runtime_version.py
+++ b/tools/test_check_runtime_version.py
@@ -2,11 +2,13 @@
 
 The script is invoked by /org-start Block C2. It must:
 
-* print one warning line when installed != latest
+* print one warning line when installed != latest-in-pin-window
 * print nothing (and exit 0) when installed == latest
 * print nothing on every "can't tell" branch — package missing,
-  PyPI unreachable, JSON parse failure — because /org-start treats
-  silence as "no drift to report"
+  PyPI unreachable, JSON parse failure, no pin-compatible release
+* respect ja's pin window declared in pyproject.toml so the warning
+  never steers users to an out-of-window upgrade (Codex review,
+  Issue #472)
 """
 
 from __future__ import annotations
@@ -24,9 +26,21 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import check_runtime_version  # noqa: E402
 
+try:  # noqa: SIM105
+    import packaging  # type: ignore  # noqa: F401
+
+    _HAS_PACKAGING = True
+except ImportError:
+    _HAS_PACKAGING = False
+
+requires_packaging = unittest.skipUnless(
+    _HAS_PACKAGING,
+    "packaging not installed — pin-window resolution falls back to "
+    "silent skip, so the pin-aware paths are untestable here",
+)
+
 
 def _fake_urlopen(payload: dict):
-    """Return a context-manager-compatible stand-in for urlopen()."""
     body = json.dumps(payload).encode("utf-8")
 
     class _Resp(io.BytesIO):
@@ -40,7 +54,16 @@ def _fake_urlopen(payload: dict):
     return lambda *a, **kw: _Resp(body)
 
 
-class CheckRuntimeVersionTest(unittest.TestCase):
+def _payload(*versions: str) -> dict:
+    """Build a minimally-PyPI-shaped JSON payload from the given
+    release versions (newest last, as PyPI usually sorts)."""
+    return {
+        "info": {"version": versions[-1] if versions else ""},
+        "releases": {v: [{"yanked": False}] for v in versions},
+    }
+
+
+class MainCliTest(unittest.TestCase):
     def _run_main(self) -> tuple[int, str]:
         buf = io.StringIO()
         with mock.patch.object(sys, "stdout", buf):
@@ -93,15 +116,59 @@ class CheckRuntimeVersionTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(out, "")
 
-    def test_pypi_returns_garbage_is_silent(self):
-        with mock.patch.object(
-            check_runtime_version, "_installed_version", return_value="0.1.2"
-        ), mock.patch(
+
+class LatestVersionTest(unittest.TestCase):
+    """Direct tests for _latest_version() and the pin-window logic."""
+
+    @requires_packaging
+    def test_picks_latest_within_pin_window(self):
+        payload = _payload("0.1.9", "0.1.11", "0.2.0", "0.2.1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2"),
+                "0.1.11",
+            )
+
+    @requires_packaging
+    def test_no_pin_picks_global_max(self):
+        payload = _payload("0.1.9", "0.1.11", "0.2.0", "0.2.1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(
+                check_runtime_version._latest_version(pin=None),
+                "0.2.1",
+            )
+
+    @requires_packaging
+    def test_skips_prereleases(self):
+        payload = _payload("0.1.9", "0.1.11", "0.1.12a1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2"),
+                "0.1.11",
+            )
+
+    @requires_packaging
+    def test_no_pin_compatible_release_is_silent(self):
+        payload = _payload("0.2.0", "0.2.1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertIsNone(
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2")
+            )
+
+    @requires_packaging
+    def test_invalid_pin_falls_back_to_global_max(self):
+        payload = _payload("0.1.9", "0.1.11")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(
+                check_runtime_version._latest_version(pin="garbage"),
+                "0.1.11",
+            )
+
+    def test_pypi_returns_empty_payload_is_silent(self):
+        with mock.patch(
             "urllib.request.urlopen", _fake_urlopen({"info": {"version": ""}})
         ):
-            code, out = self._run_main()
-        self.assertEqual(code, 0)
-        self.assertEqual(out, "")
+            self.assertIsNone(check_runtime_version._latest_version(pin=None))
 
     def test_pypi_json_parse_failure_is_silent(self):
         class _Resp(io.BytesIO):
@@ -112,22 +179,40 @@ class CheckRuntimeVersionTest(unittest.TestCase):
                 self.close()
                 return False
 
-        with mock.patch.object(
-            check_runtime_version, "_installed_version", return_value="0.1.2"
-        ), mock.patch(
-            "urllib.request.urlopen",
-            lambda *a, **kw: _Resp(b"not-json"),
+        with mock.patch(
+            "urllib.request.urlopen", lambda *a, **kw: _Resp(b"not-json")
         ):
-            code, out = self._run_main()
-        self.assertEqual(code, 0)
-        self.assertEqual(out, "")
+            self.assertIsNone(check_runtime_version._latest_version(pin=None))
 
-    def test_latest_version_extracted_from_pypi_payload(self):
-        """End-to-end smoke: _latest_version returns the payload's
-        info.version when urlopen succeeds."""
-        payload = {"info": {"version": "9.9.9"}, "releases": {}}
+    def test_fallback_to_info_version_when_releases_missing_and_no_pin(self):
+        payload = {"info": {"version": "1.2.3"}}
         with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
-            self.assertEqual(check_runtime_version._latest_version(), "9.9.9")
+            self.assertEqual(
+                check_runtime_version._latest_version(pin=None),
+                "1.2.3",
+            )
+
+    def test_fallback_is_silent_when_pin_present_but_releases_missing(self):
+        """Without a releases dict we can't enforce a pin window, so
+        prefer silence over recommending an out-of-window upgrade."""
+        payload = {"info": {"version": "1.2.3"}}
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertIsNone(
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2")
+            )
+
+
+class ReadPinSpecTest(unittest.TestCase):
+    def test_reads_pin_from_real_pyproject(self):
+        """The script lives next to ja's pyproject.toml; sanity-check
+        the actual file has a pin we recognise."""
+        spec = check_runtime_version._read_pin_spec()
+        self.assertIsNotNone(spec)
+        self.assertIn("claude-org-runtime", "claude-org-runtime")  # tautology
+        self.assertTrue(
+            spec.startswith(">=") or spec.startswith("=="),
+            f"unexpected pin shape: {spec!r}",
+        )
 
 
 if __name__ == "__main__":

--- a/tools/test_check_runtime_version.py
+++ b/tools/test_check_runtime_version.py
@@ -54,12 +54,16 @@ def _fake_urlopen(payload: dict):
     return lambda *a, **kw: _Resp(body)
 
 
-def _payload(*versions: str) -> dict:
+def _payload(*versions: str, yanked: tuple[str, ...] = ()) -> dict:
     """Build a minimally-PyPI-shaped JSON payload from the given
-    release versions (newest last, as PyPI usually sorts)."""
+    release versions (newest last, as PyPI usually sorts). Versions
+    listed in ``yanked`` are emitted with every file marked yanked."""
+    releases = {}
+    for v in versions:
+        releases[v] = [{"yanked": v in yanked}]
     return {
         "info": {"version": versions[-1] if versions else ""},
-        "releases": {v: [{"yanked": False}] for v in versions},
+        "releases": releases,
     }
 
 
@@ -156,12 +160,28 @@ class LatestVersionTest(unittest.TestCase):
             )
 
     @requires_packaging
-    def test_invalid_pin_falls_back_to_global_max(self):
-        payload = _payload("0.1.9", "0.1.11")
+    def test_invalid_pin_is_silent(self):
+        """When the pin string fails to parse we can no longer enforce
+        the window, so prefer silence over recommending an
+        out-of-window upgrade (Codex round 2 Major)."""
+        payload = _payload("0.1.9", "0.1.11", "0.2.1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertIsNone(
+                check_runtime_version._latest_version(pin="garbage")
+            )
+
+    @requires_packaging
+    def test_yanked_release_is_excluded(self):
+        """If the only in-window release newer than installed is
+        yanked, _latest_version must not surface it as ``latest`` —
+        pip wouldn't pick it either (Codex round 2 Minor)."""
+        payload = _payload(
+            "0.1.9", "0.1.10", "0.1.11", yanked=("0.1.11",)
+        )
         with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
             self.assertEqual(
-                check_runtime_version._latest_version(pin="garbage"),
-                "0.1.11",
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2"),
+                "0.1.10",
             )
 
     def test_pypi_returns_empty_payload_is_silent(self):
@@ -208,11 +228,41 @@ class ReadPinSpecTest(unittest.TestCase):
         the actual file has a pin we recognise."""
         spec = check_runtime_version._read_pin_spec()
         self.assertIsNotNone(spec)
-        self.assertIn("claude-org-runtime", "claude-org-runtime")  # tautology
         self.assertTrue(
             spec.startswith(">=") or spec.startswith("=="),
             f"unexpected pin shape: {spec!r}",
         )
+
+
+class UpgradeCommandShapeTest(unittest.TestCase):
+    """Warning text must bake the pin spec into the recommended
+    upgrade command so users never get steered to an out-of-window
+    release (Codex round 2 Major)."""
+
+    def _drive_main_with_pin(self, pin):
+        buf = io.StringIO()
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.2"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=pin
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.11"
+        ), mock.patch.object(sys, "stdout", buf):
+            check_runtime_version.main()
+        return buf.getvalue()
+
+    def test_command_includes_pin_when_pin_known(self):
+        out = self._drive_main_with_pin(">=0.1.9,<0.2")
+        self.assertIn(
+            "'claude-org-runtime>=0.1.9,<0.2'",
+            out,
+            "upgrade command must carry the pin spec",
+        )
+
+    def test_command_is_bare_when_pin_missing(self):
+        out = self._drive_main_with_pin(None)
+        self.assertIn("'claude-org-runtime'", out)
+        self.assertNotIn("<", out.split("install --upgrade")[-1])
 
 
 if __name__ == "__main__":

--- a/tools/test_check_runtime_version.py
+++ b/tools/test_check_runtime_version.py
@@ -1,0 +1,134 @@
+"""Unit tests for tools/check_runtime_version.py (Issue #472).
+
+The script is invoked by /org-start Block C2. It must:
+
+* print one warning line when installed != latest
+* print nothing (and exit 0) when installed == latest
+* print nothing on every "can't tell" branch — package missing,
+  PyPI unreachable, JSON parse failure — because /org-start treats
+  silence as "no drift to report"
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_runtime_version  # noqa: E402
+
+
+def _fake_urlopen(payload: dict):
+    """Return a context-manager-compatible stand-in for urlopen()."""
+    body = json.dumps(payload).encode("utf-8")
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.close()
+            return False
+
+    return lambda *a, **kw: _Resp(body)
+
+
+class CheckRuntimeVersionTest(unittest.TestCase):
+    def _run_main(self) -> tuple[int, str]:
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stdout", buf):
+            code = check_runtime_version.main()
+        return code, buf.getvalue()
+
+    def test_drift_prints_one_warning_line(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.11"
+        ):
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        lines = [ln for ln in out.splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1)
+        self.assertIn("[runtime drift]", lines[0])
+        self.assertIn("installed=0.1.2", lines[0])
+        self.assertIn("latest=0.1.11", lines[0])
+
+    def test_match_is_silent(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.11"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.11"
+        ):
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+
+    def test_package_not_installed_is_silent(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value=None
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version"
+        ) as latest_mock:
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+        latest_mock.assert_not_called()
+
+    def test_offline_is_silent(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.2"
+        ), mock.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("offline"),
+        ):
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+
+    def test_pypi_returns_garbage_is_silent(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.2"
+        ), mock.patch(
+            "urllib.request.urlopen", _fake_urlopen({"info": {"version": ""}})
+        ):
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+
+    def test_pypi_json_parse_failure_is_silent(self):
+        class _Resp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self.close()
+                return False
+
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.2"
+        ), mock.patch(
+            "urllib.request.urlopen",
+            lambda *a, **kw: _Resp(b"not-json"),
+        ):
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+
+    def test_latest_version_extracted_from_pypi_payload(self):
+        """End-to-end smoke: _latest_version returns the payload's
+        info.version when urlopen succeeds."""
+        payload = {"info": {"version": "9.9.9"}, "releases": {}}
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(check_runtime_version._latest_version(), "9.9.9")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a runtime version drift check to `/org-start` so the Secretary surfaces a one-line warning when the locally installed `claude-org-runtime` falls behind the latest in-window release on PyPI. Notification only — no auto-upgrade.

Closes #472. See #470 for the original incident (worker delegation failed because the runtime was 9 versions behind and nobody noticed until `gen_delegate_payload.py apply` rejected unknown CLI args).

## Changes

- `.claude/skills/org-start/SKILL.md`: new **Block C2** that runs in parallel with Block A spawn and Block C dashboard startup. The drift check result is transcribed verbatim into the Step 4 startup report.
- `tools/check_runtime_version.py` (new): pin-window-aware drift detection CLI.
  - installed version: `importlib.metadata.version`
  - latest version: PyPI JSON API (`/pypi/<pkg>/json`) via `urllib.request` with 3s timeout
  - pin window: parsed from `pyproject.toml` via `packaging.specifiers.SpecifierSet`. Latest is restricted to releases that satisfy the pin so the warning never suggests an out-of-window upgrade.
  - yanked / invalid versions are excluded.
  - the suggested `pip install` command bakes the pin into the spec (e.g. `pip install 'claude-org-runtime>=X,<Y'`) so users don't accidentally jump out of the window.
- `tools/test_check_runtime_version.py` (new): 17 unit tests. With `packaging` installed all pass; without `packaging` 6 tests skip and the remaining 11 still pass.

## Silent-skip conditions (no warning emitted)

- `installed == latest_in_window`
- runtime not installed
- offline (PyPI fetch fails)
- PyPI response parse failure
- pin parse failure (`InvalidSpecifier`)
- no releases satisfy the pin window
- `packaging` library not available

## Verification (3 scenarios, all pass)

1. **Old install**: `pip install claude-org-runtime==0.1.2` → `[runtime drift] ...` one-liner with a pin-aware `pip install` command suggested.
2. **Up to date**: stdout empty (silent).
3. **Offline**: `urllib.request.urlopen` patched to raise `URLError` → silent skip.

## Codex self-review

- Round 1: 1 Major (pin window not respected) + 1 Minor (bare pip command) → fixed in 4cdc924.
- Round 2: 2 Major (pin not baked into upgrade command / `InvalidSpecifier` not silenced) + 1 Minor (yanked exclusion) + 1 Nit (tautology) → fixed in cb3531c.
- Round 3: no Blocker / Major remaining (no-issue).

The doc-side fix `d5a9b85` drops hard-coded version numbers from the SKILL.md examples (placeholder form `{installed}` / `{latest}`) so future runtime releases don't make the docs rot — Secretary's explicit follow-up instruction.

## Test plan

- [ ] CI passes
- [ ] Manual: `pip install claude-org-runtime==0.1.2 && python tools/check_runtime_version.py` shows drift warning with pin-aware upgrade command
- [ ] Manual: with latest runtime installed, `python tools/check_runtime_version.py` exits silently
- [ ] Manual: offline run silently skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
