### PR TITLE
fix(delegate): fetch origin before Pattern B worktree creation so it branches off latest main (Closes #480)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -110,6 +110,8 @@ work-skill の手順をそのままコピーしない。参考情報として提
 
 詳細条件・実行コマンド・worker permissions deny の根拠（fetch 漏れ → 着手 5 分以内に worker BLOCKER → 10 分以上ロスの背景）は [`references/release-pre-fetch.md`](references/release-pre-fetch.md) を一次参照。**トリガー見逃しが BLOCKER 直結のため本体に残す 4 条件は省略禁止。**
 
+> **Pattern B との切り分け（Issue #480）**: Pattern B の worktree 作成は apply 自身が `git fetch origin` してから `origin/HEAD` 起点で切るため、worktree の起点鮮度はこの Step 0.6 に依存しない。Step 0.6 が担保するのは Pattern A（worker が local main から `release/*` を切る）の **local main の鮮度** であり、両者は対象が異なる。詳細は [`.claude/skills/org-delegate/references/release-pre-fetch.md`](references/release-pre-fetch.md) の「Issue #480 との関係」節。
+
 ## Step 0.7 / 1 / 1.5 / 2: 1 コマンドで派遣ペイロードを生成（Issue #283）
 
 Step 0.7 (gitignore 事前チェック) / Step 1 (Pattern 判定) / Step 1.5 (ワーカーディレクトリ準備 + role 決定 + settings 生成) / Step 2 (DELEGATE 本文組み立て) は **`tools/gen_delegate_payload.py` が一括で行う**。窓口の責務はタスク特定 (Step 0)・work-skill 検索 (Step 0.5)・対象ファイルの抽出・depth 判断のみ。

--- a/.claude/skills/org-delegate/references/release-pre-fetch.md
+++ b/.claude/skills/org-delegate/references/release-pre-fetch.md
@@ -25,6 +25,25 @@ git pull --ff-only origin main
 
 通常の feature / fix / docs タスクでは実行しない。worker permissions deny は「worker は本流履歴を引き寄せず sandbox 内で完結する」意図的設計であり、release だけが「最新 main からの branch」を必須とする例外フローである。
 
+## Issue #480 との関係（Pattern B は apply が自動 fetch するため重複しない）
+
+Issue #480 以降、**Pattern B**（並走 run がベースクローンを占有しているため worktree を切るケース）の **新規 worktree 作成** は `gen_delegate_payload.py apply`（内部の `_ensure_worktree`）が **`git worktree add` の直前に自動で `git fetch origin` を実行し、最新の `origin/HEAD`（= `origin/main`）から分岐する**。この fetch は **fail-closed**: `origin` remote が設定済みで fetch に失敗した場合は apply が `WorktreeApplyError` で abort する（stale な `origin/main` 起点で worktree を切ることはない／DB 予約前に abort するので queued 行も残さない）。
+
+スコープと例外（実装どおりの正確な表現）:
+
+- **新規作成時** かつ `origin` remote 設定済みなら、worktree 起点は最新 trunk になる（fail-closed で保証）。
+- `origin` remote が未設定のローカル専用ベースは fetch をスキップする（取り込む remote が無いため）。
+- **既存登録済み worktree の再利用パス**（Issue #309 の partial-retry）は fetch しない。既にコミット済みの branch tip は fetch では進められず、reset は worker の作業を破壊し得るため。stale な再利用 worktree を最新化したい場合は窓口が当該 worktree を削除し、apply に再作成させる（再作成は上記のとおり fetch を通る）。
+
+したがって **新規作成パスでは Step 0.6 の pre-fetch を実行していなくても worktree の起点は最新 trunk** になり、Step 0.6 の「最新 main から branch させる」目的とは重複する（二重に実行しても害はない: fetch が冪等なだけ）。
+
+一方 Step 0.6 は引き続き必須である。理由は対象が **Pattern A**（並走 run が無く worker がベースクローン自体で直接 `release/*` を local main から切るケース）だから:
+
+- Pattern A の worker はベースクローン内の **local `main`** から branch する。worker 側 permissions が `git fetch` / `git pull` を deny しているため、ローカル main が古いままだと着手直後に BLOCKER になる。apply の自動 fetch は Pattern B の worktree 起点（`origin/main` remote-tracking ref）を更新するだけで、Pattern A が使う **local main ブランチ自体** は ff 更新しない。
+- よって「local main を最新へ ff する」窓口側 pre-fetch（`git pull --ff-only origin main`）は Pattern A release タスクで依然必要。
+
+要約: **worktree 起点の鮮度は Issue #480 が apply 内で担保（Pattern B）。local main の鮮度は Step 0.6 が窓口側で担保（Pattern A release）。** 両者は対象が異なり、片方が他方を不要にはしない。
+
 ## 背景・経緯
 
 詳細な経緯（worker 5 分以内 BLOCKER → 10 分追加ロスの実測、4 つの対応選択肢の比較、permissions 側根本原因）は [`knowledge/curated/release-process.md`](../../../../knowledge/curated/release-process.md) の「release ブランチ作成時は窓口側で `git fetch` を代行する」節を参照。

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -1331,6 +1331,19 @@ class TestPatternBClaudeOrgRepoWorktreePlan(unittest.TestCase):
             claude_org_root=self.sb.claude_org_root,
             state_db_path=self.sb.db_path,
         )
