### PR TITLE
fix(close-phase): make Pattern C CLAUDE.local.md cleanup order-independent of remove_worker_dir (Closes #486)

### DIFF
--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -50,11 +50,12 @@ claude-org 自己編集タスクでは、SKILL.md Step 1.5 および `worker-cla
 - **Pattern B（`live_repo_worktree`）**: ブリーフは worktree 直下（`{claude_org_path}/.worktrees/{task_id}/CLAUDE.local.md`）にあるので、close 時の `git -C {claude_org_path} worktree remove .worktrees/{task_id}` がディレクトリごと回収する。個別削除は不要。
 - **Pattern C（`gitignored_repo_root`）**: `worker_dir` が claude-org repo root 自身なので、worktree remove も dir 削除も効かない。`{claude_org_root}/CLAUDE.local.md` を **個別に削除しないと残留**し、次回 `/org-start` で Secretary が「窓口かつワーカー」という矛盾した role identity（冒頭の「あなたは窓口ではなくワーカーである」）を context に読み込む。gitignored なので CI でも検出されず地層化する（Issue #478 の発生事例: `lt-lapras-392778-01`）。
 
-Pattern C の個別削除は close phase の責務として [`.claude/skills/org-pull-request/SKILL.md`](../../org-pull-request/SKILL.md) 2b-ii に組み込まれている。実体は [`tools/run_complete_on_merge.py`](../../../../tools/run_complete_on_merge.py) の `cleanup_pattern_c_local_md(conn, task_id=..., claude_org_root=...)`:
+Pattern C の個別削除は close phase の責務として [`.claude/skills/org-pull-request/SKILL.md`](../../org-pull-request/SKILL.md) 2b-ii に組み込まれている。実体は [`tools/run_complete_on_merge.py`](../../../../tools/run_complete_on_merge.py) の `cleanup_pattern_c_local_md(conn, task_id=..., claude_org_root=..., worker_dir_abs=...)`:
 
-- 判定: `runs.pattern == 'C'` AND `worker_dirs.abs_path == claude_org_root`（schema 拡張不要。ephemeral C は `worker_dir != root` で自動的に no-op）。
+- 判定: `runs.pattern == 'C'` AND `worker_dir == claude_org_root`（schema 拡張不要。ephemeral C は `worker_dir != root` で自動的に no-op）。`worker_dir` は `worker_dir_abs` 引数があればそれを、無ければ `runs.worker_dir_id` → `worker_dirs` の join から解決する。
 - 動作: `{claude_org_root}/CLAUDE.local.md` を `Path.unlink(missing_ok=True)` で削除し、`events` に `pattern_c_cleanup`（payload: `task` / `removed_path` / `mode`）を 1 行残す。idempotent（ファイル不在なら `mode=skip`、エラーで止めない）。
-- PR 起点のクローズで `tools/run_complete_on_merge.py --pr <PR>` を呼ぶ場合は merge 記録時に自動で同 cleanup が走る。ただし gitignored タスクは PR を生まないことが多いため、close phase の StateWriter ブロックでの明示呼び出しが本筋。
+- **順序非依存（Issue #486）**: close phase の StateWriter ブロックは `remove_worker_dir()` で `worker_dirs` 行を DELETE する（`runs.worker_dir_id` は `ON DELETE SET NULL`）。cleanup を行削除の後に呼ぶと join が `abs_path=NULL` を返し no-op 化するため、呼び出し側は削除した `abs_path` を `worker_dir_abs=` に明示で渡し、検出が行削除の前後どちらでも壊れないようにする。
+- PR 起点のクローズで `tools/run_complete_on_merge.py --pr <PR>` を呼ぶ場合は merge 記録時に自動で同 cleanup が走る（このパスは `remove_worker_dir()` を呼ばないので join フォールバックで足りる）。ただし gitignored タスクは PR を生まないことが多いため、close phase の StateWriter ブロックでの明示呼び出しが本筋。
 
 > **scope**: 本 Issue のスコープは `CLAUDE.local.md` のみ。`.claude/settings.local.json` の自動削除は worker 由来 / Secretary 由来（renga-peers MCP allow 等で Secretary 自身も使う）の切り分け設計が要るため別 Issue。
 

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -52,7 +52,7 @@ claude-org 自己編集タスクでは、SKILL.md Step 1.5 および `worker-cla
 
 Pattern C の個別削除は close phase の責務として [`.claude/skills/org-pull-request/SKILL.md`](../../org-pull-request/SKILL.md) 2b-ii に組み込まれている。実体は [`tools/run_complete_on_merge.py`](../../../../tools/run_complete_on_merge.py) の `cleanup_pattern_c_local_md(conn, task_id=..., claude_org_root=..., worker_dir_abs=...)`:
 
-- 判定: `runs.pattern == 'C'` AND `worker_dir == claude_org_root`（schema 拡張不要。ephemeral C は `worker_dir != root` で自動的に no-op）。`worker_dir` は `worker_dir_abs` 引数があればそれを、無ければ `runs.worker_dir_id` → `worker_dirs` の join から解決する。
+- 判定: `runs.pattern == 'C'` AND `worker_dir == claude_org_root`（schema 拡張不要。ephemeral C は `worker_dir != root` で自動的に no-op）。`worker_dir` は `runs.worker_dir_id` → `worker_dirs` の join を優先し、join が NULL（= `remove_worker_dir()` 済み）のときだけ `worker_dir_abs` 引数にフォールバックする（live 行を stray な引数で override させない）。
 - 動作: `{claude_org_root}/CLAUDE.local.md` を `Path.unlink(missing_ok=True)` で削除し、`events` に `pattern_c_cleanup`（payload: `task` / `removed_path` / `mode`）を 1 行残す。idempotent（ファイル不在なら `mode=skip`、エラーで止めない）。
 - **順序非依存（Issue #486）**: close phase の StateWriter ブロックは `remove_worker_dir()` で `worker_dirs` 行を DELETE する（`runs.worker_dir_id` は `ON DELETE SET NULL`）。cleanup を行削除の後に呼ぶと join が `abs_path=NULL` を返し no-op 化するため、呼び出し側は削除した `abs_path` を `worker_dir_abs=` に明示で渡し、検出が行削除の前後どちらでも壊れないようにする。
 - PR 起点のクローズで `tools/run_complete_on_merge.py --pr <PR>` を呼ぶ場合は merge 記録時に自動で同 cleanup が走る（このパスは `remove_worker_dir()` を呼ばないので join フォールバックで足りる）。ただし gitignored タスクは PR を生まないことが多いため、close phase の StateWriter ブロックでの明示呼び出しが本筋。

--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -118,7 +118,7 @@ allowed-tools:
   - パターン B（worktree）: `git -C {workers_dir}/{project_slug}/ worktree remove .worktrees/{task_id}` を実行。ブランチは残す（マージ済みでもブランチ削除はしない、PR 履歴用）
     - **self-edit (`pattern_variant='live_repo_worktree'`) の場合**: worktree base が `{claude_org_path}` なので `git -C {claude_org_path} worktree remove .worktrees/{task_id}` を実行する（Issue #289）。ブランチは同様に残す
   - パターン C（エフェメラル, `pattern_variant='ephemeral'`）: ディレクトリは保持する（容量が問題になった場合のみ手動削除を検討）
-  - **パターン C（`gitignored_repo_root`, claude-org 自己編集）の特例 cleanup（Issue #478）**: `worker_dir` が claude-org-ja repo root 自身なので、worktree remove も dir 削除も効かず、`{claude_org_root}/CLAUDE.local.md`（ワーカー指示ブリーフ）が残留する。残ると次回 `/org-start` で Secretary が「窓口かつワーカー」という矛盾 role identity を読み込む。**close 時に `tools/run_complete_on_merge.py` の `cleanup_pattern_c_local_md()` を呼んでブリーフを削除する**（下記 StateWriter ブロックに同梱）。判定は `runs.pattern == 'C'` AND `worker_dirs.abs_path == claude_org_root` で行われ、ephemeral C / パターン A・B では no-op。`events` に `pattern_c_cleanup`（payload: `task` / `removed_path` / `mode`）が 1 行残る。idempotent（ファイル不在なら `mode=skip`）。PR 起点のクローズで `tools/run_complete_on_merge.py --pr <PR>` を呼ぶ場合は merge 記録時に自動で同 cleanup が走るが、gitignored タスクは PR を生まないことが多いので、下記 StateWriter ブロックでの明示呼び出しが本筋の経路。`.claude/settings.local.json` は worker 由来 / Secretary 由来の切り分けが要るためスコープ外（別 Issue）
+  - **パターン C（`gitignored_repo_root`, claude-org 自己編集）の特例 cleanup（Issue #478）**: `worker_dir` が claude-org-ja repo root 自身なので、worktree remove も dir 削除も効かず、`{claude_org_root}/CLAUDE.local.md`（ワーカー指示ブリーフ）が残留する。残ると次回 `/org-start` で Secretary が「窓口かつワーカー」という矛盾 role identity を読み込む。**close 時に `tools/run_complete_on_merge.py` の `cleanup_pattern_c_local_md()` を呼んでブリーフを削除する**（下記 StateWriter ブロックに同梱）。判定は `runs.pattern == 'C'` AND `worker_dir == claude_org_root` で行われ、ephemeral C / パターン A・B では no-op。`events` に `pattern_c_cleanup`（payload: `task` / `removed_path` / `mode`）が 1 行残る。idempotent（ファイル不在なら `mode=skip`）。**Issue #486**: 下記ブロックの `remove_worker_dir()` が `worker_dirs` 行を DELETE すると `runs.worker_dir_id` が `ON DELETE SET NULL` になり join 経由の `worker_dir` 解決が NULL 化して cleanup が no-op になるため、`worker_dir_abs=` に削除した abs パスを明示で渡して順序非依存にする。PR 起点のクローズで `tools/run_complete_on_merge.py --pr <PR>` を呼ぶ場合は merge 記録時に自動で同 cleanup が走るが、gitignored タスクは PR を生まないことが多いので、下記 StateWriter ブロックでの明示呼び出しが本筋の経路。`.claude/settings.local.json` は worker 由来 / Secretary 由来の切り分けが要るためスコープ外（別 Issue）
 - **dogfood 対象 PR の paired issue クローズ時（Issue #338）**: 実装 PR のマージと paired follow-up issue のクローズはライフサイクルが独立しうるため、本スキル側では「実装 PR マージで `consumed → closed` をする」という保証はしない。`consumed → closed` の終端遷移は窓口の register hygiene 責務として [`.claude/skills/org-delegate/SKILL.md`](../org-delegate/SKILL.md) Step 1.8 §consumed → closed 観察タイミング（register 書き込み時 + `/org-resume` 起動時に `gh issue view` で paired issue 状態確認）で回収する。本スキルが PR マージ時にたまたま該当行を観察した場合のみ、ついでに hygiene 手順を呼ぶ
 - **PR 起点のクローズの場合は `tools/run_complete_on_merge.py` を呼ぶ** (Issue #317。`pr-watch --merge-watch` の merge-watch ループが自動で起動するので通常は手動実行不要だが、merge-watch を skip した場合や手動でマージを観測した場合のみ明示的に呼ぶ):
   ```bash
@@ -135,12 +135,17 @@ allowed-tools:
   from tools.state_db.writer import StateWriter
   from tools.run_complete_on_merge import cleanup_pattern_c_local_md
   conn = connect('.state/state.db')
+  abs_path = '<abs>'  # worker_dir の絶対パス（パターン B / C）
   with StateWriter(conn).transaction() as w:
       w.update_run_status('<task_id>', 'completed')  # post-commit hook が worker-{task}.md を archive
-      w.remove_worker_dir('<abs>')  # パターン B / C のみ
-  # Issue #478: Pattern C gitignored_repo_root の CLAUDE.local.md を削除
-  # （runs.pattern=='C' AND worker_dir==root のときのみ実削除。他は no-op）
-  cleanup_pattern_c_local_md(conn, task_id='<task_id>', claude_org_root=Path('.').resolve())
+      w.remove_worker_dir(abs_path)  # パターン B / C のみ
+  # Issue #478 / #486: Pattern C gitignored_repo_root の CLAUDE.local.md を削除
+  # （runs.pattern=='C' AND worker_dir==root のときのみ実削除。他は no-op）。
+  # remove_worker_dir() が worker_dirs 行を DELETE し runs.worker_dir_id は
+  # ON DELETE SET NULL になるため、join 経由の検出は NULL 化して no-op になる。
+  # worker_dir_abs= に削除した abs_path を明示で渡し、行削除の前後どちらで呼んでも
+  # 検出が壊れないようにする（Issue #486）。
+  cleanup_pattern_c_local_md(conn, task_id='<task_id>', claude_org_root=Path('.').resolve(), worker_dir_abs=abs_path)
   "
   ```
   legacy のハンドロール完了スクリプトは `docs/legacy/pr-merge-completion-manual.md` に保管されている。標準経路は上記 `tools/run_complete_on_merge.py` であり、museum copy へ reach するのは Issue を切ってユーザー判断を仰いだ後に限る (PR #315 と同じ pattern)

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -99,17 +99,21 @@ def cleanup_pattern_c_local_md(
     ``{workers_dir}/{task_id}`` (≠ root), so it is reclaimed by ordinary dir
     removal and naturally falls through here as ``not_applicable``.
 
-    The worker_dir is taken from the explicit ``worker_dir_abs`` argument when
-    provided, otherwise from the live ``runs.worker_dir_id`` → ``worker_dirs``
-    join. Issue #486: the close-phase runbook calls
+    The worker_dir is resolved from the live ``runs.worker_dir_id`` →
+    ``worker_dirs`` join, which stays authoritative whenever the row is
+    present, and only falls back to the explicit ``worker_dir_abs`` argument
+    when that join yields ``NULL``. Issue #486: the close-phase runbook calls
     ``StateWriter.remove_worker_dir()`` which DELETEs the ``worker_dirs`` row,
     and ``runs.worker_dir_id`` is ``ON DELETE SET NULL`` (schema.sql:84), so a
     cleanup invoked *after* the removal would see ``abs_path = NULL`` through
     the join and no-op even for a genuine gitignored_repo_root run. Callers
-    that are about to (or just did) drop the worker_dirs row must pass the
-    path they hold via ``worker_dir_abs`` so detection stays order-independent.
-    The in-process PR-merge path (:func:`complete_on_merge`) leaves the row in
-    place and so relies on the join fallback.
+    that are about to (or just did) drop the worker_dirs row pass the path they
+    hold via ``worker_dir_abs`` so detection stays order-independent. The
+    fallback is deliberately *not* an override: while the row is live the DB
+    value wins, so a caller that mistakenly passes ``root`` for a Pattern C
+    *ephemeral* run cannot trick the helper into deleting ``root``'s brief. The
+    in-process PR-merge path (:func:`complete_on_merge`) leaves the row in
+    place and so always uses the join value.
 
     Idempotent: ``Path.unlink(missing_ok=True)`` never raises on a missing
     file, and a re-call after the brief is gone returns
@@ -131,9 +135,11 @@ def cleanup_pattern_c_local_md(
     if row is None:
         return CLEANUP_NOT_APPLICABLE
     pattern = (row["pattern"] or "").upper()
-    # Prefer the caller-supplied path: it survives a prior remove_worker_dir()
-    # that NULLs the join. Fall back to the live join when omitted.
-    worker_dir = worker_dir_abs if worker_dir_abs is not None else row["abs_path"]
+    # The live join is authoritative; only fall back to the caller-supplied
+    # path when the worker_dirs row is already gone (Issue #486:
+    # remove_worker_dir() NULLs the join via ON DELETE SET NULL). Keeping the
+    # DB value in front means a stray worker_dir_abs cannot override a live row.
+    worker_dir = row["abs_path"] if row["abs_path"] is not None else worker_dir_abs
     if pattern != "C" or not worker_dir:
         return CLEANUP_NOT_APPLICABLE
 

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -88,15 +88,28 @@ def cleanup_pattern_c_local_md(
     *,
     task_id: str,
     claude_org_root: Path,
+    worker_dir_abs: Optional[str] = None,
 ) -> str:
     """Remove a leftover ``CLAUDE.local.md`` from the claude-org repo root
     for a Pattern C ``gitignored_repo_root`` self-edit run (Issue #478).
 
     Detection (design judgment 1 of Issue #478): ``runs.pattern == 'C'`` AND
-    the run's ``worker_dirs.abs_path`` equals ``claude_org_root``. This needs
-    no schema change — Pattern C *ephemeral* has ``worker_dir`` at
+    the run's worker_dir equals ``claude_org_root``. This needs no schema
+    change — Pattern C *ephemeral* has ``worker_dir`` at
     ``{workers_dir}/{task_id}`` (≠ root), so it is reclaimed by ordinary dir
     removal and naturally falls through here as ``not_applicable``.
+
+    The worker_dir is taken from the explicit ``worker_dir_abs`` argument when
+    provided, otherwise from the live ``runs.worker_dir_id`` → ``worker_dirs``
+    join. Issue #486: the close-phase runbook calls
+    ``StateWriter.remove_worker_dir()`` which DELETEs the ``worker_dirs`` row,
+    and ``runs.worker_dir_id`` is ``ON DELETE SET NULL`` (schema.sql:84), so a
+    cleanup invoked *after* the removal would see ``abs_path = NULL`` through
+    the join and no-op even for a genuine gitignored_repo_root run. Callers
+    that are about to (or just did) drop the worker_dirs row must pass the
+    path they hold via ``worker_dir_abs`` so detection stays order-independent.
+    The in-process PR-merge path (:func:`complete_on_merge`) leaves the row in
+    place and so relies on the join fallback.
 
     Idempotent: ``Path.unlink(missing_ok=True)`` never raises on a missing
     file, and a re-call after the brief is gone returns
@@ -118,7 +131,9 @@ def cleanup_pattern_c_local_md(
     if row is None:
         return CLEANUP_NOT_APPLICABLE
     pattern = (row["pattern"] or "").upper()
-    worker_dir = row["abs_path"]
+    # Prefer the caller-supplied path: it survives a prior remove_worker_dir()
+    # that NULLs the join. Fall back to the live join when omitted.
+    worker_dir = worker_dir_abs if worker_dir_abs is not None else row["abs_path"]
     if pattern != "C" or not worker_dir:
         return CLEANUP_NOT_APPLICABLE
 

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -468,5 +468,124 @@ class CleanupPatternCTests(unittest.TestCase):
             )
 
 
+class CleanupPatternCCloseOrderTests(unittest.TestCase):
+    """Issue #486: cleanup must fire even after remove_worker_dir().
+
+    The org-pull-request close-phase StateWriter block runs
+    ``remove_worker_dir()`` (DELETE on worker_dirs), and ``runs.worker_dir_id``
+    is ``ON DELETE SET NULL``. A cleanup that resolves the worker_dir via the
+    live join therefore sees ``abs_path = NULL`` and no-ops, leaving the
+    Pattern C gitignored_repo_root ``CLAUDE.local.md`` behind. The fix is the
+    explicit ``worker_dir_abs`` argument, which survives the row removal.
+    """
+
+    def _brief_path(self, root: Path) -> Path:
+        return root / run_complete_on_merge.PATTERN_C_BRIEF_FILENAME
+
+    def _close_remove_worker_dir(self, db: Path, abs_path: str) -> None:
+        """Mimic the SKILL StateWriter close block: status flip + row delete."""
+        conn = connect(db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.update_run_status(TASK_ID, "completed")
+                w.remove_worker_dir(abs_path)
+        finally:
+            conn.close()
+
+    def test_cleanup_after_remove_with_worker_dir_abs_fires(self) -> None:
+        """The fix: passing worker_dir_abs keeps cleanup firing post-removal."""
+        with TempDB() as db:
+            root = db.parent
+            abs_path = str(root.resolve())
+            brief = self._brief_path(root)
+            brief.write_text("worker brief\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=abs_path)
+
+            # Close-phase ordering: worker_dirs row is gone before cleanup.
+            self._close_remove_worker_dir(db, abs_path)
+
+            conn = connect(db)
+            try:
+                # Sanity: the join no longer resolves the worker_dir.
+                row = conn.execute(
+                    "SELECT d.abs_path FROM runs r "
+                    "LEFT JOIN worker_dirs d ON d.id = r.worker_dir_id "
+                    "WHERE r.task_id = ?",
+                    (TASK_ID,),
+                ).fetchone()
+                self.assertIsNone(row["abs_path"])
+
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                    worker_dir_abs=abs_path,
+                )
+            finally:
+                conn.close()
+
+            self.assertEqual(result, run_complete_on_merge.CLEANUP_REMOVED)
+            self.assertFalse(brief.exists())
+            evts = _events_of_kind(db, "pattern_c_cleanup")
+            self.assertEqual(len(evts), 1)
+            self.assertEqual(json.loads(evts[0]["payload_json"])["mode"], "auto")
+
+    def test_cleanup_after_remove_without_abs_regresses_to_noop(self) -> None:
+        """Root cause: the join-only path no-ops once the row is deleted.
+
+        Without ``worker_dir_abs`` the helper falls back to the live join,
+        which returns NULL after remove_worker_dir() — exactly the Issue #486
+        bug this test pins. The brief is (incorrectly) left behind.
+        """
+        with TempDB() as db:
+            root = db.parent
+            abs_path = str(root.resolve())
+            brief = self._brief_path(root)
+            brief.write_text("worker brief\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=abs_path)
+
+            self._close_remove_worker_dir(db, abs_path)
+
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+            finally:
+                conn.close()
+
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
+            self.assertTrue(brief.exists())
+            self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
+    def test_worker_dir_abs_ephemeral_stays_noop(self) -> None:
+        """worker_dir_abs for an ephemeral C run (≠ root) must not delete."""
+        with TempDB() as db:
+            root = db.parent
+            ephemeral = root / "ephemeral_worker"
+            ephemeral.mkdir()
+            eph_abs = str(ephemeral.resolve())
+            brief = self._brief_path(root)
+            brief.write_text("untouched\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=eph_abs)
+
+            self._close_remove_worker_dir(db, eph_abs)
+
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                    worker_dir_abs=eph_abs,
+                )
+            finally:
+                conn.close()
+
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
+            self.assertTrue(brief.exists())
+            self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -586,6 +586,38 @@ class CleanupPatternCCloseOrderTests(unittest.TestCase):
             self.assertTrue(brief.exists())
             self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
 
+    def test_live_row_wins_over_stray_worker_dir_abs(self) -> None:
+        """Codex Major: a stray worker_dir_abs must not override a live row.
+
+        While the worker_dirs row is still present (ephemeral C: abs_path
+        != root), a caller that mistakenly passes root via worker_dir_abs
+        must NOT delete root's brief — the DB value stays authoritative.
+        """
+        with TempDB() as db:
+            root = db.parent
+            ephemeral = root / "ephemeral_worker"
+            ephemeral.mkdir()
+            brief = self._brief_path(root)
+            brief.write_text("untouched\n", encoding="utf-8")
+            # Row is left in place (no remove_worker_dir): join resolves to
+            # the ephemeral dir, so root must be ignored.
+            _seed_pattern_c_run(db, worker_dir=str(ephemeral.resolve()))
+
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                    worker_dir_abs=str(root.resolve()),  # stray override attempt
+                )
+            finally:
+                conn.close()
+
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
+            self.assertTrue(brief.exists())
+            self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #486. In the org-pull-request close-phase StateWriter block, `remove_worker_dir()` deletes the `worker_dirs` row, and `runs.worker_dir_id` is `ON DELETE SET NULL`. The subsequent `cleanup_pattern_c_local_md()` resolved the worker dir via a `runs LEFT JOIN worker_dirs` on `abs_path`, so after the delete it saw `abs_path = NULL` → classified NOT_APPLICABLE → **no-op**. The Issue #478 cleanup of a leftover Pattern C (`gitignored_repo_root`) `CLAUDE.local.md` therefore never ran on that path.

## Fix

Make the cleanup order-independent:

- `cleanup_pattern_c_local_md()` gains an optional `worker_dir_abs` argument. Resolution is **DB-join-first**, falling back to `worker_dir_abs` only when the join yields NULL (i.e. the row was already removed). A live `worker_dirs` row is never overridden by a stray passed-in path (Codex Major fix).
- The close-phase docs in `org-pull-request/SKILL.md` and `claude-org-self-edit.md` are updated to pass `worker_dir_abs=` and to match the implementation.
- The in-process `complete_on_merge` path does not call `remove_worker_dir`, so the join still suffices there (unchanged).

## Verification

- `tools/` suite green: 408 passed, 4 skipped.
- New regression suite `CleanupPatternCCloseOrderTests`: (1) after remove, passing `worker_dir_abs` deletes the brief + emits the event; (2) without the arg it regresses to no-op (captures the bug); (3) ephemeral Pattern C stays no-op; (4) a live row + a passed root still prefers the DB value (no-op).
- Codex self-review (full), 2 rounds: 0 Blocker/Major remaining (1 Major + 1 Minor addressed).