### PR TITLE
fix(claude): dispatcher-resume の /loop 3m 自己再帰を恒久対策

### DIFF
--- a/.claude/skills/dispatcher-resume/SKILL.md
+++ b/.claude/skills/dispatcher-resume/SKILL.md
@@ -51,6 +51,60 @@ allowed-tools:
 >
 > `new_tab` / `focus_pane` は broker surface に**無い**（意図的除外）。契約面の正本は [`docs/contracts/backend-interface-contract.md`](../../../docs/contracts/backend-interface-contract.md) Surface 8 + push-primary amendment（broker push 一次が **既定の契約**、pull は fallback として retain）。**opt-in `renga` は削除せず常時有効な切戻しの安全装置**として維持する。broker 実走（dogfood）は Epic #6 Issue G スコープで本ファイルの既定運用経路ではない（**二フレーム注記（Refs #604）**: ここの「既定 `broker`」は**コード既定**（`tools/transport.py: DEFAULT_TRANSPORT`、生成面はこれで render）。**運用既定**は broker dogfood が Epic #6 Issue G まで未活性のため `renga` で、両者は指す対象が異なり矛盾しない。総説は root [`CLAUDE.md`](../../../CLAUDE.md)。）
 
+## Step 0 の前: 残存 loop 予約 / stale 再発火ガード（重複起動の早期遮断）
+
+`/dispatcher-resume` は **handover を 1 回だけ消費する one-shot** である（Step 7 で
+`.state/dispatcher-handover.md` を `.consumed.md` に rename する）。だが Step 5 で起動する
+`/loop 3m` の予約が、過去のバグや手動操作で `/dispatcher-resume` 自身を反復対象に握って
+いると、監視サイクルのたびに本 skill が再発火する。この **stale 再発火 / 重複起動** を
+Step 0 に入る前に遮断する（恒久対策の経緯は
+[`knowledge/raw/2026-06-19-dispatcher-resume-loop-recursion.md`](../../../knowledge/raw/2026-06-19-dispatcher-resume-loop-recursion.md)）。
+
+1. live / consumed の handover 状態を **存在ベース**で判定する（`now` との時刻比較に
+   依存しない。cold-start vs resume の分岐が live `.md` のみを対象とする
+   `.dispatcher/CLAUDE.md` の規約と揃える）:
+   ```bash
+   python3 -c "
+   import os
+   md = '../.state/dispatcher-handover.md'
+   cm = '../.state/dispatcher-handover.consumed.md'
+   if os.path.exists(md):
+       print('resume')            # 正規の resume: live handover あり
+   elif os.path.exists(cm):
+       print('already_consumed')  # 既に消費済み: 残存 loop / 重複起動の疑い
+   else:
+       print('no_handover')       # handover が一度も無い: 真の cold-start 候補
+   "
+   ```
+2. **`already_consumed`（live `.md` なし・`.consumed.md` あり）**: live handover が無い
+   resume 起動だが `.consumed.md` が残っている。これは「(i) 直前に成功した resume の残存
+   loop 予約による再発火 / 重複起動（組織は健全・監視ループ稼働中）」か「(ii) 組織が止まって
+   いて本来 cold-start が要る状況での誤起動」のいずれか。**存在判定だけで no-op に倒すと (ii)
+   の cold-start 案内を恒久的に隠す**ので、監視対象が実際に live かを観測して分岐する:
+   - `mcp__org-broker__list_panes` / `mcp__org-broker__list_peers` で **監視対象が live か**を確認する: active な
+     worker ペイン（`role == "worker"`）が 1 つ以上ある、または
+     `.state/dispatcher/curate-inflight.json` が存在する（= 監視ループが回っているべき状態）。
+   - **(i) 監視対象が live = stale 再発火 / 重複起動**: 組織は健全で cold-start 不要。
+     `DISPATCHER_RESUME_FAILED` を **送らず**（誤った `/org-start` 案内を出さない）、
+     Step 1 以降に進まず早期 exit する。**残存予約を空のまま放置しない**: 監視 `/loop` が
+     `/dispatcher-resume` を反復対象に握っている兆候があれば、Step 5 の monitoring 専用
+     ディレクティブ（INVARIANT(loop-prompt) 準拠の `/loop 3m ...`）で loop を明示的に再 arm
+     して予約を上書きする（重複起動はしない＝単一 loop に収束）。既に monitoring ディレクティブ
+     で回っていれば当該サイクルは **no-op heartbeat**（何も出力しない）。どちらの分岐でも予約を
+     skill 自身に握らせたまま放置しない。再発火の事実だけ journal に残す:
+     ```bash
+     bash ../tools/journal_append.sh anomaly_observed \
+         source=dispatcher_resume worker=dispatcher kind=stale_loop_refire confidence=n/a \
+         note=handover_already_consumed
+     ```
+   - **(ii) 監視対象が無い = 本来 cold-start が要る誤起動**: stale 再発火ではない。no-op に
+     倒さず **Step 1 の「handover ファイルなし」分岐へフォールスルーし `DISPATCHER_RESUME_FAILED`
+     → cold-start 案内を出す**（cold-start 案内を隠さない）。
+3. **`resume`（live `.md` あり）**: 通常どおり Step 0 へ進む。
+4. **`no_handover`（live `.md` も `.consumed.md` も無し）**: 通常どおり Step 0 → Step 1 へ
+   進み、Step 1 の「handover ファイルなし」分岐で `DISPATCHER_RESUME_FAILED` → cold-start
+   案内に落ちる。
+
 ## Step 0: 自分の identity を確認する
 
 1. `mcp__org-broker__set_summary` で「Dispatcher: 監視（resumed）」をセット
