### PR TITLE
fix(org_metrics_report): bad-DB に actionable な exit-2 + JSON 型/key-set 安定化 (Closes #562, Closes #563)

### DIFF
--- a/tools/org_metrics_report.py
+++ b/tools/org_metrics_report.py
@@ -208,9 +208,24 @@ def load_pending_decisions(path: Path) -> Optional[dict[str, Any]]:
     try:
         data = json.loads(path.read_text(encoding="utf-8") or "[]")
     except (OSError, ValueError) as exc:
-        return {"error": f"could not read register: {exc}", "by_status": {}}
+        # Keep the key-set identical to the success branch (Issue #563): a
+        # downstream JSON consumer that reads ``.total`` must not KeyError just
+        # because the register was unreadable. The three register states stay
+        # distinguishable (``None`` file-absent / ``error`` non-null / ``error``
+        # null), so total/pending are surfaced as ``null`` here, not 0.
+        return {
+            "error": f"could not read register: {exc}",
+            "total": None,
+            "pending": None,
+            "by_status": {},
+        }
     if not isinstance(data, list):
-        return {"error": "register top-level is not a list", "by_status": {}}
+        return {
+            "error": "register top-level is not a list",
+            "total": None,
+            "pending": None,
+            "by_status": {},
+        }
     by_status: dict[str, int] = {}
     for entry in data:
         if not isinstance(entry, dict):
@@ -351,13 +366,26 @@ def gather_events_and_ci(
                 ci_matched_run_id += 1
                 continue
             repo = payload.get("repo")
-            pr = payload.get("pr")
-            key = None
-            if isinstance(repo, str) and isinstance(pr, (int, str)):
+            pr_raw = payload.get("pr")
+            # Normalize ``pr`` to int (or None) up front so the value stored in
+            # an unmatched entry has a stable type (Issue #563): the same JSON
+            # array previously mixed int (pr=259) and str (pr='37') because the
+            # join coerced ``int(pr)`` but the unmatched bucket stored the raw
+            # payload value. A non-numeric / missing pr normalizes to None.
+            pr: Optional[int]
+            if isinstance(pr_raw, bool):
+                # bool is a subclass of int; a JSON true/false is not a PR no.
+                pr = None
+            elif isinstance(pr_raw, int):
+                pr = pr_raw
+            elif isinstance(pr_raw, str):
                 try:
-                    key = (repo.lower(), int(pr))
-                except (TypeError, ValueError):
-                    key = None
+                    pr = int(pr_raw)
+                except ValueError:
+                    pr = None
+            else:
+                pr = None
+            key = (repo.lower(), pr) if isinstance(repo, str) and pr is not None else None
             if key is not None and key in pr_index:
                 ci_matched_pr += 1
                 continue
@@ -653,8 +681,18 @@ def run(argv: Optional[list[str]] = None, *, now: Optional[datetime] = None) -> 
         now=now,
     )
 
-    conn = open_readonly(db_path)
+    # The DB may exist but not be a usable state.db: wrong schema (no ``runs``
+    # table), schema drift (a column we SELECT is gone), an empty-but-valid
+    # sqlite file, or a non-sqlite file altogether. ``mode=ro`` opens lazily so
+    # the failure usually surfaces on the first query inside ``build_report``,
+    # but ``open_readonly`` also runs a PRAGMA, so wrap both. ``sqlite3.Error``
+    # is the base class of OperationalError / DatabaseError -- catching it gives
+    # the week-running human an actionable next step instead of a raw traceback
+    # + exit 1 (Issue #562; this also unifies the exit code on 2 for all
+    # bad-DB cases, matching the missing-DB branch above).
+    conn = None
     try:
+        conn = open_readonly(db_path)
         report = build_report(
             conn,
             lo=lo,
@@ -663,8 +701,16 @@ def run(argv: Optional[list[str]] = None, *, now: Optional[datetime] = None) -> 
             generated_at=generated_at,
             db_path=db_path,
         )
+    except sqlite3.Error as exc:
+        sys.stderr.write(
+            f"tools/org_metrics_report.py: error: DB at {db_path} is not a "
+            f"valid/expected state.db ({exc}). Check --db-path or "
+            f"STATE_DB_PATH.\n"
+        )
+        return 2
     finally:
-        conn.close()
+        if conn is not None:
+            conn.close()
 
     if args.format == "json":
         out = render_json(report)

--- a/tools/test_org_metrics_report.py
+++ b/tools/test_org_metrics_report.py
@@ -383,5 +383,193 @@ class CliArgvTest(unittest.TestCase):
                      "--since", "2026-06-10", "--last-days", "3"])
 
 
