### PR TITLE
fix(claude): #594 retro gate の否定文誤 ack を _NEG_Q ガードで解消

### DIFF
--- a/tests/test_dispatcher_retro_gate.py
+++ b/tests/test_dispatcher_retro_gate.py
@@ -371,6 +371,44 @@ class DispatcherRetroGateTests(unittest.TestCase):
                 self.assertEqual(proc.returncode, 4, msg=proc.stderr)
                 self.assertEqual(_final(proc)["status"], "polling")
 
+    # --- Issue #594: _NEG_Q guard on the bare 届い/受領/受け取 tokens ------
+
+    def test_received_token_negation_does_not_ack(self) -> None:
+        # Regression (Issue #594): the receipt tokens 届い/受領/受け取 were
+        # bare (no _NEG_Q guard), so a negative reply that contains one of
+        # them in a negation clause wrongly acked — falsely passing the
+        # gate while the completion report is actually NOT yet received.
+        # The guarded form must keep polling at a non-final attempt.
+        for body in (
+            "完了報告はまだ届いておりません",        # 届い + polite negation
+            "完了報告はまだ届いていません",          # 届い + plain polite negation
+            "まだ受領しておりません",                # 受領 + polite negation
+            "まだ受領していません",                  # 受領 + plain polite negation
+            "完了報告を受け取っていません",          # 受け取 + negation
+            "完了報告は届いていますか？",            # 届い + question 助詞 か
+        ):
+            with self.subTest(body=body):
+                proc = _run({"messages": [{"from_id": "secretary",
+                                            "message": body}]},
+                            attempt=1, max_attempts=3)
+                self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+                self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_received_token_affirmative_still_acks(self) -> None:
+        # The _NEG_Q guard must not regress the affirmative receipt acks:
+        # plain "届きました" / "受領しました" / "受け取りました" still pass.
+        for body in (
+            "完了報告が届きました",                  # 届き affirmative
+            "完了報告は届いています",                # 届い affirmative
+            "完了報告を受領しました",                # 受領 affirmative
+            "完了報告を受け取りました",              # 受け取 affirmative
+        ):
+            with self.subTest(body=body):
+                proc = _run({"messages": [{"from_id": "secretary",
+                                            "message": body}]}, attempt=1)
+                self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+                self.assertEqual(_final(proc)["status"], "acked")
+
     # --- --print-initial-prompt mode -----------------------------------
 
     def test_print_initial_prompt(self) -> None:

--- a/tools/dispatcher_retro_gate.py
+++ b/tools/dispatcher_retro_gate.py
@@ -75,14 +75,19 @@ for _stream_name in ("stdout", "stderr", "stdin"):
     except (AttributeError, io.UnsupportedOperation):
         pass
 
-# ``完了`` / ``マージ済み`` are the two completion-phrasing acks added for
-# Issue #584. Both are guarded to fire ONLY on an affirmative assertion,
-# never on a negation/question/noun, so the retro gate keeps its safe-side
-# "completion report not yet received" judgement (a false positive here
-# would wrongly pass the gate; a false negative merely keeps polling).
+# Every receipt/completion-phrasing ack token — ``届い`` / ``受領`` /
+# ``受け取`` (the receipt tokens) and ``完了`` / ``マージ済み`` (the
+# completion-phrasing tokens added for Issue #584) — is guarded to fire
+# ONLY on an affirmative assertion, never on a negation/question/noun, so
+# the retro gate keeps its safe-side "completion report not yet received"
+# judgement (a false positive here would wrongly pass the gate; a false
+# negative merely keeps polling). The receipt tokens were originally bare
+# (no guard), which let a negative reply like "完了報告はまだ届いており
+# ません" wrongly ack on the unguarded ``届い`` — Issue #594 fixes that by
+# extending the same ``_NEG_Q`` guard to all of them.
 #
-# Rather than enumerate every negation/question phrasing, BOTH tokens
-# share one CLAUSE-SCOPED negative lookahead (``_NEG_Q``): the token is
+# Rather than enumerate every negation/question phrasing, EVERY token
+# shares one CLAUSE-SCOPED negative lookahead (``_NEG_Q``): the token is
 # rejected if a question 助詞 ``か`` or a negation (``ない`` / ``ませ``)
 # appears before the next sentence terminator (``。．！？!?`` / newline).
 # ``_CLAUSE`` is that "rest of the current clause" character class — note
@@ -112,16 +117,21 @@ for _stream_name in ("stdout", "stderr", "stdin"):
 #     問題あれば連絡します", Issue #591 false-negative fix). A clause-terminal
 #     何か (何か？, optionally with trailing spaces before the terminator) is
 #     re-rejected as a question via ``何か(?=[ \t　]*(?:[。．！？!?\n]|$))``.
-# These are deliberately stricter than the bare ``受領``/``届い`` tokens
-# above because the completion wording collides with the gate's own
-# ``完了報告`` prompt noun; erring toward extra polling is the safe side.
+# The completion-phrasing tokens are additionally strict (未-prefix /
+# 完了報告-noun exclusions) because the completion wording collides with
+# the gate's own ``完了報告`` prompt noun; the receipt tokens carry the
+# same clause-scoped ``_NEG_Q`` guard so a negated 届い/受領/受け取 (e.g.
+# "まだ受領しておりません") also keeps polling. Erring toward extra polling
+# is the safe side for all of them.
 _CLAUSE = r"[^。．！？!?\n]*"
 _NEG_Q = (
     r"(?!" + _CLAUSE +
     r"(?:(?<!何)か|何か(?=[ \t　]*(?:[。．！？!?\n]|$))|ない|ませ))"
 )
 DEFAULT_ACK_PATTERN = (
-    r"(届[いきけくこ]|受領|受け取"
+    r"(届[いきけくこ]" + _NEG_Q +
+    r"|受領" + _NEG_Q +
+    r"|受け取" + _NEG_Q +
     r"|マージ済み" + _NEG_Q +
     r"|(?<!未)完了(?:しました|しています|した(?![いくな])|です|でした|済)" + _NEG_Q +
     r"|ack|received|got it)"


### PR DESCRIPTION
## 概要
`tools/dispatcher_retro_gate.py` の `DEFAULT_ACK_PATTERN` で、裸だった受領系トークン `届[いきけくこ]` / `受領` / `受け取` に、既存の `マージ済み`・`完了` と同一の clause-scoped 否定ガード `_NEG_Q` を各トークン個別に適用。「完了報告はまだ届いておりません」のような否定文が裸の `届い` 部分マッチで誤 ack され retro gate を不正通過していた false positive を解消。肯定文（届きました / 受領しました / 受け取りました）は従来どおり ack。

## 検証
- `python3 -m unittest tests.test_dispatcher_retro_gate` で 31 件全 green（既存 29 + 否定/肯定 回帰 2 追加）。実バグ文が exit 4(polling) を返すことを直接確認。
- Codex ゲート: 1 ラウンド → No Blocker/Major findings。

軽量レーン（subagent 直処理 + Codex in-loop）で実装。

Closes #594