### PR TITLE
fix(claude): demote renga (and node/npm) from required to optional in installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ claude-org-ja は、Claude Code を 1 つの窓口から複数のワーカーへ
 
 ## すぐ試す
 
-前提ツール（git / claude / gh / jq / Node.js / Python）が入っていれば、1 行のコマンドでクローンとセットアップができます。
+前提ツール（git / claude / gh / jq / Python）が入っていれば、1 行のコマンドでクローンとセットアップができます。Node.js は renga（オプションのフォールバック経路）を入れて使う場合にのみ必要です。
 
 ```bash
 # macOS / Linux

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ claude-org-ja は、Claude Code を 1 つの窓口から複数のワーカーへ
 
 ## すぐ試す
 
-前提ツール（git / claude / gh / jq / Python）が入っていれば、1 行のコマンドでクローンとセットアップができます。Node.js は renga（オプションのフォールバック経路）を入れて使う場合にのみ必要です。
+前提ツール（git / claude / gh / jq / Python）が入っていれば、1 行のコマンドでクローンとセットアップができます。
 
 ```bash
 # macOS / Linux
@@ -47,7 +47,7 @@ claude-org-runtime org up                                # 窓口（Secretary）
 
 ### renga で起動する場合
 
-通常は `claude-org-runtime org up` で起動します。renga は、claude-org-ja に合わせて開発された、Windows・Linux・macOS 対応のターミナル作業環境です（[GitHub](https://github.com/suisya-systems/renga) / [npm](https://www.npmjs.com/package/@suisya-systems/renga)）。複数の Claude Code ペインを 1 つの画面に並べ、窓口・ディスパッチャー・ワーカーのペイン管理と、ペイン同士の連絡を扱います。画面全体でペインの動きを見ながら起動したい場合は、renga を使って起動できます。クローン後のディレクトリで次を実行します。
+通常は `claude-org-runtime org up` で起動します。renga は、claude-org-ja に合わせて開発された、Windows・Linux・macOS 対応のターミナル作業環境です（[GitHub](https://github.com/suisya-systems/renga) / [npm](https://www.npmjs.com/package/@suisya-systems/renga)）。複数の Claude Code ペインを 1 つの画面に並べ、窓口・ディスパッチャー・ワーカーのペイン管理と、ペイン同士の連絡を扱います。画面全体でペインの動きを見ながら起動したい場合は、renga を使って起動できます。renga は npm パッケージなので、別途 Node.js（LTS 推奨）のインストールが必要です。クローン後のディレクトリで次を実行します。
 
 ```bash
 # macOS / Linux

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4,12 +4,13 @@
 #   pwsh -NoProfile -File scripts/install.ps1 [-Dir <path>] [-DryRun] [-SkipMcp]
 #
 # This script:
-#   1. Checks for required commands (git, claude, renga, gh, jq) and prints
-#      installation hints when something is missing.
+#   1. Checks for required commands (git, claude, gh, jq) and prints
+#      installation hints when something is missing. renga is optional
+#      (only needed for ORG_TRANSPORT=renga) and is skipped when absent.
 #   2. Clones suisya-systems/claude-org-ja (asks before reusing an
 #      existing directory).
-#   3. Runs `renga mcp install` (user-scope) so the renga-peers MCP
-#      server is registered with Claude Code.
+#   3. Runs `renga mcp install` (user-scope) when renga is present, so the
+#      renga-peers MCP server is registered with Claude Code.
 #   4. Prints next steps.
 #
 # It never auto-installs missing tools and never bypasses Claude Code's
@@ -67,6 +68,21 @@ function Test-Prerequisite {
     return $false
 }
 
+function Test-OptionalCommand {
+    # Soft variant of Test-Prerequisite for tools the default (broker)
+    # transport never needs. Reports presence (so a present tool can still
+    # drive the later `renga mcp install` step) but the caller does NOT
+    # flip $missing on absence, so the install proceeds without it.
+    param([string]$Name, [string]$Hint, [string]$Why)
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($null -ne $cmd) {
+        Write-Host "  [ok]   $Name`: $($cmd.Source)"
+        return $true
+    }
+    Write-Host "  [skip] $Name not found - $Why. Install hint: $Hint"
+    return $false
+}
+
 function Read-YesNo {
     param([string]$Prompt, [string]$Default = 'Y')
     $hint = if ($Default -eq 'Y') { '[Y/n]' } else { '[y/N]' }
@@ -89,7 +105,10 @@ Write-Host 'Checking prerequisites...'
 $missing = $false
 if (-not (Test-Prerequisite 'git'    'https://git-scm.com/downloads'))                          { $missing = $true }
 if (-not (Test-Prerequisite 'claude' 'https://claude.ai/code (Claude Code CLI)'))               { $missing = $true }
-if (-not (Test-Prerequisite 'renga'  'npm install -g @suisya-systems/renga@0.18.0'))            { $missing = $true }
+# renga is optional: the code-default broker transport never needs it, so an
+# absent renga must not abort the install. Capture presence (a present renga
+# still drives `renga mcp install` below) but never set $missing.
+$rengaPresent = Test-OptionalCommand 'renga' 'npm install -g @suisya-systems/renga@0.18.0' 'optional; only needed when ORG_TRANSPORT=renga'
 if (-not (Test-Prerequisite 'gh'     'https://cli.github.com/'))                                { $missing = $true }
 if (-not (Test-Prerequisite 'jq'     'https://jqlang.org/download/'))                           { $missing = $true }
 Write-Host ''
@@ -175,6 +194,14 @@ if (Test-Path -LiteralPath $Dir) {
 
 if ($SkipMcp) {
     Write-Host 'Skipping `renga mcp install` (-SkipMcp).'
+} elseif (-not $rengaPresent) {
+    # renga is optional and not installed: the default broker transport does
+    # not use it, so this is not an error. Skip the MCP registration and tell
+    # the user how to enable it later if they want the renga transport.
+    Write-Host ''
+    Write-Host 'Skipping `renga mcp install`: renga is not installed (optional).'
+    Write-Host 'It is only needed for the renga transport (ORG_TRANSPORT=renga).'
+    Write-Host 'To enable it later: npm install -g @suisya-systems/renga@0.18.0; renga mcp install'
 } else {
     Write-Host ''
     Write-Host 'Registering renga-peers MCP with Claude Code (user-scope)...'
@@ -264,11 +291,23 @@ if ((Test-Path -LiteralPath $pyprojectFile) -and $pyCmd) {
 # documented `py -3` Windows default when no interpreter was detected.
 $pyInvoke = if ($pyCmd) { ($pyCmd -join ' ') } else { 'py -3' }
 $launchStep = "$pyInvoke -m claude_org_runtime.cli org up                       # launch the org (broker daemon + Secretary pane)"
-$launchNote = @"
+# Tailor the renga fallback note to whether renga is actually installed.
+# renga is optional, so when it's absent the note must say how to install it
+# first rather than implying it's ready to use.
+$launchNote = if ($rengaPresent) {
+    @"
 
 To fall back to renga, set ORG_TRANSPORT=renga and run 'renga --layout ops'
 instead (see docs/getting-started.md).
 "@
+} else {
+    @"
+
+renga (optional) is not installed. To use the renga transport, first install it
+(npm install -g @suisya-systems/renga@0.18.0; renga mcp install), then set
+ORG_TRANSPORT=renga and run 'renga --layout ops' (see docs/getting-started.md).
+"@
+}
 if (-not $DryRun) {
     $orgUpOk = $false
     if ($pyCmd) {
@@ -281,8 +320,21 @@ if (-not $DryRun) {
         }
     }
     if (-not $orgUpOk) {
+        # Falling back to the renga launcher: renga is now the *only* working
+        # launcher for this checkout. renga is optional, so when it's absent we
+        # must not print a bare 'renga --layout ops' with an empty note --
+        # surface an install hint instead.
         $launchStep = "renga --layout ops                                           # launch the Secretary pane (this ref predates 'claude-org-runtime org up')"
-        $launchNote = ''
+        $launchNote = if ($rengaPresent) {
+            ''
+        } else {
+            @"
+
+renga is not installed, but this checkout's runtime predates
+'claude-org-runtime org up', so renga is the launcher here. Install it first:
+  npm install -g @suisya-systems/renga@0.18.0; renga mcp install
+"@
+        }
     }
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -122,6 +122,44 @@ Install the listed tools, then re-run this installer.
     exit 1
 }
 
+# Shared Python 3.10+ probe (the runtime's pyproject pins
+# `requires-python = ">=3.10"`). Asking Python itself via version_info -- not
+# parsing a bare `--version` -- exactly rejects Python 2.x / <3.10, and also
+# rejects the Microsoft Store python stub (which fails the probe), so an
+# unusable interpreter never counts as a working broker launcher.
+$pyVersionProbe = 'import sys; sys.exit(0 if sys.version_info[:2] >= (3, 10) else 1)'
+
+# No-usable-launcher guard: the org starts via either the broker (needs a
+# Python 3.10+ interpreter for `claude-org-runtime org up`) or renga. renga is
+# optional and Python is only soft-handled below, so a box with NEITHER would
+# otherwise reach a "success" whose final step points at an uninstalled
+# launcher. Only probe Python when renga is absent (so a renga-present box
+# never touches the Microsoft Store python stub), then fail fast if neither
+# launcher exists. The later $pyCmd probe can't be reused here: it runs after
+# the clone and only when a dep file exists (never under -DryRun).
+if (-not $rengaPresent) {
+    $pythonAvailable = $false
+    foreach ($cand in @(@('python'), @('python3'), @('py', '-3'))) {
+        if (-not (Get-Command $cand[0] -ErrorAction SilentlyContinue)) { continue }
+        $rest = if ($cand.Length -gt 1) { $cand[1..($cand.Length - 1)] } else { @() }
+        try {
+            & $cand[0] @($rest + @('-c', $pyVersionProbe)) > $null 2>&1
+            if ($LASTEXITCODE -eq 0) { $pythonAvailable = $true; break }
+        } catch {
+            # candidate is on PATH but failed to launch; try the next one
+        }
+    }
+    if (-not $pythonAvailable) {
+        [Console]::Error.WriteLine('install.ps1: no usable launcher found. The org starts via either:')
+        [Console]::Error.WriteLine("  - the broker (default): needs a Python 3.10+ interpreter for 'claude-org-runtime org up', or")
+        [Console]::Error.WriteLine("  - renga: set ORG_TRANSPORT=renga and run 'renga --layout ops'.")
+        [Console]::Error.WriteLine('No Python 3.10+ interpreter and no renga are available. Install at least one and re-run:')
+        [Console]::Error.WriteLine('  - Python 3.10+ (broker): https://www.python.org/downloads/')
+        [Console]::Error.WriteLine('  - renga (fallback):      npm install -g @suisya-systems/renga@0.18.0')
+        exit 1
+    }
+}
+
 # --- Clone ---------------------------------------------------------------
 
 if (Test-Path -LiteralPath $Dir) {
@@ -234,12 +272,13 @@ $reqFile = Join-Path $Dir 'requirements.txt'
 # boxes still carrying 2.7. Each candidate is its own token list so
 # the launcher flag rides with the executable through Invoke-Step.
 #
-# Each candidate is then probed with `--version` to weed out the
-# Microsoft Store App Execution Alias stub — Windows preinstalls
-# `python.exe` under `...\WindowsApps\` even without a real Python,
-# and that stub exits non-zero (or pops the Store) on any real call.
-# A successful `--version` proves a working interpreter is on the
-# other end while still accepting genuine Store-installed Pythons.
+# Each candidate is then probed with the shared $pyVersionProbe (Python
+# 3.10+ via version_info) to weed out both the Microsoft Store App Execution
+# Alias stub — Windows preinstalls `python.exe` under `...\WindowsApps\` even
+# without a real Python, and that stub exits non-zero (or pops the Store) on
+# any real call — and any Python 2.x / <3.10 that couldn't install the
+# runtime anyway. A successful probe proves a usable interpreter is on the
+# other end. (Same probe the no-usable-launcher guard above uses.)
 $pyCmd = $null
 if ((Test-Path -LiteralPath $pyprojectFile) -or (Test-Path -LiteralPath $reqFile)) {
     $pyCandidates = @(
@@ -251,7 +290,7 @@ if ((Test-Path -LiteralPath $pyprojectFile) -or (Test-Path -LiteralPath $reqFile
         if (-not (Get-Command $cand[0] -ErrorAction SilentlyContinue)) { continue }
         $rest = if ($cand.Length -gt 1) { $cand[1..($cand.Length - 1)] } else { @() }
         try {
-            & $cand[0] @($rest + @('--version')) > $null 2>&1
+            & $cand[0] @($rest + @('-c', $pyVersionProbe)) > $null 2>&1
             if ($LASTEXITCODE -eq 0) { $pyCmd = $cand; break }
         } catch {
             # candidate is on PATH but failed to launch; try the next one

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -286,6 +286,51 @@ MSG
   exit 1
 fi
 
+# Detect a Python 3.10+ interpreter up front: it is both the broker launcher
+# (`claude-org-runtime org up`) and what installs the runtime below, whose
+# pyproject pins `requires-python = ">=3.10"`. Ask Python itself via
+# version_info rather than parsing a bare `--version`: that exactly rejects
+# Python 2.x / <3.10, and also rejects the Microsoft Store App Execution
+# Alias stub on Windows (`python.exe` under `WindowsApps\` that exits
+# non-zero or pops the Store on real calls), so an unusable interpreter never
+# counts as a working broker launcher. `py -3` is the Windows-specific
+# fallback for stock boxes that ship only the launcher. PY_LAUNCHER carries
+# the optional `-3` so the unquoted expansion in `run $PY $PY_LAUNCHER ...`
+# drops empty when not needed.
+PY=""
+PY_LAUNCHER=""
+PY_MIN_CHECK='import sys; sys.exit(0 if sys.version_info[:2] >= (3, 10) else 1)'
+for cand in python3 python; do
+  if command -v "$cand" >/dev/null 2>&1 && "$cand" -c "$PY_MIN_CHECK" >/dev/null 2>&1; then
+    PY="$cand"; break
+  fi
+done
+if [[ -z "$PY" && "$IS_WINDOWS_BASH" == "1" ]]; then
+  if command -v py >/dev/null 2>&1 && py -3 -c "$PY_MIN_CHECK" >/dev/null 2>&1; then
+    PY="py"; PY_LAUNCHER="-3"
+  fi
+fi
+
+# No-usable-launcher guard: the org starts via either the broker (needs a
+# Python 3.10+ interpreter for `claude-org-runtime org up`) or renga. renga
+# is optional and Python is only soft-warned below, so a box with NEITHER
+# would otherwise sail past every check to a "success" whose final step
+# points at an uninstalled launcher. Fail fast here, mirroring the prereq
+# abort above.
+if [[ -z "$RENGA_BIN" && -z "$PY" ]]; then
+  cat <<'MSG' >&2
+install.sh: no usable launcher found. The org starts via either:
+  - the broker (default): needs a Python 3.10+ interpreter for
+    'claude-org-runtime org up', or
+  - renga: set ORG_TRANSPORT=renga and run 'renga --layout ops'.
+No Python 3.10+ interpreter and no renga are available. Install at least one
+and re-run this installer:
+  - Python 3.10+ (broker): https://www.python.org/downloads/ or your OS package manager
+  - renga (fallback):      npm install -g @suisya-systems/renga@0.18.0
+MSG
+  exit 1
+fi
+
 # --- Clone -----------------------------------------------------------------
 
 if [[ -e "$TARGET_DIR" ]]; then
@@ -368,25 +413,8 @@ fi
 # claude-org-runtime package. Phase 5c (Issue #130) moved the install
 # path from `requirements.txt` to `pyproject.toml`; we prefer the
 # editable install so the dep set comes from the canonical source.
-# Probe each candidate with `--version` so the Microsoft Store App
-# Execution Alias stub on Windows (`python.exe` under `WindowsApps\`
-# that exits non-zero or pops the Store on real calls) doesn't get
-# selected. `py -3` is the Windows-specific fallback for stock boxes
-# that ship only the launcher; pinning `-3` skips any leftover 2.7.
-# PY_LAUNCHER carries the optional `-3` so the unquoted expansion in
-# `run $PY $PY_LAUNCHER ...` drops empty when not needed.
-PY=""
-PY_LAUNCHER=""
-for cand in python3 python; do
-  if command -v "$cand" >/dev/null 2>&1 && "$cand" --version >/dev/null 2>&1; then
-    PY="$cand"; break
-  fi
-done
-if [[ -z "$PY" && "$IS_WINDOWS_BASH" == "1" ]]; then
-  if command -v py >/dev/null 2>&1 && py -3 --version >/dev/null 2>&1; then
-    PY="py"; PY_LAUNCHER="-3"
-  fi
-fi
+# PY / PY_LAUNCHER were detected up front (alongside the no-usable-launcher
+# guard); reuse them here.
 PYPROJECT_FILE="$TARGET_DIR/pyproject.toml"
 REQ_FILE="$TARGET_DIR/requirements.txt"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,8 @@
 # This script:
 #   1. Checks for required commands (git, claude, gh, jq) and prints
 #      installation hints when something is missing. renga is optional
-#      (only needed for ORG_TRANSPORT=renga) and is skipped when absent.
+#      (only needed for ORG_TRANSPORT=renga), as are the node/npm used
+#      only to install it; all are skipped when absent.
 #   2. Clones suisya-systems/claude-org-ja (asks before reusing an
 #      existing directory).
 #   3. Runs `renga mcp install` (user-scope) when renga is present, so the
@@ -243,21 +244,22 @@ fi
 missing=0
 require_or_warn git    "https://git-scm.com/downloads" || missing=1
 require_or_warn claude "https://claude.ai/code (Claude Code CLI)" || missing=1
-# Surface node + npm as prereqs on Linux/macOS so a fresh WSL2 /
-# Ubuntu / macOS box doesn't follow the renga "npm install -g ..."
-# hint into a "command not found: npm" wall. On Windows / Git Bash,
-# renga can ship via npm shims, scoop, cargo, or standalone
-# installers (resolve_command's fallback ladder handles all of
-# those), so a global node/npm requirement there would be a
-# regression for working installs — leave that path's prereqs alone.
+# Probe node + npm on Linux/macOS, but treat them as OPTIONAL: their only
+# purpose here is to let a fresh WSL2 / Ubuntu / macOS box follow the renga
+# "npm install -g ..." hint, and renga itself is optional (the default
+# broker transport is pure Python and needs neither). So a missing node/npm
+# must not abort a broker-only install -- soft-warn and continue. On Windows
+# / Git Bash, renga can ship via npm shims, scoop, cargo, or standalone
+# installers (resolve_command's fallback ladder handles all of those), so
+# node/npm aren't probed there at all.
 if [[ "$IS_LINUX" == "1" || "$IS_MAC" == "1" ]]; then
   if [[ "$IS_LINUX" == "1" ]]; then
     NODE_HINT='install Node 20 LTS via nvm — https://github.com/nvm-sh/nvm (then: nvm install --lts)'
   else
     NODE_HINT='brew install node  (or use nvm: https://github.com/nvm-sh/nvm)'
   fi
-  require_or_warn node "$NODE_HINT" || missing=1
-  require_or_warn npm  "ships with Node — install Node first ($NODE_HINT)" || missing=1
+  optional_or_warn node "$NODE_HINT" "optional; only needed to install renga (ORG_TRANSPORT=renga)"
+  optional_or_warn npm  "ships with Node — install Node first ($NODE_HINT)" "optional; only needed to install renga (ORG_TRANSPORT=renga)"
 fi
 # renga is optional: the code-default broker transport never needs it, so
 # an absent renga must not abort the install. Probe it (a present renga is

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,12 +5,13 @@
 #   bash scripts/install.sh [--dir <path>] [--dry-run] [--skip-mcp]
 #
 # This script:
-#   1. Checks for required commands (git, claude, renga, gh, jq) and prints
-#      installation hints when something is missing.
+#   1. Checks for required commands (git, claude, gh, jq) and prints
+#      installation hints when something is missing. renga is optional
+#      (only needed for ORG_TRANSPORT=renga) and is skipped when absent.
 #   2. Clones suisya-systems/claude-org-ja (asks before reusing an
 #      existing directory).
-#   3. Runs `renga mcp install` (user-scope) so the renga-peers MCP
-#      server is registered with Claude Code.
+#   3. Runs `renga mcp install` (user-scope) when renga is present, so the
+#      renga-peers MCP server is registered with Claude Code.
 #   4. Prints next steps.
 #
 # It never auto-installs missing tools and never bypasses Claude Code's
@@ -198,6 +199,29 @@ require_or_warn() {
   return 1
 }
 
+optional_or_warn() {
+  # Soft variant of require_or_warn for tools the default (broker)
+  # transport never needs. Resolves with the same Windows fallback ladder
+  # and PATH-prepend so a *present* tool stays usable by the later
+  # `renga mcp install` step, but an *absent* tool prints a soft [skip]
+  # note and NEVER flips `missing` — the install proceeds without it.
+  # $1 = command name, $2 = install hint, $3 = short reason it's optional.
+  local cmd="$1" hint="$2" why="$3" resolved="" parent
+  if resolved=$(resolve_command "$cmd"); then
+    echo "  [ok]   $cmd: $resolved"
+    if [[ "$IS_WINDOWS_BASH" == "1" ]]; then
+      parent=$(dirname -- "$resolved")
+      case ":$PATH:" in
+        *":$parent:"*) ;;
+        *) PATH="$parent:$PATH" ;;
+      esac
+    fi
+    return 0
+  fi
+  echo "  [skip] $cmd not found - $why. Install hint: $hint"
+  return 0
+}
+
 echo "== claude-org-ja installer =="
 echo
 
@@ -235,7 +259,10 @@ if [[ "$IS_LINUX" == "1" || "$IS_MAC" == "1" ]]; then
   require_or_warn node "$NODE_HINT" || missing=1
   require_or_warn npm  "ships with Node — install Node first ($NODE_HINT)" || missing=1
 fi
-require_or_warn renga  "npm install -g @suisya-systems/renga@0.18.0" || missing=1
+# renga is optional: the code-default broker transport never needs it, so
+# an absent renga must not abort the install. Probe it (a present renga is
+# still wired into `renga mcp install` below) but never set `missing`.
+optional_or_warn renga "npm install -g @suisya-systems/renga@0.18.0" "optional; only needed when ORG_TRANSPORT=renga"
 require_or_warn gh     "https://cli.github.com/" || missing=1
 require_or_warn jq     "apt install jq / brew install jq / https://jqlang.org/download/" || missing=1
 # Capture the absolute path so the later `run renga mcp install` can
@@ -315,6 +342,14 @@ fi
 
 if [[ "$SKIP_MCP" == "1" ]]; then
   echo "Skipping 'renga mcp install' (--skip-mcp)."
+elif [[ -z "$RENGA_BIN" ]]; then
+  # renga is optional and not installed: the default broker transport
+  # doesn't use it, so this is not an error. Skip the MCP registration and
+  # tell the user how to enable it later if they want the renga transport.
+  echo
+  echo "Skipping 'renga mcp install': renga is not installed (optional)."
+  echo "It is only needed for the renga transport (ORG_TRANSPORT=renga)."
+  echo "To enable it later: npm install -g @suisya-systems/renga@0.18.0 && renga mcp install"
 else
   echo
   echo "Registering renga-peers MCP with Claude Code (user-scope)..."
@@ -481,9 +516,31 @@ else
   BROKER_LAUNCH="claude-org-runtime org up"
 fi
 LAUNCH_STEP="$BROKER_LAUNCH                                    # launch the org (broker daemon + Secretary pane)"
-LAUNCH_NOTE="
+# Tailor the renga fallback note to whether renga is actually installed.
+# renga is optional, so when it's absent the note must say how to install
+# it first rather than implying it's ready to use.
+if [[ -n "$RENGA_BIN" ]]; then
+  LAUNCH_NOTE="
 To fall back to renga, set ORG_TRANSPORT=renga and run 'renga --layout ops'
 instead (see docs/getting-started.md)."
+else
+  LAUNCH_NOTE="
+renga (optional) is not installed. To use the renga transport, first install it
+(npm install -g @suisya-systems/renga@0.18.0 && renga mcp install), then set
+ORG_TRANSPORT=renga and run 'renga --layout ops' (see docs/getting-started.md)."
+fi
+# When the runtime probe below falls back to the renga launcher (legacy ref or
+# a missing runtime), renga becomes the *only* working launcher for this
+# checkout. renga is now optional, so if it's absent we must not print a bare
+# 'renga --layout ops' with an empty note — surface an install hint instead.
+if [[ -n "$RENGA_BIN" ]]; then
+  RENGA_LAUNCHER_NOTE=""
+else
+  RENGA_LAUNCHER_NOTE="
+renga is not installed, but this checkout's runtime predates
+'claude-org-runtime org up', so renga is the launcher here. Install it first:
+  npm install -g @suisya-systems/renga@0.18.0 && renga mcp install"
+fi
 if [[ "$DRY_RUN" != "1" ]]; then
   # Real install: only advertise `org up` if the installed runtime can
   # actually provide it. Otherwise (legacy pinned ref, or no runtime
@@ -496,7 +553,7 @@ if [[ "$DRY_RUN" != "1" ]]; then
     # shipped with. (install.ps1 gets this for free: it only detects a
     # python when a dep file exists.)
     LAUNCH_STEP="renga --layout ops                                           # launch the Secretary pane (this ref predates 'claude-org-runtime org up')"
-    LAUNCH_NOTE=""
+    LAUNCH_NOTE="$RENGA_LAUNCHER_NOTE"
   else
     # Probe the runtime we just installed for this checkout (venv on
     # Linux/macOS, --user interpreter on Windows / Git Bash).
@@ -509,7 +566,7 @@ if [[ "$DRY_RUN" != "1" ]]; then
     if ! { [[ -n "$PROBE_PY" ]] \
            && "$PROBE_PY" $PY_LAUNCHER -m claude_org_runtime.cli org up --help >/dev/null 2>&1; }; then
       LAUNCH_STEP="renga --layout ops                                           # launch the Secretary pane (this ref predates 'claude-org-runtime org up')"
-      LAUNCH_NOTE=""
+      LAUNCH_NOTE="$RENGA_LAUNCHER_NOTE"
     fi
   fi
 fi


### PR DESCRIPTION
## Summary

Closes #634.

The one-liner installers (`scripts/install.sh` / `scripts/install.ps1`) listed `renga` as a **required** prerequisite, blocking installs with `missing=1` when renga wasn't on PATH. Since runtime 0.1.28 the code default transport is **broker** and renga is positioned as an opt-in fallback (`ORG_TRANSPORT=renga`). This PR demotes `renga` to optional, plus (per scope-expansion judgments during review) does the same for `node` / `npm`, aligns the README prerequisite list, and adds a no-usable-launcher guard so the installer doesn't claim success when neither broker (Python ≥3.10) nor renga is available.

## Commits (4)

1. **eb6d6f6** `fix(claude): make renga optional in install.sh/install.ps1 (Closes #634)`
   - New `optional_or_warn` (bash) / `Test-OptionalCommand` (PowerShell) — soft-warn helpers that do not flip the `missing` flag.
   - `renga` uses these. When absent: skip `renga mcp install`, emit guidance ("to enable renga, run `npm install -g @suisya-systems/renga@0.18.0`"). When present: behavior unchanged.
   - `--skip-mcp` / `-SkipMcp` explicit-skip paths preserved.

2. **2afa9bb** `fix(claude): demote node/npm to optional and align README prereqs (renga-optional follow-through)`
   - `install.sh`: `require_or_warn node|npm` → `optional_or_warn node|npm` (node/npm were only required as the bootstrap path for the renga npm hint per existing inline comments).
   - `install.ps1`: confirmed no hard `node`/`npm` prereq existed, no change there.
   - `README.md`: removed `Node.js` from the "前提ツール" list.

3. **f42b059** `docs(claude): move Node.js prereq note from prereq list to renga section`
   - Initial README diff put a "Node.js is required only for the optional renga fallback" footnote on the prereq line, but renga isn't introduced until the renga section further down — the forward reference broke the context. Moved the Node.js note into the "renga で起動する場合" section where renga is naturally introduced.

4. **7c01b44** `fix(claude): guard against no-usable-launcher (no Python 3.10+ and no renga) in installers`
   - With renga optional, "Python 3.10+ AND renga both absent" became a corner where the installer would exit 0 even though no launcher was available. Added a fail-fast guard (exit 1 + guidance to install Python ≥3.10 or renga) when neither launcher is usable.
   - Python detection uses `sys.version_info[:2] >= (3,10)` (not bare `--version`) to reject Python <3.10 and Windows Store stubs uniformly. install.ps1's post-prereq `$pyCmd` detection unified to the same probe.

## Final behavior matrix

| Python ≥3.10 | renga | Outcome |
|---|---|---|
| present | present | exit 0, runs `renga mcp install`, next-step shows broker launcher |
| present | absent | exit 0, skips renga MCP step, broker launcher in next-step |
| absent | present | exit 0, runs `renga mcp install`, renga fallback in next-step |
| absent | absent | **exit 1**, "no usable launcher" + install guidance for Python or renga |

## Test plan (executed)

- `shellcheck` (Docker `koalaman/shellcheck`) clean on `scripts/install.sh`
- `bash -n` parse clean on `install.sh`
- `pwsh -NoProfile` ParseFile clean on `install.ps1`
- Both shells dry-run-exercised across {none / good (≥3.10) / old (<3.10)} × {renga present / absent}: only the (none, absent) cell exits 1, every other cell exits 0
- All pre-existing scenarios (renga absent + Python present, `-h`/`-Help`/`--skip-mcp`/`-SkipMcp`, legacy-fallback runtime) still exit 0
- Codex review across 6 rounds: round 1 P2×2 → resolved by commit 2afa9bb; round 3 clean; round 4/5 P2s → resolved by commit 7c01b44; round 6 P2 (install.ps1 Windows Store-alias candidate-ordering — pre-existing root in `$pyCandidates`) → deferred to a separate follow-up Issue (root is pre-existing, Windows-real-machine verification unavailable in the worker environment, 3-round Codex budget already exceeded; documented in worker handover)

## Follow-up (out of scope here)

- `install.ps1` Python candidate ordering (`python` before `py -3`) can surface the Windows Store alias on stock Windows boxes. Same root sits in the pre-existing `$pyCandidates`. To be fixed in a follow-up Issue with Windows real-machine verification.
- `ORG_TRANSPORT=renga` runtime path itself (env var, dispatcher/worker prose in `docs/operations/*`, org-start spawn ritual) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RbkkKGsaXC6zvZRNPNPuF