### PR TITLE
fix(pattern-c-cleanup): delete leftover CLAUDE.local.md for Pattern C self-edit (Closes #478)

### DIFF
--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -43,6 +43,21 @@ claude-org 自己編集タスクでは、SKILL.md Step 1.5 および `worker-cla
 
 ルートの `CLAUDE.md`（Secretary 指示）はいかなる場合も上書きしない。
 
+### ワーカー完了時の Secretary 側 cleanup 責務（Issue #478）
+
+`CLAUDE.local.md` は **生成して終わりではなく、ワーカー完了時に Secretary が回収する**責務まで含む。回収経路はパターンで分かれる:
+
+- **Pattern B（`live_repo_worktree`）**: ブリーフは worktree 直下（`{claude_org_path}/.worktrees/{task_id}/CLAUDE.local.md`）にあるので、close 時の `git -C {claude_org_path} worktree remove .worktrees/{task_id}` がディレクトリごと回収する。個別削除は不要。
+- **Pattern C（`gitignored_repo_root`）**: `worker_dir` が claude-org repo root 自身なので、worktree remove も dir 削除も効かない。`{claude_org_root}/CLAUDE.local.md` を **個別に削除しないと残留**し、次回 `/org-start` で Secretary が「窓口かつワーカー」という矛盾した role identity（冒頭の「あなたは窓口ではなくワーカーである」）を context に読み込む。gitignored なので CI でも検出されず地層化する（Issue #478 の発生事例: `lt-lapras-392778-01`）。
+
+Pattern C の個別削除は close phase の責務として [`.claude/skills/org-pull-request/SKILL.md`](../../org-pull-request/SKILL.md) 2b-ii に組み込まれている。実体は [`tools/run_complete_on_merge.py`](../../../../tools/run_complete_on_merge.py) の `cleanup_pattern_c_local_md(conn, task_id=..., claude_org_root=...)`:
+
+- 判定: `runs.pattern == 'C'` AND `worker_dirs.abs_path == claude_org_root`（schema 拡張不要。ephemeral C は `worker_dir != root` で自動的に no-op）。
+- 動作: `{claude_org_root}/CLAUDE.local.md` を `Path.unlink(missing_ok=True)` で削除し、`events` に `pattern_c_cleanup`（payload: `task` / `removed_path` / `mode`）を 1 行残す。idempotent（ファイル不在なら `mode=skip`、エラーで止めない）。
+- PR 起点のクローズで `tools/run_complete_on_merge.py --pr <PR>` を呼ぶ場合は merge 記録時に自動で同 cleanup が走る。ただし gitignored タスクは PR を生まないことが多いため、close phase の StateWriter ブロックでの明示呼び出しが本筋。
+
+> **scope**: 本 Issue のスコープは `CLAUDE.local.md` のみ。`.claude/settings.local.json` の自動削除は worker 由来 / Secretary 由来（renga-peers MCP allow 等で Secretary 自身も使う）の切り分け設計が要るため別 Issue。
+
 ## 3. Pattern B の worktree base は **Secretary の live repo** に置く（live_repo_worktree variant）
 
 claude-org 自己編集タスクで Pattern B（worktree）を採る場合、worktree base は **通常パターンの `{workers_dir}/{project_slug}/.worktrees/{task_id}/` ではなく Secretary 自身の live repo の `.worktrees/`** に置く:

--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -117,7 +117,8 @@ allowed-tools:
   - パターン A（プロジェクトディレクトリ）: ディレクトリは保持する（次タスクで再利用）
   - パターン B（worktree）: `git -C {workers_dir}/{project_slug}/ worktree remove .worktrees/{task_id}` を実行。ブランチは残す（マージ済みでもブランチ削除はしない、PR 履歴用）
     - **self-edit (`pattern_variant='live_repo_worktree'`) の場合**: worktree base が `{claude_org_path}` なので `git -C {claude_org_path} worktree remove .worktrees/{task_id}` を実行する（Issue #289）。ブランチは同様に残す
-  - パターン C（エフェメラル）: ディレクトリは保持する（容量が問題になった場合のみ手動削除を検討）
+  - パターン C（エフェメラル, `pattern_variant='ephemeral'`）: ディレクトリは保持する（容量が問題になった場合のみ手動削除を検討）
+  - **パターン C（`gitignored_repo_root`, claude-org 自己編集）の特例 cleanup（Issue #478）**: `worker_dir` が claude-org-ja repo root 自身なので、worktree remove も dir 削除も効かず、`{claude_org_root}/CLAUDE.local.md`（ワーカー指示ブリーフ）が残留する。残ると次回 `/org-start` で Secretary が「窓口かつワーカー」という矛盾 role identity を読み込む。**close 時に `tools/run_complete_on_merge.py` の `cleanup_pattern_c_local_md()` を呼んでブリーフを削除する**（下記 StateWriter ブロックに同梱）。判定は `runs.pattern == 'C'` AND `worker_dirs.abs_path == claude_org_root` で行われ、ephemeral C / パターン A・B では no-op。`events` に `pattern_c_cleanup`（payload: `task` / `removed_path` / `mode`）が 1 行残る。idempotent（ファイル不在なら `mode=skip`）。PR 起点のクローズで `tools/run_complete_on_merge.py --pr <PR>` を呼ぶ場合は merge 記録時に自動で同 cleanup が走るが、gitignored タスクは PR を生まないことが多いので、下記 StateWriter ブロックでの明示呼び出しが本筋の経路。`.claude/settings.local.json` は worker 由来 / Secretary 由来の切り分けが要るためスコープ外（別 Issue）
 - **dogfood 対象 PR の paired issue クローズ時（Issue #338）**: 実装 PR のマージと paired follow-up issue のクローズはライフサイクルが独立しうるため、本スキル側では「実装 PR マージで `consumed → closed` をする」という保証はしない。`consumed → closed` の終端遷移は窓口の register hygiene 責務として [`.claude/skills/org-delegate/SKILL.md`](../org-delegate/SKILL.md) Step 1.8 §consumed → closed 観察タイミング（register 書き込み時 + `/org-resume` 起動時に `gh issue view` で paired issue 状態確認）で回収する。本スキルが PR マージ時にたまたま該当行を観察した場合のみ、ついでに hygiene 手順を呼ぶ
 - **PR 起点のクローズの場合は `tools/run_complete_on_merge.py` を呼ぶ** (Issue #317。`pr-watch --merge-watch` の merge-watch ループが自動で起動するので通常は手動実行不要だが、merge-watch を skip した場合や手動でマージを観測した場合のみ明示的に呼ぶ):
   ```bash
@@ -129,12 +130,17 @@ allowed-tools:
 - **パターン B / C のレジストリエントリ削除と最終 close は別途 StateWriter を呼ぶ**（markdown 直接編集禁止。run_complete_on_merge が `pr_state='merged'` と `completed_at` を既に書いているので、ここでは status flip と worker_dir 削除のみ行う）:
   ```bash
   python -c "
+  from pathlib import Path
   from tools.state_db import connect
   from tools.state_db.writer import StateWriter
+  from tools.run_complete_on_merge import cleanup_pattern_c_local_md
   conn = connect('.state/state.db')
   with StateWriter(conn).transaction() as w:
       w.update_run_status('<task_id>', 'completed')  # post-commit hook が worker-{task}.md を archive
       w.remove_worker_dir('<abs>')  # パターン B / C のみ
+  # Issue #478: Pattern C gitignored_repo_root の CLAUDE.local.md を削除
+  # （runs.pattern=='C' AND worker_dir==root のときのみ実削除。他は no-op）
+  cleanup_pattern_c_local_md(conn, task_id='<task_id>', claude_org_root=Path('.').resolve())
   "
   ```
   legacy のハンドロール完了スクリプトは `docs/legacy/pr-merge-completion-manual.md` に保管されている。標準経路は上記 `tools/run_complete_on_merge.py` であり、museum copy へ reach するのは Issue を切ってユーザー判断を仰いだ後に限る (PR #315 と同じ pattern)

--- a/docs/contracts/role-pattern-sandbox-contract.md
+++ b/docs/contracts/role-pattern-sandbox-contract.md
@@ -731,6 +731,62 @@ existing branch. Therefore:
   Phase 1** could consider denying `Bash(git checkout *)` /
   `Bash(git switch *)` for this sub-mode.
 
+##### Post-completion cleanup contract (Issue #478)
+
+Because `worker_dir == <existing_repo_root>` (and, for the claude-org
+self-edit case, that root is the secretary's live `<claude_org_path>/`), the
+brief file the secretary placed at `<worker_dir>/CLAUDE.local.md` (per
+[`.claude/skills/org-delegate/references/claude-org-self-edit.md`](../../.claude/skills/org-delegate/references/claude-org-self-edit.md)
+§2) is **not reclaimed by the close-time directory teardown** that Patterns A
+/ B / C-ephemeral rely on:
+
+| Pattern / variant | `worker_dir` | Brief reclaimed at close by | Residue risk |
+|---|---|---|---|
+| B (default / `live_repo_worktree`) | a `.worktrees/<task_id>/` subtree | `git worktree remove` deletes the subtree | none |
+| C ephemeral | `<workers_dir>/<task_id>/` | dir retained or `rm -rf` (manual) | none (no `CLAUDE.local.md` there) |
+| **C `gitignored_repo_root`** | `<existing_repo_root>/` (host repo, **not removable**) | **nothing** — there is no worktree / disposable dir to delete | `CLAUDE.local.md` lingers in the repo root |
+
+A lingering self-edit `CLAUDE.local.md` is not cosmetic: its first line tells
+the reader "あなたは窓口ではなくワーカーである", so on the next `/org-start` the
+secretary loads a contradictory role identity (secretary *and* that worker),
+inherits the worker's `git push` / Codex / verification constraints, and the
+worker's completion `send_message(to_id="secretary", ...)` becomes a self-loop.
+It is gitignored, so CI never flags it (the Issue #478 stratification example:
+task `lt-lapras-392778-01`, residual for a week).
+
+**Contract**: a Pattern C `gitignored_repo_root` run carries a
+**post-completion cleanup obligation on the secretary** — at close, the brief
+`<existing_repo_root>/CLAUDE.local.md` MUST be deleted. The canonical
+mechanization is [`tools/run_complete_on_merge.py`](../../tools/run_complete_on_merge.py)
+`cleanup_pattern_c_local_md()`:
+
+- **Detection** (no schema change): `runs.pattern == 'C'` AND the run's
+  `worker_dirs.abs_path` equals `<claude_org_path>` (the repo root). Pattern C
+  ephemeral has `worker_dir == <workers_dir>/<task_id> ≠ root`, so it falls
+  through as a no-op; Patterns A / B are excluded by the `pattern == 'C'` gate.
+  (The schema stores `runs.pattern` but **not** `pattern_variant`; the
+  root-equality check is the cheap derivation that distinguishes the two
+  Pattern C sub-modes without a migration.)
+- **Idempotency**: `Path.unlink(missing_ok=True)` — never raises on a missing
+  file; safe to re-invoke.
+- **Audit**: appends one `events` row `kind='pattern_c_cleanup'`
+  (payload `task` / `removed_path` / `mode`, where `mode='auto'` on actual
+  removal and `mode='skip'` when the brief was already gone). Non-qualifying
+  runs write nothing.
+- **Trigger paths**: the PR-merge close path
+  (`tools/run_complete_on_merge.py --pr <PR>`) runs it automatically when it
+  records the merge; the non-PR close path — the common case, since gitignored
+  edits rarely produce a merged PR — invokes it from the secretary's close
+  block in [`.claude/skills/org-pull-request/SKILL.md`](../../.claude/skills/org-pull-request/SKILL.md)
+  2b-ii.
+
+**Scope boundary**: `<existing_repo_root>/.claude/settings.local.json` is
+**NOT** covered by this cleanup. The secretary itself uses that file (e.g.
+renga-peers MCP allows), so deleting it requires a worker-origin-vs-secretary-
+origin discrimination design that is deferred to a follow-up Issue. Phase 0 /
+Issue #478 cover only the `CLAUDE.local.md` brief. **Gap → follow-up Issue**
+for the settings file.
+
 #### 4.3.3 knowledge/raw/ carve-out
 
 Same as §4.1.4 (full-only).

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -67,6 +67,86 @@ RESULT_NO_RUN = "no_run"        # No matching run row; nothing written.
 RESULT_MERGED_PENDING_CLEANUP = RESULT_MERGED
 
 
+# --- Pattern C (gitignored_repo_root) post-completion cleanup (Issue #478) --
+# The brief filename the secretary writes into a claude-org self-edit worker's
+# dir (per .claude/skills/org-delegate/references/claude-org-self-edit.md §2).
+# For Pattern B (live_repo_worktree) the worktree removal at close reclaims it;
+# for Pattern C gitignored_repo_root the worker_dir *is* the claude-org repo
+# root, so there is no directory to remove and the brief must be deleted
+# file-by-file or it lingers and overwrites the secretary's role identity on
+# the next /org-start.
+PATTERN_C_BRIEF_FILENAME = "CLAUDE.local.md"
+
+# Return codes for :func:`cleanup_pattern_c_local_md`.
+CLEANUP_REMOVED = "removed"          # file existed and was deleted; event mode=auto.
+CLEANUP_ABSENT = "absent"            # Pattern C @ root but file already gone; event mode=skip.
+CLEANUP_NOT_APPLICABLE = "not_applicable"  # not Pattern C, or worker_dir != root; no event.
+
+
+def cleanup_pattern_c_local_md(
+    conn,
+    *,
+    task_id: str,
+    claude_org_root: Path,
+) -> str:
+    """Remove a leftover ``CLAUDE.local.md`` from the claude-org repo root
+    for a Pattern C ``gitignored_repo_root`` self-edit run (Issue #478).
+
+    Detection (design judgment 1 of Issue #478): ``runs.pattern == 'C'`` AND
+    the run's ``worker_dirs.abs_path`` equals ``claude_org_root``. This needs
+    no schema change — Pattern C *ephemeral* has ``worker_dir`` at
+    ``{workers_dir}/{task_id}`` (≠ root), so it is reclaimed by ordinary dir
+    removal and naturally falls through here as ``not_applicable``.
+
+    Idempotent: ``Path.unlink(missing_ok=True)`` never raises on a missing
+    file, and a re-call after the brief is gone returns
+    :data:`CLEANUP_ABSENT`. An audit row (``kind='pattern_c_cleanup'``) is
+    appended whenever the run qualifies — ``mode='auto'`` when the file was
+    actually removed, ``mode='skip'`` when it was already absent — so the
+    hook firing is observable in the events table. Non-qualifying runs
+    (Pattern A/B, or Pattern C ephemeral) write nothing.
+
+    Returns one of :data:`CLEANUP_REMOVED`, :data:`CLEANUP_ABSENT`,
+    :data:`CLEANUP_NOT_APPLICABLE`.
+    """
+    row = conn.execute(
+        "SELECT r.pattern, d.abs_path "
+        "FROM runs r LEFT JOIN worker_dirs d ON d.id = r.worker_dir_id "
+        "WHERE r.task_id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return CLEANUP_NOT_APPLICABLE
+    pattern = (row["pattern"] or "").upper()
+    worker_dir = row["abs_path"]
+    if pattern != "C" or not worker_dir:
+        return CLEANUP_NOT_APPLICABLE
+
+    root = Path(claude_org_root).resolve()
+    if Path(worker_dir).resolve() != root:
+        # Pattern C ephemeral: worker_dir is {workers_dir}/{task_id}, a
+        # disposable dir whose CLAUDE.md is reclaimed by dir removal.
+        return CLEANUP_NOT_APPLICABLE
+
+    target = root / PATTERN_C_BRIEF_FILENAME
+    existed = target.exists()
+    target.unlink(missing_ok=True)  # OS-level idempotent
+
+    from tools.state_db.writer import StateWriter
+    with StateWriter(conn).transaction() as w:
+        w.append_event(
+            kind="pattern_c_cleanup",
+            actor="run_complete_on_merge",
+            payload={
+                "task": task_id,
+                "removed_path": str(target),
+                "mode": "auto" if existed else "skip",
+            },
+            run_task_id=task_id,
+        )
+    return CLEANUP_REMOVED if existed else CLEANUP_ABSENT
+
+
 def _ensure_gh_installed() -> None:
     if shutil.which("gh") is None:
         sys.stderr.write(
@@ -321,6 +401,18 @@ def complete_on_merge(
             "CLOSE_PANE / remove_worker_dir and call "
             "update_run_status('<task>', 'completed') (Step 5 2b-ii / "
             "delegation-lifecycle-contract §T5).\n"
+        )
+        # Issue #478: a Pattern C gitignored_repo_root self-edit run keeps
+        # its CLAUDE.local.md inside the claude-org repo root (worker_dir ==
+        # root), so the worktree-remove path the secretary runs at close has
+        # no directory to reclaim it. Delete the brief here while we have the
+        # connection. No-op for every other pattern/variant. The non-PR
+        # close path (gitignored tasks rarely produce a merged PR) must call
+        # this helper from the runbook too — see org-pull-request 2b-ii.
+        cleanup_pattern_c_local_md(
+            conn,
+            task_id=resolved_task_id,
+            claude_org_root=db_path.parent.parent,
         )
         return RESULT_MERGED
     finally:

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -56,6 +56,30 @@ def _seed_run(db_path: Path, *, pr_url: str = PR_URL, branch: str = BRANCH,
         conn.close()
 
 
+def _seed_pattern_c_run(db_path: Path, *, worker_dir: str, pattern: str = "C",
+                        task_id: str = TASK_ID) -> None:
+    """Seed a run linked to a worker_dir, for the Issue #478 cleanup tests.
+
+    ``worker_dir`` is registered first so ``upsert_run`` can resolve it to a
+    ``worker_dir_id`` within the same transaction.
+    """
+    apply_schema(connect(db_path))
+    conn = connect(db_path)
+    try:
+        with StateWriter(conn).transaction() as w:
+            w.register_worker_dir(abs_path=worker_dir, is_git_repo=True)
+            w.upsert_run(
+                task_id=task_id,
+                project_slug="claude-org-ja",
+                pattern=pattern,
+                title="pattern C self-edit",
+                status="review",
+                worker_dir_abs_path=worker_dir,
+            )
+    finally:
+        conn.close()
+
+
 def _make_pr_view(*, merged_at=MERGED_AT, merge_oid=MERGE_OID) -> dict:
     return {
         "number": PR,
@@ -323,6 +347,125 @@ class CLITests(unittest.TestCase):
                     "--db-path", str(db),
                 ])
             self.assertEqual(rc, 3)
+
+
+class CleanupPatternCTests(unittest.TestCase):
+    """Issue #478: Pattern C gitignored_repo_root CLAUDE.local.md cleanup."""
+
+    def _brief_path(self, root: Path) -> Path:
+        return root / run_complete_on_merge.PATTERN_C_BRIEF_FILENAME
+
+    def test_pattern_c_at_root_removes_brief_and_records_event(self) -> None:
+        """Case 1: Pattern C + worker_dir == claude_org_root → delete + event."""
+        with TempDB() as db:
+            root = db.parent
+            brief = self._brief_path(root)
+            brief.write_text("worker brief\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=str(root.resolve()))
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+            finally:
+                conn.close()
+            self.assertEqual(result, run_complete_on_merge.CLEANUP_REMOVED)
+            self.assertFalse(brief.exists())
+            evts = _events_of_kind(db, "pattern_c_cleanup")
+            self.assertEqual(len(evts), 1)
+            payload = json.loads(evts[0]["payload_json"])
+            self.assertEqual(payload["task"], TASK_ID)
+            self.assertEqual(payload["mode"], "auto")
+            self.assertEqual(
+                payload["removed_path"],
+                str(root.resolve() / run_complete_on_merge.PATTERN_C_BRIEF_FILENAME),
+            )
+
+    def test_pattern_c_ephemeral_does_nothing(self) -> None:
+        """Case 2: Pattern C ephemeral (worker_dir != root) → no-op, no event."""
+        with TempDB() as db:
+            root = db.parent
+            ephemeral = root / "ephemeral_worker"
+            ephemeral.mkdir()
+            brief = self._brief_path(root)
+            brief.write_text("untouched\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=str(ephemeral.resolve()))
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+            finally:
+                conn.close()
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
+            self.assertTrue(brief.exists())
+            self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
+    def test_pattern_a_and_b_do_nothing(self) -> None:
+        """Case 3: even with worker_dir == root, non-C patterns are no-ops."""
+        for pattern in ("A", "B"):
+            with self.subTest(pattern=pattern), TempDB() as db:
+                root = db.parent
+                brief = self._brief_path(root)
+                brief.write_text("untouched\n", encoding="utf-8")
+                _seed_pattern_c_run(
+                    db, worker_dir=str(root.resolve()), pattern=pattern,
+                )
+                conn = connect(db)
+                try:
+                    result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                        conn, task_id=TASK_ID, claude_org_root=root,
+                    )
+                finally:
+                    conn.close()
+                self.assertEqual(
+                    result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+                )
+                self.assertTrue(brief.exists())
+                self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
+    def test_idempotent_second_call_when_absent(self) -> None:
+        """Case 4: re-call after the brief is gone does not raise."""
+        with TempDB() as db:
+            root = db.parent
+            brief = self._brief_path(root)
+            brief.write_text("worker brief\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=str(root.resolve()))
+            conn = connect(db)
+            try:
+                first = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+                second = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+            finally:
+                conn.close()
+            self.assertEqual(first, run_complete_on_merge.CLEANUP_REMOVED)
+            self.assertEqual(second, run_complete_on_merge.CLEANUP_ABSENT)
+            self.assertFalse(brief.exists())
+            modes = [
+                json.loads(e["payload_json"])["mode"]
+                for e in _events_of_kind(db, "pattern_c_cleanup")
+            ]
+            self.assertEqual(modes, ["auto", "skip"])
+
+    def test_no_run_row_is_not_applicable(self) -> None:
+        """A task_id with no run row resolves cleanly to not_applicable."""
+        with TempDB() as db:
+            apply_schema(connect(db))
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id="ghost-task", claude_org_root=db.parent,
+                )
+            finally:
+                conn.close()
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Pattern C (gitignored_repo_root, claude-org self-edit) workers reuse the host claude-org repo root as their `worker_dir`. When `worker_closed` fires, the standard worktree/dir cleanup cannot run (it would wipe the host repo), and the stranded `CLAUDE.local.md` survives — contaminating the next Secretary session's role identity by injecting "ignore root CLAUDE.md, you are not secretary."

Closes #478.

## Approach: A (contract / runbook) + C (auto cleanup hook)

### A — Contract / runbook updates

- `docs/contracts/role-pattern-sandbox-contract.md` §4.3.2 — adds post-completion cleanup contract for Pattern C (previously only same-repo exclusion was specified)
- `.claude/skills/org-delegate/references/claude-org-self-edit.md` §2 — adds Secretary-side cleanup responsibility (previously only the generator side was specified)
- `.claude/skills/org-pull-request/SKILL.md` 2b-ii — wires the cleanup step into the close phase

### C — Automatic cleanup hook

- `tools/run_complete_on_merge.py` — new `cleanup_pattern_c_local_md()`, invoked from the merge-recording path
- Detection: `runs.pattern == 'C' AND worker_dirs.abs_path == claude_org_root` (no schema migration needed; `pattern_variant` was not added because the existing values already let us derive the gitignored_repo_root sub-mode unambiguously)
- Idempotent at both OS level (`rm -f`) and Python (`Path.unlink(missing_ok=True)`)
- Emits one `pattern_c_cleanup` event with payload `{task, removed_path, mode}` (`mode=auto` for actual delete / `mode=skip` for already-absent)
- Pattern A / Pattern B / Pattern C ephemeral (worker_dir != claude_org_root) are gated out and write no event

## Scope out

- `.claude/settings.local.json` auto-cleanup is out of scope: Secretary itself uses this file (renga-peers MCP allow-list, etc.), so distinguishing worker-authored vs Secretary-authored requires separate design work. A follow-up issue is noted in #478.

## Test plan

- [x] `tools/test_run_complete_on_merge.py` — 5 new tests covering: (1) Pattern C + worker_dir==root → file removed + event recorded, (2) Pattern C ephemeral (worker_dir != root) → no-op, (3) Pattern A → no-op, (4) Pattern B → no-op, (5) idempotent re-call when file already absent
- [x] Full suite: 15 passed (10 existing + 5 new)
- [x] Related suites (writer / queries): 88 passed
- [x] Link audit: no new violations (27 pre-existing debt entries unchanged)
- [x] Codex self-review: skipped — Codex not installed in this environment (`verification_depth=full` brief permits skip when Codex unavailable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)