+class BadDbExitCodeTest(unittest.TestCase):
+    """Issue #562 regression: a present-but-unusable DB must yield a friendly
+    actionable message on stderr + exit 2, NOT a raw sqlite traceback + exit 1.
+
+    These fixtures are built WITHOUT ``apply_schema`` on purpose -- the gap
+    that escaped to the dogfood pass was that every prior test used a
+    well-formed schema, so the no-such-table / no-such-column / not-a-database
+    failure paths were never exercised. Each case asserts both the exit code
+    and that the stderr message is actionable (names the path, points at
+    --db-path), since an actionable message is the entire point of the fix.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _run_capturing_stderr(self, db_path: Path):
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            rc = omr.run(["--db-path", str(db_path)])
+        return rc, buf.getvalue()
+
+    def _assert_friendly(self, rc: int, err: str, db_path: Path) -> None:
+        self.assertEqual(rc, 2)
+        # actionable: names the offending path and points at the override knob
+        self.assertIn(str(db_path), err)
+        self.assertIn("--db-path", err)
+        # not a raw traceback dumped to stderr
+        self.assertNotIn("Traceback (most recent call last)", err)
+        # output stays cp932-safe (ASCII hyphens only, no em/en dash)
+        self.assertNotIn("—", err)
+        self.assertNotIn("–", err)
+        err.encode("cp932")  # must not raise
+
+    def test_wrong_schema_no_such_table(self) -> None:
+        # valid sqlite file, but no ``runs`` table -> first query fails
+        db = self.dir / "wrong_schema.db"
+        c = sqlite3.connect(db)
+        c.execute("CREATE TABLE not_runs (id INTEGER PRIMARY KEY)")
+        c.commit()
+        c.close()
+        rc, err = self._run_capturing_stderr(db)
+        self._assert_friendly(rc, err, db)
+
+    def test_schema_drift_missing_column(self) -> None:
+        # ``runs`` exists but lacks columns the report SELECTs (e.g. pattern)
+        db = self.dir / "drift.db"
+        c = sqlite3.connect(db)
+        c.execute(
+            "CREATE TABLE projects (id INTEGER PRIMARY KEY, slug TEXT, "
+            "display_name TEXT)"
+        )
+        c.execute(
+            "CREATE TABLE runs (id INTEGER PRIMARY KEY, task_id TEXT, "
+            "project_id INTEGER)"  # missing status/pattern/pr_url/dispatched_at
+        )
+        c.commit()
+        c.close()
+        rc, err = self._run_capturing_stderr(db)
+        self._assert_friendly(rc, err, db)
+
+    def test_empty_valid_db(self) -> None:
+        # a valid but empty sqlite file (connect + close, no tables)
+        db = self.dir / "empty.db"
+        sqlite3.connect(db).close()
+        rc, err = self._run_capturing_stderr(db)
+        self._assert_friendly(rc, err, db)
+
+    def test_not_a_database_file(self) -> None:
+        # arbitrary bytes at a .db path -> "file is not a database"
+        db = self.dir / "garbage.db"
+        db.write_bytes(b"this is plainly not an sqlite database\n" * 4)
+        rc, err = self._run_capturing_stderr(db)
+        self._assert_friendly(rc, err, db)
+
+
+class JsonContractTest(unittest.TestCase):
+    """Issue #563 regression: JSON output type / key-set stability."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "state.db"
+        self.pending = self.db_path.parent / "pending_decisions.json"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _build(self, lo=None, hi=None):
+        conn = omr.open_readonly(self.db_path)
+        try:
+            return omr.build_report(
+                conn, lo=lo, hi=hi, pending_path=self.pending,
+                generated_at="g", db_path=self.db_path)
+        finally:
+            conn.close()
+
+    # --- Minor 1: ci.unmatched[].pr type is stable across the array --------
+    def test_unmatched_pr_type_is_consistently_int_or_none(self) -> None:
+        conn = _conn(self.db_path)
+        apply_schema(conn)
+        conn.execute(
+            "INSERT INTO projects (id, slug, display_name) VALUES "
+            "(1, 'claude-org', 'c')"
+        )
+
+        def ev(payload):
+            conn.execute(
+                "INSERT INTO events (kind, occurred_at, payload_json) VALUES "
+                "('ci_completed', '2026-06-11T00:00:00.000Z', ?)",
+                (json.dumps(payload),),
+            )
+
+        # one unmatched with int pr, one with str pr, one with missing pr:
+        # all must be surfaced as unmatched (no run owns these PRs) and their
+        # ``pr`` field must be int-or-None, never a mix of int and str.
+        ev({"repo": "octo/repo", "pr": 259, "status": "success"})
+        ev({"repo": "octo/repo", "pr": "37", "status": "success"})
+        ev({"status": "incomplete"})  # no repo/pr
+        conn.commit()
+        conn.close()
+
+        ci = self._build()["ci"]
+        self.assertEqual(ci["unmatched_count"], 3)
+        prs = [u["pr"] for u in ci["unmatched"]]
+        # every value is int or None -- no str leaks through
+        for v in prs:
+            self.assertTrue(
+                v is None or (isinstance(v, int) and not isinstance(v, bool)),
+                f"pr value {v!r} is neither int nor None",
+            )
+        # the str '37' was normalized to int 37
+        self.assertIn(37, prs)
+        self.assertIn(259, prs)
+        self.assertIn(None, prs)
+        # and the whole thing survives a JSON round-trip with stable types
+        data = json.loads(omr.render_json(self._build()))
+        for u in data["ci"]["unmatched"]:
+            self.assertTrue(u["pr"] is None or isinstance(u["pr"], int))
+
+    # --- Minor 2: pending_decisions key-set is stable across states --------
+    def test_pending_error_branch_has_full_key_set(self) -> None:
+        conn = _conn(self.db_path)
+        apply_schema(conn)
+        conn.commit()
+        conn.close()
+        # corrupt register: not valid JSON
+        self.pending.write_text("{ this is not json", encoding="utf-8")
+        pd = self._build()["pending_decisions"]
+        self.assertIsNotNone(pd)
+        self.assertIsNotNone(pd["error"])
+        # full key-set present so downstream ``.total`` reads never KeyError
+        self.assertEqual(
+            set(pd.keys()), {"error", "total", "pending", "by_status"})
+        self.assertIsNone(pd["total"])
+        self.assertIsNone(pd["pending"])
+
+    def test_pending_not_list_branch_has_full_key_set(self) -> None:
+        conn = _conn(self.db_path)
+        apply_schema(conn)
+        conn.commit()
+        conn.close()
+        # valid JSON but not a list (e.g. an object)
+        self.pending.write_text('{"oops": true}', encoding="utf-8")
+        pd = self._build()["pending_decisions"]
+        self.assertIsNotNone(pd)
+        self.assertIsNotNone(pd["error"])
+        self.assertEqual(
+            set(pd.keys()), {"error", "total", "pending", "by_status"})
+        self.assertIsNone(pd["total"])
+        self.assertIsNone(pd["pending"])
+
+    def test_pending_success_branch_key_set_matches_error_branch(self) -> None:
+        conn = _conn(self.db_path)
+        apply_schema(conn)
+        conn.commit()
+        conn.close()
+        self.pending.write_text("[]", encoding="utf-8")
+        pd = self._build()["pending_decisions"]
+        # same key-set as the error branches -> stable contract
+        self.assertEqual(
+            set(pd.keys()), {"error", "total", "pending", "by_status"})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要

