### PR TITLE
fix(org-attention-stop): verify pane identity before close_pane to avoid closing recycled pane

### DIFF
--- a/.claude/skills/org-attention-stop/SKILL.md
+++ b/.claude/skills/org-attention-stop/SKILL.md
@@ -2,8 +2,9 @@
 name: org-attention-stop
 description: >
   `/org-attention-start` で起動した attention watcher ペインを停止する。
-  `.state/attention_pane.json` に記録された pane_id を参照して
-  `close_pane`（pane 破棄）で破棄し、sidecar を削除する。
+  `.state/attention_pane.json` に記録された pane_id を `list_panes` の name/role で
+  identity 確認し、いまも attention watcher を指している場合だけ `close_pane`（pane 破棄）で
+  破棄する（pane_id が別ペインへ再割当て済みなら close せず stale sidecar として削除）。
   「attention 止めて」「通知監視を停止」「watcher 落として」等で発動。
 effort: low
 allowed-tools:
@@ -39,46 +40,71 @@ sidecar (`.state/attention_pane.json`) をクリアする。
 >
 > 契約面の正本は [`docs/contracts/backend-interface-contract.md`](../../../docs/contracts/backend-interface-contract.md) Surface 8（broker auth & delivery、ratified 2026-06-14）+ 末尾「Ratified amendment (2026-06-15): push-primary delivery」（S3。**broker push 一次が既定の契約**、pull は structural fallback として retain）、設計 SoT は transport-lab `docs/design/broker-native-roles.md` §9（push 一次）/ `docs/design/ja-migration-plan.md` §5・§8。**opt-in `renga` は削除せず常時有効な fallback として維持する**（切戻しの安全装置）。broker 実走（dogfood）は Epic #6 Issue G スコープであり、本ファイルの既定運用経路ではない（**既定の二フレーム注記（Refs #604）**: ここでの「既定 `broker`」は**コード既定**フレーム — `tools/transport.py: DEFAULT_TRANSPORT` が runtime 0.1.28 (Epic #586) で `broker` にフリップ済みで、ja 生成器・`transport.resolve()` はこのコードフレームで render するため生成面はこう表示する。別に**運用既定**フレームがあり、broker 実走 dogfood が Epic #6 Issue G まで未活性のため運用上の既定経路は `renga`。両フレームは指す対象（コード定数 vs 運用経路）が異なり矛盾しない。総説は root [`CLAUDE.md`](../../../CLAUDE.md)「輸送層（transport）両系」節。）
 
-## Step 1: sidecar と live pane の状態確認
+## Step 1: ライブペインと sidecar の照合（close 前に identity を確定する）
 
-1. `mcp__org-broker__list_panes` を呼び、`name="attention"` または `role="attention"` の
-   live pane があれば pane_id を控える（**name と role の両方を見る**: 手動起動の孤児ペインは
-   name を付けずに role だけ持っている可能性がある）
-2. `.state/attention_pane.json` を `Read` で開けたら `pane_id` を読み取る。存在しなければ skip
-3. 分岐:
-   - **sidecar あり** → 2-a へ
-   - **sidecar 無し + 孤児 pane 検出** → 2-b へ
-   - **sidecar 無し + 孤児 pane 無し** → 「attention watcher は既に停止しています」と報告して終了
+> **なぜ identity 確認が必要か（Issue #468）**: renga 0.18+ / broker は pane id を
+> lifecycle 跨ぎで **recycle** する。watcher がクラッシュすると、その pane_id が
+> 別ペイン（新規 spawn された worker 等）へ再割当てされることがある。このとき sidecar
+> (`.state/attention_pane.json`) に残った pane_id を**無検証で `close_pane` すると、
+> 無関係なペインを kill する**。よって本 skill は **`list_panes` の name/role で identity を
+> 確認したペインだけを close 対象**とし、sidecar の pane_id を close の直接の根拠にしない。
 
