### PR TITLE
docs(claude): worker brief テンプレに生成物 prose の drift 再発防止注記を追加

### DIFF
--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -89,7 +89,7 @@ probe / 検証 / fuzzing 系タスク（sandbox 探索・hook 動作確認・フ
 実装の目安:
 1. **着手時に生成物か実測**: `grep <編集対象ファイルのパス> tools/skill_src/manifest.json` を実行する。manifest の `output` にヒットすればそのファイルは生成物（生成元あり）。ヒットしなければ手保守ファイルなので直接編集してよい
 2. **生成物なら生成元を編集**: ヒットした場合は対応する `source`（`.md.in` / fragment 側）を編集する。生成物本体（`output` 側の `.md`）は直接編集しない
-3. **drift ゼロを確認**: 編集後に `python3 tools/gen_skill_prose.py --check` を実行し、生成元と生成物が一致（drift ゼロ）していることを確認してから完了報告する
+3. **drift ゼロを確認**: 編集後に `python3 tools/gen_skill_prose.py --manifest tools/skill_src/manifest.json --check` を実行し、生成元と生成物が一致（drift ゼロ、exit 0）していることを確認してから完了報告する（`--manifest` を省くと「nothing to do」で何も検査せず exit 0 になり、ゲートが no-op になる点に注意）
 
 背景: 過去に生成物 prose を直接編集して生成元との drift を生む事故を複数回踏んでいる。生成元から render し直して `--check` で照合することで再発を防ぐ。
 

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -82,6 +82,17 @@ probe / 検証 / fuzzing 系タスク（sandbox 探索・hook 動作確認・フ
 
 背景: 過去 probe タスクで `cat ~/.config/gh/hosts.yml` の実 oauth_token を dispatcher stdout に露出した事故あり。probe 系タスクは「読み取りそのもの」が攻撃面になるため、testbed への切替を実行前ゲートとして強制する。
 
+## 生成物 prose（生成元あり）の編集タスク
+
+編集対象に `.dispatcher/` または `.claude/skills/` 配下の prose ファイル（`.md` 等）を含む場合、**そのファイルが生成物（生成元から自動生成される output）かどうかを着手時に実測してから編集する**。生成物本体を直接編集すると、次回の生成で上書きされ変更が消える（drift）。
+
+実装の目安:
+1. **着手時に生成物か実測**: `grep <編集対象ファイルのパス> tools/skill_src/manifest.json` を実行する。manifest の `output` にヒットすればそのファイルは生成物（生成元あり）。ヒットしなければ手保守ファイルなので直接編集してよい
+2. **生成物なら生成元を編集**: ヒットした場合は対応する `source`（`.md.in` / fragment 側）を編集する。生成物本体（`output` 側の `.md`）は直接編集しない
+3. **drift ゼロを確認**: 編集後に `python3 tools/gen_skill_prose.py --check` を実行し、生成元と生成物が一致（drift ゼロ）していることを確認してから完了報告する
+
+背景: 過去に生成物 prose を直接編集して生成元との drift を生む事故を複数回踏んでいる。生成元から render し直して `--check` で照合することで再発を防ぐ。
+
 ## Codex セルフレビュー手順
 
 派遣指示に**必ず含まれる「検証深度」行**（`full` または `minimal`）に従うこと。指示に値が無い・不明瞭な場合は勝手に決めず窓口（`secretary`）に確認すること。

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -89,7 +89,8 @@ probe / 検証 / fuzzing 系タスク（sandbox 探索・hook 動作確認・フ
 実装の目安:
 1. **着手時に生成物か実測**: `grep <編集対象ファイルのパス> tools/skill_src/manifest.json` を実行する。manifest の `output` にヒットすればそのファイルは生成物（生成元あり）。ヒットしなければ手保守ファイルなので直接編集してよい
 2. **生成物なら生成元を編集**: ヒットした場合は対応する `source`（`.md.in` / fragment 側）を編集する。生成物本体（`output` 側の `.md`）は直接編集しない
-3. **drift ゼロを確認**: 編集後に `python3 tools/gen_skill_prose.py --manifest tools/skill_src/manifest.json --check` を実行し、生成元と生成物が一致（drift ゼロ、exit 0）していることを確認してから完了報告する（`--manifest` を省くと「nothing to do」で何も検査せず exit 0 になり、ゲートが no-op になる点に注意）
+3. **生成元から再生成**: 編集後に `python3 tools/gen_skill_prose.py --manifest tools/skill_src/manifest.json`（`--check` なし）を実行して生成物（`output` 側の `.md`）を render し直し、生成元と生成物の **両方を commit する**（`--check` は照合のみで output を書き換えないため、再生成を省くと生成物が stale なまま残る）
+4. **drift ゼロを確認**: 最後に `python3 tools/gen_skill_prose.py --manifest tools/skill_src/manifest.json --check` を実行し、生成元と生成物が一致（drift ゼロ、exit 0）していることを確認してから完了報告する（`--manifest` を省くと「nothing to do」で何も検査せず exit 0 になり、ゲートが no-op になる点に注意）
 
 背景: 過去に生成物 prose を直接編集して生成元との drift を生む事故を複数回踏んでいる。生成元から render し直して `--check` で照合することで再発を防ぐ。
 


### PR DESCRIPTION
## 概要
worker brief テンプレ `.claude/skills/org-delegate/references/worker-claude-template.md` に、**生成物 prose（生成元あり）を編集対象に含むタスク向けの定型注記**を追加。#603・#604 で 2 回連続して踏んだ「生成物 `.md` を直接編集 → 次回生成で上書き（drift）→ Codex P1」の再発を防ぐ（curator 提案）。

## 追加した注記（常時表示の条件付き）
編集対象に `.dispatcher/` または `.claude/skills/` 配下の prose を含む場合の 4 step:
1. 着手時に `grep <file> tools/skill_src/manifest.json` で生成物か実測
2. 生成物なら `source`（`.md.in`/fragment）側を編集
3. `gen_skill_prose.py --manifest ...`（`--check` なし）で再生成し生成元・生成物を両方 commit
4. `--manifest ... --check` で drift ゼロ（exit 0）を確認

## 設計判断
- 配置: 「常時表示の条件付き注記」（worker が編集対象パスで自己判定）。gen_delegate_payload への対象パス解析注入は不採用（実装単純・監査容易）。
- Codex P2 反映: (a) `--check` は `--manifest` 省略時 no-op → 明示必須を注記、(b) 生成元編集後は `--check` だけだと output が stale → 再生成 step を独立化。

## 検証
- Codex `exec review --base main` 3 ラウンド → Blocker/Major ゼロ
- 編集対象 worker-claude-template.md は hand-maintained（manifest 未登録）を実測確認

Closes #612