### PR TITLE
build(deps): bump claude-org-runtime pin floor 0.1.22 -> 0.1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.22,<0.2",
+    "claude-org-runtime>=0.1.26,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,13 +26,14 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
-# Floor bumped to 0.1.22 for the broker admin surface (admin RPC and the
-# --root-role/--root-cwd flags) exercised by broker-dogfood-runbook; ja#565
-# flagged the pin mismatch against the installed runtime. The 0.1.17 floor
-# (transport surface descriptor claude_org_runtime.transport consumed by
-# tools/transport.py — Epic #6 next-stage D / ja#513) is subsumed. Keep in
-# sync with pyproject.toml.
-claude-org-runtime>=0.1.22,<0.2
+# Floor bumped to 0.1.26 to adopt the WezTerm Windows fixes (0.1.25 cli
+# window flicker suppression, runtime#87; 0.1.26 child-pane tab aggregation,
+# runtime#88). The 0.1.22 floor (broker admin surface — admin RPC and the
+# --root-role/--root-cwd flags exercised by broker-dogfood-runbook; ja#565)
+# and the 0.1.17 floor (transport surface descriptor
+# claude_org_runtime.transport consumed by tools/transport.py — Epic #6
+# next-stage D / ja#513) are subsumed. Keep in sync with pyproject.toml.
+claude-org-runtime>=0.1.26,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
Bump the `claude-org-runtime` pin floor from 0.1.22 to 0.1.26 (upper bound `<0.2` unchanged) in both mirrored pin files (`pyproject.toml` and `requirements.txt`, kept in sync per the documented convention and the #574 precedent).

## Why
runtime 0.1.26 is published to PyPI and carries the WezTerm Windows fixes that ja needs to consume:
- 0.1.25: suppress WezTerm `cli` console-window flicker on Windows (`CREATE_NO_WINDOW`) — runtime #87
- 0.1.26: consolidate WezTerm child panes into anchor-window tabs — runtime #88

Both surfaced during the WezTerm real-terminal broker dogfood (ja#576).

## Changes
- `pyproject.toml`: pin floor 0.1.22 -> 0.1.26.
- `requirements.txt`: pin floor 0.1.22 -> 0.1.26 + fold the prior 0.1.22 floor into the subsumed-history comment (same pattern as #574).
- `tools/check_runtime_schema_drift.py` `RUNTIME_PIN_LOWER_INCLUSIVE` left at (0,1,17) per the #574 precedent (conservative drift floor, safe to leave).

Refs #576