### PR TITLE
fix(claude): expand dispatcher ERROR detection (full-visible scan + 529/transient codes + spinner-age) (Closes #492)

### DIFF
--- a/.dispatcher/references/worker-monitoring.md
+++ b/.dispatcher/references/worker-monitoring.md
@@ -67,13 +67,13 @@
      ```
      result = mcp__renga-peers__inspect_pane(
          target="worker-{task_id}",
-         lines=10,
+         lines=<該当 worker pane の height>,   # Step 3 list_panes の height。取れなければ十分大きい固定値 (例 200)
          include_cursor=true,
          format="grid"
      )
      # result.structuredContent に {lines: [{row, text}], cursor: {visible, row, col}} が入る
      ```
-     を順次実行 (16 ワーカー並列でも合計 1 秒未満)
+     を順次実行 (16 ワーカー並列でも合計 1 秒未満)。`lines` は **Step 3 の `list_panes` で得た該当 worker pane の `height`** を渡し、pane の全 visible 行を取得して (d) の ERROR scan を全行対象にする (Issue #492 gap 1: `lines=10` の bottom-10 窓では row 15 のような scroll-up した error banner を取りこぼす。`inspect_pane` の `lines` は「末尾 N 行への trim」なので、固定値だと pane height がそれを超えた環境で上段を取りこぼす — 必ず実 height を使う)。`list_panes` の height が取れない場合のみ十分大きい固定値 (例 200) でフォールバックする。APPROVAL_BLOCKED の target line は (a) の通り「最後の非空行」なので返却行数を増やしても変わらない。
    - **エラー時の挙動**: tool result テキストに `[<code>] <msg>` 形式でエラーが埋まる。code で分岐する (詳細は `.claude/skills/org-delegate/references/renga-error-codes.md`):
      - `[pane_not_found]` / `[pane_vanished]` — ワーカーが既に閉じた。そのワーカーの inspect を skip して Step 3 の list 結果で `WORKER_PANE_EXITED` 経路に回す (二重検出は de-dup で吸収される)
      - `[shutting_down]` — renga 停止中。監視ループを即停止し、`mcp__renga-peers__send_message` で `FOREMAN_STOPPING` を窓口に通知
@@ -82,7 +82,7 @@
 
    #### (a) マッチ対象の定義
    返却された `lines` 配列 (各要素 `{row, text}`) の中で、**`text != ""` を満たす最後の 1 要素** だけを APPROVAL_BLOCKED パターンの match 対象とする (複数行を対象にしない)。
-   この 1 行を以降 **target line** と呼ぶ。ERROR パターンは bottom 10 行すべてが対象で良い (プロンプト位置と無関係なため)。
+   この 1 行を以降 **target line** と呼ぶ。ERROR / spinner-age パターン ((d)) は **全 visible 行** が対象 (プロンプト位置と無関係で、scroll-up した banner も拾うため。Issue #492 gap 1)。`inspect_pane(lines=<pane height>)` で取得した **返却行配列全体** を scan する。
 
    #### (b) APPROVAL_BLOCKED 検出 — target line の anchored regex 完全一致
    以下のいずれか:
@@ -102,13 +102,24 @@
 
    **high-confidence のみ journal 記録 + `mcp__renga-peers__send_message` 通知の両方を発行**。low-confidence は journal のみに記録し、窓口通知はスキップする (誤検出による窓口への偽通知を抑えるため)。
 
-   #### (d) ERROR 検出 — substring match
-   bottom 10 行のいずれかが以下を含む:
-   - `API Error`, `api error`
-   - `rate limit`, `429`, `500`
-   - `^Error: `, `^ERROR: `
+   #### (d) ERROR 検出 — 全 visible 行 substring / regex / spinner-age
+   **全 visible 行** ((a) で説明した `inspect_pane(lines=<pane height>)` の **返却行配列全体**。bottom 10 ではない — Issue #492 gap 1) のいずれかが以下に該当:
 
-   ERROR は cursor 補強なしで journal + 通知の両方を発行する (error banner は cursor 位置と相関しないため)。
+   - **strong substring (大文字小文字無視、無条件で発火)**: `API Error`, `api error`, `rate limit`
+   - **status code (語境界 + エラー文脈ゲート)**: `429`, `500`, `502`, `503`, `504`, `529` のいずれかが **語境界トークン** (`(?<!#)\b...\b`) として現れ、**かつ同一行に error 文脈キーワード** (`error` / `overload` / `unavailable` / `rate limit` / `too many requests` / `retry`(ing) / `gateway` / `server error` / `throttl`) がある場合のみ発火
+     - `529` は Anthropic overload、`502/503/504` は transient gateway 系 (Issue #492 gap 2)。全行 scan に広げたことで bare 数字 substring の誤検出 (`localhost:5000` / `500 passed` / issue ref `#529` 等) が増えるため、語境界 + 文脈ゲート + `#` 接頭の issue ref 除外 (`(?<!#)`) で絞る (Codex review 対応)。主信号は `API Error` substring と spinner-age で、status code は文言変更への futureproof な補足
+   - **anchored regex (大文字小文字区別)**: `^Error: `, `^ERROR: `
+   - **spinner-age (Issue #492 gap 3)**: `^\s*[spinner glyphs]+\s+\w+\s+for\s+(\d+)m\s+(\d+)s` に該当し、かつ捕捉した分が **threshold (default 5 分) 以上**。Claude Code の `{glyph} {動詞} for {Xm Ys}` スピナーが 5 分以上回り続けるのは API retry loop / hang の signal で、substring とは独立に **ERROR 同等** として扱う (観測 case: `✻ Sautéed for 9m 12s`)
+
+   ERROR / spinner-age は cursor 補強なしで journal + 通知の両方を発行する (error banner / 停止スピナーは cursor 位置と相関しないため)。spinner-age 検出も notify フォーマット上は `ERROR_DETECTED` 経路に乗せる (kind=error)。
+
+   **正準実装**: 上記 substring / regex / spinner-age 判定の決定論的コアは `tools/inspect_anomaly_scan.py` (`scan_lines()`) に codify 済み。ディスパッチャーは inspect_pane 結果を JSON で渡してこの helper を呼ぶことで全行 scan を 1 コマンドで実行できる (cwd は `.dispatcher/` なので `../tools/`):
+   ```bash
+   # inspect_pane の structuredContent を JSON 化して渡す。
+   # exit 3 = anomaly 検出、exit 0 = clean。detections[] に {kind, reason, row, matched}。
+   echo "$inspect_json" | py -3 ../tools/inspect_anomaly_scan.py --spinner-threshold-min 5
+   ```
+   threshold やパターンの単一定義はこの module 側にあり、regression test (`tests/test_inspect_anomaly_scan.py`、観測 case = row 15 の 529 banner + 9m spinner + bottom 10 空) が契約を pin する。手で判定する場合も上記リストと同義。
 
    #### (e) 実行シーケンス (journal + de-dup + notify)
    以下の順番で厳密に実行する:
@@ -149,6 +160,9 @@
 
    #### (g) worker 自己申告 (Step 2) と inspect (Step 4) の併用設計
    両チャネルが同じ anomaly を通知しても de-dup ((e) の step 2) が 30 秒窓で合算するので、窓口は重複通知を受け取らない。self-report は先に届けば inspect を抑制、inspect は worker が通知を忘れていれば self-report を補完する。両方独立稼働で OK。
+
+   #### (h) 設計メモ — secretary 側 inspect cadence は別 Issue (Issue #492 gap 4)
+   Issue #492 gap 4「secretary 自身が active inspect cadence を持つべきか」は **本 PR スコープ外として別 Issue に切り出す判断**。理由: dispatcher の Step 4 を全 visible 行 scan + spinner-age に強化する (本 PR の gap 1–3) 方が変更が小さく、観測 case (529 + 9m spin) は dispatcher 側の検出強化だけで 5 分時点の ERROR 通知に乗る。secretary に二重の inspect ループを足すのは監視層の二重化で、まず dispatcher 強化の効果を観測してから要否を判断するのが妥当。secretary cadence / `secretary-monitor` skill が必要と判明したら別 Issue で扱う。
 
 5. **stall 検出 (STALL_SUSPECTED)** — 「stuck」と「Secretary 判断待ち idle」を補助シグナルで区別する独立チャネル:
 

--- a/tests/test_inspect_anomaly_scan.py
+++ b/tests/test_inspect_anomaly_scan.py
@@ -1,0 +1,238 @@
+"""Regression tests for tools/inspect_anomaly_scan.py (Issue #492).
+
+These lock the three ERROR-detection gaps fixed in
+``.dispatcher/references/worker-monitoring.md`` §4(d):
+
+* gap (1) — the scan must cover every visible row, not just bottom 10;
+* gap (2) — ``529`` (and ``502`` / ``503`` / ``504``) must be detected;
+* gap (3) — a spinner that has been counting for >= 5 minutes is an
+  ERROR-equivalent.
+
+The headline test reproduces the 2026-05-28 observation from
+``worker-skill-worktree-remove-force-491``: an ``API Error: 529`` banner
+parked at row 15 of a 43-row pane, a ``✻ ... for 9m ...`` spinner, and a
+bottom-10 window that contains only blanks + prompt + status bar.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools import inspect_anomaly_scan as ias  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "inspect_anomaly_scan.py"
+
+
+def _observed_pane() -> list[dict]:
+    """The 2026-05-28 pane: 529 banner at row 15, 9m spinner, empty bottom 10.
+
+    Mirrors the grid quoted in Issue #492. Rows are 1-indexed to match how
+    the Issue describes them; the detector is row-agnostic so the exact
+    numbering only matters for the bottom-N slice below.
+    """
+    lines = [{"row": r, "text": ""} for r in range(1, 44)]
+
+    def put(row: int, text: str) -> None:
+        lines[row - 1] = {"row": row, "text": text}
+
+    put(12, "Ran 1 shell command")
+    put(13, "  ⎿  ok")
+    put(14, "←renga-peers: ack from secretary")
+    put(15, "API Error: 529 Overloaded. Retrying…")
+    put(17, "✻ Sautéed for 9m 12s")
+    put(39, "──────────────────────")
+    put(40, "❯")
+    put(41, "  ⏵⏵ accept edits on")
+    put(42, "claude-opus-4-8")
+    return lines
+
+
+class ObservedRegressionTests(unittest.TestCase):
+    """The headline Issue #492 case must fire ERROR; bottom-10 alone must not."""
+
+    def test_full_scan_detects_529_and_stuck_spinner(self) -> None:
+        detections = ias.scan_lines(_observed_pane())
+        reasons = {d.reason for d in detections}
+
+        # gap (2): the 529 banner is caught (by the bare 529 code and/or by
+        # the "API Error" substring — at least one substring detection on
+        # the banner row).
+        banner = [d for d in detections if d.row == 15]
+        self.assertTrue(banner, "529 banner at row 15 must be detected")
+        self.assertTrue(
+            any(r.startswith("substring:") for r in reasons),
+            f"expected a substring detection, got {reasons}",
+        )
+
+        # gap (3): the 9m spinner is an ERROR-equivalent.
+        self.assertIn("spinner_age:9m", reasons)
+
+        # every detection maps onto the ERROR notification path.
+        self.assertTrue(all(d.kind == "error" for d in detections))
+
+    def test_bottom_10_window_misses_the_banner(self) -> None:
+        """Demonstrates gap (1): the old bottom-10 scan is blind here."""
+        pane = _observed_pane()
+        bottom_10 = pane[-10:]  # rows 34-43: blanks + prompt + status bar
+        self.assertEqual(ias.scan_lines(bottom_10), [])
+
+
+class SubstringTests(unittest.TestCase):
+    def test_api_error_case_insensitive(self) -> None:
+        self.assertTrue(ias.scan_lines(["some api error happened"]))
+        self.assertTrue(ias.scan_lines(["SOME API ERROR HAPPENED"]))
+
+    def test_rate_limit_detected(self) -> None:
+        self.assertTrue(ias.scan_lines(["rate limit reached, backing off"]))
+
+    def test_clean_line_no_detection(self) -> None:
+        self.assertEqual(ias.scan_lines(["Ran 1 shell command", "  ⎿  ok"]), [])
+
+    def test_single_reason_per_line(self) -> None:
+        # "API Error" (strong substring) wins; the gated 529 code does not add
+        # a second detection on the same line.
+        dets = ias.scan_lines(["API Error: 529 Overloaded"])
+        self.assertEqual(len(dets), 1)
+        self.assertEqual(dets[0].reason, "substring:API Error")
+
+
+class StatusCodeTests(unittest.TestCase):
+    """gap (2): status codes detected, but only as gated tokens.
+
+    These guard the regression without leaning on the ``API Error``
+    substring — removing a code from ``ERROR_STATUS_CODES`` makes the
+    relevant subTest fail.
+    """
+
+    def test_each_code_detected_without_api_error_wording(self) -> None:
+        # Lines carry an error-context keyword but NOT "API Error", so the
+        # bare-code path is what fires.
+        contexts = {
+            "429": "HTTP 429 too many requests, retrying",
+            "500": "Upstream 500 server error",
+            "502": "got 502 from gateway",
+            "503": "service unavailable (503)",
+            "504": "504 gateway timeout, retry",
+            "529": "Overloaded (529), retrying…",
+        }
+        for code, line in contexts.items():
+            with self.subTest(code=code):
+                dets = ias.scan_lines([line])
+                self.assertEqual(
+                    [d.reason for d in dets],
+                    [f"status_code:{code}"],
+                    f"{code} should be detected via the gated code path",
+                )
+
+    def test_bare_code_without_error_context_not_detected(self) -> None:
+        # No error keyword on the line → benign, must not fire.
+        for benign in ("500 passed, 0 failed", "see issue #529", "build 502 ok"):
+            with self.subTest(line=benign):
+                self.assertEqual(ias.scan_lines([benign]), [])
+
+    def test_substring_of_larger_number_not_detected(self) -> None:
+        # "5000" must not match \b500\b even with error context present.
+        self.assertEqual(
+            ias.scan_lines(["error connecting to localhost:5000"]), []
+        )
+
+    def test_issue_ref_with_error_context_not_detected(self) -> None:
+        # A "#529" GitHub ref must not fire even when the same line mentions
+        # "error" (e.g. an issue conversation in the pane). The (?<!#) guard
+        # drops it; \b alone would let it through.
+        for line in (
+            "Issue #529: error detection",
+            "error in issue #529 reproduction",
+        ):
+            with self.subTest(line=line):
+                self.assertEqual(ias.scan_lines([line]), [])
+
+
+class AnchoredRegexTests(unittest.TestCase):
+    def test_error_prefix_detected(self) -> None:
+        dets = ias.scan_lines(["Error: boom"])
+        self.assertEqual(len(dets), 1)
+        self.assertTrue(dets[0].reason.startswith("regex:"))
+
+    def test_error_uppercase_prefix_detected(self) -> None:
+        self.assertTrue(ias.scan_lines(["ERROR: boom"]))
+
+    def test_error_not_at_line_start_not_matched_by_regex(self) -> None:
+        # "  Error: " is not line-anchored, so the regex path does not fire.
+        dets = ias.scan_lines(["  Error: indented"])
+        self.assertFalse(any(d.reason.startswith("regex:") for d in dets))
+
+
+class SpinnerAgeTests(unittest.TestCase):
+    def test_spinner_below_threshold_not_detected(self) -> None:
+        self.assertEqual(ias.scan_lines(["✻ Cogitating for 2m 30s"]), [])
+
+    def test_spinner_at_threshold_detected(self) -> None:
+        dets = ias.scan_lines(["✻ Cogitating for 5m 0s"])
+        self.assertEqual([d.reason for d in dets], ["spinner_age:5m"])
+
+    def test_spinner_above_threshold_detected(self) -> None:
+        dets = ias.scan_lines(["✺ Pondering for 12m 8s"])
+        self.assertEqual([d.reason for d in dets], ["spinner_age:12m"])
+
+    def test_non_ascii_verb_matches(self) -> None:
+        dets = ias.scan_lines(["✻ Sautéed for 6m 23s"])
+        self.assertEqual([d.reason for d in dets], ["spinner_age:6m"])
+
+    def test_custom_threshold(self) -> None:
+        dets = ias.scan_lines(
+            ["✻ Working for 3m 0s"], spinner_threshold_min=2
+        )
+        self.assertEqual([d.reason for d in dets], ["spinner_age:3m"])
+
+    def test_not_a_spinner_line(self) -> None:
+        self.assertEqual(ias.scan_lines(["working for 9m on the task"]), [])
+
+
+class NormalizationTests(unittest.TestCase):
+    def test_accepts_bare_strings(self) -> None:
+        dets = ias.scan_lines(["API Error: 529"])
+        self.assertEqual(dets[0].row, 0)
+
+    def test_handles_none_text(self) -> None:
+        self.assertEqual(ias.scan_lines([{"row": 1, "text": None}]), [])
+
+
+class CliTests(unittest.TestCase):
+    def _run(self, payload: dict, *extra: str):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *extra],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+        )
+
+    def test_cli_structured_content_exit_3_on_anomaly(self) -> None:
+        payload = {"structuredContent": {"lines": _observed_pane()}}
+        proc = self._run(payload)
+        self.assertEqual(proc.returncode, 3)
+        out = json.loads(proc.stdout)
+        reasons = {d["reason"] for d in out["detections"]}
+        self.assertIn("spinner_age:9m", reasons)
+
+    def test_cli_clean_pane_exit_0(self) -> None:
+        payload = {"lines": [{"row": 1, "text": "Ran 1 shell command"}]}
+        proc = self._run(payload)
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(json.loads(proc.stdout)["detections"], [])
+
+    def test_cli_custom_threshold(self) -> None:
+        payload = {"lines": ["✻ Working for 3m 0s"]}
+        proc = self._run(payload, "--spinner-threshold-min", "2")
+        self.assertEqual(proc.returncode, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/inspect_anomaly_scan.py
+++ b/tools/inspect_anomaly_scan.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Deterministic ERROR / spinner-age anomaly detector for dispatcher §4(d).
+
+This is the codified core of ``.dispatcher/references/worker-monitoring.md``
+Step 4 (d) "ERROR 検出". The detection used to live as prose that the
+dispatcher Claude applied by eyeballing the ``inspect_pane`` grid, which
+let three classes of failure slip through (Issue #492):
+
+* **Gap (1) — bottom-N window**: §4(d) scanned only the bottom 10 rows, so
+  an error banner that scrolled up (e.g. row 15 of a 43-row pane, with a
+  blank middle band below it) was invisible. This module scans **every
+  visible row** returned by ``inspect_pane``.
+* **Gap (2) — missing 529**: Anthropic's overload code ``529`` (and the
+  transient ``502`` / ``503`` / ``504``) were not in the substring list.
+* **Gap (3) — stuck spinner**: a ``{glyph} {verb} for {Xm Ys}`` spinner
+  that grows past a threshold (default 5 minutes) signals an effectively
+  hung API retry loop, independent of any substring match. This module
+  treats an aged spinner as an ERROR-equivalent detection.
+
+Keeping the logic as a pure function (:func:`scan_lines`) gives the
+contract a regression test (``tests/test_inspect_anomaly_scan.py``
+reproduces the 2026-05-28 case: 529 banner at row 15 + 9m spinner +
+empty bottom 10) and lets the dispatcher pipe ``inspect_pane`` output
+through a single deterministic detector via the CLI below.
+
+Scope: this module covers the ERROR-class detections (substring + anchored
+regex + spinner age). APPROVAL_BLOCKED detection stays in the prose §4(b)
+because it is target-line + cursor-position sensitive and not part of
+Issue #492.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from typing import Iterable, Optional, Sequence, Union
+
+# Default spinner-age threshold in minutes. A Claude Code spinner that has
+# been counting for this many minutes or more is treated as a stuck run.
+# Issue #492: observed 6m23s / 9m spins that never recovered on their own.
+SPINNER_AGE_THRESHOLD_MIN = 5
+
+# Case-insensitive *strong* substrings — these fire unconditionally because
+# they are unambiguous error wording. ``API Error`` covers the lowercase
+# ``api error`` variant via the case-insensitive compare, but both are kept
+# to mirror the documented §4(d) list verbatim.
+ERROR_SUBSTRINGS: tuple[str, ...] = (
+    "API Error",
+    "api error",
+    "rate limit",
+)
+
+# HTTP / Anthropic status codes. Matched only as standalone tokens (word
+# boundaries) AND only when the same line carries an error-ish keyword.
+# Broadening the scan from bottom-10 to *all* visible rows (Issue #492 gap 1)
+# amplifies the false-positive risk of bare-digit substrings, so a benign
+# line like ``localhost:5000``, ``500 passed``, or an issue ref ``#529`` must
+# not trip ``ERROR_DETECTED``. The codes remain the deliberate, futureproof
+# supplement for when Claude Code renames its error wording (Issue #492 gap 2):
+# ``529`` = Anthropic overload, ``502``/``503``/``504`` = transient gateway.
+ERROR_STATUS_CODES: tuple[str, ...] = ("429", "500", "502", "503", "504", "529")
+# ``(?<!#)`` drops GitHub-style issue refs (``#529``) which ``\b`` alone keeps
+# (``#`` is a non-word char, so a word boundary sits before the digit). A
+# longer-digit token like ``5000`` is already excluded by the trailing ``\b``.
+_STATUS_CODE_RE = re.compile(r"(?<!#)\b(429|500|502|503|504|529)\b")
+_ERROR_CONTEXT_RE = re.compile(
+    r"error|overload|unavailable|rate limit|too many requests|"
+    r"retry|retrying|gateway|server error|throttl",
+    re.IGNORECASE,
+)
+
+# Line-prefix anchored regexes (case-sensitive, matching the §4(d) prose).
+ERROR_ANCHORED_PATTERNS: tuple[str, ...] = (
+    r"^Error: ",
+    r"^ERROR: ",
+)
+_ERROR_ANCHORED_RES = tuple(re.compile(p) for p in ERROR_ANCHORED_PATTERNS)
+
+# Stuck-spinner regex. Claude Code renders ``{spinner_glyph} {verb} for
+# {Xm Ys}`` while a tool call or API retry runs; under healthy operation the
+# counter clears within seconds. The glyph class covers the rotating braille
+# / star glyphs Claude Code cycles through (kept generous on purpose — a new
+# glyph should not silently disable the detector). ``\w+`` matches the verb
+# including non-ASCII letters (e.g. "Sautéed") since Python's ``\w`` is
+# Unicode-aware for ``str`` patterns.
+SPINNER_AGE_PATTERN = (
+    r"^\s*[✻✺✶✷✸✹✦✧✱✲✳·∙▪●○◍◌◐◑◒◓*]+\s+\w+\s+for\s+(\d+)m\s+(\d+)s"
+)
+_SPINNER_AGE_RE = re.compile(SPINNER_AGE_PATTERN)
+
+
+@dataclass(frozen=True)
+class Detection:
+    """One ERROR-class anomaly found on a pane line.
+
+    ``kind`` is always ``"error"`` so callers map every detection onto the
+    existing ``ERROR_DETECTED`` notification path (spinner age is an
+    ERROR-equivalent per Issue #492 gap 3). ``reason`` distinguishes the
+    trigger for journal / debugging (``substring:API Error`` /
+    ``status_code:529`` / ``regex:^Error: `` / ``spinner_age:9m``).
+    """
+
+    kind: str
+    reason: str
+    row: Optional[int]
+    matched: str
+
+
+def _normalize(
+    lines: Iterable[Union[str, dict]],
+) -> list[tuple[Optional[int], str]]:
+    """Coerce the ``inspect_pane`` ``lines`` payload to ``(row, text)`` pairs.
+
+    Accepts either the structured ``[{"row": int, "text": str}, ...]`` shape
+    or a bare list of strings (row index inferred positionally).
+    """
+    out: list[tuple[Optional[int], str]] = []
+    for idx, item in enumerate(lines):
+        if isinstance(item, dict):
+            row = item.get("row")
+            text = item.get("text", "")
+        else:
+            row = idx
+            text = item
+        out.append((row, "" if text is None else str(text)))
+    return out
+
+
+def scan_lines(
+    lines: Iterable[Union[str, dict]],
+    *,
+    spinner_threshold_min: int = SPINNER_AGE_THRESHOLD_MIN,
+) -> list[Detection]:
+    """Scan **all** visible pane lines for ERROR-class anomalies.
+
+    Returns a list of :class:`Detection`, one per matching line/trigger.
+    An empty list means the pane looks clean. The scan deliberately covers
+    every row (Issue #492 gap 1) rather than only the bottom N.
+    """
+    detections: list[Detection] = []
+    for row, text in _normalize(lines):
+        if not text:
+            continue
+
+        lowered = text.lower()
+        content_hit = False
+        for needle in ERROR_SUBSTRINGS:
+            if needle.lower() in lowered:
+                detections.append(
+                    Detection(
+                        kind="error",
+                        reason=f"substring:{needle}",
+                        row=row,
+                        matched=text,
+                    )
+                )
+                # One content hit per line is enough to flag it.
+                content_hit = True
+                break
+
+        # Status code, gated on error context (only if no strong substring
+        # already flagged the line, to avoid a duplicate detection).
+        if not content_hit:
+            code_m = _STATUS_CODE_RE.search(text)
+            if code_m and _ERROR_CONTEXT_RE.search(text):
+                detections.append(
+                    Detection(
+                        kind="error",
+                        reason=f"status_code:{code_m.group(1)}",
+                        row=row,
+                        matched=text,
+                    )
+                )
+
+        for rx in _ERROR_ANCHORED_RES:
+            if rx.search(text):
+                detections.append(
+                    Detection(
+                        kind="error",
+                        reason=f"regex:{rx.pattern}",
+                        row=row,
+                        matched=text,
+                    )
+                )
+                break
+
+        m = _SPINNER_AGE_RE.match(text)
+        if m:
+            minutes = int(m.group(1))
+            if minutes >= spinner_threshold_min:
+                detections.append(
+                    Detection(
+                        kind="error",
+                        reason=f"spinner_age:{minutes}m",
+                        row=row,
+                        matched=text,
+                    )
+                )
+
+    return detections
+
+
+def _load_lines(payload: dict) -> Sequence[Union[str, dict]]:
+    """Pull the ``lines`` array out of an ``inspect_pane`` result blob.
+
+    Accepts the raw ``structuredContent`` object (``{"lines": [...]}``) or a
+    bare list already at the top level.
+    """
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        if isinstance(payload.get("lines"), list):
+            return payload["lines"]
+        sc = payload.get("structuredContent")
+        if isinstance(sc, dict) and isinstance(sc.get("lines"), list):
+            return sc["lines"]
+    raise ValueError(
+        "input JSON must be a list of lines or contain a 'lines' / "
+        "'structuredContent.lines' array"
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan inspect_pane grid lines for ERROR / spinner-age anomalies "
+            "(dispatcher worker-monitoring §4(d), Issue #492)."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        type=argparse.FileType("r", encoding="utf-8"),
+        default=sys.stdin,
+        help="JSON file with inspect_pane result (default: stdin).",
+    )
+    parser.add_argument(
+        "--spinner-threshold-min",
+        type=int,
+        default=SPINNER_AGE_THRESHOLD_MIN,
+        help=(
+            "Spinner-age threshold in minutes; a spinner counting for >= this "
+            f"many minutes is an ERROR-equivalent (default: {SPINNER_AGE_THRESHOLD_MIN})."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    payload = json.load(args.input)
+    detections = scan_lines(
+        _load_lines(payload), spinner_threshold_min=args.spinner_threshold_min
+    )
+    json.dump(
+        {"detections": [asdict(d) for d in detections]},
+        sys.stdout,
+        ensure_ascii=False,
+    )
+    sys.stdout.write("\n")
+    # Exit 3 when an anomaly is found so a shell caller can branch without
+    # parsing JSON; exit 0 means the pane is clean.
+    return 3 if detections else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes the four ERROR-detection gaps in dispatcher worker-monitoring observed on 2026-05-28 (worker hit `529 Overloaded`, auto-retry spun ~9m, dispatcher did not classify the screen as ERROR).

- **gap (1) bottom-N window**: `§4(d)` ERROR scan expanded from bottom-10 rows to **all visible rows**. `inspect_pane` `lines` now receives the real pane height from `list_panes` (a fixed value drops top rows on taller panes). Catches scrolled-up banners like the observed row-15 `529`.
- **gap (2) status codes**: added `429/500/502/503/504/529` (529 = Anthropic overload; 502/503/504 = transient gateway). To avoid bare-number false positives under full-row scan, matches are gated on word-boundary + error-context keyword + `#issue-ref` exclusion.
- **gap (3) spinner age**: added a spinner-age regex + threshold (default 5m) that routes stuck spinners (e.g. `✻ ... for 9m`) to the same ERROR notification path.
- **gap (4) secretary cadence**: judged better split into a separate Issue — strengthening dispatcher Step 4 is a smaller change that already catches the observed case at the 5-minute mark. Rationale recorded in design note (h).

## Changes (3 files)

- `tools/inspect_anomaly_scan.py` (new): deterministic detection core, importable `scan_lines()` + CLI (exit 3 = anomaly).
- `tests/test_inspect_anomaly_scan.py` (new): 24 cases incl. regression for the observed case (row-15 529 + 9m spinner + empty bottom-10).
- `.dispatcher/references/worker-monitoring.md`: updated §4(a)(d) prose to full-row scan + spinner-age + helper reference; added design note (h).

## Verification

- 24 new regression tests OK
- tests/ 339 OK · tools/ 409 OK (2 skip) · shell 372 passed / 0 failed
- Codex self-review (full) converged over 3 rounds (no Blocker/Major)

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)