### PR TITLE
fix(delegate): stop self-edit boilerplate leaking into normal worker briefs; resolve alias remote to Pattern A/B (Closes #484)

### DIFF
--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -23,7 +23,7 @@ org-delegate の Step 1.5 でワーカー専用ディレクトリ（`{workers_di
 
 ### 禁止事項（permissions.deny + PreToolUse Hooks により技術的にブロックされる）
 1. `{worker_dir}` 内に claude-org の構造（.claude/, .dispatcher/, .curator/, .state/, registry/, dashboard/, knowledge/ 等）を再現してはならない
-2. claude-org リポジトリ（`{claude_org_path}`）を別途 clone してはならない（直接編集すること）
+2. claude-org リポジトリ（`{claude_org_path}`）を `{worker_dir}` 内へ clone してはならない（claude-org 本体は参照専用。編集対象は本ワーカーディレクトリのプロジェクトのみ）
 3. `git push` は実行できない（完了報告で窓口に依頼すること）
 
 ### 正しい作業手順

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -25,6 +25,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools import gen_delegate_payload as gdp  # noqa: E402
+from tools import gen_worker_brief as gwb  # noqa: E402
 from tools.state_db import apply_schema, connect  # noqa: E402
 from tools.state_db.writer import StateWriter  # noqa: E402
 
@@ -184,6 +185,63 @@ class TestBuildDelegatePlan(unittest.TestCase):
         # audit on Pattern A worker dir (which is outside claude-org).
         # (claude-org-ja audit uses Pattern A → workers/claude-org-ja/.)
         self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+
+
+class TestIssue484AliasRemoteRow(unittest.TestCase):
+    """End-to-end (``build_delegate_plan``) coverage for the Issue #484 repro:
+    a remote project registered under the alias *name* ``claude-org-en`` with
+    a clone URL, dispatched on the first delegation (no local mirror clone, no
+    state-DB run). Both bugs must be fixed together:
+
+    - bug 2: resolves to Pattern A (clone the URL), not Pattern C ephemeral.
+    - bug 1: renders the *normal* brief (CLAUDE.md) with no self-edit
+      ``直接編集すること`` directive — the worker clones the EN upstream rather
+      than being told to edit the live claude-org-ja repo in place.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # Replace the default registry with an alias-named remote URL row.
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| 時計アプリ | clock-app | - | Web 時計 | デザイン |\n"
+            "| claude-org-en | claude-org-en | "
+            "https://github.com/suisya-systems/claude-org | EN upstream | 翻訳同期 |\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_alias_remote_row_pattern_a_normal_brief(self):
+        plan = gdp.build_delegate_plan(
+            task_id="en-translation-sync-v2",
+            project_slug="claude-org-en",
+            description="translation sync",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        # bug 2: Pattern A, anchored on the registered alias name.
+        self.assertEqual(plan.layout.pattern, "A")
+        self.assertIsNone(plan.layout.pattern_variant)
+        self.assertFalse(plan.layout.self_edit)
+        self.assertEqual(
+            Path(plan.layout.worker_dir),
+            (self.sb.workers / "claude-org-en").resolve(),
+        )
+        # The DELEGATE body advertises a clone source (Pattern A label).
+        self.assertIn("clone or reuse:", plan.delegate_body)
+        self.assertIn(
+            "https://github.com/suisya-systems/claude-org", plan.delegate_body
+        )
+        # bug 1: non-self-edit brief, no in-place-edit directive.
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+        brief = gwb.render(plan.config)
+        self.assertNotIn("直接編集すること", brief)
+        self.assertNotIn("ルート CLAUDE.md", brief)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -1125,6 +1125,170 @@ class TestPatternBClaudeOrgRepoWorktree(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Issue #484: a remote project registered under an alias *name* (e.g.
+# ``claude-org-en``) with a clone URL must resolve to Pattern A on the first
+# delegation, not fall through to Pattern C ephemeral. The alias normalization
+# (``claude-org-en`` → ``claude-org``) is for the local mirror's 通称; it must
+# not hide a registry row keyed by the alias name itself.
+# ---------------------------------------------------------------------------
+
+
+class TestAliasNamedRemoteRow(unittest.TestCase):
+    """Issue #484 bug 2: ``registry/projects.md`` carries
+    ``| … | claude-org-en | https://github.com/suisya-systems/claude-org | … |``
+    (the row's プロジェクト名/slug column is the alias). With no local
+    ``{workers_dir}/claude-org`` mirror clone present, the slug alias
+    normalization used to rewrite ``claude-org-en`` → ``claude-org`` *before*
+    the registry lookup, so ``find_project`` missed the row and the resolver
+    dropped to Pattern C ephemeral. The fix retries the lookup with the
+    original (un-normalized) slug and adopts the registered row."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_alias_named_url_row_resolves_pattern_a_first_delegation(self):
+        # No local mirror clone, empty state.db (no projects/runs rows) —
+        # the "first delegation" scenario from the Issue #484 repro.
+        self.sb.write_registry(
+            [
+                ("時計", "clock-app", "-", "Demo clock"),
+                (
+                    "claude-org-en",
+                    "claude-org-en",
+                    "https://github.com/suisya-systems/claude-org",
+                    "EN upstream",
+                ),
+            ]
+        )
+        layout = rwl.resolve(
+            task_id="en-translation-sync-v2",
+            project_slug="claude-org-en",
+            description="translation sync",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertIsNone(layout.pattern_variant)
+        # worker_dir keeps the registered alias name (not the mirror's
+        # canonical ``claude-org``) — this row is a distinct remote project.
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "claude-org-en").resolve(),
+        )
+        self.assertEqual(layout.role, "default")
+        self.assertFalse(layout.self_edit)
+        self.assertEqual(layout.planned_branch, "feat/en-translation-sync-v2")
+
+    def test_alias_named_url_row_without_state_db(self):
+        """The registry row alone must drive Pattern A — no pre-existing
+        state-DB ``projects`` row required (``state_db_path=None``)."""
+        self.sb.write_registry(
+            [
+                (
+                    "claude-org-en",
+                    "claude-org-en",
+                    "https://github.com/suisya-systems/claude-org",
+                    "EN upstream",
+                ),
+            ]
+        )
+        layout = rwl.resolve(
+            task_id="en-first",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=None,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "claude-org-en").resolve(),
+        )
+
+    def test_canonical_named_row_still_normalizes_via_alias(self):
+        """Regression guard: the canonical registry shape
+        ``| claude-org-en | claude-org | URL | … |`` (通称=alias, name=canonical)
+        must still resolve via the alias slug to Pattern A — the original-slug
+        fallback only fires when the canonical lookup misses."""
+        self.sb.write_registry(
+            [
+                (
+                    "claude-org-en",
+                    "claude-org",
+                    "https://github.com/suisya-systems/claude-org",
+                    "EN upstream",
+                ),
+            ]
+        )
+        layout = rwl.resolve(
+            task_id="en-canonical",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        # canonical name → worker_dir anchored on the canonical slug.
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "claude-org").resolve(),
+        )
+
+    def test_unknown_alias_with_no_row_still_pattern_c(self):
+        """Regression guard for the no-clone / no-row deployment: an alias
+        slug with neither a mirror clone nor any registry row must still fall
+        to Pattern C ephemeral (the original-slug fallback finds nothing)."""
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        layout = rwl.resolve(
+            task_id="en-orphan",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "C")
+        self.assertEqual(layout.pattern_variant, "ephemeral")
+
+    def test_mirror_clone_wins_over_alias_named_row(self):
+        """Codex review guard: when a local mirror clone exists at
+        ``{workers_dir}/claude-org`` AND an alias-named row is also present,
+        the Issue #370 mirror machinery must win (anchor on the clone) so the
+        resolver stays consistent with ``gen_delegate_payload``'s own
+        canonical normalization. The alias-row fallback must NOT hijack the
+        slug back to ``claude-org-en`` in that case."""
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        clone = self.sb.workers / "claude-org"
+        clone.mkdir()
+        _Sandbox.init_git_with_origin(
+            clone, "https://github.com/suisya-systems/claude-org.git"
+        )
+        self.sb.write_registry(
+            [
+                ("時計", "clock-app", "-", "Demo clock"),
+                (
+                    "claude-org-en",
+                    "claude-org-en",
+                    "https://github.com/suisya-systems/claude-org",
+                    "EN upstream",
+                ),
+            ]
+        )
+        layout = rwl.resolve(
+            task_id="en-with-clone",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        # Anchored on the canonical mirror clone, NOT workers/claude-org-en.
+        self.assertEqual(Path(layout.worker_dir), clone.resolve())
+
+
+# ---------------------------------------------------------------------------
 # Issue #374: self-edit first-run short-circuit + mirror_of + --pattern override
 # ---------------------------------------------------------------------------
 

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -487,6 +487,7 @@ def resolve(
     # Normalize registry-display aliases to the canonical project slug.
     # ``claude-org-en`` is the 通称 (display name) for the ``claude-org``
     # mirror; downstream code only operates on the canonical form.
+    original_slug = project_slug
     project_slug = _CLAUDE_ORG_SLUG_ALIASES.get(project_slug, project_slug)
 
     targets = list(targets or [])
@@ -502,6 +503,35 @@ def resolve(
     else:
         projects = []
     project = find_project(projects, project_slug)
+    # Issue #484: the alias normalization above assumes ``claude-org-en`` is
+    # only ever the 通称 for the canonical ``claude-org`` *mirror* row. But a
+    # remote project can be registered under the alias *name* itself
+    # (``| … | claude-org-en | https://github.com/…/claude-org | … |``).
+    # Normalizing to ``claude-org`` then made ``find_project`` miss that row,
+    # so the resolver dropped to Pattern C ephemeral on the very first
+    # delegation even though a clone URL was registered. When the canonical
+    # slug matches nothing but the original (un-normalized) slug does, that
+    # row is a genuinely distinct registered project — not the mirror — so
+    # adopt it and revert ``project_slug`` to the registered name (keeps
+    # worker_dir naming / active-run gating consistent with the registry and
+    # leaves the ``find_claude_org_clone`` mirror path inert for this slug).
+    #
+    # Gated on "no local mirror clone for the canonical slug": when a clone
+    # *does* exist at ``{workers_dir}/claude-org`` the established Issue #370
+    # mirror machinery owns the alias (it re-pins onto the clone below), and
+    # gen_delegate_payload re-applies the same canonical normalization for the
+    # DELEGATE body / DB reservation — reverting here would diverge the two
+    # (Codex review). So the alias-row fallback only fires for the genuine
+    # no-clone deployment that Issue #484 hit.
+    if (
+        project is None
+        and original_slug != project_slug
+        and find_claude_org_clone(project_slug, workers_dir) is None
+    ):
+        fallback = find_project(projects, original_slug)
+        if fallback is not None:
+            project = fallback
+            project_slug = original_slug
 
     # claude-org-ja is intentionally absent from the checked-in registry
     # (the row used to leak a user-specific local path). When the slug +

--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -11,7 +11,7 @@
 
 ### 禁止事項（permissions.deny + PreToolUse Hooks により技術的にブロックされる）
 1. `${worker_dir}` 内に claude-org の構造（.claude/, .dispatcher/, .curator/, .state/, registry/, dashboard/, knowledge/ 等）を再現してはならない
-2. claude-org リポジトリ（`${claude_org_path}`）を別途 clone してはならない（直接編集すること）
+2. claude-org リポジトリ（`${claude_org_path}`）を `${worker_dir}` 内へ clone してはならない（claude-org 本体は参照専用。編集対象は本ワーカーディレクトリのプロジェクトのみ）
 3. `git push` は実行できない（完了報告で窓口に依頼すること）
 
 ### Windows 環境の注意事項

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -64,6 +64,19 @@ class RenderNormal(unittest.TestCase):
         # no leftover ${...} placeholders
         self.assertNotIn("${", out)
 
+    def test_normal_does_not_emit_self_edit_clone_directive(self):
+        """Issue #484 bug 1: a non-self-edit worker (e.g. a remote
+        translation-sync clone) must NOT be told to edit claude-org directly.
+        The self-edit ``（直接編集すること）`` prohibition is reserved for the
+        self-edit brief; the normal brief instructs the worker to clone the
+        infra repo nowhere and work inside its own project clone."""
+        cfg = _base_config(self_edit=False)
+        out = gwb.render(cfg)
+        self.assertNotIn("直接編集すること", out)
+        self.assertNotIn("別途 clone", out)
+        # The reworded guard still tells the worker claude-org is reference-only.
+        self.assertIn("参照専用", out)
+
 
 class RenderSelfEdit(unittest.TestCase):
     def test_self_edit_emits_ignore_root_note(self):
@@ -73,6 +86,15 @@ class RenderSelfEdit(unittest.TestCase):
         self.assertIn("Secretary 指示は無視せよ", out)
         self.assertIn("あなたは窓口ではなくワーカーである", out)
         self.assertNotIn("<!--BEGIN:", out)
+
+    def test_self_edit_keeps_direct_edit_prohibition(self):
+        """The self-edit brief (origin URL == suisya-systems/claude-org-ja)
+        legitimately works *inside* the live repo, so its prohibition still
+        says ``直接編集`` (don't re-clone, edit in place). Issue #484 only
+        moved this directive out of the *normal* brief."""
+        cfg = _base_config(self_edit=True)
+        out = gwb.render(cfg)
+        self.assertIn("直接編集", out)
 
 
 class OptionalSections(unittest.TestCase):


### PR DESCRIPTION
## Summary

Two resolver/brief bugs blocked delegating against the English upstream (`suisya-systems/claude-org`) for an auto-mirror translation sync. Both are fixed.

### Bug 1 — self-edit boilerplate leaked into non-self-edit briefs

The template-selection logic already chose between self-edit / normal briefs correctly via the `self_edit` flag (`is_claude_org_project()` = origin URL is `suisya-systems/claude-org-ja`). The real cause was that the **normal** template (`tools/templates/worker_brief_normal.md`) unconditionally contained self-edit-only boilerplate:

> claude-org リポジトリ（…/claude-org-ja）を別途 clone してはならない（直接編集すること）

So any normal worker got told to "directly edit claude-org-ja". Fixed by rewording the normal template to "claude-org core is reference-only; edit only the project in this worker directory" (the legacy reference template `worker-claude-template.md` was reworded the same way). The "直接編集" instruction is retained for the self-edit template only.

### Bug 2 — alias-registered remote project fell back to Pattern C ephemeral

Alias normalization (`claude-org-en → claude-org`) ran **before** the registry lookup, so a row registered under the alias name was missed and the project resolved to Pattern C ephemeral (`base_repo: None`). Added a fallback in `resolve()` that re-looks-up under the original slug when the normalized lookup misses, gated to the **no-mirror-clone** case so the existing mirror-clone path (#370) and `gen_delegate_payload` normalization stay authoritative. No pre-existing state-DB `projects` row is required.

## Changes (6 files)

- `tools/resolve_worker_layout.py` — original-slug fallback + mirror-clone gate.
- `tools/templates/worker_brief_normal.md`, `.claude/skills/org-delegate/references/worker-claude-template.md` — reword.
- `tests/test_resolve_worker_layout.py`, `tests/test_gen_delegate_payload.py`, `tools/test_gen_worker_brief.py` — regression tests.

## Verification

- 698 passed, 4 skipped (git-absence guards); 8 new regression tests.
- Codex self-review (full): Round 1 surfaced one Major (resolver↔gen_delegate_payload inconsistency when a mirror clone exists) → fixed with the gate; Round 2 clean.

## Note (out of scope)

Registering the English upstream in canonical form `| claude-org-en | claude-org | URL |` (通称=alias, 名前=canonical) already resolves to Pattern A via normalization even before this fix; this PR additionally rescues rows that put the alias in the 名前 column. A registry-notation recommendation may be worth a separate pass.