### PR TITLE
fix: cp932 UnicodeDecodeError → NoneType cascade in work_discovery_scan (Closes #537)

### DIFF
--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -522,6 +522,7 @@ class TestCliWiring(unittest.TestCase):
                 [sys.executable, str(SCRIPT), "--from-file", name],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
             )
         finally:
             os.unlink(name)
@@ -553,6 +554,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--from-file", "/no/such/file.json"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         self.assertEqual(json.loads(proc.stdout)["status"], "error")
@@ -569,6 +571,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--from-file", "/no/such/file.json"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         data = json.loads(proc.stdout)
         for key in (
@@ -593,6 +596,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--top-n", "not-an-int"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         data = json.loads(proc.stdout)  # stdout is valid JSON
@@ -606,6 +610,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--top-n", "nope", "--trigger", "post_merge"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         data = json.loads(proc.stdout)
@@ -620,6 +625,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--trigger"],  # missing value
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         self.assertEqual(proc.stderr, "")
@@ -647,6 +653,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--top-n", "0"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         data = json.loads(proc.stdout)
@@ -658,6 +665,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--top-n=-5"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         data = json.loads(proc.stdout)
@@ -670,6 +678,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--top-n", "0", "--trigger", "post_merge"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         data = json.loads(proc.stdout)
@@ -683,6 +692,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--recent-merges", "0"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         data = json.loads(proc.stdout)
@@ -694,6 +704,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--recent-merges=-3"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         data = json.loads(proc.stdout)
@@ -705,6 +716,7 @@ class TestCliWiring(unittest.TestCase):
             [sys.executable, str(SCRIPT), "--free-panes=-2"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
         )
         self.assertEqual(proc.returncode, wds.EXIT_ERROR)
         data = json.loads(proc.stdout)
@@ -984,6 +996,41 @@ class TestFetchRobustness(unittest.TestCase):
                 wds.fetch_open_pr_numbers(None)
 
 
+class TestGhUtf8Decoding(unittest.TestCase):
+    """#537 regression: gh stdout is decoded as UTF-8 in the caller's thread,
+    so a cp932 locale can neither corrupt Japanese output nor swallow a decode
+    error into a NoneType cascade."""
+
+    def test_decode_japanese_stdout(self):
+        # gh emits UTF-8; the bytes below are invalid under cp932 (the exact
+        # failure mode of #537) but must decode cleanly here.
+        raw = "ログイン機能 — 並列可".encode("utf-8")
+        self.assertEqual(wds._decode_gh_stdout(raw, ["x"]), "ログイン機能 — 並列可")
+
+    def test_invalid_utf8_raises_clear_gherror(self):
+        # A genuinely non-UTF-8 byte must surface as a GhError naming the byte
+        # and position — NOT be swallowed into proc.stdout=None / a NoneType
+        # 'JSON object must be str/bytes' cascade (the #537 symptom).
+        with self.assertRaises(wds.GhError) as ctx:
+            wds._decode_gh_stdout(b"\x96\x96", ["issue", "list"])
+        msg = str(ctx.exception)
+        self.assertIn("not valid UTF-8", msg)
+        self.assertIn("0x96", msg)
+        self.assertNotIn("NoneType", msg)
+
+    def test_run_gh_json_parses_japanese_via_bytes(self):
+        # End-to-end: subprocess returns *bytes* stdout (as it does without
+        # text=True); _run_gh_json must decode + parse it regardless of locale.
+        payload = json.dumps([{"number": 1, "title": "日本語"}]).encode("utf-8")
+        completed = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout=payload, stderr=b""
+        )
+        with mock.patch.object(wds.shutil, "which", return_value="/usr/bin/gh"):
+            with mock.patch.object(wds.subprocess, "run", return_value=completed):
+                data = wds._run_gh_json(["issue", "list"])
+        self.assertEqual(data, [{"number": 1, "title": "日本語"}])
+
+
 class TestMalformedFieldNormalization(unittest.TestCase):
     """Non-list `comments` / `labels` shapes must normalize to empty, never
     crash the pure core (a bare comment *count* is a real gh-shape risk)."""