+        # Issue #480: apply now `git fetch origin` before branching. Detection
+        # above needed the github origin URL, but the fetch must stay offline —
+        # repoint origin at a local (empty) bare repo. The synthesized
+        # origin/main remote-tracking ref survives the no-op fetch and is what
+        # the worktree branches off (this test asserts registration, not fetch
+        # freshness — see TestPatternBWorktreeFetchesStaleOrigin for that).
+        upstream = Path(self._td.name) / "claude-org-upstream.git"
+        _sp.run(["git", "init", "-q", "--bare", str(upstream)], check=True)
+        _sp.run(
+            ["git", "-C", str(self.clone), "remote", "set-url", "origin",
+             str(upstream)],
+            check=True,
+        )
         gdp.apply_delegate_plan(
             plan,
             state_db_path=self.sb.db_path,
@@ -1735,6 +1748,194 @@ class TestPatternOverrideCLI(unittest.TestCase):
                 *self._common_args(slug="claude-org-ja"),
                 "--pattern", "A",
             ])
+
+
+# ---------------------------------------------------------------------------
+# Issue #480: apply must fetch origin before branching the Pattern B worktree
+# ---------------------------------------------------------------------------
+
+
+class TestFetchBaseOrigin(unittest.TestCase):
+    """Unit coverage for :func:`gen_delegate_payload._fetch_base_origin`
+    (Issue #480): refresh the base clone's remote-tracking refs before a
+    Pattern B worktree branches off them, best-effort."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.repo = Path(self._td.name) / "repo"
+        self.repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(self.repo), "init", "-q", "-b", "main"],
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_skips_quietly_when_no_origin_remote(self):
+        """No origin remote (local-only repo / synthetic-ref fixture) → no
+        fetch attempt, no raise, no output."""
+        import contextlib
+        import io
+
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            # Must not raise even though there is nothing to fetch.
+            gdp._fetch_base_origin(self.repo)
+        self.assertEqual(err.getvalue(), "")
+
+    def test_raises_when_fetch_fails(self):
+        """An origin pointing at an unreachable (local, nonexistent) path must
+        abort with WorktreeApplyError — branching off a possibly-stale
+        origin/main is exactly the Issue #480 bug, so apply fails closed
+        instead of silently proceeding."""
+        bogus = Path(self._td.name) / "does-not-exist.git"
+        subprocess.run(
+            ["git", "-C", str(self.repo), "remote", "add", "origin",
+             str(bogus)],
+            check=True,
+        )
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp._fetch_base_origin(self.repo)
+        self.assertIn("git fetch origin", str(cm.exception))
+        self.assertIn("480", str(cm.exception))
+
+
+class TestPatternBWorktreeFetchesStaleOrigin(unittest.TestCase):
+    """Issue #480: apply must ``git fetch origin`` before branching the
+    Pattern B worktree, so a base clone that has fallen behind origin still
+    branches off the *latest* remote default-branch tip — not the stale local
+    ``origin/main`` captured at the last fetch."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
+        import os
+        self._git_env = os.environ.copy()
+        self._git_env.update(
+            {
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+        # A local non-bare repo plays the role of the GitHub remote; we commit
+        # directly in its working tree to "advance origin" mid-test.
+        self.upstream = Path(self._td.name) / "upstream"
+        self.upstream.mkdir()
+        self._git(self.upstream, "init", "-q", "-b", "main")
+        (self.upstream / "trunk.txt").write_text("v1", encoding="utf-8")
+        self._git(self.upstream, "add", "trunk.txt")
+        self._git(self.upstream, "commit", "-q", "-m", "c1")
+        self.c1 = self._rev(self.upstream, "main")
+        # claude_org_root is a clone of upstream: a real origin remote,
+        # origin/main + origin/HEAD set, local main == c1.
+        base = self.sb.claude_org_root
+        self._git(base, "init", "-q", "-b", "main")
+        self._git(base, "remote", "add", "origin", str(self.upstream))
+        self._git(base, "fetch", "-q", "origin")
+        self._git(base, "symbolic-ref", "refs/remotes/origin/HEAD",
+                  "refs/remotes/origin/main")
+        self._git(base, "reset", "-q", "--hard", "origin/main")
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _git(self, repo: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args], check=True, env=self._git_env,
+        )
+
+    def _rev(self, repo: Path, ref: str) -> str:
+        return subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", ref],
+        ).decode().strip()
+
+    def _build_self_edit_b(self, *, task_id: str):
+        return gdp.build_delegate_plan(
+            task_id=task_id,
+            project_slug="claude-org-ja",
+            description="self-edit pattern B",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={
+                "pattern": "B",
+                "pattern_variant": "live_repo_worktree",
+                "role": "claude-org-self-edit",
+                "self_edit": True,
+            },
+        )
+
+    def test_apply_fetches_so_worktree_branches_off_latest_origin(self):
+        # Advance the upstream trunk to c2 AFTER the base clone last fetched,
+        # so the base's local origin/main is now stale (still c1).
+        (self.upstream / "trunk.txt").write_text("v2", encoding="utf-8")
+        self._git(self.upstream, "add", "trunk.txt")
+        self._git(self.upstream, "commit", "-q", "-m", "c2")
+        c2 = self._rev(self.upstream, "main")
+        self.assertNotEqual(self.c1, c2)
+        # Precondition: the base clone is stale — origin/main still points at c1.
+        self.assertEqual(
+            self._rev(self.sb.claude_org_root, "refs/remotes/origin/main"),
+            self.c1,
+        )
+
+        plan = self._build_self_edit_b(task_id="stale-origin-task")
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+
+        worker_dir = Path(plan.layout.worker_dir)
+        self.assertEqual(
+            self._rev(worker_dir, "HEAD"), c2,
+            "apply must `git fetch origin` and branch the worktree off the "
+            "latest origin tip (c2), not the base clone's stale origin/main "
+            "(c1)",
+        )
+        # The worktree reflects c2's content, not c1's.
+        self.assertEqual(
+            (worker_dir / "trunk.txt").read_text(encoding="utf-8"), "v2",
+        )
+        # The fetch also advanced the base clone's own origin/main.
+        self.assertEqual(
+            self._rev(self.sb.claude_org_root, "refs/remotes/origin/main"), c2,
+        )
+
+    def test_apply_aborts_when_fetch_fails_without_leaking_db_row(self):
+        """Fail-closed: an origin that cannot be fetched aborts apply rather
+        than branching off a possibly-stale ref (Issue #480). The abort runs
+        before the DB reservation, so no queued run row leaks (which would
+        otherwise steer the next delegation onto another Pattern B branch)."""
+        # Repoint origin at a nonexistent path so the pre-branch fetch fails.
+        self._git(self.sb.claude_org_root, "remote", "set-url", "origin",
+                  str(Path(self._td.name) / "gone.git"))
+        plan = self._build_self_edit_b(task_id="fetch-fail-task")
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("480", str(cm.exception))
+        self.assertFalse(
+            any(r["task_id"] == "fetch-fail-task" for r in self.sb.list_runs()),
+            "queued row leaked after fetch-failure abort",
+        )
+        # No worktree was created.
+        self.assertFalse(Path(plan.layout.worker_dir).exists())
 
 
 if __name__ == "__main__":

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -478,6 +478,10 @@ def _resolve_base_ref(base_repo: Path) -> Optional[str]:
 
     Returns ``None`` when ``origin/HEAD`` is not set — apply then aborts
     with a recovery hint pointing to ``git remote set-head origin --auto``.
