### PR TITLE
fix(claude): remove unary commas from install.ps1 $pyCandidates literal

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -216,9 +216,9 @@ $reqFile = Join-Path $Dir 'requirements.txt'
 $pyCmd = $null
 if ((Test-Path -LiteralPath $pyprojectFile) -or (Test-Path -LiteralPath $reqFile)) {
     $pyCandidates = @(
-        ,@('python'),
-        ,@('python3'),
-        ,@('py', '-3')
+        @('python'),
+        @('python3'),
+        @('py', '-3')
     )
     foreach ($cand in $pyCandidates) {
         if (-not (Get-Command $cand[0] -ErrorAction SilentlyContinue)) { continue }


### PR DESCRIPTION
## Summary

Fix the one-liner install path (`iwr https://.../install.ps1 | iex`) so that the printed "Next steps" no longer reads `System.Object[] -m claude_org_runtime.cli org up` and instead shows the real interpreter command (`python -m claude_org_runtime.cli org up` / `py -3 -m ...`).

## Root cause

`scripts/install.ps1`'s `$pyCandidates` literal had a unary comma in front of each element:

```powershell
$pyCandidates = @(
    ,@('python'),
    ,@('python3'),
    ,@('py', '-3')
)
```

The unary `,` wraps each operand in a 1-element array, producing a 3D shape `[ [ ['python'] ], [ ['python3'] ], [ ['py','-3'] ] ]` rather than the intended 2D `[ ['python'], ['python3'], ['py','-3'] ]`. (`@(A, B, C)` with comma-separated elements does NOT flatten its elements; the unary commas are unnecessary and harmful.)

Downstream, `foreach ($cand in $pyCandidates)` then yielded a 2D array per iteration, `$pyCmd = $cand` stored that nested shape, and `$pyCmd -join ' '` stringified the inner array as `System.Object[]`, which was interpolated into the next-step banner.

## Fix

Drop the three leading unary commas — single-line change for each of the three array entries:

```powershell
$pyCandidates = @(
    @('python'),
    @('python3'),
    @('py', '-3')
)
```

Diff: 1 file changed, 3 insertions(+), 3 deletions(-).

## Verification (depth = full, executed)

Real pwsh execution via `mcr.microsoft.com/powershell:latest` (pwsh 7.4.2 + python3 3.10.12) of `pwsh -NoProfile -File scripts/install.ps1 -DryRun`:

| | launchStep line |
|---|---|
| Before (buggy) | `System.Object[] -m claude_org_runtime.cli org up` (bug reproduced) |
| After (this PR) | `python3 -m claude_org_runtime.cli org up` |

Array shape after fix (direct dump): `pyCandidates.Count = 3`, each entry is a 1D `[string]` array (`[0]=['python']`, `[1]=['python3']`, `[2]=['py','-3']`, joined as `'py -3'`).

### Codex self-review

- 1 round, 1 P2 finding only, **rejected as false-positive**: Codex claimed removing all unary commas would yield a flat string list where `$cand[0]` would be a single character. The empirical array dump above (Count=3, jagged 2D, each `cand[0]` is the full interpreter name) contradicts this. Codex was conflating the single-operand `@(@(1))` flattening rule with the comma-separated `@(A, B, C)` literal which does NOT flatten elements. Reverting the fix per the P2 suggestion would re-introduce the `System.Object[]` bug.

## Scope

`scripts/install.ps1` only. README phrasing of the `iwr | iex` one-liner itself (pwsh 5.1 compatibility, argument passing, side-effect pollution) is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RbkkKGsaXC6zvZRNPNPuF