@@ -159,10 +213,21 @@ secretary に **報告して** 判断を仰ぐ（勝手に再 spawn / status 変
    active worker dirs が非空、**または `curate-inflight.json` が存在する**
    （1 の再生成分を含む。オンデマンド curate の完了監視が引き継ぎ対象。
    `.dispatcher/references/worker-monitoring.md` Step 5.3）のいずれかを満たせば
-   `/loop 3m` で worker monitoring を再開する:
+   下記の monitoring 専用ディレクティブを渡して `/loop 3m` で worker monitoring を
+   再開する（**prompt を省略しない**）:
+
+<!--
+INVARIANT(loop-prompt): `/loop` の prompt 引数に skill 自身（`/dispatcher-resume`）や
+他のスラッシュコマンドを渡さない。skill 実行ターン内で prompt を省略して `/loop` を
+起動すると、反復対象としてアクティブな slash command が捕捉され、本 skill が 3 分ごとに
+自己再帰する（2026-06-19 incident。詳細は
+knowledge/raw/2026-06-19-dispatcher-resume-loop-recursion.md）。必ず monitoring 専用の
+自然文ディレクティブを明示的に渡すこと。tests/test_dispatcher_resume_loop_invariant.py が
+この不変条件を pin する。
+-->
 
 ```
-/loop 3m
+/loop 3m references/worker-monitoring.md（ディスパッチャー cwd .dispatcher/ 基準）の「監視ループ 1 サイクル」を 1 回だけ実行する（poll_events → check_messages → list_panes → inspect_pane → stall / relay-gap / pane_output 評価）。anomaly / stall / relay-gap / pane_exited を検出したサイクルのみ secretary へ通知し、検出が無ければ何も出力しない（毎サイクルの状況サマリや自然言語の状況描写を書かない）。cadence は 3 分以上を保ち短縮しない。スラッシュコマンドや本 skill を反復対象にしない。
 ```
 
 - 監視ループの 1 サイクル目で `mcp__org-broker__poll_events` は
@@ -231,3 +296,6 @@ bash ../tools/journal_append.sh dispatcher_resumed \
 - handover の内容と state.db の現状が食い違うときに、勝手にどちらかへ寄せる
   （必ず secretary に報告して判断を仰ぐ）
 - atomic 更新を分割して書く（必ず `StateWriter.transaction()` 1 ブロックで完結させる）
+- Step 5 の `/loop 3m` を prompt 省略で起動する / `/dispatcher-resume`（本 skill 自身）や
+  他のスラッシュコマンドを `/loop` の反復対象に渡す（skill が 3 分ごとに自己再帰する。
+  必ず monitoring 専用ディレクティブを明示的に渡す。Step 5 の INVARIANT(loop-prompt) 参照）

