### PR TITLE
build(deps): runtime pin を 0.1.28 に bump（Epic #586 既定 transport フリップを活性化）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.27,<0.2",
+    "claude-org-runtime>=0.1.28,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,21 +26,22 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
-# Floor bumped to 0.1.27 to adopt the broker-native push-first wiring fixes
-# (0.1.27 delegate-plan accepts the broker-native list_panes snapshot,
-# runtime#89; secretary(root) startup path wires org-broker-channel so
-# push-first delivery reaches the secretary too, runtime#90). The 0.1.26 floor
-# (WezTerm Windows fixes — 0.1.25 cli window flicker suppression, runtime#87;
-# 0.1.26 child-pane tab aggregation, runtime#88), the 0.1.24 floor (broker
-# push-first delivery — per-pane channel_sidecar + daemon delivery lifecycle +
-# RECEIVE_MODE=push, PR #24; the runtime surface the ja push-first prose and
-# the contract S3 amendment proposal follow, transport-lab#23/#18), the 0.1.22
-# floor (broker admin surface — admin RPC and the --root-role/--root-cwd flags
-# exercised by broker-dogfood-runbook; ja#565), and the 0.1.17 floor (transport
-# surface descriptor claude_org_runtime.transport consumed by tools/transport.py
-# — Epic #6 next-stage D / ja#513) are subsumed by 0.1.27. Keep in sync with
-# pyproject.toml.
-claude-org-runtime>=0.1.27,<0.2
+# Floor bumped to 0.1.28 to activate the Epic #586 default-transport flip:
+# 0.1.28 ships DEFAULT_TRANSPORT=broker, so with ORG_TRANSPORT unset the ja
+# default flips renga->broker (renga retained as the opt-in fallback). The
+# 0.1.27 floor (broker-native push-first wiring — delegate-plan accepts the
+# broker-native list_panes snapshot, runtime#89; secretary(root) startup wires
+# org-broker-channel so push-first delivery reaches the secretary too,
+# runtime#90), the 0.1.26 floor (WezTerm Windows fixes — 0.1.25 cli window
+# flicker suppression, runtime#87; 0.1.26 child-pane tab aggregation,
+# runtime#88), the 0.1.24 floor (broker push-first delivery — per-pane
+# channel_sidecar + daemon delivery lifecycle + RECEIVE_MODE=push, PR #24), the
+# 0.1.22 floor (broker admin surface — admin RPC and the --root-role/--root-cwd
+# flags exercised by broker-dogfood-runbook; ja#565), and the 0.1.17 floor
+# (transport surface descriptor claude_org_runtime.transport consumed by
+# tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
+# Keep in sync with pyproject.toml.
+claude-org-runtime>=0.1.28,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).

--- a/tests/test_transport_allowlist_consume.py
+++ b/tests/test_transport_allowlist_consume.py
@@ -71,18 +71,25 @@ def _secretary_template_allow() -> list:
 
 
 class RewriteIdentityUnderRenga(unittest.TestCase):
-    """flag=renga (既定) では rewrite_allow_entries が恒等 = bit 等価の核。"""
+    """flag=renga (テンプレ著述面 / opt-in fallback) では rewrite_allow_entries が
+    恒等 = bit 等価の核。恒等の基準はテンプレ著述面 (renga) であって既定 transport
+    ではない (Epic #586 で既定が broker にフリップしても renga 恒等は不変)。"""
 
     def test_explicit_renga_is_identity(self):
         allow = _secretary_template_allow()
         out = t.rewrite_allow_entries(allow, "secretary", flag="renga")
         self.assertEqual(out, allow)
 
-    def test_default_unset_env_is_renga_identity(self):
+    def test_default_unset_env_is_broker_swap(self):
+        # Epic #586: 無設定の既定が broker にフリップしたため、テンプレ (renga 著述)
+        # は broker tier へ付け替えられる (もはや恒等ではない)。恒等は明示 renga
+        # (test_explicit_renga_is_identity) が担保する。
         allow = _secretary_template_allow()
-        with _env_transport(None):  # ORG_TRANSPORT 無設定 = 既定 renga
+        with _env_transport(None):  # ORG_TRANSPORT 無設定 = 既定 broker
             out = t.rewrite_allow_entries(allow, "secretary")
