### PR TITLE
fix(retro-gate): DEFAULT_ACK_PATTERN に「マージ済み」「完了」を追加

### DIFF
--- a/tests/test_dispatcher_retro_gate.py
+++ b/tests/test_dispatcher_retro_gate.py
@@ -201,6 +201,127 @@ class DispatcherRetroGateTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 2, msg=proc.stderr)
         self.assertIn("out of range", _final(proc)["reason"])
 
+    # --- Issue #584: completion-phrasing acks in DEFAULT_ACK_PATTERN ----
+
+    def test_secretary_merged_phrase_acks(self) -> None:
+        # "マージ済み" from the secretary must trip the default pattern so
+        # the gate passes without a per-invocation --ack-pattern override.
+        proc = _run({"messages": [
+            {"from_id": "secretary", "message": "PR #584 マージ済みです"},
+        ]}, attempt=1)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "acked")
+        self.assertIn("マージ済み", final["raw"])
+
+    def test_secretary_kanryo_phrase_acks(self) -> None:
+        # "完了" from the secretary (without any 届い/受領 token) acks.
+        proc = _run({"messages": [
+            {"from_id": "secretary", "message": "対応完了しました"},
+        ]}, attempt=1)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "acked")
+        self.assertIn("完了", final["raw"])
+
+    def test_non_secretary_completion_phrase_does_not_ack(self) -> None:
+        # The same completion wording from a non-secretary sender must
+        # still be gated out by _is_secretary_message (no false positive).
+        proc = _run({"messages": [
+            {"from_id": "worker-x", "message": "マージ済み、完了しました"},
+        ]}, attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_kanryo_houkoku_negative_reply_does_not_ack(self) -> None:
+        # Regression: the secretary's negative reply "完了報告は見当たり
+        # ません" contains 完了 (inside the 完了報告 noun) but is NOT an ack.
+        # A bare 完了 in the pattern would falsely pass the gate here; the
+        # guarded form must keep it polling at a non-final attempt.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "完了報告は見当たりません"}]},
+                    attempt=1, max_attempts=3)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_negated_completion_verb_does_not_ack(self) -> None:
+        # "まだ完了していません" — secretary says it is NOT done. The 完了
+        # token is directly negated and must not ack.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "まだ完了していません"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_mikanryo_does_not_ack(self) -> None:
+        # "未完了です" — 完了 preceded by 未 (incomplete) must not ack.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "タスクは未完了です"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_completion_question_does_not_ack(self) -> None:
+        # "作業は完了しましたか？" — a question, not an assertion, must
+        # not pass the gate (trailing 疑問助詞 か is excluded).
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "作業は完了しましたか？"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_merged_affirmative_acks(self) -> None:
+        # "マージ済みです" — affirmative merged assertion acks.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "PR はマージ済みです"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "acked")
+
+    def test_merged_negation_does_not_ack(self) -> None:
+        # "マージ済みではありません" — negation of merged must not ack.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "PR はまだマージ済みではありません"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_colloquial_and_polite_negation_question_do_not_ack(self) -> None:
+        # The clause-scoped guard must reject colloquial negation and
+        # polite question forms, not just the literal ではありません/〜か？.
+        for body in (
+            "マージ済みじゃありません",          # 口語否定
+            "作業は完了しましたでしょうか？",      # 丁寧疑問
+            "PR はマージ済みでしょうか？",         # 丁寧疑問 (merged)
+            "マージ済みか確認します",             # 確認中（疑問助詞 か）
+        ):
+            with self.subTest(body=body):
+                proc = _run({"messages": [{"from_id": "secretary",
+                                            "message": body}]}, attempt=1)
+                self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+                self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_cross_clause_negation_does_not_ack(self) -> None:
+        # "対応は完了しましたが、マージ済みではありません" — the 完了 verb is
+        # affirmative but the SAME sentence (past the read-point 、) negates
+        # the merge. The shared clause-scoped guard spans 、 so neither
+        # 完了 nor マージ済み may ack here.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "対応は完了しましたが、マージ済みではありません"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_affirmative_with_trailing_sentence_still_acks(self) -> None:
+        # The clause-scoped か/negation guard stops at the sentence
+        # terminator, so an affirmative ack followed by an unrelated
+        # question in the NEXT sentence still acks.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "完了しました。次は何をしますか？"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "acked")
+
     # --- --print-initial-prompt mode -----------------------------------
 
     def test_print_initial_prompt(self) -> None:

