### PR TITLE
feat(claude): triage-back post-merge proactive-next-dispatch — #520 Phase 4

### DIFF
--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -154,3 +154,12 @@ allowed-tools:
   - パターン A: lifecycle='active' のまま、run.status='completed' で snapshotter が available 相当の表示にする
   - パターン B / C: 物理 dir は別途処理（worktree remove / dir 保持）。レジストリエントリ削除は上記 with ブロック内に `w.remove_worker_dir('<abs>')` を追加
 - JSON snapshot は StateWriter post-commit hook が自動再生成 (Issue #284)
+
+## 2b-iii. マージ後の次タスク提案（proactive next-dispatch）
+
+2b-ii の post-merge cleanup（run COMPLETED 化・ペインクローズ・worktree 後処理）まで終わったら、窓口はユーザーの催促を待たず次の仕事候補を能動的に提示する。**候補生成はその場で `gh issue list` を即興で叩くのではなく、[`/work-discovery`](../work-discovery/SKILL.md) skill（= 決定的ツール `tools/work_discovery_scan.py` の triage 出力）を消費する**。判定基準（依存解決済み / 優先度 / 工数）が明文化され、提示に再現性・監査性が付く。方針の一次参照は [`CLAUDE.md`](../../../CLAUDE.md)「PR マージ後の次タスク提案（proactive next-dispatch）」、設計の一次参照は [`docs/design/work-discovery-triage.md`](../../../docs/design/work-discovery-triage.md) §8（post-merge 統合）。
+
+- **post_merge トリガで走らせる**: `/work-discovery` を post-merge 文脈で起動する（scan を `--trigger post_merge`、空き pane があれば `--free-panes <数>` 付き）。候補 JSON に `generated_for: "post_merge"` が載り、**post-merge では「直近マージで unblock された / 自然な follow-up」を上位に出す `unblocked_by_recent_merge` 軸が強く効く**（設計 §4.2 / §8.1-3）。空き枠があれば `parallelizable` 候補のランクが上がり並列枠を埋められる。
+- **提示と人間ゲートは現行と互換**: triage 結果を設計 §5.2 形式（候補 N 件 + 推奨 1、推定軸には `(推定)`、除外枠も提示）で窓口が人間へ提示する。**人間が番号で選択 → 選ばれた候補は [`/org-delegate`](../org-delegate/SKILL.md) の Step 0 から**通常委譲フローに入る。候補生成の手段が即興から triage に替わるだけで、人間の操作・人間ゲートの外形は変えない（設計 §8.1-4）。
+- **propose-only で停止**: 候補を出したら止める。rank 1（推奨）の自動着手・自動 commit・自動 PR はしない（着手判断は人間のみ。設計 INV-1 / INV-2）。本ステップ・`/work-discovery` が org-delegate を呼んだり spawn することも禁止。
+- 手動・任意タイミングの提示（idle 時など）は同じ `/work-discovery` を `--trigger manual` で起動する。skill 内の exit code 分岐・レンダリング規則は [`/work-discovery`](../work-discovery/SKILL.md) を一次参照する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,15 @@
 ## PR 後の CI 監視
 - PR 作成直後に `tools/pr-watch.ps1 <PR番号>` (Windows) または `tools/pr-watch.sh <PR番号>` (POSIX) を実行すると、`gh pr checks --watch` をブロッキングで起動し、完了時に `.state/journal.jsonl` へ `ci_completed` イベントを 1 行追記する。`--repo OWNER/REPO` 省略時はカレントリポジトリを自動解決する。
 
+## PR マージ後の次タスク提案（proactive next-dispatch）
+
+PR マージ → post-merge cleanup が終わったら、ユーザーの催促を待たず窓口側から「次の仕事候補」を能動的に提示する。**候補生成はその場で `gh issue list` を即興で叩くのではなく、[`/work-discovery`](./.claude/skills/work-discovery/SKILL.md) skill（= 決定的ツール `tools/work_discovery_scan.py` の triage 出力）を消費する**。これにより判定基準（依存解決済み / 優先度 / 工数）が明文化され、提示に再現性・網羅性・監査性が付く（即興提示には無かった性質）。設計の一次参照は [`docs/design/work-discovery-triage.md`](./docs/design/work-discovery-triage.md)（§5.2 提示フォーマット / §8 post-merge 統合 / §7 不変条件）。
+
+- **起動主体は窓口**。post-merge の文脈では `/work-discovery` を `post_merge` トリガで走らせる（候補 JSON に `generated_for: "post_merge"` が載る）。post-merge では「直近マージで unblock された / 自然な follow-up」を上位に出す `unblocked_by_recent_merge` 軸が強く効く。空き pane があれば free-pane 数を渡し、`parallelizable` 候補のランクを上げて並列枠を埋める。
+- **外形は完全に維持する**: triage 結果を §5.2 形式（候補 N 件 + 推奨 1、推定軸には `(推定)`、除外枠も提示）で**窓口が人間へ提示 → 人間が番号で選択 → 選ばれた候補は [`/org-delegate`](./.claude/skills/org-delegate/SKILL.md) の Step 0 から**通常委譲フローに入る。候補生成の手段が即興から triage に替わるだけで、人間の操作・人間ゲートは変えない。
+- **propose-only**: 候補を出したら停止する。rank 1（推奨）の自動着手・自動 commit・自動 PR はしない（着手判断は人間のみ）。`/work-discovery` 自身が org-delegate を呼んだり spawn することも禁止。
+- マージ後クローズ直後の具体的な提示手順は [`/org-pull-request`](./.claude/skills/org-pull-request/SKILL.md)（2b-ii post-merge cleanup 後の next-dispatch）を参照。
+
 ## ドキュメント表記
 - markdown のリンク表記は `[`<repo-root path>`](<document-relative path>)` を採用する。詳細と検証スクリプトは [`docs/contributing/markdown-conventions.md`](./docs/contributing/markdown-conventions.md) を参照。
 

--- a/docs/design/work-discovery-triage.md
+++ b/docs/design/work-discovery-triage.md
@@ -1,12 +1,18 @@
 # 自律 work-discovery（Issue triage）— 設計
 
-> ステータス: **design only / 実装なし**。本リポジトリにこの設計の実装・配線は一切存在しない。本ドキュメントは「未実装の将来設計」であり、以下の記述はすべて**提案・計画**である。`.claude/` スキル・`.dispatcher/` prose・`tools/` への変更は本ブランチでは行っていない（成果物は本設計書 1 本のみ）。
+> ステータス: **Phase 1〜4 実装済み（運用中）**。本設計は [§9](#9-段階導入と検証提案) の段階導入計画に沿って実装・配線済みである。実体（すべてリポジトリルート相対）:
+> - **Phase 1 — 計算層**: [`tools/work_discovery_scan.py`](../../tools/work_discovery_scan.py)（read-only scan・候補 JSON stdout・exit code 分岐）。
+> - **Phase 2 — 案 B 手動エントリ**: [`.claude/skills/work-discovery/SKILL.md`](../../.claude/skills/work-discovery/SKILL.md)（窓口が手動 / イベント起動して提示）。
+> - **Phase 3 — 案 C 定常トリガ**: worker クローズ時に scan を起動し窓口へ転送する配線（[`.dispatcher/references/pane-close.md`](../../.dispatcher/references/pane-close.md) ほか dispatcher prose）。
+> - **Phase 4 — post-merge 統合**: proactive next-dispatch の候補生成を triage 出力へ差し替え（[`CLAUDE.md`](../../CLAUDE.md)「PR マージ後の次タスク提案」と [`.claude/skills/org-pull-request/SKILL.md`](../../.claude/skills/org-pull-request/SKILL.md) 2b-iii）。
+>
+> **以降の本文は当初の設計記述をそのまま残している**。本文中の「未実装」「（未実装の）提案」「proposed tool」「本設計書ではインタフェースのみ定義し実装はしない」等の表現は**設計時点の framing** であり、現在の実体は上記パスに存在する。不変条件 [§7](#7-安全レール不変条件)（INV-1〜5）は実装後も維持される契約である。
 >
 > 一次入力:
 > - [`.state/reports/loop-engineering-assessment.md`](../../.state/reports/loop-engineering-assessment.md) の **§5-1（唯一の構造的ギャップ = 仕事の自律発見が無い）** と **§7(b)（限定的な自律 work-discovery を「提案まで自動・着手判断は人間維持」で導入、+2〜3 点）**。
 > - originating Issue: suisya-systems/claude-org-ja#520。
 >
-> 依存ドキュメント（参照は本設計書 → 既存文書の一方向のみ。既存文書側からの参照追加は行わない）:
+> 依存ドキュメント（設計時点では本設計書 → 既存文書の一方向参照のみとしていた。実装後の現在は Phase 2/4 で [`CLAUDE.md`](../../CLAUDE.md) と [`.claude/skills/work-discovery/SKILL.md`](../../.claude/skills/work-discovery/SKILL.md) / [`.claude/skills/org-pull-request/SKILL.md`](../../.claude/skills/org-pull-request/SKILL.md) から本設計書への参照が加わっている）:
 > - [`CLAUDE.md`](../../CLAUDE.md)（窓口 = 唯一の人間接点 / 実作業は全委譲 / proactive next-dispatch / 役割の境界）
 > - [`.claude/skills/org-delegate/SKILL.md`](../../.claude/skills/org-delegate/SKILL.md)（着手の正準経路 = 人間ゲート後の Step 0 から）
 > - [`tools/check_curate_threshold.py`](../../tools/check_curate_threshold.py) と [`.dispatcher/references/pane-close.md`](../../.dispatcher/references/pane-close.md)（worker クローズ時のオンデマンド spawn = 本設計の delivery 先例）


### PR DESCRIPTION
## Summary

Refs #520. Final phase of autonomous work-discovery per `docs/design/work-discovery-triage.md` §8: upgrades the post-merge proactive-next-dispatch so candidate generation consumes the `/work-discovery` triage output instead of an ad-hoc `gh issue list`. Prose only — no code. Completes Phases 1–4.

## What changed (3 files, +26/-2)

1. **CLAUDE.md**: adds a canonical "proactive next-dispatch after PR merge" policy. Candidate generation moves from ad-hoc `gh issue list` to consuming the `/work-discovery` skill (the `tools/work_discovery_scan.py` triage output), so the selection basis (dependency-resolved / priority / effort) is documented, reproducible, and auditable. (The policy had no CLAUDE.md section before — it lived only in operator memory; this is its first canonical statement.)
2. **org-pull-request/SKILL.md**: new 2b-iii. After 2b-ii post-merge cleanup, next-dispatch becomes triage-backed (`generated_for=post_merge`; the `unblocked_by_recent_merge` axis and free-pane → parallelizable boost matter here). The human-facing shape — present → pick by number → `/org-delegate` Step 0 — is unchanged.
3. **docs/design/work-discovery-triage.md**: flips the header status from "design only / not implemented" to "Phases 1–4 implemented (in operation)", listing each phase's real paths.

## Invariants

- The candidate-generation step is swapped to triage; the present → human-picks-by-number → org-delegate shape is fully preserved (INV-2/4). Propose-only; no auto-dispatch (INV-1/3).

## Verification

- Codex self-review: 1 round, no Blocker/Major; INV-1..5 not violated; skill/tool flags consistent. One Minor fixed (design-doc dependency-section back-reference); the other (link-audit display-mismatch) left as the dominant existing convention shared by CLAUDE.md and all skills (audit is not a CI gate).