-        self.assertEqual(out, allow)
+        self.assertFalse(any(e.startswith(RENGA_PREFIX) for e in out))
+        broker = [e for e in out if e.startswith(BROKER_PREFIX)]
+        self.assertEqual(broker, t.allow_entries("secretary", flag="broker"))
 
     def test_identity_for_all_org_roles(self):
         # renga ではどのロールでも入力をそのまま返す (per-role 手書きサブセットを
@@ -192,15 +199,17 @@ class OrgSetupPruneBitEquivalence(unittest.TestCase):
             )
         return written["permissions"]["allow"]
 
-    def test_renga_default_generates_template_allow_byte_equivalent(self):
-        # ORG_TRANSPORT 無設定 (既定 renga) → 生成 allow == permissions.md テンプレ。
+    def test_renga_explicit_generates_template_allow_byte_equivalent(self):
+        # ORG_TRANSPORT=renga (opt-in fallback) → 生成 allow == permissions.md
+        # テンプレ (renga 著述面で byte 等価 = 切戻し忠実性)。
         template_allow = _secretary_template_allow()
-        generated = self._write_secretary(None)
+        generated = self._write_secretary("renga")
         self.assertEqual(generated, template_allow)
 
-    def test_renga_explicit_equals_default(self):
+    def test_default_unset_equals_explicit_broker(self):
+        # Epic #586: 無設定の既定が broker にフリップ。明示 broker と生成物が一致。
         self.assertEqual(
-            self._write_secretary("renga"), self._write_secretary(None)
+            self._write_secretary(None), self._write_secretary("broker")
         )
 
     def test_broker_generates_org_broker_allow(self):
@@ -215,9 +224,9 @@ class CheckRoleConfigsTransportAware(unittest.TestCase):
 
     def test_renga_returns_same_object_identity(self):
         rs = {"required_allow": [RENGA_PREFIX + "send_message", RENGA_PREFIX + "list_panes"]}
-        with _env_transport(None):
+        with _env_transport("renga"):  # renga (opt-in fallback): schema を触らない
             out = crc._transport_aware_role_schema("secretary", rs)
-        self.assertIs(out, rs)  # 既定 renga: schema オブジェクトを一切触らない
+        self.assertIs(out, rs)  # renga 恒等: schema オブジェクトを一切触らない
 
     def test_no_required_allow_returns_same_object(self):
         rs = {"settings_paths": ["x"]}
@@ -269,7 +278,7 @@ class CheckRoleConfigsOnDiskBrokerValidation(unittest.TestCase):
         schema, root = self._settings_for("broker")
         sec = {**schema["roles"]["secretary"], "settings_paths": [".claude/settings.local.json"]}
         schema = {**schema, "roles": {**schema["roles"], "secretary": sec}}
-        with _env_transport(None):  # renga 期待
+        with _env_transport("renga"):  # renga 期待 (明示 fallback; 既定は broker)
             findings = crc.check_on_disk(
                 schema, root, include_untracked=True, role_override="secretary"
             )
