### PR TITLE
docs(claude): add secretary_awaiting_user to attention-scan kind set (Closes #496)

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -608,7 +608,7 @@ claude-org-ja 本体は Issue #429 Task C（本 addendum と同 PR）で共有 `
    ```
 3. 出力 JSON を確認する。`events` 配列の各要素が以下のフィールドを持つこと:
    - `key`: dedup 用安定 ID（`event:<events.id>` または `pending:<task_id>:<kind>` のいずれか）
-   - `kind`: runtime 0.1.x の分類 kind の集合（`approval_blocked` / `relay_gap_suspected` / `silent_worker_output` / `ci_failed` / `pending_decision` / `user_reply_not_forwarded` / `pane_silent` / `pane_crashed` / `worker_stalled` / `worker_not_reported` / `worker_error` / `worker_completed` / `pr_merged`）
+   - `kind`: runtime 0.1.x の分類 kind の集合（`approval_blocked` / `relay_gap_suspected` / `silent_worker_output` / `ci_failed` / `pending_decision` / `user_reply_not_forwarded` / `pane_silent` / `pane_crashed` / `worker_stalled` / `worker_not_reported` / `worker_error` / `worker_completed` / `pr_merged` / `secretary_awaiting_user`）
    - `severity`: `urgent` または `normal`
    - `title` / `body`: ja config のテンプレートが適用された文字列（日本語）
    - 必要に応じて `task_id` / `worker` / `created_at`
@@ -619,6 +619,7 @@ claude-org-ja 本体は Issue #429 Task C（本 addendum と同 PR）で共有 `
 - `ci_completed` で `status` が `failed` / `canceled` / `incomplete` のいずれかなら `kind: "ci_failed"`, `severity: "urgent"`
 - `worker_completed` / `pr_merged` は `severity: "normal"`、それ以外の上記分類は ja default で `urgent`
 - pending decision が `pending_decision_min`（既定 15 分）を超えていれば `kind: "pending_decision"`, `severity: "urgent"`
+- `notify_sent kind=awaiting_user`（Secretary が user の判断待ちで停止する 4 ゲート）は `kind: "secretary_awaiting_user"`, `severity: "urgent"`
 - title / body が ja default の日本語文字列で、`{worker}` / `{task_id}` / `{pr}` / `{status}` 等の placeholder が解決済み
 - `--dry-run` 指定なので desktop notification subprocess が呼ばれない（macOS で notification center に何も出ない、Linux で `notify-send` が走らない）
 - `--config .state/attention.json` を外して再実行すると runtime の中立的な英語 default が title / body に出ること（ja 上書きが effective であることの裏取り）


### PR DESCRIPTION
Adds the `secretary_awaiting_user` kind to the attention-scan classification enumeration in `docs/verification.md` (was omitted). The runtime classifier maps `notify_sent` `kind=awaiting_user` → `secretary_awaiting_user` (default severity `urgent`), so the doc enumeration was stale.

Doc-only, 1 file (+2/-1). Pre-existing gap, split out from the PR #495 (escalation_to_user gate) work per maintainer instruction.

Closes #496.