### PR TITLE
fix(claude): regenerate runtime 0.1.30 schema-drift fixture goldens + bump pin floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.29,<0.2",
+    "claude-org-runtime>=0.1.30,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,13 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.30 to match the PR #97 sandbox output normalization:
+# 0.1.30 renders sandbox denyRead/denyWrite as contract-§2.1 resolved string
+# arrays (was dict entries). ja's semantic-drift goldens under
+# tests/fixtures/runtime_schema_drift/sandbox_intent/ were regenerated for the
+# string shape, so a 0.1.29 install renders the old dict shape and fails those
+# tests; exclude it from the floor (upper bound stays <0.2). The earlier
+# 0.1.29 floor (runtime 0.1.29 BREAKING rename, below) is subsumed.
 # Floor bumped to 0.1.29 for the runtime 0.1.29 BREAKING rename
 # (claude-org-spike->claude-org-broker socket / SPIKE_SOCKET->BROKER_SOCKET /
 # SPIKE_BACKEND->ORG_BACKEND, session prefix spike-{pid}-{n}->claude-org-broker-{pid}-{n}).
@@ -47,7 +54,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.29,<0.2
+claude-org-runtime>=0.1.30,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
@@ -151,38 +151,18 @@
   },
   "expected_rendered_sandbox": {
     "enabled": true,
-    "failIfUnavailable": false,
     "filesystem": {
       "additionalDirectories": [
         "/home/u/co/knowledge"
       ],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/co/.curator/.env",
+        "/home/u/co/.curator/.env.*",
+        "/home/u/co/.curator/**/credentials*",
+        "/home/u/co/.curator/**/*.pem"
       ],
       "denyWrite": []
-    }
+    },
+    "failIfUnavailable": false
   }
 }

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
@@ -64,65 +64,25 @@
   },
   "expected_rendered_sandbox": {
     "enabled": true,
-    "failIfUnavailable": false,
     "filesystem": {
       "additionalDirectories": [
         "/home/u/co"
       ],
       "denyRead": [
-        {
-          "anchor": "claude_org_path",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true
-        },
-        {
-          "anchor": "claude_org_path",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true
-        },
-        {
-          "anchor": "claude_org_path",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true
-        },
-        {
-          "anchor": "claude_org_path",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true
-        }
+        "/home/u/co/**/credentials*",
+        "/home/u/co/**/*.pem",
+        "/home/u/co/.env",
+        "/home/u/co/.env.*"
       ],
       "denyWrite": [
-        {
-          "anchor": "claude_org_path",
-          "path": "tools",
-          "suppressOnSymlinkEscape": true
-        },
-        {
-          "anchor": "claude_org_path",
-          "path": "dashboard",
-          "suppressOnSymlinkEscape": true
-        },
-        {
-          "anchor": "claude_org_path",
-          "path": "tests",
-          "suppressOnSymlinkEscape": true
-        },
-        {
-          "anchor": "claude_org_path",
-          "path": ".claude/skills",
-          "suppressOnSymlinkEscape": true
-        },
-        {
-          "anchor": "claude_org_path",
-          "path": "docs",
-          "suppressOnSymlinkEscape": true
-        },
-        {
-          "anchor": "claude_org_path",
-          "path": "registry",
-          "suppressOnSymlinkEscape": true
-        }
+        "/home/u/co/tools",
+        "/home/u/co/dashboard",
+        "/home/u/co/tests",
+        "/home/u/co/.claude/skills",
+        "/home/u/co/docs",
+        "/home/u/co/registry"
       ]
-    }
+    },
+    "failIfUnavailable": false
   }
 }

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
@@ -67,38 +67,18 @@
   },
   "expected_rendered_sandbox": {
     "enabled": true,
-    "failIfUnavailable": false,
     "filesystem": {
       "additionalDirectories": [
         "/home/u/co/../workers"
       ],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/co/.env",
+        "/home/u/co/.env.*",
+        "/home/u/co/**/credentials*",
+        "/home/u/co/**/*.pem"
       ],
       "denyWrite": []
-    }
+    },
+    "failIfUnavailable": false
   }
 }

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_A.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_A.json
@@ -73,30 +73,10 @@
         "/home/u/co/knowledge/raw"
       ],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/workers/proj/.env",