@@ -281,7 +290,8 @@ class UserCommonAllowlistProjection(unittest.TestCase):
     """user_common (~/.claude/settings.json) の broker 射影 (Option A, §5.3)。
 
     curator / worker / dispatcher が継承する messaging MCP floor を broker 化する
-    経路。**renga は strict no-op (file を 1 byte も書かない)**。
+    経路。**renga (明示) は strict no-op (file を 1 byte も書かない)**。Epic #586 で
+    無設定の既定は broker にフリップしたため、無設定では broker floor を射影する。
     """
 
     _RENGA_SETTINGS = {
@@ -304,16 +314,22 @@ class UserCommonAllowlistProjection(unittest.TestCase):
         p.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
         return p
 
-    def test_renga_is_strict_no_op_file_untouched(self):
+    def test_default_unset_projects_broker_floor(self):
+        # Epic #586: 無設定の既定が broker にフリップしたため、user_common は
+        # broker messaging floor へ射影される (renga 時の strict no-op は
+        # test_renga_explicit_is_no_op が担保)。
         p = self._write_tmp(self._RENGA_SETTINGS)
-        before = p.read_bytes()
-        with _env_transport(None):  # 既定 renga
+        with _env_transport(None):  # ORG_TRANSPORT 無設定 = 既定 broker
             rc = osp.process_user_common_allowlist(
                 settings_path=p, dry_run=False, no_backup=True
             )
         self.assertEqual(rc, 0)
-        # byte 完全一致 (read-modify-write すら起こさない)。
-        self.assertEqual(p.read_bytes(), before)
+        allow = json.loads(p.read_text(encoding="utf-8"))["permissions"]["allow"]
+        self.assertFalse(any(e.startswith(RENGA_PREFIX) for e in allow))
+        broker = [e for e in allow if e.startswith(BROKER_PREFIX)]
+        self.assertEqual(
+            sorted(broker), sorted(t.allow_entries("user_common", flag="broker"))
+        )
 
     def test_renga_explicit_is_no_op(self):
         p = self._write_tmp(self._RENGA_SETTINGS)

--- a/tests/test_transport_seam.py
+++ b/tests/test_transport_seam.py
@@ -89,10 +89,17 @@ def _env_transport(value):
 
 
 class WorkerBriefBitEquivalence(unittest.TestCase):
-    """flag=renga (既定) で worker_brief が golden と byte 一致する。"""
+    """flag=renga (opt-in fallback) で worker_brief が golden と byte 一致し、
+    既定 (無設定) は broker 面を指す (Epic #586 既定フリップ)。
 
-    def test_default_unset_is_bit_equivalent(self):
-        with _env_transport(None):
+    renga golden は切戻し忠実性の不変条件として retain。明示 renga 経路で
+    1 byte も変わらないことを担保しつつ、無設定の既定は broker にフリップした
+    ことを併せて検証する。"""
+
+    def test_explicit_renga_is_bit_equivalent(self):
+        # renga は opt-in fallback として retain。明示時は golden と byte 一致
+        # (切戻し忠実性 / 非破壊の絶対条件は renga 経路で不変)。
+        with _env_transport("renga"):
             for name, self_edit, depth in _BRIEF_CASES:
                 with self.subTest(fixture=name):
                     golden = (FIXTURES / name).read_text(encoding="utf-8")
@@ -102,14 +109,14 @@ class WorkerBriefBitEquivalence(unittest.TestCase):
                         "mcp__renga-peers__send_message", out
                     )
 
-    def test_explicit_renga_matches_default(self):
-        with _env_transport("renga"):
+    def test_default_unset_is_broker_surface(self):
+        # Epic #586: 既定 (ORG_TRANSPORT 無設定) は broker にフリップ。
+        with _env_transport(None):
             for name, self_edit, depth in _BRIEF_CASES:
                 with self.subTest(fixture=name):
-                    golden = (FIXTURES / name).read_text(encoding="utf-8")
-                    self.assertEqual(
-                        gwb.render(_base_config(self_edit, depth)), golden
-                    )
+                    out = gwb.render(_base_config(self_edit, depth))
+                    self.assertIn("mcp__org-broker__send_message", out)
+                    self.assertNotIn("mcp__renga-peers__", out)
 
 
 class WorkerBriefBrokerSurface(unittest.TestCase):
@@ -225,8 +232,18 @@ class DelegateNextStepHintMatchesDescriptor(unittest.TestCase):
                 server = rt_descriptor.get_surface(flag).server
                 self.assertIn(f"{server} send_message call.", hint)
 
-    def test_hint_default_is_renga_byte_for_byte(self):
+    def test_hint_default_is_broker_byte_for_byte(self):
+        # Epic #586: 既定 (無設定) は broker。hint も broker server を指す。
         with _env_transport(None):
