### PR TITLE
fix(retro-gate): ack guard の edge-case（丁寧否定「ございません」/「か」終端疑問限定）を修正

### DIFF
--- a/tests/test_dispatcher_retro_gate.py
+++ b/tests/test_dispatcher_retro_gate.py
@@ -359,6 +359,8 @@ class DispatcherRetroGateTests(unittest.TestCase):
         # (whose mid-word か the (?<!何)か rule still rejects) does not ack.
         for body in (
             "マージ済みは何か？",                    # terminal 何か question
+            "マージ済みは何か ？",                   # terminal 何か with spacing
+            "マージ済みは何か　？",                  # terminal 何か, full-width space
             "マージ済みにはできかねます",             # polite negation できかね
             "完了しましたとかいう話です",             # hearsay とか, not own completion
         ):

--- a/tests/test_dispatcher_retro_gate.py
+++ b/tests/test_dispatcher_retro_gate.py
@@ -322,6 +322,53 @@ class DispatcherRetroGateTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
         self.assertEqual(_final(proc)["status"], "acked")
 
+    # --- Issue #591: ございません false-positive / 何か false-negative ----
+
+    def test_polite_negation_gozaimasen_does_not_ack(self) -> None:
+        # Regression (Issue #591 BUG-FP): the polite negation ございません
+        # was NOT caught by the old ありませ stem, so an affirmative token
+        # followed by ございません wrongly acked. The negation stem is now
+        # ませ — the shared substring of the whole ません family — so these
+        # negative replies keep polling at a non-final attempt.
+        for body in (
+            "マージ済みではございません",            # merged-negation, polite
+            "完了済みですが報告はございません",        # 完了済 token then ございません
+            "完了報告はございません",                # 完了報告 noun + polite negation
+        ):
+            with self.subTest(body=body):
+                proc = _run({"messages": [{"from_id": "secretary",
+                                            "message": body}]},
+                            attempt=1, max_attempts=3)
+                self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+                self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_affirmative_with_incidental_nanika_acks(self) -> None:
+        # Regression (Issue #591 BUG-FN): an affirmative completion that
+        # merely carries the indefinite 何か ("something") mid-clause was
+        # wrongly suppressed by the blanket か rejection. The (?<!何)か
+        # carve-out lets the real ack through.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "マージ済みですが何か問題あれば連絡します"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "acked")
+
+    def test_kano_negation_and_terminal_nanika_question_do_not_ack(self) -> None:
+        # The 何か carve-out must NOT open a hole: a clause-terminal 何か
+        # question stays suppressed, and a polite-negation 〜できかねます
+        # (whose mid-word か the (?<!何)か rule still rejects) does not ack.
+        for body in (
+            "マージ済みは何か？",                    # terminal 何か question
+            "マージ済みにはできかねます",             # polite negation できかね
+            "完了しましたとかいう話です",             # hearsay とか, not own completion
+        ):
+            with self.subTest(body=body):
+                proc = _run({"messages": [{"from_id": "secretary",
+                                            "message": body}]},
+                            attempt=1, max_attempts=3)
+                self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+                self.assertEqual(_final(proc)["status"], "polling")
+
     # --- --print-initial-prompt mode -----------------------------------
 
     def test_print_initial_prompt(self) -> None:

--- a/tools/dispatcher_retro_gate.py
+++ b/tools/dispatcher_retro_gate.py
@@ -83,7 +83,7 @@ for _stream_name in ("stdout", "stderr", "stdin"):
 #
 # Rather than enumerate every negation/question phrasing, BOTH tokens
 # share one CLAUSE-SCOPED negative lookahead (``_NEG_Q``): the token is
-# rejected if a question 助詞 ``か`` or a negation (``ない`` / ``ありませ``)
+# rejected if a question 助詞 ``か`` or a negation (``ない`` / ``ませ``)
 # appears before the next sentence terminator (``。．！？!?`` / newline).
 # ``_CLAUSE`` is that "rest of the current clause" character class — note
 # it spans ``、`` (read-point), so a negation in a later comma-clause of
@@ -95,14 +95,27 @@ for _stream_name in ("stdout", "stderr", "stdin"):
 #     additionally NOT inside the noun ``完了報告`` (which appears in
 #     negatives like "完了報告は見当たりません") and NOT ``未完了`` (incomplete).
 #   * ``マージ済み`` matches the bare affirmative form.