@@ -1037,6 +1084,7 @@ class TestBundleValidation(unittest.TestCase):
                 [sys.executable, str(SCRIPT), "--from-file", name],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",  # script emits UTF-8; don't decode via cp932 locale (#537)
             )
         finally:
             os.unlink(name)

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -165,6 +165,7 @@ def _resolve_repo() -> str:
             ["gh", "repo", "view", "--json", "nameWithOwner"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
             check=True,
         )
     except subprocess.CalledProcessError as exc:
@@ -284,6 +285,7 @@ def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
             check=False,
         )
     except FileNotFoundError:
@@ -508,6 +510,7 @@ def _pr_exists(pr: int, repo: str) -> bool:
             ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "number"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
             check=True,
         )
     except subprocess.CalledProcessError:

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -302,6 +302,7 @@ def _git_origin_url(repo_path: Path) -> Optional[str]:
             ["git", "-C", str(repo_path), "remote", "get-url", "origin"],
             capture_output=True,
             text=True,
+            encoding="utf-8",  # decode git output as UTF-8, not the cp932 locale (#537)
         )
     except (FileNotFoundError, OSError):
         return None

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -181,7 +181,7 @@ def _resolve_repo() -> str:
     try:
         result = subprocess.run(
             ["gh", "repo", "view", "--json", "nameWithOwner"],
-            capture_output=True, text=True, check=True,
+            capture_output=True, text=True, encoding="utf-8", check=True,  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
         )
     except subprocess.CalledProcessError as exc:
         sys.stderr.write(
@@ -213,7 +213,7 @@ def fetch_pr_view(pr: int, repo: str) -> dict:
             "--repo", repo,
             "--json", "number,url,state,mergedAt,mergeCommit,headRefName",
         ],