+            self.assertEqual(
+                gdp._next_step_hint(),
+                "Next step: copy send_plan.json's `to_id`/`message` into a "
+                "org-broker send_message call.",
+            )
+
+    def test_hint_explicit_renga_byte_for_byte(self):
+        # renga (opt-in fallback) 明示時は renga-peers を指す (切戻し忠実性)。
+        with _env_transport("renga"):
             self.assertEqual(
                 gdp._next_step_hint(),
                 "Next step: copy send_plan.json's `to_id`/`message` into a "
@@ -238,13 +255,16 @@ class JaSeamMatchesRuntimeDescriptor(unittest.TestCase):
     """ja 側 ``tools.transport`` が runtime descriptor と一致 (単一 SoT, no drift)。"""
 
     def test_resolution_order(self):
-        self.assertEqual(t.resolve(env={}), "renga")
+        # Epic #586: 無設定の既定は broker にフリップ。
+        self.assertEqual(t.resolve(env={}), "broker")
+        self.assertEqual(t.resolve(env={t.ENV_KEY: "renga"}), "renga")
         self.assertEqual(t.resolve(env={t.ENV_KEY: "broker"}), "broker")
         # explicit > env (§5.1)
         self.assertEqual(t.resolve("renga", env={t.ENV_KEY: "broker"}), "renga")
 
-    def test_default_is_renga(self):
-        self.assertEqual(t.DEFAULT_TRANSPORT, "renga")
+    def test_default_is_broker(self):
+        # Epic #586: DEFAULT_TRANSPORT が renga→broker にフリップ。
+        self.assertEqual(t.DEFAULT_TRANSPORT, "broker")
         self.assertEqual(t.resolve(env={}), t.DEFAULT_TRANSPORT)
 
     def test_unknown_flag_rejected(self):
@@ -290,12 +310,16 @@ class JaSeamMatchesRuntimeDescriptor(unittest.TestCase):
             "--mcp-config /x/b.json",
         )
 
-    def test_renga_surface_is_current_behavior(self):
-        # 既定 renga の spawn 注入は現行の dev-channel flag (非破壊)。
+    def test_renga_surface_spawn_inject(self):
+        # renga (opt-in fallback) の spawn 注入は dev-channel flag (非破壊)。
         self.assertEqual(
-            t.spawn_inject(env={}),
+            t.spawn_inject(env={t.ENV_KEY: "renga"}),
             "--dangerously-load-development-channels server:renga-peers",
         )
+
+    def test_default_unset_spawn_inject_is_broker(self):
+        # Epic #586: 既定 (無設定) は broker の mcp-config 注入。
+        self.assertEqual(t.spawn_inject(env={}), "--mcp-config <broker>")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/org_setup_prune.py
+++ b/tools/org_setup_prune.py
@@ -713,12 +713,14 @@ def process_user_common_allowlist(
             file=sys.stderr,
         )
         return 2
-    if flag == _transport.DEFAULT_TRANSPORT:
-        # 既定 renga: 不変保証のため file には一切触れない (read もしない)。
+    if flag == _transport.TEMPLATE_TRANSPORT:
+        # renga (テンプレ著述面): 不変保証のため file には一切触れない (read もしない)。
+        # 基準はテンプレ著述面であって既定 transport ではない (Epic #586 で既定が
+        # broker にフリップしても、no-op になるのは renga 解決時のみ)。
         print(
-            "[org_setup_prune] user_common allowlist: transport=renga (既定); "
+            "[org_setup_prune] user_common allowlist: transport=renga; "
             "no-op — ~/.claude/settings.json は不変 (renga allowlist は org-setup "
-            "スキル + permissions.md が SoT)。ORG_TRANSPORT=broker で broker 射影。"
+            "スキル + permissions.md が SoT)。ORG_TRANSPORT 未設定/broker で broker 射影。"
         )
         return 0
 

--- a/tools/transport.py
+++ b/tools/transport.py
@@ -14,12 +14,18 @@ runtime の transport surface descriptor
 モジュール 1 つを経由してそれを読む**。runtime には一切変更を加えず、ja は
 pin (``>=0.1.17``) で consume するだけ。
 
