### PR TITLE
build(deps): bump claude-org-runtime floor 0.1.17 -> 0.1.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.17,<0.2",
+    "claude-org-runtime>=0.1.22,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,10 +26,13 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
-# Floor bumped to 0.1.17 for the transport surface descriptor
-# (claude_org_runtime.transport) consumed by tools/transport.py — Epic #6
-# next-stage D / ja#513 ja integration seam. Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.17,<0.2
+# Floor bumped to 0.1.22 for the broker admin surface (admin RPC and the
+# --root-role/--root-cwd flags) exercised by broker-dogfood-runbook; ja#565
+# flagged the pin mismatch against the installed runtime. The 0.1.17 floor
+# (transport surface descriptor claude_org_runtime.transport consumed by
+# tools/transport.py — Epic #6 next-stage D / ja#513) is subsumed. Keep in
+# sync with pyproject.toml.
+claude-org-runtime>=0.1.22,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
## Summary

Bumps the `claude-org-runtime` dependency floor from `>=0.1.17` to `>=0.1.22` (upper bound `<0.2` unchanged) in both `pyproject.toml` and `requirements.txt`. Declarative pin only.

Flagged during #565: the `broker-dogfood-runbook` surface (admin RPC, `--root-role`/`--root-cwd`, daemon.json sidecar) requires runtime ≥ 0.1.22, but the floor was still 0.1.17.

## Changes
- `pyproject.toml`: `claude-org-runtime>=0.1.17,<0.2` → `>=0.1.22,<0.2`
- `requirements.txt`: same pin bump + comment updated to cite the 0.1.22 rationale (broker admin RPC / `--root-role`/`--root-cwd` surface, ja#565 pin mismatch); old 0.1.17 transport-surface floor noted as subsumed.

No behavior/upper-bound/other-dependency changes. Codex full review round2 clean (against the authoritative `origin/main...HEAD` diff = these 2 files).

## Environment note
This raises the **declared** floor only. Environments must have `claude-org-runtime>=0.1.22` installed (`python -m pip install -U claude-org-runtime`; 0.1.24 is on PyPI). The maintainer's local env is already at 0.1.24, so it satisfies the new floor; fresh installs will pull a compliant version automatically.

Refs #565. (No `Closes` — #565 was closed by #573.)
