### PR TITLE
fix(claude): add escalation_to_user ask-time gate for awaiting_user emit

### DIFF
--- a/.claude/skills/org-escalation/SKILL.md
+++ b/.claude/skills/org-escalation/SKILL.md
@@ -48,10 +48,12 @@ allowed-tools:
      ```
      同 task_id の pending entry が既存なら idempotent (no-op)。register はディスパッチャーの SECRETARY_RELAY_GAP_SUSPECTED 検出 ([`../../../.dispatcher/references/worker-monitoring.md` Step 5.1](../../../.dispatcher/references/worker-monitoring.md#step-5-1)) の primary lookup source
 
-3. **人間に伝達する**: 内容と選択肢を整理して提示する。提示直後に register を `escalated` に更新:
+3. **人間に伝達する**: 内容と選択肢を整理して提示する。**選択肢を提示した時点（ask の瞬間）** で、register を `escalated` に更新する直前/同時に attention watcher へ awaiting_user を即時 emit する（Issue #28、ask-time ゲート）:
    ```bash
+   bash tools/journal_append.sh notify_sent kind=awaiting_user task_id={task_id} gate=escalation_to_user note="<選択肢提示の短い要約>"
    python tools/pending_decisions.py resolve --task-id {task_id} --kind to_user
    ```
+   classifier が `secretary_awaiting_user` (default severity `urgent`) として拾い、判断を仰がれた瞬間に即ビープする。interactive ではユーザーが数十秒〜数分で返答するため pending_decision aging (15分) は実質発火せず、この ask-time emit が urgent 通知の主経路となる。Step 4.5 (`escalation_reply_forward`, 転送時) の emit はそのまま別タイミングとして残す（Step 3=ask 時 / 4.5=転送時）。本 emit は journal 1 行追記のみで register / pending_decisions の状態は触らない。
 
 4. **ユーザーから返答を受領した時点** — ワーカーへ転送する **前に** `user_replied_at` marker を register に記録する (Issue #301):
    ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,17 +58,18 @@ retro gate ack は必ず `mcp__renga-peers__send_message(to_id="dispatcher", ...
 
 Secretary が「次の一手はユーザーの返答待ち」で停止する gate では、attention watcher がユーザーに気付かせるための信号を 1 行 emit する。Secretary 側は claude-org-ja の本リポジトリで stop しているため、画面前にユーザーが居ない場合 awaiting_user の状態が長時間放置される。この emit を runtime classifier 側で `secretary_awaiting_user` (default severity `urgent`) にマップすることで、ビープ等で通知される。
 
-### 対象 gate（3 箇所）
+### 対象 gate（4 箇所）
 - **`worker_completed`**: ワーカーから完了報告を受領 → ack + DB の events テーブルへ review transition を追記 → ユーザーへ承認待ちで停止する直前。[`/org-delegate`](./.claude/skills/org-delegate/SKILL.md) Step 5 sub 2a。
 - **`ci_green_merge_gate`**: PR 作成後の CI 監視で `CI_COMPLETED` 受信（CI green）→ ユーザーへ merge 承認を仰ぐ直前。[`/org-pull-request`](./.claude/skills/org-pull-request/SKILL.md) 2b-i。
+- **`escalation_to_user`**: ワーカーからの判断仰ぎを人間に上げ、選択肢を提示してユーザー返答待ちで停止する直前（ask の瞬間）。[`/org-escalation`](./.claude/skills/org-escalation/SKILL.md) Step 3。interactive ではユーザーが数十秒〜数分で返答するため pending_decision aging (15分) は実質発火せず、この ask-time emit が urgent 通知の主経路となる。
 - **`escalation_reply_forward`**: 判断仰ぎを人間に上げ、ユーザー返答を受け取り、ワーカーへ転送する直前。[`/org-escalation`](./.claude/skills/org-escalation/SKILL.md) の `mark-user-replied` → `resolve --kind to_worker` の境界。
 
 ### Canonical emit 形
 ```
 bash tools/journal_append.sh notify_sent kind=awaiting_user task_id=TASK gate=GATE note=SHORT
 ```
-- `task_id`: 対象ワーカー / PR / decision に対応する task_id（escalation_reply_forward の場合は decision に紐付く task_id）。
-- `gate`: `worker_completed` / `ci_green_merge_gate` / `escalation_reply_forward` のいずれか。
+- `task_id`: 対象ワーカー / PR / decision に対応する task_id（escalation_to_user / escalation_reply_forward の場合は decision に紐付く task_id）。
+- `gate`: `worker_completed` / `ci_green_merge_gate` / `escalation_to_user` / `escalation_reply_forward` のいずれか。
 - `note`: 1 行以下の短い文脈（PR 番号 / Issue 番号 / 要約等）。
 
 ### 通知側の挙動

--- a/tools/templates/attention.example.json
+++ b/tools/templates/attention.example.json
@@ -22,7 +22,8 @@
     "worker_not_reported": "normal",
     "worker_error": "normal",
     "worker_completed": "normal",
-    "pr_merged": "normal"
+    "pr_merged": "normal",
+    "secretary_awaiting_user": "urgent"
   },
   "templates": {
     "approval_blocked": {


### PR DESCRIPTION
## Problem

The attention watcher's immediate `secretary_awaiting_user` (urgent) signal was emitted only at three gates: `worker_completed`, `ci_green_merge_gate`, and `escalation_reply_forward`. The last fires when *forwarding the user's reply to the worker* — i.e. **after** the user has answered. There was no immediate emit at the moment the secretary *presents a decision to the user* (the ask). The only urgent path for that moment was the `pending_decisions` aging timer (`pending_decision_min`, default 15 min), which in interactive use never fires because the user answers within seconds/minutes. Result: when the secretary escalates a decision and stops for the user, **no beep**.

Confirmed empirically: the sound backend itself works (user heard a test beep); this was purely a timing/routing gap.

## Fix

Add a 4th gate `escalation_to_user`: org-escalation emits `notify_sent kind=awaiting_user gate=escalation_to_user` immediately when presenting the decision to the user (Step 3), alongside `resolve --kind to_user`. The runtime classifier already maps `kind=awaiting_user` → `secretary_awaiting_user` (urgent) regardless of gate, so the new gate is a label only — **no runtime change**.

## Changes (3 files, ja-only)
- `.claude/skills/org-escalation/SKILL.md` — Step 3 adds the immediate ask-time emit; Step 4.5 (forward-time emit) retained as a distinct moment.
- `CLAUDE.md` — gate list 3 → 4, adds `escalation_to_user`; canonical-emit gate enumeration updated.
- `tools/templates/attention.example.json` — pin `notify.secretary_awaiting_user: "urgent"` (was relying on runtime default).

## Verification
- unit tests: 36 passed; role_configs / runtime schema drift OK; JSON valid.
- Confirmed against bundled runtime: `classifier.py` maps `kind=awaiting_user`→`secretary_awaiting_user` gate-agnostically; `config.py` default severity urgent.
- gate-count 3→4 consistent across SKILL.md and CLAUDE.md.
- codex self-review: no Blocker/Major.

Pre-existing out-of-scope gap noted separately (docs/verification.md kind enumeration missing `secretary_awaiting_user`) — tracked in a follow-up issue.