-## Step 2: ペインを閉じる
+1. `mcp__org-broker__list_panes` を呼び、`name="attention"` **または** `role="attention"` の
+   live pane を**全て**収集する（複数あれば全部）。これを「**確認済み attention ペイン集合**」と
+   呼び、各 pane の **数値 pane_id** を控える（**name と role の両方を見る**: 手動起動の孤児
+   ペインは name を付けず role だけ持っていることがある）
+2. `.state/attention_pane.json` を `Read` で開けたら `pane_id` を読み取る（= **sidecar pane_id**）。
+   存在しなければ「sidecar 無し」として扱う
+3. sidecar pane_id の identity を `list_panes` の結果に照らして分類する（**sidecar に記録された
+   name は信用せず、いま list_panes が返す name/role で判定する**）:
+   - **verified**: sidecar pane_id が「確認済み attention ペイン集合」に含まれる
+     → その pane はいまも本物の watcher。close 対象
+   - **recycled**: sidecar pane_id が list_panes に存在するが、その pane の name/role が
+     attention では**ない** → pane_id が無関係なペイン（worker 等）へ再割当てされている。
+     **絶対に close しない**
+   - **gone**: sidecar pane_id が list_panes に存在しない → watcher は既に消えている
+   - **sidecar 無し**: 上記判定はスキップ（孤児ペインの掃除のみ検討する）
 
-### 2-a: 記録された pane_id で close
+   判定が紛らわしい場合（list_panes の name/role が空・曖昧）は
+   `mcp__org-broker__inspect_pane(target="<sidecar pane_id>")` で内容を確認して補強してよいが、
+   **一次の identity ソースは list_panes が返す name/role** である。
+
+## Step 2: close 対象の決定と実行
+
+**close してよいのは「確認済み attention ペイン集合」のペインだけ**である（identity を確認した
+ペインのみ）。sidecar pane_id は **verified のとき（=その id が確認済み集合に入っているとき）に
+限り** close 対象になる。recycled / gone の sidecar pane_id は close 対象にしない。
+
+確認済み attention ペイン集合の各 pane を、**list_panes から得た数値 pane_id** で順に close する:
 
 ```
-mcp__org-broker__close_pane(target="<sidecar の pane_id>")
+mcp__org-broker__close_pane(target="<確認済み集合の数値 pane_id>")
 ```
 
 - 成功時: `"Closed pane id=N."` テキストが返る
-- `[pane_not_found]` / `[pane_vanished]`: 既に閉じている。sidecar が stale。Step 3 へ進む
+- `[pane_not_found]` / `[pane_vanished]`: 直前に消えた。skip 扱いで次へ
 - `[last_pane]`: タブの唯一のペインが attention だった（通常発生しない、dispatcher / secretary が
   残っているはず）。状況をユーザーに報告して abort（手動対応に委ねる）
 
-Step 1 で得た「list_panes 上の attention ペイン」と sidecar の pane_id が一致しない場合は、
-**sidecar の id を優先して close した後**、`list_panes` を再取得して残っていれば 2-b に進む
-（drift / orphan の追加掃除）。
+`target="attention"` のような **name 指定は使わない**（role だけ持って name を持たない孤児ペインに
+当たらないため）。必ず数値 pane_id で指定する。
 
-### 2-b: sidecar 無し / drift で孤児ペインを掃除する場合
+分類別の挙動:
 
-Step 1 で `list_panes` から得た **pane_id（name ではなく数値 id）** で close する:
-
-```
-mcp__org-broker__close_pane(target="<list_panes から取得した数値 pane_id>")
-```
-
-`target="attention"` のような name 指定は、role だけ持って name を持たない孤児ペインに当たらない
-ため使用しない。`[pane_not_found]` / `[pane_vanished]` は skip 扱い。
+- **verified**: sidecar pane_id は確認済み集合に含まれるので、上記の close で一緒に閉じられる。
+  集合に他の attention ペイン（drift / 二重起動の孤児）が居れば、それらも同じく数値 pane_id で
+  close する
+- **recycled / gone**: sidecar pane_id は **close しない**。ただし確認済み集合に
+  （sidecar とは別 id の）孤児 watcher が居れば、それは数値 pane_id で close する。
+  sidecar が指していた watcher 本体は既に消えている → Step 4 で「watcher は既に消えていた
+  （sidecar が stale）」と報告する
+- **sidecar 無し**: 確認済み集合に孤児 attention ペインが居ればそれを数値 pane_id で close する。
+  集合が空なら close は何もしない（Step 4 で「既に停止しています」と報告）
 
 ## Step 3: sidecar の削除