--- a/tools/dispatcher_retro_gate.py
+++ b/tools/dispatcher_retro_gate.py
@@ -75,7 +75,40 @@ for _stream_name in ("stdout", "stderr", "stdin"):
     except (AttributeError, io.UnsupportedOperation):
         pass
 
-DEFAULT_ACK_PATTERN = r"(届[いきけくこ]|受領|受け取|ack|received|got it)"
+# ``完了`` / ``マージ済み`` are the two completion-phrasing acks added for
+# Issue #584. Both are guarded to fire ONLY on an affirmative assertion,
+# never on a negation/question/noun, so the retro gate keeps its safe-side
+# "completion report not yet received" judgement (a false positive here
+# would wrongly pass the gate; a false negative merely keeps polling).
+#
+# Rather than enumerate every negation/question phrasing, BOTH tokens
+# share one CLAUSE-SCOPED negative lookahead (``_NEG_Q``): the token is
+# rejected if a question 助詞 ``か`` or a negation (``ない`` / ``ありませ``)
+# appears before the next sentence terminator (``。．！？!?`` / newline).
+# ``_CLAUSE`` is that "rest of the current clause" character class — note
+# it spans ``、`` (read-point), so a negation in a later comma-clause of
+# the SAME sentence still suppresses the ack (e.g. "完了しましたが、マージ
+# 済みではありません" stays non-acking).
+#   * ``完了`` matches an affirmative completion ending
+#     (完了しました/した/しています/です/でした/済) — the ending whitelist
+#     already excludes negated verbs (完了していません/完了しません) — and is
+#     additionally NOT inside the noun ``完了報告`` (which appears in
+#     negatives like "完了報告は見当たりません") and NOT ``未完了`` (incomplete).
+#   * ``マージ済み`` matches the bare affirmative form.
+#   * ``_NEG_Q`` then rejects either token when the clause turns it into a
+#     negation or question (マージ済みではありません/じゃありません/でない,
+#     完了しましたか？/完了しましたでしょうか？, マージ済みか確認します).
+# These are deliberately stricter than the bare ``受領``/``届い`` tokens
+# above because the completion wording collides with the gate's own
+# ``完了報告`` prompt noun; erring toward extra polling is the safe side.
+_CLAUSE = r"[^。．！？!?\n]*"
+_NEG_Q = r"(?!" + _CLAUSE + r"(?:か|ない|ありませ))"
+DEFAULT_ACK_PATTERN = (
+    r"(届[いきけくこ]|受領|受け取"
+    r"|マージ済み" + _NEG_Q +
+    r"|(?<!未)完了(?:しました|しています|した(?![いくな])|です|でした|済)" + _NEG_Q +
+    r"|ack|received|got it)"
+)
 
 
 def _now_iso() -> str:


### PR DESCRIPTION
## 背景

Closes #584。broker 運用中、retro gate（委譲の振り返り関門）の ack 自動検出が窓口の完了系文言（「PR マージ済み」「タスク完了」等）を拾えず、`--ack-pattern` での都度上書きが必要だった（実発生: team-metrics-report PR #555 クローズ時）。

## 変更

`tools/dispatcher_retro_gate.py:78` の `DEFAULT_ACK_PATTERN` に「マージ済み」「完了」を追加し、既定で窓口の完了系文言を ack として検出できるようにする。

実装上の設計判断（Codex full レビュー 4 ラウンドで Blocker 検出 → 修正）:
- 裸の「完了」は retro gate 自身のプロンプト名詞「**完了報告**」に部分マッチし、窓口の否定応答「完了報告は見当たりません」を誤 ack して安全判定を壊す Blocker があった。
- 対策として「完了」を肯定終端（完了しました/した/しています/です/でした/済）に限定し、名詞「完了報告」「未完了」を除外。
- 否定・疑問・読点跨ぎ否定を**節スコープ negative lookahead で一括ガード**（「〜ではありません」「〜か？」「完了しましたが、マージ済みではありません」等はいずれも ack しない）。
- ack 検出は既存の `_is_secretary_message` gate で sender=secretary に限定済み。新規追加 2 語のみ厳しめにし、過剰 polling（安全側 false negative）は許容。

## テスト

- `tests/test_dispatcher_retro_gate.py` に 13 ケース追加（肯定 ack / 「完了報告」否定の回帰 / 未完了 / 口語否定 / 丁寧疑問 / コンマ節跨ぎ否定 / 別文疑問後続でも ack 維持）。
- pytest: 26 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)