-        capture_output=True, text=True, check=False,
+        capture_output=True, text=True, encoding="utf-8", check=False,  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
     )
     if proc.returncode != 0:
         raise RuntimeError(

--- a/tools/set_run_pr_open.py
+++ b/tools/set_run_pr_open.py
@@ -64,7 +64,7 @@ def _resolve_repo() -> str:
     try:
         result = subprocess.run(
             ["gh", "repo", "view", "--json", "nameWithOwner"],
-            capture_output=True, text=True, check=True,
+            capture_output=True, text=True, encoding="utf-8", check=True,  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
         )
     except subprocess.CalledProcessError as exc:
         sys.stderr.write(
@@ -90,7 +90,7 @@ def fetch_pr_view(pr: int, repo: str) -> dict:
             "--repo", repo,
             "--json", "url,headRefName",
         ],
-        capture_output=True, text=True, check=False,
+        capture_output=True, text=True, encoding="utf-8", check=False,  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
     )
     if proc.returncode != 0:
         raise RuntimeError(

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -800,25 +800,58 @@ class GhError(RuntimeError):
     """A `gh` read call failed (missing binary, auth, API error, bad JSON)."""
 
 
+def _decode_gh_stdout(raw: bytes, args: list[str]) -> str:
+    """Decode a ``gh`` stdout byte stream as UTF-8 in the **caller's** thread.
+
+    ``gh`` always emits UTF-8 regardless of the OS locale. We deliberately
+    capture *bytes* (no ``text=True``) and decode here, rather than letting
+    ``subprocess`` decode inside its reader thread: on a non-UTF-8 locale
+    (e.g. cp932 on Japanese Windows) ``text=True`` decodes with the *locale*
+    codec, and a ``UnicodeDecodeError`` raised in that daemon reader thread is
+    **swallowed** — ``proc.stdout`` comes back ``None`` and the failure
+    resurfaces downstream as a baffling ``the JSON object must be str, bytes
+    or bytearray, not NoneType`` (Issue #537). Decoding in the main thread
+    means a genuine decode failure raises *here*, naming the offending byte
+    and the command, instead of cascading into a misleading NoneType error.
+    """
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise GhError(
+            f"`gh {' '.join(args)}` stdout was not valid UTF-8 "
+            f"(byte 0x{exc.object[exc.start]:02x} at position {exc.start}); "
+            f"gh emits UTF-8 regardless of locale — {exc}"
+        ) from exc
+
+
 def _run_gh_json(args: list[str]) -> list | dict:
     """Run a read-only ``gh`` command and parse its JSON stdout.
 
     Only ``gh`` subcommands that *read* are ever passed here (callers pass
     ``repo view`` / ``issue list`` / ``pr list``). Raises ``GhError`` on
     any failure so ``main`` can emit ``status=error`` / exit 2.
+
+    Output is captured as bytes and decoded as UTF-8 in this thread (see
+    ``_decode_gh_stdout``) so a cp932-locale decode failure surfaces as a
+    clear ``GhError`` rather than being swallowed in subprocess's reader
+    thread and cascading into a NoneType error (Issue #537).
     """
     if shutil.which("gh") is None:
         raise GhError("GitHub CLI (gh) not found in PATH")
     try:
         proc = subprocess.run(
-            ["gh", *args], capture_output=True, text=True, check=True
+            ["gh", *args], capture_output=True, check=True
         )
     except subprocess.CalledProcessError as exc:
+        # stderr is diagnostic only → lossy decode is fine (a mangled error
+        # message must not mask the real `gh` failure being reported).
+        stderr = (exc.stderr or b"").decode("utf-8", "replace").strip()
         raise GhError(
-            f"`gh {' '.join(args)}` failed: {exc.stderr.strip() or exc}"
+            f"`gh {' '.join(args)}` failed: {stderr or exc}"
         ) from exc
+    stdout = _decode_gh_stdout(proc.stdout or b"", args)
     try:
-        return json.loads(proc.stdout)
+        return json.loads(stdout)
     except json.JSONDecodeError as exc:
         raise GhError(
             f"`gh {' '.join(args)}` returned non-JSON output: {exc}"


### PR DESCRIPTION
## Summary

Fixes the cp932 `UnicodeDecodeError` that crashed `tools/work_discovery_scan.py` (exit 2) on Windows during the dispatcher pane-close triage scan. Closes #537.

### Root cause

`gh`'s UTF-8 JSON output was decoded by `subprocess`'s reader thread under the platform default encoding (cp932 on Windows). The decode exception was swallowed in the daemon reader thread → `proc.stdout = None` → `json.loads(None)` → opaque `TypeError: ... not NoneType` → exit 2.

### Fix

- `work_discovery_scan.py`: capture `gh` stdout as **bytes** and decode explicitly as UTF-8 on the main thread (`_decode_gh_stdout` / `_run_gh_json`). A non-UTF-8 byte now fails loudly as a `GhError` naming the offending byte/position, instead of cascading into the `NoneType` error.
- Sibling audit: same "decode `gh` output under locale" pattern made explicit `encoding="utf-8"` in `run_complete_on_merge.py`, `pr_watch.py`, `set_run_pr_open.py`, `resolve_worker_layout.py`. (`check_curate_threshold.py` is gh-independent — out of scope.)
- Regression tests: Japanese decode success / explicit `GhError` on bad bytes / bytes-path end-to-end. The test harness itself had 2 pre-existing failures from the same cp932 bug, now green.

### Design note

Chose **bytes capture + manual main-thread decode** over merely adding `encoding="utf-8"`: the latter still decodes inside the reader thread, so a future malformed byte would again be swallowed → re-introduce the NoneType cascade. Main-thread decode guarantees an explicit failure (satisfies the "fail with a legible cause, don't cascade into NoneType" requirement).

### Verification

Bare `python tools/work_discovery_scan.py --trigger post_merge` (no `PYTHONUTF8`): before = exit 2 + reader-thread `UnicodeDecodeError`; after = exit 10 (candidates_found), stderr 0 bytes, Japanese titles intact. 187+ tests pass; Codex full review: no Blocker/Major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