+
+sidecar が存在した場合は **分類によらず必ず削除する**（verified で close した後も、
+recycled / gone で stale と判定した場合も削除する）:
 
 ```bash
 rm -f .state/attention_pane.json
@@ -86,22 +112,43 @@ rm -f .state/attention_pane.json
 
 Windows native: `del .state\attention_pane.json` （既に削除済みでも無害化のため `2>nul` 等で抑制）。
 
-journal event を 1 行追記する:
+journal event を 1 行追記する。**実際に close したペインがある場合のみ** `attention_watch_stopped`
+を記録する（recycled / gone で close を 1 つも行わなかった場合は、無関係なペインを停めた誤記録に
+ならないよう `<N>` を省き `reason=stale_sidecar` を付ける）:
 
 ```bash
+# 確認済み attention ペインを close した場合（verified / 孤児掃除）
 bash tools/journal_append.sh attention_watch_stopped pane_id=<N>
+
+# sidecar が recycled / gone で close を行わなかった場合
+bash tools/journal_append.sh attention_watch_stopped reason=stale_sidecar
 ```
 
-Windows native では `py -3 tools/journal_append.py attention_watch_stopped pane_id=<N>`。
+Windows native では `py -3 tools/journal_append.py attention_watch_stopped ...`。
 
 ## Step 4: 報告
+
+**verified（記録された watcher を停止した）/ 孤児掃除した場合**:
 
 ```
 attention watcher を停止しました（pane id={N}）。
 再開するときは /org-attention-start を実行してください。
 ```
 
-sidecar が無く孤児ペインも無かった場合は:
+**recycled / gone（sidecar が stale で、watcher 本体は既に消えていた）場合** — 無関係なペインを
+close していないことを明示して報告する:
+
+```
+attention watcher は既に消えていました（sidecar が stale）。
+記録されていた pane id={sidecar pane_id} は別のペインに再割当て済み / 既に消滅していたため、
+無関係なペインを閉じないよう close は行わず、stale な sidecar だけを削除しました。
+再開するときは /org-attention-start を実行してください。
+```
+
+（recycled で別 id の孤児 watcher も掃除した場合は、上に「孤児 attention ペイン id={M} も
+併せて掃除しました」を 1 行添える。）
+
+**sidecar が無く孤児ペインも無かった場合**:
 
 ```
 attention watcher は既に停止しています。

--- a/.claude/skills/org-attention-stop/SKILL.md.in
+++ b/.claude/skills/org-attention-stop/SKILL.md.in
@@ -2,8 +2,9 @@
 name: org-attention-stop
 description: >
   `/org-attention-start` で起動した attention watcher ペインを停止する。
-  `.state/attention_pane.json` に記録された pane_id を参照して
-  `close_pane`（pane 破棄）で破棄し、sidecar を削除する。
+  `.state/attention_pane.json` に記録された pane_id を `list_panes` の name/role で
+  identity 確認し、いまも attention watcher を指している場合だけ `close_pane`（pane 破棄）で
+  破棄する（pane_id が別ペインへ再割当て済みなら close せず stale sidecar として削除）。
   「attention 止めて」「通知監視を停止」「watcher 落として」等で発動。
 effort: low
 allowed-tools:
@@ -22,46 +23,71 @@ sidecar (`.state/attention_pane.json`) をクリアする。
 
 {{> dual-system-header-long }}
 
-## Step 1: sidecar と live pane の状態確認
+## Step 1: ライブペインと sidecar の照合（close 前に identity を確定する）
 
-1. `{{FQ}}list_panes` を呼び、`name="attention"` または `role="attention"` の
-   live pane があれば pane_id を控える（**name と role の両方を見る**: 手動起動の孤児ペインは
-   name を付けずに role だけ持っている可能性がある）
-2. `.state/attention_pane.json` を `Read` で開けたら `pane_id` を読み取る。存在しなければ skip
-3. 分岐:
-   - **sidecar あり** → 2-a へ
-   - **sidecar 無し + 孤児 pane 検出** → 2-b へ
-   - **sidecar 無し + 孤児 pane 無し** → 「attention watcher は既に停止しています」と報告して終了
+> **なぜ identity 確認が必要か（Issue #468）**: renga 0.18+ / broker は pane id を
+> lifecycle 跨ぎで **recycle** する。watcher がクラッシュすると、その pane_id が
+> 別ペイン（新規 spawn された worker 等）へ再割当てされることがある。このとき sidecar
+> (`.state/attention_pane.json`) に残った pane_id を**無検証で `close_pane` すると、
+> 無関係なペインを kill する**。よって本 skill は **`list_panes` の name/role で identity を
+> 確認したペインだけを close 対象**とし、sidecar の pane_id を close の直接の根拠にしない。
 