+
+    Freshness of the returned ref is the caller's job: :func:`_ensure_worktree`
+    runs :func:`_fetch_base_origin` immediately before this, so ``origin/HEAD``
+    reflects the live remote tip rather than a stale local clone (Issue #480).
     """
     proc = subprocess.run(
         ["git", "-C", str(base_repo), "symbolic-ref", "--short",
@@ -489,6 +493,52 @@ def _resolve_base_ref(base_repo: Path) -> Optional[str]:
         if ref:
             return ref
     return None
+
+
+def _fetch_base_origin(base_repo: Path) -> None:
+    """Refresh ``base_repo``'s remote-tracking refs before a Pattern B
+    worktree is branched off them (Issue #480).
+
+    :func:`_resolve_base_ref` branches the new worktree off ``origin/HEAD``
+    (i.e. ``origin/main``) — a *remote-tracking* ref only as fresh as the base
+    clone's last ``git fetch``. A stale clone (e.g. another PR merged into the
+    trunk after the last local fetch) would silently branch off an out-of-date
+    commit, so the worker starts from a trunk missing already-merged work — the
+    logical conflict / rework this fix eliminates. Fetching here makes the
+    start ref the live remote tip.
+
+    Fail-closed: the freshness guarantee only holds if the fetch actually
+    succeeds, so a configured ``origin`` whose fetch fails aborts apply with a
+    recovery hint (consistent with :func:`_resolve_base_ref` aborting on an
+    unset ``origin/HEAD``) rather than silently branching off a possibly-stale
+    ref — that silent path is exactly the Issue #480 bug. ``_ensure_worktree``
+    runs before any DB reservation, so the abort leaks no ``queued`` run row.
+
+    The only quiet path is "no ``origin`` remote configured": purely local
+    repos (and the test fixtures that synthesize ``refs/remotes/origin/*``
+    without a real remote) have nothing to fetch.
+    """
+    probe = subprocess.run(
+        ["git", "-C", str(base_repo), "remote", "get-url", "origin"],
+        capture_output=True,
+    )
+    if probe.returncode != 0:
+        return  # no origin remote — nothing to refresh
+    proc = subprocess.run(
+        ["git", "-C", str(base_repo), "fetch", "origin"],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        stderr = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise WorktreeApplyError(
+            f"`git fetch origin` failed (rc={proc.returncode}) in {base_repo} "
+            f"before creating the Pattern B worktree: {stderr}. Refusing to "
+            "branch off a possibly-stale origin/main (Issue #480). Fix the "
+            f"network / remote and retry apply (or run `git -C {base_repo} "
+            "fetch origin` manually first). If this base is intentionally "
+            "offline / local-only, remove its `origin` remote so apply skips "
+            "the fetch."
+        )
 
 
 def _worktree_branch(worker_dir: Path) -> Optional[str]:
@@ -540,6 +590,13 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
     of ``base_repo``. Aborts with :class:`WorktreeApplyError` when the dir
     exists with unrelated content (Secretary judgment call to clean up,
     per Issue #309).
+
+    The Issue #480 origin fetch gates *creation* only. A reused worktree
+    keeps the start ref it was created from — re-fetching here would not move
+    its already-committed branch tip, and force-resetting it could clobber
+    work a worker has already committed on a partial-retry. To re-base a stale
+    reused worktree the Secretary removes it so apply recreates it (which then
+    fetches). See the reuse branch below.
     """
     if plan.layout.pattern != "B":
         return
@@ -555,7 +612,11 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
         # branch the brief / DB will pin. A stale partial-retry worktree on
         # a different branch (or in detached-HEAD state) would otherwise
         # silently dispatch on the wrong ref (Codex Round 2 + Round 3
-        # Majors 2026-05-06).
+        # Majors 2026-05-06). We deliberately do NOT fetch / re-base here
+        # (Issue #480): the worktree already has a committed branch tip, so a
+        # fetch can't advance it and a reset could discard a worker's
+        # in-progress commits. Refresh = remove the worktree so the creation
+        # path below recreates it off a freshly fetched origin/HEAD.
         expected = plan.layout.planned_branch
         if expected:
             actual = _worktree_branch(worker_dir)
@@ -590,6 +651,9 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
             f"Pattern B requires a planned_branch but layout produced None "
             f"(task_id={plan.task_id!r})."
         )
+    # Issue #480: refresh remote-tracking refs first so we branch off the
+    # *current* origin/HEAD, not a stale local clone's old origin/main.
+    _fetch_base_origin(plan.base_repo)
     base_ref = _resolve_base_ref(plan.base_repo)
     if base_ref is None:
         raise WorktreeApplyError(


### PR DESCRIPTION
## Summary

Pattern B worktree creation resolved the branch point from `origin/HEAD` (a remote-tracking ref) but did **not** fetch first. When the local base repo was stale, the worktree was cut from an out-of-date commit that lacked already-merged changes — the cause of today's logical conflict and re-do on the `voice-v2-text-split` delegation.

This fetches `origin` immediately before resolving the branch point, so a freshly created Pattern B worktree always starts from the up-to-date remote default branch.

## Design (fail-closed)

- No `origin` remote configured → skip fetch (local-only base).
- `origin` configured but fetch fails → abort with `WorktreeApplyError` (do not branch off a stale base). The abort happens before the DB reservation, so no `queued` row is left behind. Consistent with the existing "abort if `origin/HEAD` is unset" policy.

## Step 0.6 reconciliation

Documented in `SKILL.md` / `release-pre-fetch.md` that Pattern B worktree base freshness is now guaranteed inside `apply` (#480), while Step 0.6 covers Pattern A local-main freshness — the two targets differ and neither makes the other redundant.

## Changes

- `tools/gen_delegate_payload.py` — add `_fetch_base_origin`, wire it into `_ensure_worktree`.
- `tests/test_gen_delegate_payload.py` — regression tests.
- `.claude/skills/org-delegate/SKILL.md`, `references/release-pre-fetch.md` — Step 0.6 reconciliation notes.

## Verification

- 122 tests green (gen_delegate_payload 60 + resolve_worker_layout 62).
- With the base behind upstream (`origin/main=c1`, upstream=`c2`), `apply` produces a worktree whose HEAD is at the latest `c2`; disabling the fetch reproduces the stale `c1` branch point (the test is meaningfully exercised).
- A test asserts `apply` aborts and leaves no `queued` row when the fetch fails.
- Codex self-review: 3 rounds, no Blocker/Major remaining.

## Follow-ups (filed separately, out of scope here)

- #481 — the worktree **reuse** path does not refresh from origin (only fresh creation fetches).
- #482 — Step 0.6 prose says "4 conditions" but lists 3 bullets (doc inconsistency; an inline fix here was blocked by the worker self-modification guard).