### PR TITLE
fix(claude): harden work-discovery scan compute layer — #520 Phase 1 follow-up

### DIFF
--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -195,6 +195,28 @@ class TestBlockingRefExtraction(unittest.TestCase):
             [5],
         )
 
+    def test_multiple_clauses_on_one_line(self):
+        # Both clauses on a single line must be extracted, not just the first.
+        self.assertEqual(
+            wds.extract_blocking_refs(
+                "Blocked by #1; depends on #2", is_epic=False
+            ),
+            [1, 2],
+        )
+        self.assertEqual(
+            wds.extract_blocking_refs(
+                "Requires #3 and Blocked by #4", is_epic=False
+            ),
+            [3, 4],
+        )
+
+    def test_ref_on_next_line_not_linked_to_keyword(self):
+        # A keyword and a bare `#N` on the *next* line are not linked (§11-3
+        # same-line precision: avoid spurious cross-line blockers).
+        self.assertEqual(
+            wds.extract_blocking_refs("Blocked by\n#5", is_epic=False), []
+        )
+
 
 class TestClassifyDependency(unittest.TestCase):
     def test_resolved_when_refs_all_closed(self):
@@ -650,6 +672,18 @@ class TestCliWiring(unittest.TestCase):
         data = json.loads(proc.stdout)
         self.assertEqual(data["status"], "error")
 
+    def test_free_panes_negative_rejected_as_error(self):
+        # `--free-panes` is a non-negative count; 0 is valid, negative is not.
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--free-panes=-2"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertIn("--free-panes", data["error"])
+
 
 class TestCommentsAndMilestone(unittest.TestCase):
     """Blockers in comments + milestone tier."""
@@ -942,6 +976,23 @@ class TestBundleValidation(unittest.TestCase):
         data = json.loads(proc.stdout)
         self.assertEqual(data["status"], "error")
         self.assertIn("open_pr_numbers", data["error"])
+
+    def test_bundle_open_pr_numbers_string_errors(self):
+        # A string `"123"` must NOT be iterated into {1,2,3}; require a list.
+        proc = self._run_bundle_text('{"issues": [], "open_pr_numbers": "123"}')
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertIn("open_pr_numbers", data["error"])
+
+    def test_bundle_issue_without_integer_number_errors(self):
+        # An issue lacking an int `number` would emit `"issue": null` —
+        # reject it so the candidate JSON schema stays consistent.
+        proc = self._run_bundle_text('{"issues": [{"title": "no number"}]}')
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertIn("number", data["error"])
 
 
 if __name__ == "__main__":

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -722,8 +722,9 @@ class TestCommentsAndMilestone(unittest.TestCase):
 
 
 class TestFetchRecentMerges(unittest.TestCase):
-    """`gh pr list` order is not guaranteed, so fetch_recent_merges must
-    sort by mergedAt (newest first) before taking the 直近 K 件 (§4.2)."""
+    """`gh pr list` defaults to createdAt-desc, NOT merge-time, so
+    fetch_recent_merges must (a) ask the server to order by recency and
+    (b) sort by mergedAt before taking the 直近 K 件 (§4.2)."""
 
     _UNSORTED = [
         {"number": 1, "title": "a", "body": "", "mergedAt": "2026-01-01T00:00:00Z"},
@@ -731,14 +732,27 @@ class TestFetchRecentMerges(unittest.TestCase):
         {"number": 2, "title": "b", "body": "", "mergedAt": "2026-02-01T00:00:00Z"},
     ]
 
+    def test_server_side_recency_ordering_requested(self):
+        # The fix for createdAt-desc dropping recent merges is a server-side
+        # recency sort + the K limit — assert both reach the gh call.
+        with mock.patch.object(
+            wds, "_run_gh_json", return_value=[]
+        ) as gh:
+            wds.fetch_recent_merges("owner/repo", 7)
+        argv = gh.call_args[0][0]
+        self.assertIn("--search", argv)
+        self.assertEqual(argv[argv.index("--search") + 1], "sort:updated-desc")
+        self.assertEqual(argv[argv.index("--limit") + 1], "7")
+        self.assertIn("merged", argv)
+
     def test_sorted_by_merged_at_desc(self):
         with mock.patch.object(wds, "_run_gh_json", return_value=list(self._UNSORTED)):
             merges = wds.fetch_recent_merges(None, 10)
         self.assertEqual([m["number"] for m in merges], [3, 2, 1])
 
-    def test_limit_takes_newest_after_sort(self):
-        # The 直近 K 件 must be the K *newest* by mergedAt, not the first K
-        # in gh's return order.
+    def test_defensive_limit_applied_after_sort(self):
+        # Even if the fetch over-returns, the client side caps to the K
+        # *newest* by mergedAt (not the first K in arrival order).
         with mock.patch.object(wds, "_run_gh_json", return_value=list(self._UNSORTED)):
             merges = wds.fetch_recent_merges(None, 2)
         self.assertEqual([m["number"] for m in merges], [3, 2])

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -107,6 +107,30 @@ class TestBlockingRefExtraction(unittest.TestCase):
             wds.extract_blocking_refs(body, is_epic=False), [11]
         )
 
+    def test_task_list_pure_ref_run_counts(self):
+        # A task item that is *only* refs is a genuine sub-task dependency.
+        body = "- [ ] #11\n- [ ] #12, #13 and #14\n"
+        self.assertEqual(
+            wds.extract_blocking_refs(body, is_epic=False), [11, 12, 13, 14]
+        )
+
+    def test_task_list_prose_after_ref_is_not_a_blocker(self):
+        # §11-3: `- [ ] #123 を参考に確認する` merely *mentions* #123 — it is
+        # not a dependency. Counting it would wrongly exclude the candidate.
+        body = "- [ ] #123 を参考に確認する\n- [ ] #124 review notes\n"
+        self.assertEqual(wds.extract_blocking_refs(body, is_epic=False), [])
+
+    def test_task_list_prose_before_ref_is_not_a_blocker(self):
+        # `- [ ] Fix #11` — prose before the ref → mention, not a blocker.
+        self.assertEqual(
+            wds.extract_blocking_refs("- [ ] Fix #11", is_epic=False), []
+        )
+
+    def test_task_list_mixed_pure_and_prose(self):
+        # Only the pure-ref items count; the prose-annotated one is dropped.
+        body = "- [ ] #11\n- [ ] #99 を参考に\n"
+        self.assertEqual(wds.extract_blocking_refs(body, is_epic=False), [11])
+
     def test_task_list_ignored_for_epic(self):
         # An epic's child checklist is tracking, not a blocker on the epic.
         body = "## Children\n- [ ] #11\n- [ ] #12\n"
@@ -428,6 +452,17 @@ class TestRankingAndScan(unittest.TestCase):
         top, _ = wds.rank_candidates(cands, top_n=3, free_panes=0)
         self.assertEqual(top[0]["issue"], 1)
 
+    def test_free_panes_none_does_not_boost(self):
+        # `--free-panes` unspecified (None) is *unknown*, not "panes free":
+        # per the documented contract it must NOT boost parallelizable, so the
+        # ranking is identical to free_panes=0 (stable original order here).
+        cands = [
+            self._cand(1, parallelizable=False),
+            self._cand(2, parallelizable=True),
+        ]
+        top, _ = wds.rank_candidates(cands, top_n=3, free_panes=None)
+        self.assertEqual(top[0]["issue"], 1)
+
 
 # ----------------------------------------------------------------------
 # CLI wiring: stdout JSON + exit codes (§5.1)
@@ -570,6 +605,29 @@ class TestCliWiring(unittest.TestCase):
         data = json.loads(proc.stdout)
         self.assertEqual(data["status"], "error")
         self.assertEqual(data["generated_for"], "post_merge")
+
+    def test_recent_merges_zero_rejected_as_error(self):
+        # `--recent-merges 0` would request a nonsensical `gh --limit 0` and
+        # break the 直近 K 件 contract — must be rejected (exit 2).
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--recent-merges", "0"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertIn("--recent-merges", data["error"])
+
+    def test_recent_merges_negative_rejected_as_error(self):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--recent-merges=-3"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
 
 
 class TestCommentsAndMilestone(unittest.TestCase):

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -599,6 +599,19 @@ class TestCliWiring(unittest.TestCase):
         self.assertEqual(data["status"], "error")
         self.assertIn("argument error", data["error"])
 
+    def test_argparse_type_error_keeps_trigger_context(self):
+        # Even an argparse type error raised mid-parse must carry the real
+        # --trigger in generated_for (best-effort probe), not "manual".
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--top-n", "nope", "--trigger", "post_merge"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertEqual(data["generated_for"], "post_merge")
+
     def test_input_truncated_present_in_normal_output(self):
         bundle = {
             "issues": [_issue(1, body="b")],

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -166,10 +166,31 @@ class TestBlockingRefExtraction(unittest.TestCase):
 
     def test_negation_only_when_adjacent_to_keyword(self):
         # The "not" here negates "a blocker", not the later "blocked by" —
-        # so the immediate `blocked by #5` still counts.
+        # a comma breaks the negation run, so `blocked by #5` still counts.
         self.assertEqual(
             wds.extract_blocking_refs(
                 "This is not a blocker, but blocked by #5", is_epic=False
+            ),
+            [5],
+        )
+
+    def test_negation_with_intervening_adverb(self):
+        # "not currently blocked by", "not yet blocked by" are negations even
+        # though an adverb sits between "not" and the keyword.
+        for s in (
+            "not currently blocked by #5",
+            "not yet blocked by #5",
+            "doesn't currently depend on #5",
+        ):
+            self.assertEqual(
+                wds.extract_blocking_refs(s, is_epic=False), [], msg=s
+            )
+
+    def test_far_away_negation_with_punctuation_still_blocks(self):
+        # A "not" separated from the keyword by punctuation does not suppress.
+        self.assertEqual(
+            wds.extract_blocking_refs(
+                "We fixed it (not the UI). Now blocked by #5", is_epic=False
             ),
             [5],
         )
@@ -757,6 +778,14 @@ class TestCommentsAndMilestone(unittest.TestCase):
             wds._pr_referenced_refs("Ref #10 and #11 & #12"), {10, 11, 12}
         )
 