-## Step 2: ペインを閉じる
+1. `{{FQ}}list_panes` を呼び、`name="attention"` **または** `role="attention"` の
+   live pane を**全て**収集する（複数あれば全部）。これを「**確認済み attention ペイン集合**」と
+   呼び、各 pane の **数値 pane_id** を控える（**name と role の両方を見る**: 手動起動の孤児
+   ペインは name を付けず role だけ持っていることがある）
+2. `.state/attention_pane.json` を `Read` で開けたら `pane_id` を読み取る（= **sidecar pane_id**）。
+   存在しなければ「sidecar 無し」として扱う
+3. sidecar pane_id の identity を `list_panes` の結果に照らして分類する（**sidecar に記録された
+   name は信用せず、いま list_panes が返す name/role で判定する**）:
+   - **verified**: sidecar pane_id が「確認済み attention ペイン集合」に含まれる
+     → その pane はいまも本物の watcher。close 対象
+   - **recycled**: sidecar pane_id が list_panes に存在するが、その pane の name/role が
+     attention では**ない** → pane_id が無関係なペイン（worker 等）へ再割当てされている。
+     **絶対に close しない**
+   - **gone**: sidecar pane_id が list_panes に存在しない → watcher は既に消えている
+   - **sidecar 無し**: 上記判定はスキップ（孤児ペインの掃除のみ検討する）
 
-### 2-a: 記録された pane_id で close
+   判定が紛らわしい場合（list_panes の name/role が空・曖昧）は
+   `{{FQ}}inspect_pane(target="<sidecar pane_id>")` で内容を確認して補強してよいが、
+   **一次の identity ソースは list_panes が返す name/role** である。
+
+## Step 2: close 対象の決定と実行
+
+**close してよいのは「確認済み attention ペイン集合」のペインだけ**である（identity を確認した
+ペインのみ）。sidecar pane_id は **verified のとき（=その id が確認済み集合に入っているとき）に
+限り** close 対象になる。recycled / gone の sidecar pane_id は close 対象にしない。
+
+確認済み attention ペイン集合の各 pane を、**list_panes から得た数値 pane_id** で順に close する:
 
 ```
-{{FQ}}close_pane(target="<sidecar の pane_id>")
+{{FQ}}close_pane(target="<確認済み集合の数値 pane_id>")
 ```
 
 - 成功時: `"Closed pane id=N."` テキストが返る
-- `[pane_not_found]` / `[pane_vanished]`: 既に閉じている。sidecar が stale。Step 3 へ進む
+- `[pane_not_found]` / `[pane_vanished]`: 直前に消えた。skip 扱いで次へ
 - `[last_pane]`: タブの唯一のペインが attention だった（通常発生しない、dispatcher / secretary が
   残っているはず）。状況をユーザーに報告して abort（手動対応に委ねる）
 
-Step 1 で得た「list_panes 上の attention ペイン」と sidecar の pane_id が一致しない場合は、
-**sidecar の id を優先して close した後**、`list_panes` を再取得して残っていれば 2-b に進む
-（drift / orphan の追加掃除）。
+`target="attention"` のような **name 指定は使わない**（role だけ持って name を持たない孤児ペインに
+当たらないため）。必ず数値 pane_id で指定する。
 
-### 2-b: sidecar 無し / drift で孤児ペインを掃除する場合
+分類別の挙動:
 
-Step 1 で `list_panes` から得た **pane_id（name ではなく数値 id）** で close する:
-
-```
-{{FQ}}close_pane(target="<list_panes から取得した数値 pane_id>")
-```
-
-`target="attention"` のような name 指定は、role だけ持って name を持たない孤児ペインに当たらない
-ため使用しない。`[pane_not_found]` / `[pane_vanished]` は skip 扱い。
+- **verified**: sidecar pane_id は確認済み集合に含まれるので、上記の close で一緒に閉じられる。
+  集合に他の attention ペイン（drift / 二重起動の孤児）が居れば、それらも同じく数値 pane_id で
+  close する
+- **recycled / gone**: sidecar pane_id は **close しない**。ただし確認済み集合に
+  （sidecar とは別 id の）孤児 watcher が居れば、それは数値 pane_id で close する。
+  sidecar が指していた watcher 本体は既に消えている → Step 4 で「watcher は既に消えていた
+  （sidecar が stale）」と報告する
+- **sidecar 無し**: 確認済み集合に孤児 attention ペインが居ればそれを数値 pane_id で close する。
+  集合が空なら close は何もしない（Step 4 で「既に停止しています」と報告）
 
 ## Step 3: sidecar の削除