+        "/home/u/workers/proj/.env.*",
+        "/home/u/workers/proj/**/credentials*",
+        "/home/u/workers/proj/**/*.pem"
       ],
       "denyWrite": []
     },

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_B.json
@@ -96,30 +96,10 @@
         "/home/u/co/knowledge/raw"
       ],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/workers/proj/.worktrees/T123/.env",
+        "/home/u/workers/proj/.worktrees/T123/.env.*",
+        "/home/u/workers/proj/.worktrees/T123/**/credentials*",
+        "/home/u/workers/proj/.worktrees/T123/**/*.pem"
       ],
       "denyWrite": []
     },

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_C.json
@@ -73,30 +73,10 @@
         "/home/u/co/knowledge/raw"
       ],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/workers/T123/.env",
+        "/home/u/workers/T123/.env.*",
+        "/home/u/workers/T123/**/credentials*",
+        "/home/u/workers/T123/**/*.pem"
       ],
       "denyWrite": []
     },

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_A.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_A.json
@@ -73,37 +73,13 @@
         "/home/u/work/wd/.claude/plans"
       ],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/work/wd/.env",
+        "/home/u/work/wd/.env.*",
+        "/home/u/work/wd/**/credentials*",
+        "/home/u/work/wd/**/*.pem"
       ],
       "denyWrite": [
-        {
-          "anchor": "worker_dir",
-          "path": "**",
-          "suppressOnSymlinkEscape": false
-        }
+        "/home/u/work/wd/**"
       ]
     },
     "failIfUnavailable": false

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_B.json
@@ -96,57 +96,17 @@
         "/home/u/workers/proj/.git/packed-refs"
       ],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/workers/proj/.worktrees/T123/.env",
+        "/home/u/workers/proj/.worktrees/T123/.env.*",
+        "/home/u/workers/proj/.worktrees/T123/**/credentials*",
+        "/home/u/workers/proj/.worktrees/T123/**/*.pem"
       ],
       "denyWrite": [
-        {
-          "anchor": "worker_dir",
-          "path": "**",
-          "suppressOnSymlinkEscape": false
-        },
-        {
-          "anchor": "base_clone",
-          "path": ".git/worktrees/T123/**",
-          "suppressOnSymlinkEscape": false
-        },
-        {
-          "anchor": "base_clone",
-          "path": ".git/objects/**",
-          "suppressOnSymlinkEscape": false
-        },
-        {
-          "anchor": "base_clone",
-          "path": ".git/refs/heads/feat/audit",
-          "suppressOnSymlinkEscape": false
-        },
-        {
-          "anchor": "base_clone",
-          "path": ".git/packed-refs",
-          "suppressOnSymlinkEscape": false
-        }
+        "/home/u/workers/proj/.worktrees/T123/**",
+        "/home/u/workers/proj/.git/worktrees/T123/**",
+        "/home/u/workers/proj/.git/objects/**",
+        "/home/u/workers/proj/.git/refs/heads/feat/audit",
+        "/home/u/workers/proj/.git/packed-refs"
       ]
     },
     "failIfUnavailable": false

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_C.json
@@ -73,37 +73,13 @@
         "/home/u/workers/T123/.claude/plans"
       ],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/workers/T123/.env",
+        "/home/u/workers/T123/.env.*",
+        "/home/u/workers/T123/**/credentials*",
+        "/home/u/workers/T123/**/*.pem"
       ],
       "denyWrite": [
-        {
-          "anchor": "worker_dir",
-          "path": "**",
-          "suppressOnSymlinkEscape": false
-        }
+        "/home/u/workers/T123/**"
       ]
     },
     "failIfUnavailable": false

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_B.json
@@ -91,30 +91,10 @@
         "/home/u/co/.git/packed-refs"
       ],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/co/.worktrees/T123/.env",
