### PR TITLE
fix(claude): pin worker settings-generate to ja org_extension_schema

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -380,7 +380,9 @@ class TestSettingsGenerateCmd(unittest.TestCase):
         # Backward compatibility: a settings_args dict that lacks the
         # PR4-added keys (e.g. an old caller that constructs the dict by
         # hand) must still render a runnable cmd — the runtime CLI's
-        # required args are only the four mandatory ones.
+        # required args are only the mandatory ones. Issue #625 added
+        # --schema to that mandatory set (always pinned to ja's
+        # org_extension_schema.json), so it appears here too.
         cmd = self._build()
         self.assertEqual(
             cmd,
@@ -396,8 +398,40 @@ class TestSettingsGenerateCmd(unittest.TestCase):
                 "/co",
                 "--out",
                 "/wd/.claude/settings.local.json",
+                "--schema",
+                "/co/tools/org_extension_schema.json",
             ],
         )
+
+    def test_schema_pinned_to_ja_extension_schema_absolute(self):
+        # Issue #625: --schema must always be emitted, pointing at ja's
+        # tools/org_extension_schema.json so the runtime emits the worker
+        # sandbox_by_pattern policy (Layer 3 bwrap isolation + ja denyRead)
+        # instead of falling back to its bundled role_configs_schema.json.
+        cmd = self._build(pattern="A", **{"task-id": "t-1"})
+        self.assertIn("--schema", cmd)
+        schema = cmd[cmd.index("--schema") + 1]
+        self.assertEqual(schema, "/co/tools/org_extension_schema.json")
+        # cwd-independent: the path is absolute, derived from
+        # --claude-org-path, not from the runtime's working directory.
+        self.assertTrue(Path(schema).is_absolute())
+
+    def test_schema_absolutized_from_relative_claude_org_path(self):
+        # The runtime resolves --schema relative to its cwd, and apply may
+        # run from an arbitrary directory, so a relative claude-org-path
+        # must still yield an absolute --schema.
+        cmd = gdp._build_settings_generate_cmd(
+            {
+                "role": "default",
+                "worker-dir": "/wd",
+                "claude-org-path": "relative/co",
+                "out": "/wd/.claude/settings.local.json",
+            },
+            runtime_cmd="claude-org-runtime",
+        )
+        schema = cmd[cmd.index("--schema") + 1]
+        self.assertTrue(Path(schema).is_absolute())
+        self.assertTrue(schema.endswith("/tools/org_extension_schema.json"))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -924,15 +924,34 @@ def _build_settings_generate_cmd(
     without subprocess mocking.
 
     The mandatory flags (``--role`` / ``--worker-dir`` / ``--claude-org-path``
-    / ``--out``) are always emitted in a stable order. The optional
-    dispatch-context flags are emitted only when the corresponding key is
-    present and non-None in ``settings_args`` — the runtime CLI accepts
+    / ``--out`` / ``--schema``) are always emitted in a stable order. The
+    optional dispatch-context flags are emitted only when the corresponding
+    key is present and non-None in ``settings_args`` — the runtime CLI accepts
     each independently and errors only if the rendered body references a
     placeholder for which the corresponding context is missing (that
     loud-failure surface is intentional: Pattern A / C without
     ``--base-clone`` must NOT silently substitute an empty string into a
     ``{base_clone}``-using sandbox body).
+
+    Issue #625: ``--schema`` is always pinned to ja's
+    ``tools/org_extension_schema.json`` (the absolute path derived from
+    ``--claude-org-path``). Without it the runtime falls back to its bundled
+    ``role_configs_schema.json``, which lacks ja's worker
+    ``sandbox_by_pattern`` policy (Layer 3 bwrap path isolation + ja-specific
+    ``denyRead`` for ``.env`` / ``**/credentials*`` / ``**/*.pem`` etc.), so
+    the generated worker ``.claude/settings.local.json`` silently ships
+    without a ``sandbox`` block. The path is absolute-ized from
+    ``claude-org-path`` because the runtime resolves ``--schema`` relative to
+    its cwd, and apply may run from an arbitrary directory. ja's schema
+    defines exactly the three roles in ``resolve_worker_layout.VALID_ROLES``
+    (``default`` / ``claude-org-self-edit`` / ``doc-audit``), so every
+    dispatchable role is covered — no fallback is required.
     """
+    schema_path = (
+        Path(settings_args["claude-org-path"]).resolve()
+        / "tools"
+        / "org_extension_schema.json"
+    )
     cmd = [
         runtime_cmd,
         "settings",
@@ -945,6 +964,8 @@ def _build_settings_generate_cmd(
         settings_args["claude-org-path"],
         "--out",
         settings_args["out"],
+        "--schema",
+        str(schema_path),
     ]
     for flag, key in (
         ("--pattern", "pattern"),


### PR DESCRIPTION
Closes #625

## Problem

The standard delegation path (`tools/gen_delegate_payload.py apply`) invokes `claude-org-runtime settings generate` without passing `--schema tools/org_extension_schema.json`. As a result the runtime falls back to its bundled schema, and the generated worker `.claude/settings.local.json` omits the Layer 3 `sandbox` block (bwrap path isolation + ja-side `denyRead` policy). Layer 2 `permissions.deny` credential entries (`Read(.env)` etc.) were retained via the bundled schema, but Bash-launched program reads (`cat .env`, Python/Node file reads) were not protected at Layer 3.

## Fix

`_build_settings_generate_cmd()` now always passes `--schema` pointing at the ja-side `tools/org_extension_schema.json`, resolved to an absolute path from `--claude-org-path` (runtime interprets `--schema` relative to cwd, and `apply` may run from any directory).

## Verification

- end-to-end: without `--schema` the generated settings have no `sandbox` block; with it, `sandbox` is present and `filesystem.denyRead` covers `.env` / `.env.*` / `**/credentials*` / `**/*.pem`.
- all role x pattern combinations generate successfully (default A/B/C, doc-audit A/B/C, self-edit B/C). self-edit x A is rejected because the schema only defines B/C for that role — the resolver already forbids self-edit Pattern A, so this never occurs in practice (known correct behavior, not a regression).
- role coverage: ja schema `worker_roles` exactly matches `resolve_worker_layout.VALID_ROLES` (default / claude-org-self-edit / doc-audit); no fallback needed.
- tests: `tests.test_gen_delegate_payload` + `tests.test_resolve_worker_layout` = 151 tests OK. New unit tests assert `--schema` is included as an absolute path even with a relative `claude-org-path`; the existing minimum-cmd exact-match test was updated to include `--schema`.
- `--help` real-terminal smoke OK.

## Notes

Out of scope (per the issue): switching `/org-start` to auto-upgrade, and importing ja-specific policy into the runtime bundled schema. Only option 1 (pass `--schema`) was adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)