--- a/.claude/skills/dispatcher-resume/SKILL.md.in
+++ b/.claude/skills/dispatcher-resume/SKILL.md.in
@@ -45,6 +45,60 @@ allowed-tools:
 
 {{> dual-system-header-short }}
 
+## Step 0 の前: 残存 loop 予約 / stale 再発火ガード（重複起動の早期遮断）
+
+`/dispatcher-resume` は **handover を 1 回だけ消費する one-shot** である（Step 7 で
+`.state/dispatcher-handover.md` を `.consumed.md` に rename する）。だが Step 5 で起動する
+`/loop 3m` の予約が、過去のバグや手動操作で `/dispatcher-resume` 自身を反復対象に握って
+いると、監視サイクルのたびに本 skill が再発火する。この **stale 再発火 / 重複起動** を
+Step 0 に入る前に遮断する（恒久対策の経緯は
+[`knowledge/raw/2026-06-19-dispatcher-resume-loop-recursion.md`](../../../knowledge/raw/2026-06-19-dispatcher-resume-loop-recursion.md)）。
+
+1. live / consumed の handover 状態を **存在ベース**で判定する（`now` との時刻比較に
+   依存しない。cold-start vs resume の分岐が live `.md` のみを対象とする
+   `.dispatcher/CLAUDE.md` の規約と揃える）:
+   ```bash
+   python3 -c "
+   import os
+   md = '../.state/dispatcher-handover.md'
+   cm = '../.state/dispatcher-handover.consumed.md'
+   if os.path.exists(md):
+       print('resume')            # 正規の resume: live handover あり
+   elif os.path.exists(cm):
+       print('already_consumed')  # 既に消費済み: 残存 loop / 重複起動の疑い
+   else:
+       print('no_handover')       # handover が一度も無い: 真の cold-start 候補
+   "
+   ```
+2. **`already_consumed`（live `.md` なし・`.consumed.md` あり）**: live handover が無い
+   resume 起動だが `.consumed.md` が残っている。これは「(i) 直前に成功した resume の残存
+   loop 予約による再発火 / 重複起動（組織は健全・監視ループ稼働中）」か「(ii) 組織が止まって
+   いて本来 cold-start が要る状況での誤起動」のいずれか。**存在判定だけで no-op に倒すと (ii)
+   の cold-start 案内を恒久的に隠す**ので、監視対象が実際に live かを観測して分岐する:
+   - `{{FQ}}list_panes` / `{{FQ}}list_peers` で **監視対象が live か**を確認する: active な
+     worker ペイン（`role == "worker"`）が 1 つ以上ある、または
+     `.state/dispatcher/curate-inflight.json` が存在する（= 監視ループが回っているべき状態）。
+   - **(i) 監視対象が live = stale 再発火 / 重複起動**: 組織は健全で cold-start 不要。
+     `DISPATCHER_RESUME_FAILED` を **送らず**（誤った `/org-start` 案内を出さない）、
+     Step 1 以降に進まず早期 exit する。**残存予約を空のまま放置しない**: 監視 `/loop` が
+     `/dispatcher-resume` を反復対象に握っている兆候があれば、Step 5 の monitoring 専用
+     ディレクティブ（INVARIANT(loop-prompt) 準拠の `/loop 3m ...`）で loop を明示的に再 arm
+     して予約を上書きする（重複起動はしない＝単一 loop に収束）。既に monitoring ディレクティブ
+     で回っていれば当該サイクルは **no-op heartbeat**（何も出力しない）。どちらの分岐でも予約を
+     skill 自身に握らせたまま放置しない。再発火の事実だけ journal に残す:
+     ```bash
+     bash ../tools/journal_append.sh anomaly_observed \
+         source=dispatcher_resume worker=dispatcher kind=stale_loop_refire confidence=n/a \
+         note=handover_already_consumed
+     ```
+   - **(ii) 監視対象が無い = 本来 cold-start が要る誤起動**: stale 再発火ではない。no-op に
+     倒さず **Step 1 の「handover ファイルなし」分岐へフォールスルーし `DISPATCHER_RESUME_FAILED`
+     → cold-start 案内を出す**（cold-start 案内を隠さない）。
+3. **`resume`（live `.md` あり）**: 通常どおり Step 0 へ進む。
+4. **`no_handover`（live `.md` も `.consumed.md` も無し）**: 通常どおり Step 0 → Step 1 へ
+   進み、Step 1 の「handover ファイルなし」分岐で `DISPATCHER_RESUME_FAILED` → cold-start
+   案内に落ちる。
+
 ## Step 0: 自分の identity を確認する
 
 1. `{{FQ}}set_summary` で「Dispatcher: 監視（resumed）」をセット