+        "/home/u/co/.worktrees/T123/.env.*",
+        "/home/u/co/.worktrees/T123/**/credentials*",
+        "/home/u/co/.worktrees/T123/**/*.pem"
       ],
       "denyWrite": []
     },

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_C.json
@@ -67,30 +67,10 @@
     "filesystem": {
       "additionalDirectories": [],
       "denyRead": [
-        {
-          "anchor": "worker_dir",
-          "path": ".env",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": ".env.*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(.env.*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/credentials*",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/credentials*)"
-        },
-        {
-          "anchor": "worker_dir",
-          "path": "**/*.pem",
-          "suppressOnSymlinkEscape": true,
-          "layer2Fallback": "Read(**/*.pem)"
-        }
+        "/home/u/co/.env",
+        "/home/u/co/.env.*",
+        "/home/u/co/**/credentials*",
+        "/home/u/co/**/*.pem"
       ],
       "denyWrite": []
     },

--- a/tools/update_runtime.py
+++ b/tools/update_runtime.py
@@ -86,7 +86,7 @@ def _is_already_current(installed: str, latest: str) -> bool:
 
 def _pip_install_target(pin: str | None) -> str:
     """Build the ``<package><pin-spec>`` install target, e.g.
-    ``claude-org-runtime>=0.1.29,<0.2``. Single source of truth so the
+    ``claude-org-runtime>=0.1.30,<0.2``. Single source of truth so the
     dry-run echo and the real pip argv use the identical string. This
     mirrors check_runtime_version.main()'s upgrade_target construction
     so pip resolves within the pin window."""


### PR DESCRIPTION
## Summary

claude-org-runtime 0.1.30 (PR #97: denyRead/denyWrite を contract §2.1 の string 配列で出力) リリース後、ja の `tests/test_runtime_schema_drift_semantic.py` の fixture goldens (旧 dict shape 期待) が実 runtime 出力 (string shape) と不整合になり、CI で 11 件 fail していた問題を修正。fixture を再生成し、合わせて install pin の floor も 0.1.30 に上げて低バージョン回帰窓を閉じる。

## Commits

1. **4d6bd6f** `fix(claude): runtime 0.1.30 出力に合わせて test_runtime_schema_drift_semantic の fixture goldens を再生成`
   - `tests/fixtures/runtime_schema_drift/sandbox_intent/` 配下 11 files (`role_curator/dispatcher/secretary`, `worker_default_A/B/C`, `worker_doc_audit_A/B/C`, `worker_self_edit_B/C`)
   - 純減 diff: +63 / -331 (dict → string で短くなる)
   - `expected_rendered_sandbox` のみ更新。`expected_explain` (suppression record) は dict shape を保持 (記録対象が違うため不変、全 11 件で無変更を検証済み)
   - 影響は `sandbox_intent` 配下に閉じている (他 fixture や delegate_payload/projects-sample 等は無関係を grep 確認済み)

2. **b7e0f92** `fix(claude): bump claude-org-runtime pin floor to 0.1.30 to match regenerated fixtures`
   - `pyproject.toml`: `claude-org-runtime>=0.1.29,<0.2` → `>=0.1.30,<0.2`
   - `requirements.txt`: 同上ミラー + floor 履歴コメント追記
   - `tools/update_runtime.py`: docstring の例示更新
   - 0.1.29 で固定された環境で旧 dict shape がレンダされて goldens が fail する Codex P2 指摘を解消

## Test plan

- [x] `python -m unittest tests/test_runtime_schema_drift_semantic.py` — 5/5 (対象テスト全 pass)
- [x] `python -m unittest discover tests -q` — 636/636 全テスト pass (回帰なし)
- [x] `tools` 配下の update_runtime / check_runtime_version も 35/35 pass (skip 9 はネットワーク/packaging 依存)
- [x] `tools/check_runtime_schema_drift.py --semantic` green
- [x] Codex review (fixture diff + bump diff 別個): Blocker/Major/Minor すべてゼロ

## Why both in one PR

Codex P2 (originally raised) で「fixture は 0.1.30 出力期待 / pin は 0.1.29 floor」のアトミック性欠如が指摘された。窓口判断で pin bump を同 PR に同梱し、結合の緩さを解消。

## 再現可能性メモ

次回 runtime release で同じ作業 (fixture 再生成) を回すための content-change ガード付きスクリプトを `knowledge/raw/2026-06-22-runtime-fixture-regen.md` に保存済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RbkkKGsaXC6zvZRNPNPuF