### PR TITLE
docs: codify 1 worker = 1 task = 1 scope (#475)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -194,6 +194,16 @@ dogfood 対象判定 / 窓口責務 (A) 実装起票時の `registry/dogfood_pen
 
 `tools/journal_append.sh` / `tools/journal_append.py` / `tools/set_run_pr_open.py` / `python -c "... StateWriter ..."` 等、`state.db` を相対パスで開く tool は ja root 相対前提。worker / worktree cwd から起動すると `no such table: runs` / `no such table: events` でサイレント or クラッシュ失敗し、後段の post-commit hook や snapshot 再生成も走らない。必ず `cd <ja-root>` してから実行すること。Issue #398 で根本対応中。
 
+### 窓口 → worker のメッセージング規約（Issue #475: 1 worker = 1 task = 1 scope）
+
+窓口から既存 worker へ送る全 message は「1 worker = 1 task = 1 scope」の原則に従う。canonical な 3 rule は CLAUDE.md「役割の境界 > worker への追加依頼の境界」を SoT 参照:
+
+1. **追加依頼は元タスクのスコープ内に限る**: brief で示した範囲内の補足・修正指示のみ追送する。スコープ外の別件は同 worker に投入せず、Step 0 から本 SKILL を回し直してディスパッチャー経由で別 worker を派遣する
+2. **worker のスコープ拡張提案は escalation 経由**: 窓口は一次承認せず [`/org-escalation`](../org-escalation/SKILL.md) を発動する
+3. **窓口は worker 作業を代行しない**: ファイル編集・commit・テスト等を窓口側 worktree で手を出さず、追加依頼として worker に戻すか別 worker を派遣する
+
+違反事例: 2026-05-21 voice-v2-independent ペインへの別件混入投入（スコープ外作業を同 worker に追送し、本来別 worker を立てるべき別件を 1 worker に集約してしまった）。本節の guard / CI 実装は別 Issue。
+
 ### DELEGATE_COMPLETE 受信時
 
 ディスパッチャーから派遣完了報告を受け取ったら、各ワーカーに挨拶メッセージを送る:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,16 @@
 - 実作業は全てワーカーに委譲する（コード編集、デバッグ、テスト、ビルド、git commit、環境構築等）
 - 問題が報告されたら、自分で調査せずワーカーに投げる
 
+### worker への追加依頼の境界（Issue #475: 1 worker = 1 task = 1 scope）
+
+派遣済 worker への追加依頼は「1 worker = 1 task = 1 scope」の原則に従う。窓口から既存ワーカーに追送するメッセージは以下 3 rule を満たすこと:
+
+1. **追加依頼は元タスクのスコープ内に限る**: 同一 worker への追送は brief で示された範囲内の補足・修正指示のみ。スコープ外の別件を同 worker に混入させない。別件は Step 0 から [`/org-delegate`](./.claude/skills/org-delegate/SKILL.md) を回し直し、ディスパッチャー経由で別 worker を派遣する。
+2. **worker のスコープ拡張は escalation 経由**: worker から「ついでにこれもやっていいか」「想定外のこの修正も必要」等のスコープ拡張提案が来た場合、窓口は一次承認せず [`/org-escalation`](./.claude/skills/org-escalation/SKILL.md) で人間に上げる。
+3. **窓口は worker 作業を代行しない**: ファイル編集・commit・テスト等の実作業を窓口側 worktree で手を出さず、追加依頼として元 worker に戻すか、別 worker を派遣する。
+
+違反事例: 2026-05-21 voice-v2-independent ペインへの別件混入投入（スコープ外の作業を同一 worker に追送し、1 worker 1 task 1 scope を破った）。本 Issue は明文化のみが対象で、guard / CI 実装は別 Issue で扱う。
+
 ## ワーカー peer message を受けたら必ず ack を返す（Issue #312）
 
 ワーカーから renga-peers で完了 / 進捗 / Codex round / 判断仰ぎ いずれの message を受け取っても、Secretary は **最初に worker 宛 ack** を `mcp__renga-peers__send_message(to_id="worker-{task_id}", ...)` で発行する。ack を返さないと worker は「ペイン保持。次の指示お待ちします」のまま idle で dead-lock する。canonical event flow と ack 文例は [`.claude/skills/org-delegate/SKILL.md` Step 5](./.claude/skills/org-delegate/SKILL.md) と [`.claude/skills/org-delegate/references/ack-template.md`](./.claude/skills/org-delegate/references/ack-template.md) を参照。**ack ≠ user 承認**: push / `gh pr create` / `tools/pr-watch.*` は user の明示的 OK を受けてから発行する。


### PR DESCRIPTION
## Summary

Issue #475 解消: 「1 worker = 1 task = 1 scope」の組織原則を明文化する。

- `CLAUDE.md`「役割の境界」セクションに **「worker への追加依頼の境界」** サブセクションを追加。3 rule:
  1. 窓口 → worker への追加依頼は元タスクスコープ内に限る。スコープ外の別件は dispatcher 経由で別 worker を派遣する
  2. worker は自身のスコープ拡張を独断で判断せず escalation で窓口に上げる
  3. 窓口は worker の作業を「ついでに」処理しない
- `.claude/skills/org-delegate/SKILL.md` Step 5（窓口 → worker のメッセージング規約）に同原則を追記
- 違反事例として 2026-05-21 voice-v2-independent への混入投入を short citation で記載
- 本 PR は明文化のみ。guard / CI による強制は別 Issue で扱う

Closes #475.

## Test plan

- [ ] Doc-only diff (+20 lines、2 files)。runtime behavior に影響なし
- [ ] CLAUDE.md 「役割の境界」のサブセクションと org-delegate Step 5 の文言が rule 整合
- [ ] auto-mirror runtime が translation-pending を en 側に立てることを確認 (P2 flow)

Generated with [Claude Code](https://claude.com/claude-code)