@@ -153,10 +207,21 @@ secretary に **報告して** 判断を仰ぐ（勝手に再 spawn / status 変
    active worker dirs が非空、**または `curate-inflight.json` が存在する**
    （1 の再生成分を含む。オンデマンド curate の完了監視が引き継ぎ対象。
    `.dispatcher/references/worker-monitoring.md` Step 5.3）のいずれかを満たせば
-   `/loop 3m` で worker monitoring を再開する:
+   下記の monitoring 専用ディレクティブを渡して `/loop 3m` で worker monitoring を
+   再開する（**prompt を省略しない**）:
+
+<!--
+INVARIANT(loop-prompt): `/loop` の prompt 引数に skill 自身（`/dispatcher-resume`）や
+他のスラッシュコマンドを渡さない。skill 実行ターン内で prompt を省略して `/loop` を
+起動すると、反復対象としてアクティブな slash command が捕捉され、本 skill が 3 分ごとに
+自己再帰する（2026-06-19 incident。詳細は
+knowledge/raw/2026-06-19-dispatcher-resume-loop-recursion.md）。必ず monitoring 専用の
+自然文ディレクティブを明示的に渡すこと。tests/test_dispatcher_resume_loop_invariant.py が
+この不変条件を pin する。
+-->
 
 ```
-/loop 3m
+/loop 3m references/worker-monitoring.md（ディスパッチャー cwd .dispatcher/ 基準）の「監視ループ 1 サイクル」を 1 回だけ実行する（poll_events → check_messages → list_panes → inspect_pane → stall / relay-gap / pane_output 評価）。anomaly / stall / relay-gap / pane_exited を検出したサイクルのみ secretary へ通知し、検出が無ければ何も出力しない（毎サイクルの状況サマリや自然言語の状況描写を書かない）。cadence は 3 分以上を保ち短縮しない。スラッシュコマンドや本 skill を反復対象にしない。
 ```
 
 - 監視ループの 1 サイクル目で `{{FQ}}poll_events` は
@@ -225,3 +290,6 @@ bash ../tools/journal_append.sh dispatcher_resumed \
 - handover の内容と state.db の現状が食い違うときに、勝手にどちらかへ寄せる
   （必ず secretary に報告して判断を仰ぐ）
 - atomic 更新を分割して書く（必ず `StateWriter.transaction()` 1 ブロックで完結させる）
+- Step 5 の `/loop 3m` を prompt 省略で起動する / `/dispatcher-resume`（本 skill 自身）や
+  他のスラッシュコマンドを `/loop` の反復対象に渡す（skill が 3 分ごとに自己再帰する。
+  必ず monitoring 専用ディレクティブを明示的に渡す。Step 5 の INVARIANT(loop-prompt) 参照）

