### PR TITLE
feat(claude): add tools/update_runtime.py (check + apply runtime update helper)

### DIFF
--- a/tools/test_update_runtime.py
+++ b/tools/test_update_runtime.py
@@ -1,0 +1,349 @@
+"""Unit tests for tools/update_runtime.py (Issue #626).
+
+The updater layers a CLI (check + apply) over check_runtime_version's
+pin-window resolution. It must:
+
+* default to dry-run: report drift, never call pip
+* with --apply: run pip, re-read installed, report old -> new, then
+  print the integrity-check hint (suppressed by --quiet)
+* be idempotent: when installed == in-window latest, no-op and NEVER
+  call pip even under --apply
+* skip non-fatally (exit 0, no traceback) for: package not installed,
+  offline / PyPI unreachable, packaging absent, no in-window release
+* respect ja's pin window (never target an out-of-window release)
+* return non-zero (1) ONLY when an explicit --apply pip subprocess
+  actually fails; 0 in every other case
+
+Patches target ``check_runtime_version`` because update_runtime calls
+its helpers through ``crv.<name>`` (late-bound module lookup).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_runtime_version  # noqa: E402
+import update_runtime  # noqa: E402
+
+try:  # noqa: SIM105
+    import packaging  # type: ignore  # noqa: F401
+
+    _HAS_PACKAGING = True
+except ImportError:
+    _HAS_PACKAGING = False
+
+requires_packaging = unittest.skipUnless(
+    _HAS_PACKAGING,
+    "packaging not installed -- pin-window resolution falls back to "
+    "silent skip, so the pin-aware paths are untestable here",
+)
+
+
+def _fake_urlopen(payload: dict):
+    body = json.dumps(payload).encode("utf-8")
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.close()
+            return False
+
+    return lambda *a, **kw: _Resp(body)
+
+
+def _payload(*versions: str, yanked: tuple[str, ...] = ()) -> dict:
+    """Build a minimally-PyPI-shaped JSON payload from the given
+    release versions (newest last). Versions in ``yanked`` are emitted
+    with every file marked yanked."""
+    releases = {}
+    for v in versions:
+        releases[v] = [{"yanked": v in yanked}]
+    return {
+        "info": {"version": versions[-1] if versions else ""},
+        "releases": releases,
+    }
+
+
+def _run_main(argv: list[str]) -> tuple[int, str]:
+    """Drive update_runtime.main(argv) with stdout captured."""
+    buf = io.StringIO()
+    with mock.patch.object(sys, "stdout", buf):
+        code = update_runtime.main(argv)
+    return code, buf.getvalue()
+
+
+class DryRunTest(unittest.TestCase):
+    def test_dry_run_default_reports_drift_and_command_no_pip(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.29"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.30"
+        ), mock.patch.object(
+            update_runtime, "_run_pip_upgrade"
+        ) as pip_mock:
+            code, out = _run_main([])
+        self.assertEqual(code, 0)
+        self.assertIn("[runtime update]", out)
+        self.assertIn("installed=0.1.29", out)
+        self.assertIn("-> 更新候補=0.1.30", out)
+        self.assertIn(
+            "python -m pip install --upgrade 'claude-org-runtime>=0.1.29,<0.2'",
+            out,
+        )
+        pip_mock.assert_not_called()
+
+
+class ApplyTest(unittest.TestCase):
+    def test_apply_runs_pip_and_reports_old_to_new(self):
+        # installed returns old before pip, new after the re-read.
+        with mock.patch.object(
+            check_runtime_version,
+            "_installed_version",
+            side_effect=["0.1.29", "0.1.30"],
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.30"
+        ), mock.patch.object(
+            update_runtime, "_run_pip_upgrade", return_value=0
+        ) as pip_mock:
+            code, out = _run_main(["--apply"])
+        self.assertEqual(code, 0)
+        self.assertIn("更新しました: 0.1.29 -> 0.1.30", out)
+        self.assertIn("check_role_configs.py", out)
+        self.assertIn("check_runtime_version.py", out)
+        pip_mock.assert_called_once_with("claude-org-runtime>=0.1.29,<0.2")
+
+    def test_apply_quiet_suppresses_integrity_hint(self):
+        with mock.patch.object(
+            check_runtime_version,
+            "_installed_version",
+            side_effect=["0.1.29", "0.1.30"],
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.30"
+        ), mock.patch.object(
+            update_runtime, "_run_pip_upgrade", return_value=0
+        ):
+            code, out = _run_main(["--apply", "--quiet"])
+        self.assertEqual(code, 0)
+        self.assertIn("更新しました: 0.1.29 -> 0.1.30", out)
+        self.assertNotIn("check_role_configs.py", out)
+
+    def test_apply_pip_failure_returns_1(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.29"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.30"
+        ), mock.patch.object(
+            update_runtime, "_run_pip_upgrade", return_value=5
+        ):
+            code, out = _run_main(["--apply"])
+        self.assertEqual(code, 1)
+        self.assertIn("pip install が失敗しました (exit=5)", out)
+        self.assertNotIn("更新しました", out)
+
+    def test_apply_reread_inconclusive_falls_back_to_latest(self):
+        # pip returns 0 but the post-apply re-read is None: still a
+        # success (tied to pip rc), reported via the resolved latest.
+        with mock.patch.object(
+            check_runtime_version,
+            "_installed_version",
+            side_effect=["0.1.29", None],
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.30"
+        ), mock.patch.object(
+            update_runtime, "_run_pip_upgrade", return_value=0
+        ):
+            code, out = _run_main(["--apply"])
+        self.assertEqual(code, 0)
+        self.assertIn("更新しました: 0.1.29 -> 0.1.30", out)
+
+
+class IdempotenceTest(unittest.TestCase):
+    def test_noop_dry_run(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.30"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.30"
+        ):
+            code, out = _run_main([])
+        self.assertEqual(code, 0)
+        self.assertIn("no-op", out)
+        self.assertIn("既にピン窓内最新", out)
+        self.assertNotIn("pip install --upgrade", out)
+
+    def test_noop_apply_does_not_call_pip(self):
+        # The idempotence-under-apply guard: pip is NOT invoked.
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.30"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.30"
+        ), mock.patch.object(
+            update_runtime, "_run_pip_upgrade"
+        ) as pip_mock:
+            code, out = _run_main(["--apply"])
+        self.assertEqual(code, 0)
+        self.assertIn("no-op", out)
+        pip_mock.assert_not_called()
+
+    @requires_packaging
+    def test_installed_ahead_of_latest_is_noop_no_phantom_upgrade(self):
+        # In-window latest can sit BELOW installed (e.g. the newer
+        # in-window release was yanked, or installed is a dev build).
+        # That must be a no-op, never a "更新候補/更新しました" upgrade
+        # claim, and never call pip even under --apply.
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.31"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.30"
+        ), mock.patch.object(
+            update_runtime, "_run_pip_upgrade"
+        ) as pip_mock:
+            code, out = _run_main(["--apply"])
+        self.assertEqual(code, 0)
+        self.assertIn("no-op", out)
+        self.assertNotIn("更新候補", out)
+        self.assertNotIn("更新しました", out)
+        pip_mock.assert_not_called()
+
+
+class SkipTest(unittest.TestCase):
+    def test_not_installed_skip_short_circuits_before_pypi(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value=None
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version"
+        ) as latest_mock:
+            code, out = _run_main([])
+        self.assertEqual(code, 0)
+        self.assertIn("未インストール", out)
+        self.assertIn("skip", out)
+        latest_mock.assert_not_called()
+
+    def test_offline_skip(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.29"
+        ), mock.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("offline"),
+        ):
+            code, out = _run_main([])
+        self.assertEqual(code, 0)
+        self.assertIn("判定できませんでした", out)
+        self.assertIn("skip", out)
+
+    @requires_packaging
+    def test_no_in_window_release_skip(self):
+        payload = _payload("0.2.0", "0.2.1")
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.29"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            code, out = _run_main([])
+        self.assertEqual(code, 0)
+        self.assertIn("判定できませんでした", out)
+
+    def test_apply_with_indeterminate_latest_skips_without_pip(self):
+        # Regression guard: a skip path (latest is None) under --apply
+        # must short-circuit BEFORE the pip branch -- real pip is never
+        # shelled out while offline / PyPI-unreachable.
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.29"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value=None
+        ), mock.patch.object(
+            update_runtime, "_run_pip_upgrade"
+        ) as pip_mock:
+            code, out = _run_main(["--apply"])
+        self.assertEqual(code, 0)
+        self.assertIn("判定できませんでした", out)
+        pip_mock.assert_not_called()
+
+    def test_apply_when_not_installed_skips_without_pip(self):
+        # Not-installed skip under --apply must also precede the pip
+        # branch (no upgrade attempt for an absent package).
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value=None
+        ), mock.patch.object(
+            update_runtime, "_run_pip_upgrade"
+        ) as pip_mock:
+            code, out = _run_main(["--apply"])
+        self.assertEqual(code, 0)
+        self.assertIn("未インストール", out)
+        pip_mock.assert_not_called()
+
+
+class PinWindowTest(unittest.TestCase):
+    @requires_packaging
+    def test_pin_window_resolution_end_to_end(self):
+        # Out-of-window 0.2.x exists on PyPI but must NOT be the target;
+        # the in-window latest 0.1.31 must be reported instead.
+        payload = _payload("0.1.29", "0.1.31", "0.2.0", "0.2.1")
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.29"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=">=0.1.29,<0.2"
+        ), mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            code, out = _run_main([])
+        self.assertEqual(code, 0)
+        self.assertIn("-> 更新候補=0.1.31", out)
+        self.assertNotIn("0.2.1", out)
+        self.assertNotIn("0.2.0", out)
+
+
+class InstallTargetTest(unittest.TestCase):
+    def test_target_carries_pin(self):
+        self.assertEqual(
+            update_runtime._pip_install_target(">=0.1.29,<0.2"),
+            "claude-org-runtime>=0.1.29,<0.2",
+        )
+
+    def test_target_bare_when_pin_none(self):
+        self.assertEqual(
+            update_runtime._pip_install_target(None),
+            "claude-org-runtime",
+        )
+
+
+class ParserTest(unittest.TestCase):
+    def test_flags_default_false(self):
+        args = update_runtime.build_parser().parse_args([])
+        self.assertFalse(args.apply)
+        self.assertFalse(args.quiet)
+
+    def test_flags_set(self):
+        args = update_runtime.build_parser().parse_args(["--apply", "--quiet"])
+        self.assertTrue(args.apply)
+        self.assertTrue(args.quiet)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/update_runtime.py
+++ b/tools/update_runtime.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Runtime updater for claude-org-runtime (check + apply, Issue #626).
+
+Brings the installed ``claude-org-runtime`` up to the newest PyPI
+release that still satisfies ja's pin window (declared in
+``pyproject.toml`` dependencies). No version number is hard-coded
+anywhere: installed comes from ``importlib.metadata``, latest from the
+PyPI JSON API, and the pin spec from ``pyproject.toml`` at read time.
+
+All of the version/PyPI/pin logic is REUSED from
+``check_runtime_version`` (imported as ``crv``) rather than
+reimplemented, so the pin-window resolution, prerelease/yanked
+filtering, and packaging-absent fallback stay in one place.
+
+Default is dry-run: it only reports what it would do. With ``--apply``
+it runs ``python -m pip install --upgrade '<package><pin-spec>'`` so
+pip resolves strictly inside the pin window (never crossing the
+exclusive upper bound to an out-of-window major/minor). It is
+idempotent: when the installed version already equals the in-window
+latest, it is a no-op and never shells out to pip, even under
+``--apply``.
+
+Exit-code convention (consistent with check_runtime_version.py, which
+returns 0 in every informational/skip/no-op/drift case):
+
+    * 0  -- dry-run report, no-op (already up to date), and every
+            non-fatal skip (offline / PyPI unreachable / package not
+            installed / packaging import absent / pin parse failure).
+    * 1  -- ONLY when an explicit ``--apply`` pip subprocess actually
+            fails (non-zero return code). This is the single non-zero
+            path.
+
+Out of scope: this tool does not change /org-start, which never
+auto-upgrades.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+except (AttributeError, OSError):
+    pass
+
+# Reuse hinge: import the sibling module as a whole so every helper
+# lookup is late-bound through ``crv.<name>``. This matters for tests:
+# the mirror suite patches via ``mock.patch.object(check_runtime_version,
+# "_latest_version", ...)``; going through the module object means those
+# patches take effect here too (a ``from ... import _latest_version``
+# would bind a local name the patch could not reach).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_runtime_version as crv  # noqa: E402
+
+# Post-apply guidance. ASCII dashes only (cp932-safe console output).
+INTEGRITY_HINT = (
+    "次に整合チェックを実行してください: "
+    "python tools/check_role_configs.py / "
+    "python tools/check_runtime_version.py"
+)
+
+
+def _is_already_current(installed: str, latest: str) -> bool:
+    """True when ``installed`` should be treated as already at (or ahead
+    of) the in-window ``latest`` -- a no-op for pip's ``>=`` floor.
+
+    The in-window latest can legitimately sit BELOW installed: a newer
+    in-window release may be yanked (``crv._release_is_yanked`` drops it)
+    or installed may be a local/dev build ahead of PyPI. Plain ``!=``
+    would then mislabel a non-existent downgrade as an upgrade. Compare
+    with ``packaging.Version`` when available; fall back to string
+    equality when packaging is absent or a version fails to parse
+    (mirrors crv's packaging-optional contract)."""
+    try:
+        from packaging.version import InvalidVersion, Version
+    except ImportError:
+        return installed == latest
+    try:
+        return Version(installed) >= Version(latest)
+    except InvalidVersion:
+        return installed == latest
+
+
+def _pip_install_target(pin: str | None) -> str:
+    """Build the ``<package><pin-spec>`` install target, e.g.
+    ``claude-org-runtime>=0.1.29,<0.2``. Single source of truth so the
+    dry-run echo and the real pip argv use the identical string. This
+    mirrors check_runtime_version.main()'s upgrade_target construction
+    so pip resolves within the pin window."""
+    return f"{crv.PACKAGE}{pin or ''}"
+
+
+def _run_pip_upgrade(target: str) -> int:
+    """Run ``python -m pip install --upgrade <target>`` and return the
+    pip return code.
+
+    ``sys.executable -m pip`` pins the upgrade to the SAME interpreter
+    this script runs under (no PATH ambiguity). The target is passed as
+    a SINGLE argv element (no shell=True), so the pin spec's ``<`` / ``>``
+    are not shell redirects and pip receives the requirement verbatim.
+    Wrapped in its own function so tests can patch it cleanly."""
+    cmd = [sys.executable, "-m", "pip", "install", "--upgrade", target]
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="update_runtime.py",
+        description=(
+            "claude-org-runtime をピン窓内の最新へ更新する (check + apply)。"
+            " 既定は dry-run で、--apply を付けたときだけ実際に更新する。"
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "ピン窓内の最新が新しければ pip install --upgrade を実行する"
+            " (既定は dry-run のみで実行しない)。"
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help=(
+            "適用後の整合チェック案内"
+            " (check_role_configs / check_runtime_version) を抑制する。"
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    # 1. Installed version. Non-fatal skip if the package is absent.
+    #    Short-circuit before any network call.
+    installed = crv._installed_version()
+    if installed is None:
+        print(f"[runtime update] {crv.PACKAGE} は未インストールです -- skip")
+        return 0
+
+    # 2. Pin window from pyproject.toml (may legitimately be None).
+    pin = crv._read_pin_spec()
+
+    # 3. In-window latest from PyPI. crv._latest_version(pin) already
+    #    collapses offline / PyPI-unreachable / JSON parse failure /
+    #    packaging-absent-with-pin / invalid-pin / no-in-window-release
+    #    all to None, so a single None check covers every non-fatal
+    #    indeterminate case here.
+    latest = crv._latest_version(pin)
+    if latest is None:
+        print(
+            "[runtime update] 最新バージョンを判定できませんでした"
+            " (オフライン / PyPI 到達不可 / packaging 不在 のいずれか)"
+            " -- skip"
+        )
+        return 0
+
+    # 4. Idempotence guard BEFORE the --apply branch: if already at (or
+    #    ahead of) the in-window latest, never shell out to pip, even
+    #    under --apply, and never report a phantom upgrade.
+    if _is_already_current(installed, latest):
+        print(
+            f"[runtime update] {crv.PACKAGE}: installed={installed}"
+            " は既にピン窓内最新です -- no-op"
+        )
+        return 0
+
+    # 5. Drift exists. latest is in-window by construction (crv applied
+    #    the SpecifierSet), so the target carries the pin window.
+    target = _pip_install_target(pin)
+    command = f"python -m pip install --upgrade '{target}'"
+
+    if not args.apply:
+        # Default: dry-run report only. Exit 0.
+        print(
+            f"[runtime update] {crv.PACKAGE}: installed={installed}"
+            f" -> 更新候補={latest}"
+        )
+        print(f"[runtime update] 適用するには --apply: {command}")
+        return 0
+
+    # --apply: run pip. The ONLY path that can return non-zero.
+    print(f"[runtime update] 適用中: {command}")
+    rc = _run_pip_upgrade(target)
+    if rc != 0:
+        print(f"[runtime update] pip install が失敗しました (exit={rc})")
+        return 1
+
+    # Re-read installed AFTER pip (fresh on-disk metadata). Defensive:
+    # success is tied to pip's return code, not to the re-read, so fall
+    # back to the resolved latest if the re-read is inconclusive.
+    new = crv._installed_version()
+    reported_new = new or latest
+    print(
+        f"[runtime update] 更新しました: {installed} -> {reported_new}"
+    )
+    if not args.quiet:
+        print(INTEGRITY_HINT)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #626

## Summary

Adds `tools/update_runtime.py`, a thin helper to check and (with `--apply`) upgrade `claude-org-runtime` to the latest version within the `pyproject.toml` pin window. Complements `tools/check_runtime_version.py` (Issue #472), which only detects drift; humans previously had to run `pip install --upgrade` by hand.

## Key points

1. **Full logic reuse**: imports `check_runtime_version` as a module and reuses pin-window resolution, PyPI fetch, prerelease/yanked filtering, and `packaging`-absent fallback. No version numbers hard-coded.
2. **Pin window respected**: upgrade target is the latest version satisfying the `pyproject.toml` constraint only; never bumps to an out-of-window major/minor. The pip target spec is derived dynamically from `pyproject.toml`.
3. **Dry-run by default / idempotent**: runs pip only with `--apply`; no-op when already at in-window latest.
4. **Non-fatal skip (exit 0)**: not-installed / offline / PyPI unreachable / `packaging` absent / pin parse failure / no in-window release all skip with an info line (no traceback).
5. **Exit-code convention** aligned with `check_runtime_version.py`; returns 1 only when the `--apply` pip subprocess actually fails.

## Self-review fix (real-impact Minor caught during review)

When the installed version is *ahead* of the in-window latest (in-window release yanked, or a dev build installed), the initial implementation showed a phantom upgrade. Fixed with `packaging.Version` comparison treating `installed >= latest` as no-op (string-equality fallback when `packaging` is absent). Added 3 regression tests.

## Verification

- `pytest tools/test_update_runtime.py tools/test_check_runtime_version.py -q` -> 35 passed
- `--help` real-terminal smoke -> clean (cp932-safe, ASCII dashes only)
- dry-run smoke -> clean (correctly reports skip when offline)
- Codex self-review (`codex exec review --base main`, full) -> 0 Blocker / 0 Major across 2 rounds

## Out of scope

Switching `/org-start` to auto-upgrade (the issue keeps the notify-only design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)