+
+sidecar が存在した場合は **分類によらず必ず削除する**（verified で close した後も、
+recycled / gone で stale と判定した場合も削除する）:
 
 ```bash
 rm -f .state/attention_pane.json
@@ -69,22 +95,43 @@ rm -f .state/attention_pane.json
 
 Windows native: `del .state\attention_pane.json` （既に削除済みでも無害化のため `2>nul` 等で抑制）。
 
-journal event を 1 行追記する:
+journal event を 1 行追記する。**実際に close したペインがある場合のみ** `attention_watch_stopped`
+を記録する（recycled / gone で close を 1 つも行わなかった場合は、無関係なペインを停めた誤記録に
+ならないよう `<N>` を省き `reason=stale_sidecar` を付ける）:
 
 ```bash
+# 確認済み attention ペインを close した場合（verified / 孤児掃除）
 bash tools/journal_append.sh attention_watch_stopped pane_id=<N>
+
+# sidecar が recycled / gone で close を行わなかった場合
+bash tools/journal_append.sh attention_watch_stopped reason=stale_sidecar
 ```
 
-Windows native では `py -3 tools/journal_append.py attention_watch_stopped pane_id=<N>`。
+Windows native では `py -3 tools/journal_append.py attention_watch_stopped ...`。
 
 ## Step 4: 報告
+
+**verified（記録された watcher を停止した）/ 孤児掃除した場合**:
 
 ```
 attention watcher を停止しました（pane id={N}）。
 再開するときは /org-attention-start を実行してください。
 ```
 
-sidecar が無く孤児ペインも無かった場合は:
+**recycled / gone（sidecar が stale で、watcher 本体は既に消えていた）場合** — 無関係なペインを
+close していないことを明示して報告する:
+
+```
+attention watcher は既に消えていました（sidecar が stale）。
+記録されていた pane id={sidecar pane_id} は別のペインに再割当て済み / 既に消滅していたため、
+無関係なペインを閉じないよう close は行わず、stale な sidecar だけを削除しました。
+再開するときは /org-attention-start を実行してください。
+```
+
+（recycled で別 id の孤児 watcher も掃除した場合は、上に「孤児 attention ペイン id={M} も
+併せて掃除しました」を 1 行添える。）
+
+**sidecar が無く孤児ペインも無かった場合**:
 
 ```
 attention watcher は既に停止しています。


### PR DESCRIPTION
Closes #468

## Problem

`/org-attention-stop` read the watcher pane_id from `.state/attention_pane.json` and called `close_pane(target=<pane_id>)` without verifying identity. If the watcher had already crashed and the backend (renga 0.18+ / broker tmux) recycled that pane_id for a different pane (e.g. a freshly spawned worker), `close_pane` would terminate the unrelated pane.

## Fix (SoT `SKILL.md.in` + regenerated `SKILL.md`)

1. The close target is restricted to "only the pane that `list_panes` confirms has `name==\"attention\"` / `role==\"attention\"`". The old step that closed the sidecar pane_id unverified is removed — the recycle-kill path is structurally gone.
2. The sidecar pane_id is classified verified / recycled / gone; recycled (id is live but not an attention pane) and gone are explicitly "never close".
3. Step 1's dual-check no longer trusts the name recorded in the sidecar — it judges by the name/role `list_panes` returns now.
4. On recycled/gone, no close is performed: only the stale sidecar is deleted, and the report/journal branch accordingly (record a closed pane_id only when one was actually closed; otherwise `reason=stale_sidecar`). The user is told "the watcher was already gone (the sidecar was stale)".

## Design note

The close set is unified to "panes whose identity `list_panes` confirmed", and the sidecar pane_id is used only for (a) staleness classification and (b) deletion. This removes the "close the sidecar id directly" path from the design, so the recycle bug cannot recur (stronger than adding a point guard). Both transports (default broker `mcp__org-broker__*` / opt-in renga) are covered via the `{{FQ}}` placeholder in the SoT; `backend-interface-contract.md §1.5` confirms `list_panes` returns id/name/role deterministically on both.

## Verification

- `gen_skill_prose.py --check`: drift zero (SoT and generated output match).
- Codex review (gpt-5.5, `--base main`): 0 Blocker / 0 Major, clean.

## Scope

ja-canonical SKILL design fix; the en mirror propagates via the auto-mirror P2 flow on the next merge (no manual en edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)