--- a/tests/test_dispatcher_resume_loop_invariant.py
+++ b/tests/test_dispatcher_resume_loop_invariant.py
@@ -1,0 +1,111 @@
+"""dispatcher-resume の /loop 再帰防止 invariant をピンするテスト。
+
+背景: ``knowledge/raw/2026-06-19-dispatcher-resume-loop-recursion.md``
+
+``/dispatcher-resume`` の Step 5 が ``/loop 3m`` を prompt 省略のまま skill 実行
+ターン内で起動すると、loop の反復対象としてアクティブな slash command
+(= ``/dispatcher-resume`` 自身) が捕捉され、skill が 3 分ごとに自己再帰する。
+本テストはその再発を機械的に防ぐ:
+
+- ``/loop`` の反復対象 (prompt) は slash command であってはならない。
+- ``/loop`` のコマンド行に skill 自身 (``/dispatcher-resume``) を名指ししない。
+- ``/loop`` は worker-monitoring を指す monitoring 専用ディレクティブで arm する。
+- invariant が SKILL.md(.in) にコメントとして明文化されている。
+
+SoT は ``SKILL.md.in``、``SKILL.md`` は ``tools/gen_skill_prose.py`` の生成物。
+両方を検査して source と rendered が同じ不変条件を満たすことを保証する。
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "dispatcher-resume"
+SKILL_SRC = SKILL_DIR / "SKILL.md.in"
+SKILL_OUT = SKILL_DIR / "SKILL.md"
+
+INVARIANT_MARKER = "INVARIANT(loop-prompt)"
+_INTERVAL_RE = re.compile(r"^\d+[smh]$")
+
+
+def _fenced_loop_command_lines(text: str) -> list[str]:
+    """fenced code block 内で ``/loop`` から始まる行 (= リテラルの起動コマンド) を返す。
+
+    prose や HTML コメント中の ``/loop`` 言及は対象外 (実際に dispatcher が打つ
+    コマンドだけを検査する)。
+    """
+    out: list[str] = []
+    in_fence = False
+    for raw in text.splitlines():
+        if raw.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence and raw.strip().startswith("/loop"):
+            out.append(raw.strip())
+    return out
+
+
+def _loop_prompt(line: str) -> str:
+    """``/loop [interval] <prompt>`` の <prompt> 部分を取り出す。"""
+    rest = line[len("/loop"):].strip()
+    parts = rest.split(None, 1)
+    if parts and _INTERVAL_RE.match(parts[0]):
+        return parts[1].strip() if len(parts) > 1 else ""
+    return rest
+
+
+class DispatcherResumeLoopInvariant(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(SKILL_SRC.exists(), f"missing {SKILL_SRC}")
+        self.assertTrue(SKILL_OUT.exists(), f"missing {SKILL_OUT}")
+        self.files = {
+            "SKILL.md.in": SKILL_SRC.read_text(encoding="utf-8"),
+            "SKILL.md": SKILL_OUT.read_text(encoding="utf-8"),
+        }
+
+    def test_loop_arms_monitoring_directive_not_a_slash_command(self) -> None:
+        for label, text in self.files.items():
+            loops = _fenced_loop_command_lines(text)
+            self.assertTrue(loops, f"{label}: fenced な /loop コマンド行が見つからない")
+            armed = False
+            for line in loops:
+                prompt = _loop_prompt(line)
+                # 反復対象が空 (prompt 省略) だと、skill 実行ターン内では
+                # アクティブな slash command が捕捉され再帰する。
+                self.assertTrue(
+                    prompt,
+                    f"{label}: /loop の反復対象 (prompt) が空 (省略禁止): {line!r}",
+                )
+                # 反復対象が slash command であってはならない (= 再帰の直接原因)。
+                self.assertFalse(
+                    prompt.startswith("/"),
+                    f"{label}: /loop の反復対象が slash command: {line!r}",
+                )
+                # コマンド行に skill 自身を名指ししない。
+                self.assertNotIn(
+                    "/dispatcher-resume",
+                    line,
+                    f"{label}: /loop コマンド行が /dispatcher-resume を含む (再帰): {line!r}",
+                )
+                if "worker-monitoring" in prompt:
+                    armed = True
+            self.assertTrue(
+                armed,
+                f"{label}: /loop に worker-monitoring を指す monitoring "
+                f"ディレクティブが無い",
+            )
+
+    def test_invariant_documented(self) -> None:
+        for label, text in self.files.items():
+            self.assertIn(
+                INVARIANT_MARKER,
+                text,
+                f"{label}: {INVARIANT_MARKER} コメントが無い (invariant 明文化を維持すること)",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
`/dispatcher-resume` skill の Step 5 で `/loop 3m` を**prompt 省略**のまま叩いていたため、Claude Code の `/loop` 仕様（prompt 省略時は現在実行中の slash command を暗黙 reuse）に被弾して **`/dispatcher-resume` が自身を 3 分おきに再発火**するループに陥っていた。handover ファイルは初回で `.consumed.md` に rename されるため、2 回目以降は `DISPATCHER_RESUME_FAILED` を返しつつ Step 1-7 を毎回走らせて context を消費し、auto-compact を誘発する症状が 2026-06-19 に観測された。本 PR で恒久対策する。

## 観察された症状（2026-06-19）
- `/dispatcher-resume` が 3 分おきに自己再発火、`DISPATCHER_RESUME_FAILED` を spam
- 「3 分後に再確認」と自然言語で自己申告しつつ実 cadence は 10 秒間隔の連続観察
- context が auto-compact 直前（残 0%）まで到達
- ScheduleWakeup の prompt が context refresh / auto-compact で消えず引き継がれた

## 変更内容（5 観点）

### (A) Step 5 の `/loop 3m` を monitoring 専用ディレクティブ付きに変更
`/loop 3m` の prompt 引数として `references/worker-monitoring.md` の 1 サイクル実行を明示する文字列を渡す。制約: 自然言語の状況描写禁止 / anomaly 検出時のみ通知 / cadence 3 分以上 / slash command を反復対象にしない。これが**再帰の根本対策**。

### (B) Step 0 前に「stale 再発火ガード」を追加
handover ファイルの存在を `live` / `consumed` / `none` の 3 値で判定:
- `live` → 通常 resume
- `consumed` → 監視対象 worker pane / curate-inflight の有無を観測。健全なら **no-op or loop 再 arm**（resume skill 全体を再実行せず loop だけ再設定）。不在なら本来の cold-start が要る誤起動として `DISPATCHER_RESUME_FAILED` にフォールスルー
- `none` → cold-start

存在ベース判定（時刻窓を使わない）にしたのは `.dispatcher/CLAUDE.md` の既存 cold-start vs resume 分岐規約と整合させるため（当初の「15 分 mtime 窓」案は却下）。

### (C) `INVARIANT(loop-prompt)` を明文化＋機械検証
「skill 自身を `/loop` の反復対象に渡さない」を Step 5 コメント + 「やってはいけないこと」節に明文化。`tests/test_dispatcher_resume_loop_invariant.py` を新規追加し、fenced な `/loop` 行のみを検査して「反復対象が slash command でない / `worker-monitoring` を指す / INVARIANT コメント存在」を assert。

### (D) SoT と生成物
- SoT: `.claude/skills/dispatcher-resume/SKILL.md.in`
- 生成物: `.claude/skills/dispatcher-resume/SKILL.md`（`gen_skill_prose.py` 再生成、`.in` と byte 一致）
- `drift --check` が byte 一致を保証（exit 0）

### (E) スコープ判断（不変更）
cold-start 側 `.dispatcher/CLAUDE.md` の `/loop 3m`（prompt 省略）は **skill ターン外起動で再帰しない**ため不変更。根拠は knowledge raw に記載。

## 検証
- `drift --check` exit 0（`.md == render(.in)` byte 一致）
- `tests/` 全 **634 OK** / `tools/` 全 **531 OK**（8 skip）/ 新規 invariant test **2 件 pass**
- `codex exec review --base main -m gpt-5.5 -c model_reasoning_effort=medium` を **3 ラウンド**実施
  - round1: 「no-op 分岐が consumed 残存後の cold-start 案内を恒久マスクする」P2 → 監視対象 live でゲート追加
  - round2: 「ディレクティブの repo-root パスは dispatcher cwd で二重化して読めない」P2 → cwd 相対 `references/worker-monitoring.md` に変更
  - round3: 「新 event 追加は briefing extractor 互換性に影響」P2 → 既存 `anomaly_observed` を再利用 + `worker=dispatcher`
  - 最終: **No actionable correctness issues**（Blocker / Major ゼロ）

## 第三者裏付け
本日の curate gate で curator が独立分析により同じ根本原因を特定、`knowledge/curated/dispatcher-monitoring.md` に整理（worker と curator が独立に到達した結論が一致）。

## 残課題（別 Issue）
- CI drift job 配線（G1+ で対応予定、本 PR は手動再生成で同期保証）
- ScheduleWakeup の context 永続化への明示 kill 手順（symptom の二次対策、設計判断は今後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)