+    def test_pr_close_refs_colon_form(self):
+        # `Closes: #1` / `Fixes: #1, #2` (colon notation) must be captured.
+        self.assertEqual(wds._pr_close_refs("Closes: #1"), {1})
+        self.assertEqual(wds._pr_close_refs("Fixes: #1, #2"), {1, 2})
+
+    def test_pr_referenced_refs_colon_form(self):
+        self.assertEqual(wds._pr_referenced_refs("Refs: #9"), {9})
+
     def test_multi_ref_in_full_scan(self):
         # A recent PR that references several issues marks every one of them
         # as referenced-by-recent-merge (the natural-follow-up axis).
@@ -853,9 +882,66 @@ class TestFetchRecentMerges(unittest.TestCase):
             merges = wds.fetch_recent_merges(None, 10)
         self.assertEqual([m["number"] for m in merges], [2, 1])
 
-    def test_non_list_payload_is_empty(self):
+    def test_non_list_payload_raises(self):
+        # A non-array gh payload is an anomaly, not "no merges": it must raise
+        # (→ exit 2), never silently degrade to [] (which reads as exit 0).
         with mock.patch.object(wds, "_run_gh_json", return_value=None):
-            self.assertEqual(wds.fetch_recent_merges(None, 10), [])
+            with self.assertRaises(wds.GhError):
+                wds.fetch_recent_merges(None, 10)
+
+
+class TestFetchRobustness(unittest.TestCase):
+    """A non-array gh payload is an error (exit 2), never a silent empty."""
+
+    def test_open_issues_non_list_raises(self):
+        with mock.patch.object(wds, "_run_gh_json", return_value={"x": 1}):
+            with self.assertRaises(wds.GhError):
+                wds.fetch_open_issues(None)
+
+    def test_open_pr_numbers_non_list_raises(self):
+        with mock.patch.object(wds, "_run_gh_json", return_value=None):
+            with self.assertRaises(wds.GhError):
+                wds.fetch_open_pr_numbers(None)
+
+
+class TestBundleValidation(unittest.TestCase):
+    """--from-file shape validation surfaces a clear error (exit 2)."""
+
+    def _run_bundle_text(self, text):
+        fd, name = tempfile.mkstemp(suffix=".json", prefix="wds_bad_")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(text)
+            return subprocess.run(
+                [sys.executable, str(SCRIPT), "--from-file", name],
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            os.unlink(name)
+
+    def test_bundle_not_object_errors(self):
+        proc = self._run_bundle_text("[1, 2, 3]")
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertIn("JSON object", data["error"])
+
+    def test_bundle_issues_not_list_errors(self):
+        proc = self._run_bundle_text('{"issues": {"not": "a list"}}')
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertIn("issues", data["error"])
+
+    def test_bundle_bad_open_pr_numbers_errors(self):
+        proc = self._run_bundle_text(
+            '{"issues": [], "open_pr_numbers": ["not-an-int"]}'
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertIn("open_pr_numbers", data["error"])
 
 
 if __name__ == "__main__":

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -612,6 +612,20 @@ class TestCliWiring(unittest.TestCase):
         self.assertEqual(data["status"], "error")
         self.assertEqual(data["generated_for"], "post_merge")
 
+    def test_malformed_arg_keeps_stderr_clean(self):
+        # The trigger-probe pre-parse must stay silent: a malformed CLI emits
+        # the JSON envelope to stdout and nothing to stderr (single-channel
+        # machine contract, §5.1).
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--trigger"],  # missing value
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        self.assertEqual(proc.stderr, "")
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+
     def test_input_truncated_present_in_normal_output(self):
         bundle = {
             "issues": [_issue(1, body="b")],
@@ -985,6 +999,21 @@ class TestMalformedFieldNormalization(unittest.TestCase):
         result = wds.scan([issue], set(), [], wds.ScanConfig())
         # No crash; the issue is a clean candidate (no blockers, no labels).
         self.assertEqual(result["candidates"][0]["issue"], 1)
+
+    def test_is_int_excludes_bool(self):
+        self.assertTrue(wds._is_int(5))
+        self.assertFalse(wds._is_int(True))
+        self.assertFalse(wds._is_int(False))
+        self.assertFalse(wds._is_int("5"))
+        self.assertFalse(wds._is_int(None))
+
+    def test_bool_pr_number_not_treated_as_issue_one(self):
+        # `number: true` must NOT be read as PR #1 (bool is an int subclass):
+        # an issue depending on #1 must stay blocked-agnostic, not "unblocked".
+        issues = [{"number": 10, "title": "t", "body": "Depends on #1"}]
+        merges = [{"number": True, "title": "x", "body": "no refs"}]
+        result = wds.scan(issues, set(), merges, wds.ScanConfig())
+        self.assertFalse(result["candidates"][0]["unblocked_by_recent_merge"])
 
     def test_candidate_title_always_a_string(self):
         # A non-string title (e.g. null from a malformed bundle) must be

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -450,8 +450,8 @@ class TestCliWiring(unittest.TestCase):
         self.assertNotIn(1, {wds.EXIT_NO_CANDIDATES, wds.EXIT_CANDIDATES_FOUND, wds.EXIT_ERROR})
 
     def test_error_json_keeps_fixed_schema(self):
-        # Codex review (Major): the error branch must carry the same audit
-        # fields as a normal result, not a bespoke shape.
+        # The error branch must carry the same audit fields as a normal
+        # result, not a bespoke shape.
         proc = subprocess.run(
             [sys.executable, str(SCRIPT), "--from-file", "/no/such/file.json"],
             capture_output=True,
@@ -474,8 +474,8 @@ class TestCliWiring(unittest.TestCase):
         self.assertEqual(data["truncated_count"], 0)
 
     def test_argparse_error_emits_json_exit_2(self):
-        # Codex review round 2 (Minor): a CLI parse error must still print a
-        # single JSON object to stdout and exit 2, not bare usage on stderr.
+        # A CLI parse error must still print a single JSON object to stdout
+        # and exit 2, not bare usage on stderr.
         proc = subprocess.run(
             [sys.executable, str(SCRIPT), "--top-n", "not-an-int"],
             capture_output=True,
@@ -501,7 +501,7 @@ class TestCliWiring(unittest.TestCase):
 
 
 class TestCommentsAndMilestone(unittest.TestCase):
-    """Codex review (Major/Minor): blockers in comments + milestone tier."""
+    """Blockers in comments + milestone tier."""
 
     def test_blocker_in_comment_detected(self):
         # §4.1: a blocker added later in a *comment* must still be detected.
@@ -534,8 +534,8 @@ class TestCommentsAndMilestone(unittest.TestCase):
         self.assertIn(10, excluded)
 
     def test_unblocked_via_ref_closed_by_recent_merge(self):
-        # Codex review (Major): Depends on #100 + a recent PR that Closes
-        # #100 → this issue is now unblocked-by-recent-merge.
+        # Depends on #100 + a recent PR that Closes #100 → this issue is now
+        # unblocked-by-recent-merge.
         ok, sig = wds.estimate_unblocked_by_recent_merge(
             _issue(10),
             blocking_refs=[100],
@@ -555,7 +555,7 @@ class TestCommentsAndMilestone(unittest.TestCase):
         )
 
     def test_bare_refs_does_not_close_blocking_ref(self):
-        # Codex review round 2 (Major): a recent PR that only `Refs #100`
+        # A recent PR that only `Refs #100`
         # (not Closes/Fixes/Resolves) must NOT mark #100 as resolved, so an
         # issue depending on #100 is not unblocked via the blocking-ref side.
         ok, _ = wds.estimate_unblocked_by_recent_merge(
@@ -574,6 +574,48 @@ class TestCommentsAndMilestone(unittest.TestCase):
         self.assertFalse(
             result["candidates"][0]["unblocked_by_recent_merge"]
         )
+
+    def test_pr_close_refs_single(self):
+        self.assertEqual(wds._pr_close_refs("Closes #100"), {100})
+
+    def test_pr_close_refs_comma_separated(self):
+        # `Closes #100, #101` must capture BOTH, not just the first.
+        self.assertEqual(wds._pr_close_refs("Closes #100, #101"), {100, 101})
+
+    def test_pr_close_refs_space_separated(self):
+        self.assertEqual(wds._pr_close_refs("Fixes #100 #101 #102"), {100, 101, 102})
+
+    def test_pr_close_refs_and_separated(self):
+        self.assertEqual(
+            wds._pr_close_refs("Resolves #100, #101 and #102"), {100, 101, 102}
+        )
+
+    def test_pr_close_refs_mixed_case_keywords(self):
+        # Keyword casing is irrelevant; every following #N is captured.
+        self.assertEqual(
+            wds._pr_close_refs("CLOSED #100, #101\nfix #200 and #201"),
+            {100, 101, 200, 201},
+        )
+
+    def test_pr_close_refs_bare_ref_not_captured(self):
+        # Only close-keyword runs count; a bare `Refs #100` closes nothing.
+        self.assertEqual(wds._pr_close_refs("Refs #100, #101"), set())
+
+    def test_multi_issue_close_in_full_scan(self):
+        # A single recent PR closing several issues must unblock dependents
+        # on *each* listed issue, not just the first.
+        issues = [
+            _issue(10, body="Depends on #100"),
+            _issue(11, body="Depends on #101"),
+        ]
+        merges = [{"number": 900, "title": "x", "body": "Closes #100, #101"}]
+        result = wds.scan(issues, set(), merges, wds.ScanConfig())
+        unblocked = {
+            c["issue"]: c["unblocked_by_recent_merge"]
+            for c in result["candidates"]
+        }
+        self.assertTrue(unblocked[10])
+        self.assertTrue(unblocked[11])
 
     def test_milestone_emitted_as_signal(self):
         issue = _issue(1, body="b")

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -786,6 +786,25 @@ class TestCommentsAndMilestone(unittest.TestCase):
         # Only close-keyword runs count; a bare `Refs #100` closes nothing.
         self.assertEqual(wds._pr_close_refs("Refs #100, #101"), set())
 
+    def test_pr_close_refs_negated_does_not_close(self):
+        # The GitHub auto-close false-positive that reopened #520: a PR body
+        # saying it does NOT close #N must not mark #N closed.
+        self.assertEqual(wds._pr_close_refs("This does not close #100"), set())
+        self.assertEqual(wds._pr_close_refs("no longer closes #5"), set())
+
+    def test_pr_close_refs_mixed_affirmed_and_negated(self):
+        self.assertEqual(
+            wds._pr_close_refs("Closes #100 but does not close #101"), {100}
+        )
+
+    def test_recent_merge_negated_close_not_unblocking(self):
+        # Full-scan: a recent PR that disclaims closing #100 must NOT unblock
+        # an issue depending on #100 via the closed-ref path.
+        issues = [_issue(10, body="Depends on #100")]
+        merges = [{"number": 900, "title": "x", "body": "This does not close #100"}]
+        result = wds.scan(issues, set(), merges, wds.ScanConfig())
+        self.assertFalse(result["candidates"][0]["unblocked_by_recent_merge"])
+
     def test_multi_issue_close_in_full_scan(self):
         # A single recent PR closing several issues must unblock dependents
         # on *each* listed issue, not just the first.
@@ -1019,6 +1038,26 @@ class TestBundleValidation(unittest.TestCase):
         data = json.loads(proc.stdout)
         self.assertEqual(data["status"], "error")
         self.assertIn("number", data["error"])
+
+    def test_bundle_falsey_non_list_field_errors(self):
+        # A *present* falsey non-list (`{}`, `""`, `false`) is malformed and
+        # must error — it must NOT be coalesced to [] (which would read as
+        # no_candidates / exit 0, hiding the malformed input).
+        for bad in ('{"issues": {}}', '{"issues": ""}', '{"issues": false}'):
+            with self.subTest(bundle=bad):
+                proc = self._run_bundle_text(bad)
+                self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+                data = json.loads(proc.stdout)
+                self.assertEqual(data["status"], "error")
+                self.assertIn("issues", data["error"])
+
+    def test_bundle_absent_or_null_fields_default_empty(self):
+        # Absent / explicit null fields legitimately default to empty (and
+        # yield a clean no_candidates / exit 0), unlike a present wrong type.
+        proc = self._run_bundle_text('{"issues": null}')
+        self.assertEqual(proc.returncode, wds.EXIT_NO_CANDIDATES)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "no_candidates")
 
 
 if __name__ == "__main__":

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -558,6 +558,19 @@ class TestCliWiring(unittest.TestCase):
         data = json.loads(proc.stdout)
         self.assertEqual(data["status"], "error")
 
+    def test_top_n_error_envelope_keeps_trigger_context(self):
+        # The error envelope must carry the real --trigger in generated_for,
+        # not a hardcoded "manual" (delivery layer reads the context).
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--top-n", "0", "--trigger", "post_merge"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertEqual(data["generated_for"], "post_merge")
+
 
 class TestCommentsAndMilestone(unittest.TestCase):
     """Blockers in comments + milestone tier."""
@@ -734,7 +747,7 @@ class TestFetchRecentMerges(unittest.TestCase):
 
     def test_server_side_recency_ordering_requested(self):
         # The fix for createdAt-desc dropping recent merges is a server-side
-        # recency sort + the K limit — assert both reach the gh call.
+        # recency sort + an over-fetched pool — assert both reach the gh call.
         with mock.patch.object(
             wds, "_run_gh_json", return_value=[]
         ) as gh:
@@ -742,8 +755,24 @@ class TestFetchRecentMerges(unittest.TestCase):
         argv = gh.call_args[0][0]
         self.assertIn("--search", argv)
         self.assertEqual(argv[argv.index("--search") + 1], "sort:updated-desc")
-        self.assertEqual(argv[argv.index("--limit") + 1], "7")
+        # Over-fetch K × factor so a freshly-commented old merge can't crowd
+        # out a genuine recent merge before the client mergedAt top-K slice.
+        self.assertEqual(
+            argv[argv.index("--limit") + 1],
+            str(7 * wds._RECENT_MERGE_OVERFETCH),
+        )
         self.assertIn("merged", argv)
+
+    def test_overfetched_pool_trimmed_to_requested_k(self):
+        # Fetch returns the over-fetched pool; the result is the mergedAt
+        # top-K for the *requested* K, regardless of the larger fetch.
+        pool = [
+            {"number": n, "mergedAt": f"2026-{n:02d}-01T00:00:00Z"}
+            for n in range(1, 10)
+        ]
+        with mock.patch.object(wds, "_run_gh_json", return_value=pool):
+            merges = wds.fetch_recent_merges(None, 3)
+        self.assertEqual([m["number"] for m in merges], [9, 8, 7])
 
     def test_sorted_by_merged_at_desc(self):
         with mock.patch.object(wds, "_run_gh_json", return_value=list(self._UNSORTED)):

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -954,6 +954,15 @@ class TestMalformedFieldNormalization(unittest.TestCase):
         # No crash; the issue is a clean candidate (no blockers, no labels).
         self.assertEqual(result["candidates"][0]["issue"], 1)
 
+    def test_candidate_title_always_a_string(self):
+        # A non-string title (e.g. null from a malformed bundle) must be
+        # coerced to "" so the candidate JSON schema holds, never crash.
+        issue = {"number": 1, "title": None, "body": "body text here"}
+        result = wds.scan([issue], set(), [], wds.ScanConfig())
+        cand = result["candidates"][0]
+        self.assertEqual(cand["title"], "")
+        self.assertIsInstance(cand["summary"], str)
+
 
 class TestBundleValidation(unittest.TestCase):
     """--from-file shape validation surfaces a clear error (exit 2)."""

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -28,6 +28,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -114,6 +115,40 @@ class TestBlockingRefExtraction(unittest.TestCase):
     def test_empty_body(self):
         self.assertEqual(wds.extract_blocking_refs(None, is_epic=False), [])
         self.assertEqual(wds.extract_blocking_refs("", is_epic=False), [])
+
+    def test_negated_not_blocked_by_yields_no_ref(self):
+        # §11-3: a negated keyword is NOT a blocker — must not exclude.
+        self.assertEqual(
+            wds.extract_blocking_refs("not blocked by #5", is_epic=False), []
+        )
+
+    def test_negated_no_longer_blocked_by_yields_no_ref(self):
+        self.assertEqual(
+            wds.extract_blocking_refs("no longer blocked by #5", is_epic=False),
+            [],
+        )
+
+    def test_unblocked_by_yields_no_ref(self):
+        # "unblocked" must not match the "blocked by" keyword mid-word.
+        self.assertEqual(
+            wds.extract_blocking_refs("unblocked by #5", is_epic=False), []
+        )
+
+    def test_negated_doesnt_depend_on_yields_no_ref(self):
+        self.assertEqual(
+            wds.extract_blocking_refs("This doesn't depend on #5", is_epic=False),
+            [],
+        )
+
+    def test_negation_only_when_adjacent_to_keyword(self):
+        # The "not" here negates "a blocker", not the later "blocked by" —
+        # so the immediate `blocked by #5` still counts.
+        self.assertEqual(
+            wds.extract_blocking_refs(
+                "This is not a blocker, but blocked by #5", is_epic=False
+            ),
+            [5],
+        )
 
 
 class TestClassifyDependency(unittest.TestCase):
@@ -499,6 +534,30 @@ class TestCliWiring(unittest.TestCase):
             data["input_truncated"], {"open_issues": False, "open_prs": False}
         )
 
+    def test_top_n_zero_rejected_as_error(self):
+        # `--top-n 0` would silently return an empty `top` (status
+        # no_candidates / exit 0) even with candidates — a contract break.
+        # It must be rejected as an argument error (exit 2, JSON envelope).
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--top-n", "0"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+        self.assertIn("--top-n", data["error"])
+
+    def test_top_n_negative_rejected_as_error(self):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--top-n=-5"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "error")
+
 
 class TestCommentsAndMilestone(unittest.TestCase):
     """Blockers in comments + milestone tier."""
@@ -617,6 +676,29 @@ class TestCommentsAndMilestone(unittest.TestCase):
         self.assertTrue(unblocked[10])
         self.assertTrue(unblocked[11])
 
+    def test_pr_referenced_refs_comma_separated(self):
+        # The reference side is symmetric with the close side: `Refs #10, #11`
+        # must capture BOTH, not just the first.
+        self.assertEqual(wds._pr_referenced_refs("Refs #10, #11"), {10, 11})
+
+    def test_pr_referenced_refs_and_separated(self):
+        self.assertEqual(
+            wds._pr_referenced_refs("Ref #10 and #11 & #12"), {10, 11, 12}
+        )
+
+    def test_multi_ref_in_full_scan(self):
+        # A recent PR that references several issues marks every one of them
+        # as referenced-by-recent-merge (the natural-follow-up axis).
+        issues = [_issue(10, body="x"), _issue(11, body="y")]
+        merges = [{"number": 900, "title": "z", "body": "Refs #10, #11"}]
+        result = wds.scan(issues, set(), merges, wds.ScanConfig())
+        unblocked = {
+            c["issue"]: c["unblocked_by_recent_merge"]
+            for c in result["candidates"]
+        }
+        self.assertTrue(unblocked[10])
+        self.assertTrue(unblocked[11])
+
     def test_milestone_emitted_as_signal(self):
         issue = _issue(1, body="b")
         issue["milestone"] = {"title": "v1.0"}
@@ -637,6 +719,42 @@ class TestCommentsAndMilestone(unittest.TestCase):
         issue["milestone"] = {"title": "v1.0"}
         result = wds.scan([issue], set(), [], wds.ScanConfig())
         self.assertNotIn("_has_milestone", result["candidates"][0])
+
+
+class TestFetchRecentMerges(unittest.TestCase):
+    """`gh pr list` order is not guaranteed, so fetch_recent_merges must
+    sort by mergedAt (newest first) before taking the 直近 K 件 (§4.2)."""
+
+    _UNSORTED = [
+        {"number": 1, "title": "a", "body": "", "mergedAt": "2026-01-01T00:00:00Z"},
+        {"number": 3, "title": "c", "body": "", "mergedAt": "2026-03-01T00:00:00Z"},
+        {"number": 2, "title": "b", "body": "", "mergedAt": "2026-02-01T00:00:00Z"},
+    ]
+
+    def test_sorted_by_merged_at_desc(self):
+        with mock.patch.object(wds, "_run_gh_json", return_value=list(self._UNSORTED)):
+            merges = wds.fetch_recent_merges(None, 10)
+        self.assertEqual([m["number"] for m in merges], [3, 2, 1])
+
+    def test_limit_takes_newest_after_sort(self):
+        # The 直近 K 件 must be the K *newest* by mergedAt, not the first K
+        # in gh's return order.
+        with mock.patch.object(wds, "_run_gh_json", return_value=list(self._UNSORTED)):
+            merges = wds.fetch_recent_merges(None, 2)
+        self.assertEqual([m["number"] for m in merges], [3, 2])
+
+    def test_missing_merged_at_sorts_last(self):
+        data = [
+            {"number": 1, "mergedAt": None},
+            {"number": 2, "mergedAt": "2026-05-01T00:00:00Z"},
+        ]
+        with mock.patch.object(wds, "_run_gh_json", return_value=data):
+            merges = wds.fetch_recent_merges(None, 10)
+        self.assertEqual([m["number"] for m in merges], [2, 1])
+
+    def test_non_list_payload_is_empty(self):
+        with mock.patch.object(wds, "_run_gh_json", return_value=None):
+            self.assertEqual(wds.fetch_recent_merges(None, 10), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -938,6 +938,23 @@ class TestFetchRobustness(unittest.TestCase):
                 wds.fetch_open_pr_numbers(None)
 
 
+class TestMalformedFieldNormalization(unittest.TestCase):
+    """Non-list `comments` / `labels` shapes must normalize to empty, never
+    crash the pure core (a bare comment *count* is a real gh-shape risk)."""
+
+    def test_comments_as_count_does_not_crash(self):
+        self.assertEqual(wds._comment_bodies({"comments": 5}), [])
+
+    def test_labels_as_string_does_not_crash(self):
+        self.assertEqual(wds._label_names({"labels": "blocked"}), [])
+
+    def test_scan_survives_non_list_comments_and_labels(self):
+        issue = {"number": 1, "title": "t", "body": "b", "comments": 3, "labels": 0}
+        result = wds.scan([issue], set(), [], wds.ScanConfig())
+        # No crash; the issue is a clean candidate (no blockers, no labels).
+        self.assertEqual(result["candidates"][0]["issue"], 1)
+
+
 class TestBundleValidation(unittest.TestCase):
     """--from-file shape validation surfaces a clear error (exit 2)."""
 

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -98,12 +98,22 @@ DEFAULT_OPEN_LIMIT = 500
 
 # --- dependency notation (design §4.1, calibrated §11-3) ---------------
 # Match a blocking *keyword* (anywhere on a line — body or comment, inline
-# or list-led, e.g. "Update: Blocked by #5") and capture the rest of the
-# line. Precision is enforced by _LEADING_REFS_RE below, not by anchoring:
-# a keyword not immediately followed by a `#N` (e.g. "requires careful
-# thought", "Depends on: Commit 1 ...") contributes no ref.
+# or list-led, e.g. "Update: Blocked by #5"), capturing the text *before*
+# the keyword (`pre`) and the rest of the line (`rest`). Precision is
+# enforced by _LEADING_REFS_RE below, not by anchoring: a keyword not
+# immediately followed by a `#N` (e.g. "requires careful thought",
+# "Depends on: Commit 1 ...") contributes no ref.
+#
+# Negation guard: a keyword carrying a *negation* immediately before it
+# ("not blocked by #5", "no longer blocked by #5", "doesn't depend on #5")
+# is NOT a blocker — extract_blocking_refs drops the clause when `pre` ends
+# with a negation marker (_BLOCK_NEG_RE). The leading `\b` on the keyword
+# also rejects "unblocked by #5": there is no word boundary inside the word
+# "unblocked", so the keyword never matches mid-word. Both guards prefer
+# *not* excluding (§11-3 over-matching guard).
+_BLOCK_NEG_RE = re.compile(r"(?i)(?:\bnot|\bno\s+longer|\bnever|n['’]t)\s+$")
 _BLOCK_KEYWORD_RE = re.compile(
-    r"(?im)(?:blocked\s+by|depends\s+on|requires)\b(.*)$"
+    r"(?im)^(?P<pre>.*?)\b(?:blocked\s+by|depends\s+on|requires)\b(?P<rest>.*)$"
 )
 # From a blocking clause, consume only the *leading* run of refs
 # (`#N`, optionally `PR #N`, comma/and-separated). #N refs are taken from
@@ -133,30 +143,42 @@ _OPEN_TASK_REF_RE = re.compile(r"(?im)^[ \t]*[-*]\s*\[ \]\s*.*?#(\d+)\b")
 #     "this Issue is referenced by (a natural follow-up of) a recent merge".
 # Conflating them would let a bare `Refs #100` mark #100 as resolved.
 #
-# A single close keyword can close several issues at once
-# (`Closes #100, #101 and #102`), so `_PR_CLOSE_RE` captures the whole
-# leading run of comma/space/`and`-separated `#N` refs (mirroring
-# `_LEADING_REFS_RE`); `_pr_close_refs` then extracts every number with
-# `_ISSUE_REF_RE`. Capturing only the first would silently drop the 2nd+
-# issue from `recent_merge_closed_issues` (hurts the unblocked_by_recent_merge
-# axis).
+# A single keyword can reference several issues at once
+# (`Closes #100, #101 and #102`), so both patterns capture the whole leading
+# run of comma/space/`and`-separated `#N` refs (mirroring `_LEADING_REFS_RE`);
+# `_extract_ref_run` then pulls every number with `_ISSUE_REF_RE`. Capturing
+# only the first would silently drop the 2nd+ issue from
+# `recent_merge_closed_issues` / `recent_merge_referenced_issues` (hurts the
+# unblocked_by_recent_merge axis).
+_KEYWORD_REF_RUN = r"\s+((?:#\d+[\s,]*(?:and\s+|&\s*)?)+)"
 _PR_CLOSE_RE = re.compile(
-    r"(?i)\b(?:closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)\s+"
-    r"((?:#\d+[\s,]*(?:and\s+|&\s*)?)+)"
+    r"(?i)\b(?:closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)"
+    + _KEYWORD_REF_RUN
 )
-_PR_REF_RE = re.compile(r"(?i)\b(?:refs|ref|re)\s+#(\d+)\b")
+_PR_REF_RE = re.compile(r"(?i)\b(?:refs|ref|re)" + _KEYWORD_REF_RUN)
+
+
+def _extract_ref_run(pattern: re.Pattern, text: str) -> set[int]:
+    """All issue numbers in `text`'s keyword-led `#N` runs (design §4.2).
+
+    Every `#N` in the leading run after each keyword is captured, so
+    `Closes #100, #101` / `Refs #100, #101` yield ``{100, 101}`` — not just
+    the first.
+    """
+    nums: set[int] = set()
+    for match in pattern.finditer(text):
+        nums.update(int(n) for n in _ISSUE_REF_RE.findall(match.group(1)))
+    return nums
 
 
 def _pr_close_refs(text: str) -> set[int]:
-    """Issue numbers closed by `text`'s close clauses (design §4.2).
+    """Issue numbers a PR *closes* (Closes/Fixes/Resolves #N, …)."""
+    return _extract_ref_run(_PR_CLOSE_RE, text)
 
-    Every `#N` in the leading run after a close keyword is captured, so
-    `Closes #100, #101` yields ``{100, 101}`` — not just the first.
-    """
-    nums: set[int] = set()
-    for match in _PR_CLOSE_RE.finditer(text):
-        nums.update(int(n) for n in _ISSUE_REF_RE.findall(match.group(1)))
-    return nums
+
+def _pr_referenced_refs(text: str) -> set[int]:
+    """Issue numbers a PR merely *references* (Refs/Ref/Re #N, …)."""
+    return _extract_ref_run(_PR_REF_RE, text)
 
 # Labels that force `blocked` regardless of refs (design §4.1).
 _BLOCK_LABELS = {"blocked", "on-hold", "on hold"}
@@ -247,8 +269,10 @@ def extract_blocking_refs(text: str | None, *, is_epic: bool) -> list[int]:
     if not text:
         return []
     refs: set[int] = set()
-    for clause in _BLOCK_KEYWORD_RE.findall(text):
-        lead = _LEADING_REFS_RE.match(clause)
+    for m in _BLOCK_KEYWORD_RE.finditer(text):
+        if _BLOCK_NEG_RE.search(m.group("pre")):
+            continue  # negated clause ("not blocked by #5") — not a blocker
+        lead = _LEADING_REFS_RE.match(m.group("rest"))
         if not lead:
             continue
         for num in _ISSUE_REF_RE.findall(lead.group(1)):
@@ -641,7 +665,7 @@ def scan(
             recent_merge_pr_numbers.add(num)
         text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
         closed = _pr_close_refs(text)
-        referenced = closed | {int(n) for n in _PR_REF_RE.findall(text)}
+        referenced = closed | _pr_referenced_refs(text)
         recent_merge_closed_issues |= closed
         recent_merge_referenced_issues |= referenced
 
@@ -796,7 +820,13 @@ def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
             "number,title,body,mergedAt",
         ]
     )
-    return data if isinstance(data, list) else []
+    merges = data if isinstance(data, list) else []
+    # `gh pr list` does not guarantee `mergedAt` order, so sort newest-first
+    # ourselves before taking the "直近 K 件" (design §4.2). ISO-8601 stamps
+    # sort lexicographically = chronologically; a missing `mergedAt` sorts
+    # last (treated as oldest).
+    merges.sort(key=lambda p: p.get("mergedAt") or "", reverse=True)
+    return merges[:limit]
 
 
 def _load_bundle(path: str) -> tuple[list[dict], set[int], list[dict]]:
@@ -894,6 +924,12 @@ def main(argv=None) -> int:
         "JSON bundle instead of calling gh (offline / validation).",
     )
     args = parser.parse_args(argv)
+
+    # `--top-n 0` (or negative) would silently return an empty `top` even
+    # when candidates exist, yielding status no_candidates / exit 0 — a
+    # contract break for the exit-code-driven delivery layer. Reject it.
+    if args.top_n < 1:
+        parser.error("--top-n must be >= 1")
 
     config = ScanConfig(
         top_n=args.top_n, free_panes=args.free_panes, trigger=args.trigger

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -128,11 +128,20 @@ _LEADING_REFS_RE = re.compile(
 # A bare-number ref like `#531`; the leading `(?<![\w/])` stops it firing
 # inside `org/repo#531`-style cross-repo refs (single-repo scope, §10).
 _ISSUE_REF_RE = re.compile(r"(?<![\w/])#(\d+)\b")
-# Unchecked task-list item that references an Issue: `- [ ] #N`. Counted
-# as a pending dependency for NON-epic issues only — an epic's child
-# checklist is tracking, not a blocker on the epic itself (calibrated
-# against epic #376; see classify_dependency).
-_OPEN_TASK_REF_RE = re.compile(r"(?im)^[ \t]*[-*]\s*\[ \]\s*.*?#(\d+)\b")
+# Unchecked task-list item used as a pending-dependency signal: `- [ ] #N`
+# (design §4.1). Counted for NON-epic issues only — an epic's child checklist
+# is tracking, not a blocker on the epic itself (calibrated against epic
+# #376; see classify_dependency).
+#
+# §11-3 calibration: the item's content must be a *pure run of issue refs*
+# (`- [ ] #11`, `- [ ] #11, #12`). An item with descriptive prose around the
+# ref (`- [ ] #123 を参考に確認する`, `- [ ] Fix #11`) is a mere *mention*,
+# NOT a blocker — counting it would wrongly exclude a live candidate. Work
+# discovery prefers false-inclusion over false-exclusion (誤除外 < 誤包含):
+# when in doubt, do not treat the item as a blocker.
+_OPEN_TASK_ITEM_RE = re.compile(r"(?im)^[ \t]*[-*]\s*\[ \]\s*(.+?)\s*$")
+# True iff the captured task content is nothing but a `#N` ref run.
+_PURE_REF_RUN_RE = re.compile(r"(?i)^(?:#\d+[\s,]*(?:and\s+|&\s*)?)+$")
 
 # PR → linked-Issue notation for the recent-merge heuristic (design §4.2).
 # §4.2 keeps two *distinct* conditions, so we keep two patterns:
@@ -278,8 +287,12 @@ def extract_blocking_refs(text: str | None, *, is_epic: bool) -> list[int]:
         for num in _ISSUE_REF_RE.findall(lead.group(1)):
             refs.add(int(num))
     if not is_epic:
-        for num in _OPEN_TASK_REF_RE.findall(text):
-            refs.add(int(num))
+        for item in _OPEN_TASK_ITEM_RE.finditer(text):
+            content = item.group(1)
+            if not _PURE_REF_RUN_RE.match(content):
+                continue  # prose-annotated mention, not a blocker (§11-3)
+            for num in _ISSUE_REF_RE.findall(content):
+                refs.add(int(num))
     return sorted(refs)
 
 
@@ -574,13 +587,12 @@ def _sort_key(cand: dict, free_panes: int | None) -> tuple:
     """
     prio = _PRIORITY_RANK.get(cand["priority"], 1)
     unblocked = 1 if cand["unblocked_by_recent_merge"] else 0
-    # parallelizable only earns rank weight when there is a free pane to
-    # fill (design §4.2); otherwise it is neutral.
-    par = (
-        1
-        if (cand["parallelizable"] and (free_panes is None or free_panes > 0))
-        else 0
-    )
+    # parallelizable only earns rank weight when there is a *known* free pane
+    # to fill (design §4.2 「空き pane があるとき」); unknown (`--free-panes`
+    # unspecified → None) and zero are both neutral, matching the documented
+    # contract. (In practice every candidate is parallelizable by
+    # construction, so this term only discriminates when free_panes > 0.)
+    par = 1 if (cand["parallelizable"] and (free_panes or 0) > 0) else 0
     effort_small = -_EFFORT_RANK.get(cand["effort"], 1)  # S best
     has_ms = 1 if cand.get("_has_milestone") else 0
     recency = cand.get("_updated_at") or ""  # ISO8601 sorts lexically
@@ -954,6 +966,11 @@ def main(argv=None) -> int:
         # `--trigger` context in `generated_for`, not a hardcoded "manual".
         if config.top_n < 1:
             raise ValueError("--top-n must be >= 1")
+        # `--recent-merges` feeds `gh pr list --limit` and the mergedAt
+        # top-K slice; a non-positive value would request a nonsensical limit
+        # and break the "直近 K 件" contract. Require a positive integer.
+        if args.recent_merges < 1:
+            raise ValueError("--recent-merges must be >= 1")
         input_truncated = {"open_issues": False, "open_prs": False}
         if args.from_file:
             issues, open_pr_numbers, recent_merges = _load_bundle(args.from_file)

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -580,10 +580,17 @@ def build_candidate(
 
     signals = prio_signals + effort_signals + par_signals + merge_signals
 
+    # Coerce `title` to a string here so the candidate JSON always satisfies
+    # its schema regardless of input shape (a malformed `--from-file` could
+    # carry `title: null`/a number). This also keeps extract_summary's
+    # title fallback safe (it calls `.strip()` on the title).
+    raw_title = issue.get("title")
+    title = raw_title if isinstance(raw_title, str) else ""
+
     return {
         "issue": issue.get("number"),
-        "title": issue.get("title", ""),
-        "summary": extract_summary(issue.get("body"), issue.get("title", "")),
+        "title": title,
+        "summary": extract_summary(issue.get("body"), title),
         "dependency": "resolved",
         "blocking_refs": all_blocking,
         "priority": priority,

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -97,10 +97,12 @@ DEFAULT_RECENT_MERGES = 10
 DEFAULT_OPEN_LIMIT = 500
 
 # --- dependency notation (design §4.1, calibrated §11-3) ---------------
-# Match a blocking *keyword* (anywhere on a line — body or comment, inline
-# or list-led, e.g. "Update: Blocked by #5"), capturing the text *before*
-# the keyword (`pre`) and the rest of the line (`rest`). Precision is
-# enforced by _LEADING_REFS_RE below, not by anchoring: a keyword not
+# Match a blocking *keyword* (anywhere — body or comment, inline or list-led,
+# e.g. "Update: Blocked by #5"). extract_blocking_refs locates every keyword
+# occurrence (so multiple clauses on one line — "Blocked by #1; depends on
+# #2" — are all seen), derives the same-line text *before* it (for the
+# negation guard) and the text *after* it (for the leading refs). Precision
+# is enforced by _LEADING_REFS_RE below, not by anchoring: a keyword not
 # immediately followed by a `#N` (e.g. "requires careful thought",
 # "Depends on: Commit 1 ...") contributes no ref.
 #
@@ -118,7 +120,7 @@ _BLOCK_NEG_RE = re.compile(
     r"(?i)(?:\b(?:not|never|no\s+longer|no\s+more)|n['’]t)[\w\s]{0,20}$"
 )
 _BLOCK_KEYWORD_RE = re.compile(
-    r"(?im)^(?P<pre>.*?)\b(?:blocked\s+by|depends\s+on|requires)\b(?P<rest>.*)$"
+    r"(?i)\b(?:blocked\s+by|depends\s+on|requires)\b"
 )
 # From a blocking clause, consume only the *leading* run of refs
 # (`#N`, optionally `PR #N`, comma/and-separated). #N refs are taken from
@@ -287,9 +289,19 @@ def extract_blocking_refs(text: str | None, *, is_epic: bool) -> list[int]:
         return []
     refs: set[int] = set()
     for m in _BLOCK_KEYWORD_RE.finditer(text):
-        if _BLOCK_NEG_RE.search(m.group("pre")):
+        # the keyword's own line, split at the keyword (`.` never crosses
+        # newlines in the original regex — keep refs same-line so a keyword on
+        # one line and a bare `#N` on the next are NOT linked, §11-3).
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        line_end = text.find("\n", m.end())
+        if line_end == -1:
+            line_end = len(text)
+        if _BLOCK_NEG_RE.search(text[line_start : m.start()]):
             continue  # negated clause ("not blocked by #5") — not a blocker
-        lead = _LEADING_REFS_RE.match(m.group("rest"))
+        # Leading refs come from immediately after THIS keyword; the run stops
+        # at the next non-ref token, so a following keyword's refs are picked
+        # up by that keyword's own iteration ("Blocked by #1; depends on #2").
+        lead = _LEADING_REFS_RE.match(text[m.end() : line_end])
         if not lead:
             continue
         for num in _ISSUE_REF_RE.findall(lead.group(1)):
@@ -893,20 +905,50 @@ def _load_bundle(path: str) -> tuple[list[dict], set[int], list[dict]]:
         )
     issues = bundle.get("issues") or []
     recent_merges = bundle.get("recent_merges") or []
-    for field, value in (("issues", issues), ("recent_merges", recent_merges)):
+    pr_raw = bundle.get("open_pr_numbers") or []
+    # Validate shapes up front so a malformed bundle yields a *pinpointed*
+    # error (exit 2) instead of a confusing downstream exception or — worse —
+    # a malformed candidate JSON (`"issue": null`). The gh path never hits
+    # this (its fetchers always return well-formed arrays); this guards the
+    # offline/test `--from-file` affordance against untrusted input.
+    for field, value in (
+        ("issues", issues),
+        ("recent_merges", recent_merges),
+        ("open_pr_numbers", pr_raw),
+    ):
         if not isinstance(value, list):
             raise GhError(
                 f"--from-file `{field}` must be a list, got "
                 f"{type(value).__name__}"
             )
-    try:
-        open_pr_numbers = {
-            int(n) for n in (bundle.get("open_pr_numbers") or [])
-        }
-    except (TypeError, ValueError) as exc:
-        raise GhError(
-            f"--from-file `open_pr_numbers` must be a list of integers: {exc}"
-        ) from exc
+    for i, item in enumerate(issues):
+        if not isinstance(item, dict):
+            raise GhError(
+                f"--from-file issues[{i}] must be an object, got "
+                f"{type(item).__name__}"
+            )
+        # `bool` is an int subclass — exclude it so True/False can't pose as a
+        # number; every candidate's `issue` field must be a real integer.
+        if not isinstance(item.get("number"), int) or isinstance(
+            item.get("number"), bool
+        ):
+            raise GhError(
+                f"--from-file issues[{i}] must have an integer `number`"
+            )
+    for i, item in enumerate(recent_merges):
+        if not isinstance(item, dict):
+            raise GhError(
+                f"--from-file recent_merges[{i}] must be an object, got "
+                f"{type(item).__name__}"
+            )
+    open_pr_numbers: set[int] = set()
+    for i, n in enumerate(pr_raw):
+        if not isinstance(n, int) or isinstance(n, bool):
+            raise GhError(
+                f"--from-file open_pr_numbers[{i}] must be an integer, got "
+                f"{type(n).__name__}"
+            )
+        open_pr_numbers.add(n)
     return issues, open_pr_numbers, recent_merges
 
 
@@ -1007,6 +1049,10 @@ def main(argv=None) -> int:
         # and break the "直近 K 件" contract. Require a positive integer.
         if args.recent_merges < 1:
             raise ValueError("--recent-merges must be >= 1")
+        # `--free-panes` is a count of free worker panes; 0 is valid (none
+        # free → no parallelizable boost), but a negative count is nonsense.
+        if args.free_panes is not None and args.free_panes < 0:
+            raise ValueError("--free-panes must be >= 0")
         input_truncated = {"open_issues": False, "open_prs": False}
         if args.from_file:
             issues, open_pr_numbers, recent_merges = _load_bundle(args.from_file)

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -238,6 +238,12 @@ class ScanConfig:
 # ----------------------------------------------------------------------
 
 
+def _is_int(value) -> bool:
+    """True for a *genuine* int — `bool` is an int subclass, so `True`/`False`
+    must be rejected as Issue/PR numbers (else `True` matches PR #1)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def _label_names(issue: dict) -> list[str]:
     """Normalize an issue's labels to a list of lowercase name strings.
 
@@ -519,7 +525,7 @@ def estimate_unblocked_by_recent_merge(
             )
             hit = True
     number = issue.get("number")
-    if isinstance(number, int) and number in recent_merge_referenced_issues:
+    if _is_int(number) and number in recent_merge_referenced_issues:
         signals.append("referenced by a recently-merged PR")
         hit = True
     if not hit:
@@ -704,7 +710,7 @@ def scan(
     is never silent (design §5.1). No I/O here.
     """
     open_issue_numbers = {
-        i["number"] for i in issues if isinstance(i.get("number"), int)
+        i["number"] for i in issues if _is_int(i.get("number"))
     }
     open_refs = open_issue_numbers | open_pr_numbers
 
@@ -714,7 +720,7 @@ def scan(
     recent_merge_referenced_issues: set[int] = set()
     for pr in recent_merges:
         num = pr.get("number")
-        if isinstance(num, int):
+        if _is_int(num):
             recent_merge_pr_numbers.add(num)
         text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
         closed = _pr_close_refs(text)
@@ -869,7 +875,7 @@ def fetch_open_pr_numbers(repo: str | None, limit: int = DEFAULT_OPEN_LIMIT) -> 
             "number",
         ]
     )
-    return {p["number"] for p in data if isinstance(p.get("number"), int)}
+    return {p["number"] for p in data if _is_int(p.get("number"))}
 
 
 # How much larger than the requested K to fetch before picking the mergedAt
@@ -1025,8 +1031,16 @@ def _probe_trigger(argv) -> str:
     A type error (e.g. ``--top-n nope``) makes argparse call ``error()``
     during ``parse_args``, before ``--trigger`` is bound — so a lightweight
     pre-parse (that tolerates unknown/other args) lets the error envelope
-    still carry the real trigger. Falls back to ``manual`` on any hiccup."""
-    probe = argparse.ArgumentParser(add_help=False)
+    still carry the real trigger. Falls back to ``manual`` on any hiccup.
+
+    The probe must stay *silent*: a malformed probe parse must NOT print
+    usage to stderr (the main parser owns error reporting — JSON to stdout)."""
+
+    class _SilentParser(argparse.ArgumentParser):
+        def error(self, message):  # no stderr usage; just abort the probe
+            raise SystemExit(2)
+
+    probe = _SilentParser(add_help=False)
     probe.add_argument("--trigger", default="manual")
     try:
         known, _ = probe.parse_known_args(argv)

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -236,7 +236,10 @@ def _label_names(issue: dict) -> list[str]:
     Accepts both ``gh``'s ``[{"name": ...}]`` shape and a plain list of
     strings (the latter is convenient for tests / `--from-file`)."""
     out: list[str] = []
-    for label in issue.get("labels") or []:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):  # malformed/absent → no labels
+        return out
+    for label in labels:
         if isinstance(label, dict):
             name = label.get("name")
         else:
@@ -252,7 +255,10 @@ def _comment_bodies(issue: dict) -> list[str]:
     Accepts ``gh``'s ``[{"body": ...}]`` shape and a plain list of strings
     (test / ``--from-file`` convenience). Missing → empty list."""
     out: list[str] = []
-    for c in issue.get("comments") or []:
+    comments = issue.get("comments")
+    if not isinstance(comments, list):  # e.g. a bare count, or absent → none
+        return out
+    for c in comments:
         if isinstance(c, dict):
             body = c.get("body")
         else:

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -806,15 +806,23 @@ def fetch_open_pr_numbers(repo: str | None, limit: int = DEFAULT_OPEN_LIMIT) -> 
     return {p["number"] for p in data if isinstance(p.get("number"), int)}
 
 
+# How much larger than the requested K to fetch before picking the mergedAt
+# top-K. `gh pr list`'s DEFAULT order is createdAt-desc (NOT merge-time), and
+# even `sort:updated-desc` is only an *approximation* of merge recency: an
+# old merged PR that later gets a comment has its `updatedAt` bumped and can
+# crowd a genuinely-recent merge out of the top-K. Over-fetching a few × K
+# and then taking the `mergedAt` top-K makes that false-negative effectively
+# impossible (it would take >2K old PRs each freshly touched). Cheap: K is
+# small (default 10) and these PRs are metadata-only.
+_RECENT_MERGE_OVERFETCH = 3
+
+
 def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
-    # `gh pr list`'s DEFAULT order is createdAt-desc, NOT merge-time — so a
-    # plain `--limit K` would drop a recently-*merged* PR that was *created*
-    # long ago, silently shrinking the "直近 K 件" pool (design §4.2) and
-    # mis-deciding `unblocked_by_recent_merge`. We therefore ask the server
-    # to order by recency via `sort:updated-desc`: for a merged PR the merge
-    # is its last (or near-last) activity, so updatedAt-desc ≈ mergedAt-desc,
-    # making the fetched K the *most recently merged* K. The client-side
-    # `mergedAt` sort below then makes the final ordering exact among them.
+    # Over-fetch in merge-recency-biased order (`sort:updated-desc`), then
+    # take the exact `mergedAt` top-K client-side. Two layers because neither
+    # alone guarantees the "直近 K 件" (design §4.2): the server sort biases
+    # the pool toward recency, the client sort + cap makes the final K exact.
+    fetch_limit = max(limit, limit * _RECENT_MERGE_OVERFETCH)
     data = _run_gh_json(
         [
             "pr",
@@ -825,7 +833,7 @@ def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
             "--search",
             "sort:updated-desc",
             "--limit",
-            str(limit),
+            str(fetch_limit),
             "--json",
             "number,title,body,mergedAt",
         ]
@@ -833,8 +841,7 @@ def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
     merges = data if isinstance(data, list) else []
     # Exact newest-first ordering by mergedAt (ISO-8601 sorts
     # lexicographically = chronologically); a missing `mergedAt` sorts last
-    # (treated as oldest). Also a defensive cap in case the fetch returned
-    # more than `limit` rows.
+    # (treated as oldest). The slice takes the genuine 直近 K 件.
     merges.sort(key=lambda p: p.get("mergedAt") or "", reverse=True)
     return merges[:limit]
 
@@ -935,17 +942,18 @@ def main(argv=None) -> int:
     )
     args = parser.parse_args(argv)
 
-    # `--top-n 0` (or negative) would silently return an empty `top` even
-    # when candidates exist, yielding status no_candidates / exit 0 — a
-    # contract break for the exit-code-driven delivery layer. Reject it.
-    if args.top_n < 1:
-        parser.error("--top-n must be >= 1")
-
     config = ScanConfig(
         top_n=args.top_n, free_panes=args.free_panes, trigger=args.trigger
     )
 
     try:
+        # `--top-n 0` (or negative) would silently return an empty `top` even
+        # when candidates exist, yielding status no_candidates / exit 0 — a
+        # contract break for the exit-code-driven delivery layer. Reject it
+        # here (not via parser.error) so the error envelope carries the real
+        # `--trigger` context in `generated_for`, not a hardcoded "manual".
+        if config.top_n < 1:
+            raise ValueError("--top-n must be >= 1")
         input_truncated = {"open_issues": False, "open_prs": False}
         if args.from_file:
             issues, open_pr_numbers, recent_merges = _load_bundle(args.from_file)

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -183,9 +183,17 @@ def _extract_ref_run(pattern: re.Pattern, text: str) -> set[int]:
     Every `#N` in the leading run after each keyword is captured, so
     `Closes #100, #101` / `Refs #100, #101` yield ``{100, 101}`` — not just
     the first.
+
+    A keyword negated on the same line (`does not close #100`,
+    `no longer closes #100`) is skipped — this is exactly GitHub's auto-close
+    false-positive that reopened #520, applied here so a recent merge that
+    *disclaims* closing #N does not wrongly mark #N resolved.
     """
     nums: set[int] = set()
     for match in pattern.finditer(text):
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        if _BLOCK_NEG_RE.search(text[line_start : match.start()]):
+            continue  # negated keyword ("does not close #100") — not a close
         nums.update(int(n) for n in _ISSUE_REF_RE.findall(match.group(1)))
     return nums
 
@@ -916,24 +924,29 @@ def _load_bundle(path: str) -> tuple[list[dict], set[int], list[dict]]:
             f"--from-file bundle must be a JSON object, got "
             f"{type(bundle).__name__}"
         )
-    issues = bundle.get("issues") or []
-    recent_merges = bundle.get("recent_merges") or []
-    pr_raw = bundle.get("open_pr_numbers") or []
     # Validate shapes up front so a malformed bundle yields a *pinpointed*
     # error (exit 2) instead of a confusing downstream exception or — worse —
     # a malformed candidate JSON (`"issue": null`). The gh path never hits
     # this (its fetchers always return well-formed arrays); this guards the
     # offline/test `--from-file` affordance against untrusted input.
-    for field, value in (
-        ("issues", issues),
-        ("recent_merges", recent_merges),
-        ("open_pr_numbers", pr_raw),
-    ):
+    #
+    # Default ONLY when the key is absent or explicitly null — a *present*
+    # non-list (`{}`, `""`, `false`, `0`) is malformed and must error, not be
+    # coalesced to `[]` (which would masquerade as no_candidates / exit 0).
+    def _list_field(name: str) -> list:
+        value = bundle.get(name)
+        if value is None:
+            return []
         if not isinstance(value, list):
             raise GhError(
-                f"--from-file `{field}` must be a list, got "
+                f"--from-file `{name}` must be a list, got "
                 f"{type(value).__name__}"
             )
+        return value
+
+    issues = _list_field("issues")
+    recent_merges = _list_field("recent_merges")
+    pr_raw = _list_field("open_pr_numbers")
     for i, item in enumerate(issues):
         if not isinstance(item, dict):
             raise GhError(

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -132,10 +132,31 @@ _OPEN_TASK_REF_RE = re.compile(r"(?im)^[ \t]*[-*]\s*\[ \]\s*.*?#(\d+)\b")
 #   * a *mere reference* (Refs #N) does not close #N — only used to decide
 #     "this Issue is referenced by (a natural follow-up of) a recent merge".
 # Conflating them would let a bare `Refs #100` mark #100 as resolved.
+#
+# A single close keyword can close several issues at once
+# (`Closes #100, #101 and #102`), so `_PR_CLOSE_RE` captures the whole
+# leading run of comma/space/`and`-separated `#N` refs (mirroring
+# `_LEADING_REFS_RE`); `_pr_close_refs` then extracts every number with
+# `_ISSUE_REF_RE`. Capturing only the first would silently drop the 2nd+
+# issue from `recent_merge_closed_issues` (hurts the unblocked_by_recent_merge
+# axis).
 _PR_CLOSE_RE = re.compile(
-    r"(?i)\b(?:closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)\s+#(\d+)\b"
+    r"(?i)\b(?:closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)\s+"
+    r"((?:#\d+[\s,]*(?:and\s+|&\s*)?)+)"
 )
 _PR_REF_RE = re.compile(r"(?i)\b(?:refs|ref|re)\s+#(\d+)\b")
+
+
+def _pr_close_refs(text: str) -> set[int]:
+    """Issue numbers closed by `text`'s close clauses (design §4.2).
+
+    Every `#N` in the leading run after a close keyword is captured, so
+    `Closes #100, #101` yields ``{100, 101}`` — not just the first.
+    """
+    nums: set[int] = set()
+    for match in _PR_CLOSE_RE.finditer(text):
+        nums.update(int(n) for n in _ISSUE_REF_RE.findall(match.group(1)))
+    return nums
 
 # Labels that force `blocked` regardless of refs (design §4.1).
 _BLOCK_LABELS = {"blocked", "on-hold", "on hold"}
@@ -619,7 +640,7 @@ def scan(
         if isinstance(num, int):
             recent_merge_pr_numbers.add(num)
         text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
-        closed = {int(n) for n in _PR_CLOSE_RE.findall(text)}
+        closed = _pr_close_refs(text)
         referenced = closed | {int(n) for n in _PR_REF_RE.findall(text)}
         recent_merge_closed_issues |= closed
         recent_merge_referenced_issues |= referenced

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -104,14 +104,19 @@ DEFAULT_OPEN_LIMIT = 500
 # immediately followed by a `#N` (e.g. "requires careful thought",
 # "Depends on: Commit 1 ...") contributes no ref.
 #
-# Negation guard: a keyword carrying a *negation* immediately before it
-# ("not blocked by #5", "no longer blocked by #5", "doesn't depend on #5")
-# is NOT a blocker — extract_blocking_refs drops the clause when `pre` ends
-# with a negation marker (_BLOCK_NEG_RE). The leading `\b` on the keyword
-# also rejects "unblocked by #5": there is no word boundary inside the word
-# "unblocked", so the keyword never matches mid-word. Both guards prefer
-# *not* excluding (§11-3 over-matching guard).
-_BLOCK_NEG_RE = re.compile(r"(?i)(?:\bnot|\bno\s+longer|\bnever|n['’]t)\s+$")
+# Negation guard: a keyword carrying a *negation* shortly before it
+# ("not blocked by #5", "no longer blocked by #5", "not currently blocked by
+# #5", "doesn't depend on #5") is NOT a blocker — extract_blocking_refs drops
+# the clause when `pre` ends with a negation marker optionally followed by a
+# short run of plain words/spaces (adverbs like "currently"/"yet"). The run
+# is word+space only, so punctuation/clause boundaries stop it: "not a
+# blocker, but blocked by #5" still counts (the comma breaks the run). The
+# leading `\b` on the keyword also rejects "unblocked by #5" (no word
+# boundary inside "unblocked", so the keyword never matches mid-word). Both
+# guards prefer *not* excluding (§11-3: false-exclusion is the worse error).
+_BLOCK_NEG_RE = re.compile(
+    r"(?i)(?:\b(?:not|never|no\s+longer|no\s+more)|n['’]t)[\w\s]{0,20}$"
+)
 _BLOCK_KEYWORD_RE = re.compile(
     r"(?im)^(?P<pre>.*?)\b(?:blocked\s+by|depends\s+on|requires)\b(?P<rest>.*)$"
 )
@@ -159,7 +164,10 @@ _PURE_REF_RUN_RE = re.compile(r"(?i)^(?:#\d+[\s,]*(?:and\s+|&\s*)?)+$")
 # only the first would silently drop the 2nd+ issue from
 # `recent_merge_closed_issues` / `recent_merge_referenced_issues` (hurts the
 # unblocked_by_recent_merge axis).
-_KEYWORD_REF_RUN = r"\s+((?:#\d+[\s,]*(?:and\s+|&\s*)?)+)"
+#
+# The keyword may be followed by a colon (`Closes: #1`, `Fixes: #1`) — a
+# common GitHub notation — so the separator is `[\s:]+`, not just `\s+`.
+_KEYWORD_REF_RUN = r"[\s:]+((?:#\d+[\s,]*(?:and\s+|&\s*)?)+)"
 _PR_CLOSE_RE = re.compile(
     r"(?i)\b(?:closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)"
     + _KEYWORD_REF_RUN
@@ -778,12 +786,28 @@ def _run_gh_json(args: list[str]) -> list | dict:
         ) from exc
 
 
+def _run_gh_json_list(args: list[str]) -> list:
+    """Like ``_run_gh_json`` but require a JSON **array**.
+
+    ``gh ... list --json`` always returns an array; a non-list payload means
+    an unexpected/changed response. Treat it as an error (``GhError`` → exit
+    2) rather than silently degrading to ``[]`` (which would masquerade as
+    ``no_candidates`` / exit 0 — a contract break, design §5.1)."""
+    data = _run_gh_json(args)
+    if not isinstance(data, list):
+        raise GhError(
+            f"`gh {' '.join(args)}` returned a non-array JSON payload "
+            f"({type(data).__name__}); expected a list"
+        )
+    return data
+
+
 def _repo_args(repo: str | None) -> list[str]:
     return ["--repo", repo] if repo else []
 
 
 def fetch_open_issues(repo: str | None, limit: int = DEFAULT_OPEN_LIMIT) -> list[dict]:
-    data = _run_gh_json(
+    return _run_gh_json_list(
         [
             "issue",
             "list",
@@ -796,11 +820,10 @@ def fetch_open_issues(repo: str | None, limit: int = DEFAULT_OPEN_LIMIT) -> list
             "number,title,body,labels,updatedAt,createdAt,milestone,comments",
         ]
     )
-    return data if isinstance(data, list) else []
 
 
 def fetch_open_pr_numbers(repo: str | None, limit: int = DEFAULT_OPEN_LIMIT) -> set[int]:
-    data = _run_gh_json(
+    data = _run_gh_json_list(
         [
             "pr",
             "list",
@@ -813,8 +836,6 @@ def fetch_open_pr_numbers(repo: str | None, limit: int = DEFAULT_OPEN_LIMIT) -> 
             "number",
         ]
     )
-    if not isinstance(data, list):
-        return set()
     return {p["number"] for p in data if isinstance(p.get("number"), int)}
 
 
@@ -835,7 +856,7 @@ def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
     # alone guarantees the "直近 K 件" (design §4.2): the server sort biases
     # the pool toward recency, the client sort + cap makes the final K exact.
     fetch_limit = max(limit, limit * _RECENT_MERGE_OVERFETCH)
-    data = _run_gh_json(
+    merges = _run_gh_json_list(
         [
             "pr",
             "list",
@@ -850,7 +871,6 @@ def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
             "number,title,body,mergedAt",
         ]
     )
-    merges = data if isinstance(data, list) else []
     # Exact newest-first ordering by mergedAt (ISO-8601 sorts
     # lexicographically = chronologically); a missing `mergedAt` sorts last
     # (treated as oldest). The slice takes the genuine 直近 K 件.
@@ -866,11 +886,27 @@ def _load_bundle(path: str) -> tuple[list[dict], set[int], list[dict]]:
     """
     with open(path, encoding="utf-8") as f:
         bundle = json.load(f)
+    if not isinstance(bundle, dict):
+        raise GhError(
+            f"--from-file bundle must be a JSON object, got "
+            f"{type(bundle).__name__}"
+        )
     issues = bundle.get("issues") or []
-    open_pr_numbers = {
-        int(n) for n in (bundle.get("open_pr_numbers") or [])
-    }
     recent_merges = bundle.get("recent_merges") or []
+    for field, value in (("issues", issues), ("recent_merges", recent_merges)):
+        if not isinstance(value, list):
+            raise GhError(
+                f"--from-file `{field}` must be a list, got "
+                f"{type(value).__name__}"
+            )
+    try:
+        open_pr_numbers = {
+            int(n) for n in (bundle.get("open_pr_numbers") or [])
+        }
+    except (TypeError, ValueError) as exc:
+        raise GhError(
+            f"--from-file `open_pr_numbers` must be a list of integers: {exc}"
+        ) from exc
     return issues, open_pr_numbers, recent_merges
 
 

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -807,6 +807,14 @@ def fetch_open_pr_numbers(repo: str | None, limit: int = DEFAULT_OPEN_LIMIT) -> 
 
 
 def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
+    # `gh pr list`'s DEFAULT order is createdAt-desc, NOT merge-time — so a
+    # plain `--limit K` would drop a recently-*merged* PR that was *created*
+    # long ago, silently shrinking the "直近 K 件" pool (design §4.2) and
+    # mis-deciding `unblocked_by_recent_merge`. We therefore ask the server
+    # to order by recency via `sort:updated-desc`: for a merged PR the merge
+    # is its last (or near-last) activity, so updatedAt-desc ≈ mergedAt-desc,
+    # making the fetched K the *most recently merged* K. The client-side
+    # `mergedAt` sort below then makes the final ordering exact among them.
     data = _run_gh_json(
         [
             "pr",
@@ -814,6 +822,8 @@ def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
             *_repo_args(repo),
             "--state",
             "merged",
+            "--search",
+            "sort:updated-desc",
             "--limit",
             str(limit),
             "--json",
@@ -821,10 +831,10 @@ def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
         ]
     )
     merges = data if isinstance(data, list) else []
-    # `gh pr list` does not guarantee `mergedAt` order, so sort newest-first
-    # ourselves before taking the "直近 K 件" (design §4.2). ISO-8601 stamps
-    # sort lexicographically = chronologically; a missing `mergedAt` sorts
-    # last (treated as oldest).
+    # Exact newest-first ordering by mergedAt (ISO-8601 sorts
+    # lexicographically = chronologically); a missing `mergedAt` sorts last
+    # (treated as oldest). Also a defensive cap in case the fetch returned
+    # more than `limit` rows.
     merges.sort(key=lambda p: p.get("mergedAt") or "", reverse=True)
     return merges[:limit]
 

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -998,12 +998,20 @@ class _JsonErrorParser(argparse.ArgumentParser):
     """ArgumentParser that emits the error envelope as a single stdout JSON
     on a usage error (instead of bare usage text), keeping the §5.1
     "stdout is a single JSON object / exit 2 on error" contract even for
-    CLI parse errors. ``--help`` still exits 0 via the default path."""
+    CLI parse errors. ``--help`` still exits 0 via the default path.
+
+    ``trigger`` is the resolved ``--trigger`` (best-effort, see
+    ``_probe_trigger``) so the error envelope's ``generated_for`` matches the
+    CLI context even for argparse type errors raised mid-parse."""
+
+    def __init__(self, *args, trigger: str = "manual", **kwargs):
+        super().__init__(*args, **kwargs)
+        self._trigger = trigger
 
     def error(self, message: str):  # noqa: D102 — argparse override
         print(
             json.dumps(
-                _error_payload("manual", f"argument error: {message}"),
+                _error_payload(self._trigger, f"argument error: {message}"),
                 ensure_ascii=False,
                 indent=2,
             )
@@ -1011,8 +1019,25 @@ class _JsonErrorParser(argparse.ArgumentParser):
         self.exit(EXIT_ERROR)
 
 
+def _probe_trigger(argv) -> str:
+    """Best-effort `--trigger` recovery *before* the main parse.
+
+    A type error (e.g. ``--top-n nope``) makes argparse call ``error()``
+    during ``parse_args``, before ``--trigger`` is bound — so a lightweight
+    pre-parse (that tolerates unknown/other args) lets the error envelope
+    still carry the real trigger. Falls back to ``manual`` on any hiccup."""
+    probe = argparse.ArgumentParser(add_help=False)
+    probe.add_argument("--trigger", default="manual")
+    try:
+        known, _ = probe.parse_known_args(argv)
+        return known.trigger
+    except SystemExit:
+        return "manual"
+
+
 def main(argv=None) -> int:
     parser = _JsonErrorParser(
+        trigger=_probe_trigger(argv),
         description=(
             "Work-discovery triage scan (read-only). Prints a single "
             "candidate JSON to stdout; exit 0=no_candidates, "


### PR DESCRIPTION
## Summary

Refs #520. Hardening pass over the Phase 1 work-discovery compute layer (`tools/work_discovery_scan.py`). Started as a fix for the multi-issue close-keyword regex and grew into a comprehensive sweep after Codex review surfaced several latent regex / input-validation / contract gaps. Converged to "no remaining bugs". The compute tool stays read-only.

## Fixes

Directed fixes:
- **`_PR_CLOSE_RE` multi-issue**: `Closes #100, #101 and #102` now captures every referenced issue, not just the first (affects `unblocked_by_recent_merge` accuracy).
- **`_BLOCK_KEYWORD_RE` negation + word boundary**: `not blocked by #5` / `no longer blocked by #5` / `unblocked by #5` are no longer treated as blockers (was wrongly excluding candidates — the core failure mode).
- **task-list calibration**: a checklist `- [ ] #N` counts as a dependency only when the item is a pure `#N` reference; prose-bearing items (`- [ ] #123 を参考に…`) are left as candidates. Bias toward false-inclusion over false-exclusion, per design §11-3.
- **`fetch_recent_merges` recency**: server-side recency ordering + over-fetch + client-side `mergedAt` top-K (was order-dependent on `gh` defaults).
- **`--top-n` / `--recent-merges` validation**: non-positive values rejected with exit 2 (was silently degrading to no_candidates/exit 0).
- **`_PR_REF_RE` symmetry**: `Refs #10, #11` now captures all references, matching the close-side fix.

Sweep-discovered fixes:
- non-array `gh` JSON → `GhError`/exit 2 (was silent `[]`/exit 0).
- multi-clause lines (`Blocked by #1; depends on #2`) capture every clause.
- `--from-file` present-but-falsey (`{}`/`""`/`false`) → exit 2; only absent/null falls back to default.
- `issues[].number` required-validation; `title` coerced to str at output (schema by construction).
- `bool` excluded from int matching (Python `bool` is an `int` subclass; `number: true` no longer matches PR #1).
- **close-keyword negation** (`does not close #100`) guarded — the same false-positive class as the GitHub auto-close trap.
- `Closes: #1` (colon form) captured; non-list `comments`/`labels` shapes normalized; argparse-error path reflects the real `--trigger` in `generated_for`.

## Verification

- Full suite **882 passed** (4 skipped); target-file tests 59 → 117 (~60 new regression tests covering negation/boundary/contract cases).
- Codex whole-file review iterated to convergence: no remaining bugs.
- read-only invariant confirmed (only `gh issue/pr list`; no journal/state.db/git/PR writes); live `gh` scan exit 10.