-#   * ``_NEG_Q`` then rejects either token when the clause turns it into a
-#     negation or question (マージ済みではありません/じゃありません/でない,
-#     完了しましたか？/完了しましたでしょうか？, マージ済みか確認します).
+#   * The negation stem is ``ませ`` (not just the older ``ありませ``):
+#     ``ませ`` is the shared substring of the whole polite-negation
+#     ``ません`` family — ありません / ございません / しません / できません /
+#     見当たりません — so "マージ済みではございません" and "完了済みですが報告
+#     はございません" stay non-acking (Issue #591 false-positive fix). ``ませ``
+#     never occurs in an affirmative continuation (polite affirmative is
+#     ``ます``/``まし`` e.g. しました/します), so broadening it loses no real
+#     ack. ``ない`` still catches plain negation (ではない/していない).
+#   * The question 助詞 ``か`` is rejected ANYWHERE in the clause EXCEPT the
+#     indefinite ``何か`` ("something") when it is NOT clause-terminal. The
+#     ``(?<!何)か`` alternative keeps suppressing マージ済みか確認します
+#     (token-adjacent whether-か), 完了しましたか？, でしょうか？ and incidental
+#     とか/から/かつ (safe-side over-suppression), while a real completion
+#     that merely carries a mid-clause 何か now acks ("マージ済みですが何か
+#     問題あれば連絡します", Issue #591 false-negative fix). A clause-terminal
+#     何か (何か？) is re-rejected as a question via ``何か(?=[。．！？!?]|$)``.
 # These are deliberately stricter than the bare ``受領``/``届い`` tokens
 # above because the completion wording collides with the gate's own
 # ``完了報告`` prompt noun; erring toward extra polling is the safe side.
 _CLAUSE = r"[^。．！？!?\n]*"
-_NEG_Q = r"(?!" + _CLAUSE + r"(?:か|ない|ありませ))"
+_NEG_Q = r"(?!" + _CLAUSE + r"(?:(?<!何)か|何か(?=[。．！？!?\n]|$)|ない|ませ))"
 DEFAULT_ACK_PATTERN = (
     r"(届[いきけくこ]|受領|受け取"
     r"|マージ済み" + _NEG_Q +

--- a/tools/dispatcher_retro_gate.py
+++ b/tools/dispatcher_retro_gate.py
@@ -110,12 +110,16 @@ for _stream_name in ("stdout", "stderr", "stdin"):
 #     とか/から/かつ (safe-side over-suppression), while a real completion
 #     that merely carries a mid-clause 何か now acks ("マージ済みですが何か
 #     問題あれば連絡します", Issue #591 false-negative fix). A clause-terminal
-#     何か (何か？) is re-rejected as a question via ``何か(?=[。．！？!?]|$)``.
+#     何か (何か？, optionally with trailing spaces before the terminator) is
+#     re-rejected as a question via ``何か(?=[ \t　]*(?:[。．！？!?\n]|$))``.
 # These are deliberately stricter than the bare ``受領``/``届い`` tokens
 # above because the completion wording collides with the gate's own
 # ``完了報告`` prompt noun; erring toward extra polling is the safe side.
 _CLAUSE = r"[^。．！？!?\n]*"
-_NEG_Q = r"(?!" + _CLAUSE + r"(?:(?<!何)か|何か(?=[。．！？!?\n]|$)|ない|ませ))"
+_NEG_Q = (
+    r"(?!" + _CLAUSE +
+    r"(?:(?<!何)か|何か(?=[ \t　]*(?:[。．！？!?\n]|$))|ない|ませ))"
+)
 DEFAULT_ACK_PATTERN = (
     r"(届[いきけくこ]|受領|受け取"
     r"|マージ済み" + _NEG_Q +


### PR DESCRIPTION
## 背景

Closes #591。#584/#589 で導入した ack negative-lookahead guard に残っていた edge-case 2 件を修正する。

## 変更

- **丁寧否定「ございません」の誤 ack 解消**: `_NEG_Q` の否定語幹を `ありませ`→`ませ` に拡張。「ません」族（ありません/ございません/しません/見当たりません）の共通部分文字列で一括ガード。肯定の丁寧形（しました/します）は `ます`/`まし` で `ませ` を含まないため本物の ack は失わない。
- **「か」終端疑問限定化で false negative 解消**: clause 全域拒否を `(?<!何)か` に変更し、不定の「何か（=something）」を含む肯定文を ack 可能に。「マージ済みですが何か問題あれば連絡します」が正しく ack。
- **「何か」文末疑問は再拒否**: `何か(?=[空白]*(?:終端|$))` で「マージ済みは何か？」型疑問を非 ack（半角/全角スペース挟み対応）。
- 回帰テスト 3 群追加。既存 #589 テストは全 green 維持（29 tests + 12 subtests pass）。

## 設計判断

「か」全域拒否のまま不定『何か』だけ例外化する最小設計。multi-agent 敵対レビューで「中間か許容」案は『〜とかいう話』『できかねます』を誤 ack することが判明し却下。`から`/`とか` の over-suppress は「迷ったら抑制（再ポーリングは安全側）」というゲート哲学に合致。Codex full 2 ラウンド（R1 Major→修正、R2 Blocker/Major 0）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)