-非破壊の絶対条件 (§5.1 / §5.3):
+解決と既定 (§5.1 / §5.3、Epic #586 で既定フリップ):
 - transport flag の所在は環境変数 ``ORG_TRANSPORT`` (``renga`` | ``broker``)。
-- **既定 (無設定) = ``renga``** で現行と bit 等価 (既存生成物が 1 byte も
-  変わらない)。``broker`` は ``ORG_TRANSPORT=broker`` を明示した時のみ。
-- 解決順は runtime と整合: explicit 引数 > ``ORG_TRANSPORT`` env > 既定 renga。
-- renga 経路は削除せず併存 (opt-in / 切戻し可)。
+- **既定 (無設定) = ``DEFAULT_TRANSPORT``**。runtime 0.1.28 (Epic #586) で
+  ``DEFAULT_TRANSPORT`` が ``renga`` → ``broker`` にフリップしたため、無設定時の
+  既定は ``broker``。``renga`` は ``ORG_TRANSPORT=renga`` を明示した時に選ぶ
+  opt-in fallback として retain される (削除せず併存 / 切戻し可)。
+- 解決順は runtime と整合: explicit 引数 > ``ORG_TRANSPORT`` env > 既定
+  (``DEFAULT_TRANSPORT``)。
+- なお、生成器の付け替え基準は「既定 transport」ではなく
+  **テンプレートの著述面 (``TEMPLATE_TRANSPORT`` = renga)** で固定する
+  (``rewrite_allow_entries`` 参照)。既定が broker になっても、renga テンプレを
+  恒等扱いし broker へは付け替えで導出する不変条件は変わらない。
 """
 from __future__ import annotations
 
@@ -43,8 +49,20 @@ from claude_org_runtime.transport import (  # noqa: F401  (re-export)
 # rename / 削除を黙って取り逃さない (drift 防止, §5.2)。
 _SEND_MESSAGE_TOOL = "send_message"
 
+# ja の on-disk テンプレート (``permissions.md`` の allowlist) と golden fixture は
+# **renga 面 (``mcp__renga-peers__*``) で著述されている**。``rewrite_allow_entries``
+# はこの renga 面を「素材 (identity) 面」とみなし、broker へは renga→broker の
+# 付け替えで導出する。したがって付け替えの基準は **テンプレートの著述面 = renga**
+# であって「既定 transport」ではない。Epic #586 で ``DEFAULT_TRANSPORT`` が
+# renga→broker にフリップしても、テンプレートが renga で書かれている事実は不変
+# なので、この定数を ``DEFAULT_TRANSPORT`` から分離して固定する (両者を混同すると
+# 既定フリップ後に broker 側が恒等 no-op に化ける = #586 で顕在化したバグ)。
+# renga は opt-in fallback として retain されるため ``TRANSPORTS`` から消えない。
+TEMPLATE_TRANSPORT = "renga"
+
 __all__ = [
     "DEFAULT_TRANSPORT",
+    "TEMPLATE_TRANSPORT",
     "ENV_KEY",
     "TRANSPORTS",
     "TransportSurface",
@@ -67,7 +85,8 @@ def resolve(
     """有効な transport flag (``renga`` | ``broker``) を返す。
 
     解決順は runtime の ``transport_allowlist`` と整合: explicit 引数 >
-    ``ORG_TRANSPORT`` env > 既定 ``renga`` (§5.1)。``env=None`` は
+    ``ORG_TRANSPORT`` env > 既定 ``DEFAULT_TRANSPORT`` (§5.1)。Epic #586 で
+    既定は ``renga`` → ``broker`` にフリップ済み。``env=None`` は
     ``os.environ`` を読む。空文字列・未知値は ``ValueError``。
     """
     return resolve_transport(explicit, env=env)
@@ -156,9 +175,10 @@ def allow_entries(
     §5.3 (allowlist の flag-aware 化) の単一 SoT。runtime の
     :func:`claude_org_runtime.settings.generator.transport_allowlist`
     (= descriptor 駆動) を consume する。``flag`` 解決順は他のアクセサと整合:
-    explicit > ``ORG_TRANSPORT`` env > 既定 ``renga``。
+    explicit > ``ORG_TRANSPORT`` env > 既定 ``DEFAULT_TRANSPORT`` (Epic #586 で
+    broker にフリップ済み)。
 
-    既定 ``renga`` では全ロールが required-14 surface
+    ``renga`` では全ロールが required-14 surface
     (``mcp__renga-peers__*``)、``broker`` ではロールの auth tier に応じた
     ``mcp__org-broker__*`` 集合 (worker/curator=4・dispatcher/secretary=ops)
     を返す。未知ロールは broker で messaging tier (4) に落ちる
@@ -181,22 +201,26 @@ def rewrite_allow_entries(
     """allow / required_allow 等の文字列リスト中の renga MCP ブロックを、
     解決した transport の role-tier 集合へ置換して返す。
 
-    **非破壊の核 (§5.3)**: 既定 ``renga`` (``DEFAULT_TRANSPORT``) では
-    **入力をそのまま返す (恒等)** ので、既存の生成物・schema 期待は 1 byte も
-    変わらない (bit 等価)。``broker`` 等の非既定 flag のときだけ、renga の FQ
-    プレフィックス (``mcp__renga-peers__``) で始まるエントリ群を除去し、**最初に
-    現れた位置へ** transport の tier エントリを挿入する。``Bash(...)`` 等の
-    非 MCP エントリは順序を保って残す。
+    **非破壊の核 (§5.3)**: 入力テンプレートの著述面である ``renga``
+    (``TEMPLATE_TRANSPORT``) に解決された場合は **入力をそのまま返す (恒等)** ので、
+    既存の生成物・schema 期待は 1 byte も変わらない (bit 等価)。``broker`` に
+    解決された場合だけ、renga の FQ プレフィックス (``mcp__renga-peers__``) で
+    始まるエントリ群を除去し、**最初に現れた位置へ** transport の tier エントリを
+    挿入する。``Bash(...)`` 等の非 MCP エントリは順序を保って残す。
+
+    付け替えの基準は **テンプレートの著述面 (renga)** であって「既定 transport」
+    ではない。Epic #586 で ``DEFAULT_TRANSPORT`` が broker にフリップしても、
+    恒等扱いになるのは飽くまで ``renga`` 解決時のみ (``broker`` は常に付け替え)。
 
     renga ブロックが 1 つも無いリスト (例: mcp を持たないロールの per-role
-    テンプレート) は非既定 flag でも素通し (tier エントリを勝手に注入しない =
+    テンプレート) は broker でも素通し (tier エントリを勝手に注入しない =
     「renga ブロックの swap」に限定し、無いものは足さない)。
     """
     resolved = resolve(flag, env=env)
-    if resolved == DEFAULT_TRANSPORT:
-        # 既定 renga: 恒等。byte 等価を構造的に保証する。
+    if resolved == TEMPLATE_TRANSPORT:
+        # テンプレ著述面 renga: 恒等。byte 等価を構造的に保証する。
         return list(entries)
-    renga_prefix = surface(DEFAULT_TRANSPORT, env=env).fq_prefix
+    renga_prefix = surface(TEMPLATE_TRANSPORT, env=env).fq_prefix
     tier = allow_entries(role, flag=resolved, env=env)
     out: list = []
     inserted = False


### PR DESCRIPTION
## 概要

Refs #586。claude-org-runtime の pin 下限を 0.1.27→0.1.28 に上げ、**Epic #586 の既定 transport フリップ（ORG_TRANSPORT 無設定時 renga→broker）を活性化**する。renga は opt-in fallback として保持（削除せず）。これは #586 計画の PR-2（コア）に相当。

## 変更（3 点）

1. **pin bump**: `pyproject.toml` + `requirements.txt`（0.1.27→0.1.28、窓/形式は踏襲・下限のみ）。
2. **潜在バグ修正（重要）**: `tools/transport.py` の `rewrite_allow_entries` と `tools/org_setup_prune.py` が「恒等（=書き換えない）分岐」を `DEFAULT_TRANSPORT` を renga の代理として判定していた。既定が broker にフリップした瞬間、broker 側が誤って no-op 化（allowlist が broker 面へ射替わらない）しテストも赤化。`TEMPLATE_TRANSPORT="renga"`（テンプレ/golden の著述面）定数を導入し恒等判定をそれに付け替えて修正。**この修正が無いと flip は機能しない。**
3. **テスト期待反転**: 無設定=renga 前提の期待を broker へ反転（DEFAULT_TRANSPORT / resolve / spawn_inject / next-step hint / worker_brief 面 / allowlist 射影）。併せて「明示 `ORG_TRANSPORT=renga` は golden と byte 等価」の回帰テストを追加（切戻し忠実性を担保）。

## スコープ（#586 計画準拠）

- 本 PR = PR-2 コア（pin + テスト反転 + latent バグ修正）のみ。
- **prose 反転（README / docs / CLAUDE.md / skills）= PR-3、tool docstring 一括 = PR-4 は別 PR**（revert 粒度を分ける設計）。contract amendment #588 は proposed/未 ratify のため、prose の全面反転は本 PR に含めない。
- org-start L66 の echo default は今回スコープ外（cosmetic）。

## 検証

full suite 1083 passed / 4 skipped。Codex セルフレビュー（本コミット対象）Blocker/Major/Minor/Nit すべてゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)