#556 dogfood pass で実データから検出した defect を修正。`tools/org_metrics_report.py`。Closes #562, Closes #563。

## #562 (Major): bad-DB の actionable なエラー
DB が存在するが usable でない 4 ケース（wrong schema / missing column / empty valid DB / not-a-DB file）で raw `sqlite3` traceback + exit 1 だったのを、`run()` で `open_readonly` + `build_report` を `try/except sqlite3.Error` で囲い、`DB at <path> is not a valid/expected state.db (<detail>). Check --db-path or STATE_DB_PATH.` を stderr に出して **exit 2** を返すよう統一（missing-DB 分岐と exit code が一致）。`build_report` は pure 関数のまま（error handling は `run()` 側）。

## #563 (Minor): JSON 出力の安定化
- `ci.unmatched[].pr` を int-or-None に正規化（bool→None / 非数値 str→None。同一配列内の int/str 混在を解消）
- `pending_decisions` の error/not-list 分岐に `total/pending: null` を追加し success 分岐と key-set 統一（file-absent の `None` は 3 状態区別のため維持）

## 検証
- pytest 30 passed（22 既存 + 8 新規 regression）@ Python 3.10.6
- **fails-before/passes-after 実測**: 新 bad-DB 4 テストは pre-fix impl に対して 4 件 fail（`no such table: runs` 伝播）→ fix で pass。Major の gap が閉じたことを実測確認
- Codex レビュー 1 ラウンド No findings。cp932 実端末スモーク PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)