### PR TITLE
fix(claude): pr_watch merge-watch を head-poll ループ化し新 CI を再観測

### DIFF
--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -177,9 +177,15 @@ dedupe_key=<sha256>`); direct DB INSERTs are forbidden per
 
 | Event          | Typical fields                                            | Writer    | Emitted by | Required for |
 |----------------|-----------------------------------------------------------|-----------|------------|--------------|
-| `ci_completed` | `pr`, `repo`, `status`, `duration_sec`                    | secretary | secretary  | E4           |
+| `ci_completed` | `pr`, `repo`, `status`, `duration_sec`, `head`            | secretary | secretary  | E4           |
 
-`status` ∈ `{passed, failed, incomplete, canceled}`. As of Issue #224
+`status` ∈ `{passed, failed, incomplete, canceled}`. `head` (Issue #636)
+is the short (7-char) sha of the head whose CI verdict this event
+records, or `null` when it could not be resolved; with `--merge-watch`
+a new commit pushed to the PR branch makes `tools/pr_watch.py` loop back
+to ci-watch and emit a fresh `ci_completed` (and `CI_COMPLETED` peer
+message) for the new `head`, so the secretary never approves a merge
+against a stale verdict. As of Issue #224
 the value is derived from `gh pr checks <pr> --json bucket,state,name`
 (per-check `bucket`, whose documented values are
 `{pass, fail, pending, skipping, cancel}`) rather than the gh process'

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -49,7 +49,17 @@ The event payload shape is::
     {"event": "ci_completed", "ts": "<ISO8601>",
      "pr": <int>, "repo": "<owner/repo>",
      "status": "passed|failed|incomplete|canceled",
-     "duration_sec": <int>}
+     "duration_sec": <int>, "head": "<short-sha|null>"}
+
+Issue #636: ``--merge-watch`` no longer assumes the head is frozen
+after CI passes. Each merge-watch iteration polls ``headRefOid`` (via
+``gh pr view``); if a new commit lands on the PR branch, the watcher
+loops back to ci-watch for the new head and re-emits ``CI_COMPLETED``,
+so the secretary never approves a merge against a stale verdict. The
+``head`` field (short sha) is added to the ``ci_completed`` event and to
+every peer message (``CI_COMPLETED`` / ``PR_MERGED`` /
+``PR_MERGED_NO_RUN`` / ``PR_MERGE_WATCH_TIMEOUT``) so callers can tell
+which head the signal belongs to.
 """
 
 from __future__ import annotations
@@ -68,6 +78,12 @@ from pathlib import Path
 # upper end of the org-delegate Step 5 2b-ii idle window so the
 # secretary can intervene manually past that.
 MERGE_WATCH_MAX_SECONDS = 24 * 60 * 60
+
+# Issue #636 (Codex review): sentinel returned by _watch_for_merge when the
+# PR merged at a head whose CI this watcher never confirmed (a push + merge
+# both landed between polls). Distinct from a clean merge so main surfaces a
+# non-zero exit and the peer signal uses a distinct prefix — fail-closed.
+MERGE_RESULT_HEAD_UNCONFIRMED = "merged_head_unconfirmed"
 
 # Issue #413: post-watch verdict-resolution retry. `gh pr checks --watch`
 # can return immediately on a freshly-created PR (before any check-run
@@ -119,9 +135,59 @@ def _notify_peer(message: str, to_id: str = _PEER_NOTIFY_TARGET) -> bool:
         return False
 
 
+def _short_head(oid: "str | None") -> "str | None":
+    """Return the 7-char short form of a commit OID, or ``None``.
+
+    None-safe (Issue #636): a missing / non-string OID degrades to
+    ``None`` so head-change detection and message formatting never raise
+    on a PR view that omits ``headRefOid``.
+    """
+    if not oid or not isinstance(oid, str):
+        return None
+    return oid[:7]
+
+
+def _fetch_head_oid(pr: int, repo: str) -> "str | None":
+    """Return the PR's current head commit OID (full sha), or ``None``.
+
+    Issue #636: fetched once at the start of each ci-watch round so the
+    recorded / messaged head is the head whose CI we actually observed,
+    and threaded into :func:`_watch_for_merge` as the baseline for
+    head-change detection. Best-effort: any gh / parse failure degrades
+    to ``None`` (treated downstream as "head unknown → no change"), so a
+    flaky probe never aborts the watch or fakes a head movement.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr), "--repo", repo,
+             "--json", "headRefOid"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
+            check=False,
+        )
+    except OSError:
+        return None
+    try:
+        # ``ValueError`` covers json.JSONDecodeError; ``TypeError`` covers a
+        # non-string stdout (e.g. a Mock in tests that don't stub this call).
+        data = json.loads(result.stdout or "")
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    oid = data.get("headRefOid")
+    return oid if isinstance(oid, str) and oid else None
+
+
 def _record_ci_completed(*, db_path: Path, pr: int, repo: str,
-                         status: str, duration: int) -> None:
-    """Append a ``ci_completed`` event to the DB events table."""
+                         status: str, duration: int,
+                         head: "str | None" = None) -> None:
+    """Append a ``ci_completed`` event to the DB events table.
+
+    ``head`` (Issue #636) is the short sha of the head whose CI verdict
+    this event records; ``None`` when the head could not be resolved.
+    """
     from tools.state_db import apply_schema, connect
     from tools.state_db.discover import verify_or_exit
     from tools.state_db.writer import StateWriter
@@ -144,6 +210,7 @@ def _record_ci_completed(*, db_path: Path, pr: int, repo: str,
                 "repo": repo,
                 "status": status,
                 "duration_sec": duration,
+                "head": head,
             },
         )
         writer.commit()
@@ -404,8 +471,9 @@ def _watch_for_merge(
     max_seconds: int = MERGE_WATCH_MAX_SECONDS,
     sleeper=time.sleep,
     monotonic=time.monotonic,
+    baseline_head: "str | None" = None,
 ) -> str:
-    """Poll `gh pr view --json mergedAt` until merged or bound elapses.
+    """Poll `gh pr view` until merged, the head moves, or the bound elapses.
 
     Issue #317. On the first poll that returns a non-null ``mergedAt``,
     invoke :func:`tools.run_complete_on_merge.complete_on_merge` to
@@ -413,6 +481,15 @@ def _watch_for_merge(
     On bound exhaustion, append a ``pr_merge_watch_timeout`` event to
     the DB and return ``"timeout"``. ``sleeper`` and ``monotonic`` are
     injectable for tests.
+
+    Issue #636: each poll also compares ``headRefOid`` against
+    ``baseline_head`` (the head whose CI we just watched). If a new
+    commit landed on the PR branch, return ``"head_changed"`` so the
+    caller loops back to ci-watch for the new head — the secretary must
+    not approve a merge against a CI verdict for an older head. The
+    comparison is None-safe: when either side is unknown we treat it as
+    "no change" and keep polling (so callers / mocks that don't supply
+    ``headRefOid`` retain the pre-#636 mergedAt-only behavior).
     """
     from tools.run_complete_on_merge import (
         complete_on_merge, fetch_pr_view, RESULT_ALREADY, RESULT_MERGED,
@@ -430,6 +507,23 @@ def _watch_for_merge(
             view = None
 
         if view is not None and view.get("mergedAt"):
+            # Head sha of the branch tip that was merged.
+            merged_full = view.get("headRefOid")
+            merged_head = _short_head(merged_full)
+            # Issue #636 (Codex review): a merge is terminal — the PR is
+            # already on main, so we can NOT loop back to ci-watch to
+            # confirm it (there is nothing left to watch and the merge is
+            # irreversible). But if the merged head differs from the head
+            # whose CI we last confirmed (baseline_head), the PR was merged
+            # at a commit pr_watch never separately verified. Rather than
+            # report a clean success, we flag the discrepancy loudly so the
+            # secretary doesn't treat the merge as "the approved head
+            # landed". The head tag already lets a consumer compare against
+            # the CI_COMPLETED it acted on; this makes the mismatch explicit.
+            stale_head = bool(
+                baseline_head and isinstance(merged_full, str)
+                and merged_full and merged_full != baseline_head
+            )
             try:
                 result = complete_on_merge(
                     pr=pr, repo=repo, db_path=db_path, pr_view=view,
@@ -452,27 +546,71 @@ def _watch_for_merge(
                 # merge was observed but no matching run row was found
                 # — Secretary must NOT treat it as the post-merge
                 # cleanup signal, so we surface a distinct error
-                # variant instead of PR_MERGED.
+                # variant instead of PR_MERGED. Issue #636: tag the head.
+                head_tag = merged_head or "unknown"
+                if stale_head:
+                    # Issue #636 (Codex review): the PR merged at a head
+                    # whose CI this watcher never confirmed (a push +
+                    # merge slipped between polls). A merge is terminal —
+                    # we cannot loop back to ci-watch — but we must NOT
+                    # report a clean PR_MERGED, or a consumer keying on
+                    # that prefix / exit 0 would proceed as if the merged
+                    # head had passing CI. Emit a DISTINCT prefix (like
+                    # PR_MERGED_NO_RUN, this fails closed: an unrecognized
+                    # signal makes the secretary escalate to a human
+                    # rather than auto-advance) and return a sentinel that
+                    # main maps to a non-zero exit.
+                    sys.stderr.write(
+                        f"pr_watch: PR #{pr} merged at {head_tag} but the "
+                        f"last CI-confirmed head was "
+                        f"{_short_head(baseline_head)}; the merged head's CI "
+                        "was never separately confirmed by pr_watch.\n"
+                    )
+                    _notify_peer(
+                        f"PR_MERGED_HEAD_UNCONFIRMED: PR #{pr} "
+                        f"(head={head_tag}, last CI-confirmed head="
+                        f"{_short_head(baseline_head)})"
+                    )
+                    return MERGE_RESULT_HEAD_UNCONFIRMED
                 if result == RESULT_NO_RUN:
-                    _notify_peer(f"PR_MERGED_NO_RUN: PR #{pr}")
+                    _notify_peer(f"PR_MERGED_NO_RUN: PR #{pr} (head={head_tag})")
                 else:
-                    _notify_peer(f"PR_MERGED: PR #{pr}")
+                    _notify_peer(f"PR_MERGED: PR #{pr} (head={head_tag})")
                 return result
             # RESULT_NOT_YET shouldn't occur once mergedAt is set; treat
             # defensively as "keep polling".
 
+        # Issue #636: detect a new commit on the PR branch and hand control
+        # back to the caller's ci-watch loop. Checked after the merge gate
+        # (a merged PR is terminal) and only when both heads are known.
+        if view is not None and baseline_head:
+            current_head = view.get("headRefOid")
+            if (isinstance(current_head, str) and current_head
+                    and current_head != baseline_head):
+                sys.stdout.write(
+                    f"pr_watch: PR #{pr} head moved "
+                    f"{_short_head(baseline_head)} -> "
+                    f"{_short_head(current_head)}; returning to ci-watch\n"
+                )
+                return "head_changed"
+
         if monotonic() >= deadline:
+            timeout_head = _short_head(baseline_head)
             _record_event(
                 db_path=db_path,
                 kind="pr_merge_watch_timeout",
                 payload={
                     "pr": pr, "repo": repo,
                     "max_seconds": max_seconds,
+                    "head": timeout_head,
                 },
             )
             # Issue #326: surface the 24h bound to secretary so a stuck
             # PR doesn't sit silently after the loop releases.
-            _notify_peer(f"PR_MERGE_WATCH_TIMEOUT: PR #{pr}")
+            _notify_peer(
+                f"PR_MERGE_WATCH_TIMEOUT: PR #{pr} "
+                f"(head={timeout_head or 'unknown'})"
+            )
             sys.stdout.write(
                 f"pr_watch: PR #{pr} merge-watch timed out after "
                 f"{max_seconds}s\n"
@@ -516,6 +654,157 @@ def _pr_exists(pr: int, repo: str) -> bool:
     except subprocess.CalledProcessError:
         return False
     return True
+
+
+def _run_ci_watch_phase(
+    *, pr: int, repo: str, interval: int, db_path: Path,
+) -> "tuple[str, int, str | None]":
+    """Run one ci-watch round and record/emit its verdict (Issue #636).
+
+    Blocks on ``gh pr checks --watch`` for ``pr``, resolves the final
+    verdict, appends a single ``ci_completed`` event and emits one
+    ``CI_COMPLETED`` peer message — both tagged with the short head sha
+    so the secretary can tell which head the verdict belongs to.
+    Returns ``(status, exit_code, head_oid)`` where ``head_oid`` is the
+    full head OID observed at verdict time (or ``None``).
+
+    Returns ``("head_changed", 0, head)`` instead when the branch advances
+    while we are resolving the verdict (see below); the caller treats that
+    like the merge-watch loop-back and re-runs a fresh ci-watch round.
+
+    Head/verdict pairing (Codex review, rounds 1-6): both
+    ``gh pr checks --watch`` and ``_resolve_final_status``'s
+    ``gh pr checks --json`` observe the PR's *live* head, so a branch that
+    advances any time between the start of the watch and the end of
+    resolution can yield a verdict describing a different commit than the
+    one we tag. We bracket the *entire* watch+resolve phase with a head
+    read taken before the watch starts and one taken after the verdict
+    resolves: if they differ, we do NOT record a (possibly stale or
+    transiently-incomplete) verdict — we return ``head_changed`` so
+    :func:`main` restarts the *full* ci-watch (``gh pr checks --watch``
+    blocks until the new head's CI actually completes) rather than tagging
+    a verdict to a head it doesn't describe or short-circuiting on the
+    bounded JSON resolver. When the head is stable across the whole phase,
+    the recorded head is exactly the one whose checks the verdict describes.
+
+    Factored out of :func:`main` so the head-poll loop (Issue #636) can
+    re-run a fresh ci-watch round — re-emitting ``CI_COMPLETED`` — when the
+    head moves, whether observed here (across the watch) or by merge-watch.
+    """
+    # Baseline head captured BEFORE the (blocking) watch starts, so an
+    # advance *during* the watch is caught when compared to the
+    # post-resolution head below (Codex review round 6).
+    head_before = _fetch_head_oid(pr, repo)
+    cmd = [
+        "gh", "pr", "checks", str(pr),
+        "--repo", repo,
+        "--watch",
+        "--interval", str(interval),
+    ]
+    started = time.monotonic()
+    canceled = False
+    try:
+        completed = subprocess.run(cmd)
+        exit_code = completed.returncode
+    except KeyboardInterrupt:
+        # Normalize parent-side cancellation to gh's standard exit code 2
+        # so callers (and the journal status mapping) see a portable signal.
+        exit_code = 2
+        canceled = True
+
+    # gh's documented cancellation exit code is 2 (parent SIGINT or
+    # subprocess-side Ctrl-C). Honor it directly so we don't overwrite a
+    # genuine cancellation with whatever the JSON probe returns.
+    head_oid: "str | None" = None
+    if canceled or exit_code == 2:
+        status = "canceled"
+        # Skip the head probe on cancellation: the user is aborting, so a
+        # second SIGINT during an extra subprocess would surface an ugly
+        # traceback for no benefit (a canceled verdict has no head to act
+        # on). head_oid stays None → "unknown".
+    else:
+        # Resolve the verdict against a stable head (see the head/verdict
+        # pairing note above). Issue #224: gh exit 1 from a transient
+        # watch-loop error must not be conflated with "CI failed". Issue
+        # #413: a freshly created PR may have no check rows yet when
+        # --watch returns, so an empty / pending JSON response is "still
+        # observing" rather than the final verdict — _resolve_final_status
+        # drives the resolver until a final verdict (or its retry budget).
+        status = _resolve_final_status(pr, repo, exit_code)
+        head_after = _fetch_head_oid(pr, repo)
+        if (head_before is not None and head_after is not None
+                and head_before != head_after):
+            # The branch advanced somewhere across the watch+resolve phase:
+            # the verdict may describe a different commit than the live
+            # head, and the new head's checks may still be running. Don't
+            # record it — hand control back to main to restart the full
+            # `gh pr checks --watch` for the new head (which blocks until it
+            # completes), rather than tagging a stale head or
+            # short-circuiting on the JSON resolver's budget.
+            sys.stderr.write(
+                f"pr_watch: PR #{pr} head advanced across the ci-watch "
+                f"phase ({_short_head(head_before)} -> "
+                f"{_short_head(head_after)}); restarting ci-watch for the "
+                "new head.\n"
+            )
+            return "head_changed", 0, head_after
+        # Anchor on the pre-watch head; fall back to the post-resolution
+        # read only if the pre-watch probe failed.
+        head_oid = head_before if head_before is not None else head_after
+    head_short = _short_head(head_oid)
+
+    # Issue #413: duration is measured from the start of the watch to
+    # the moment we have a final verdict (post-retry), so a
+    # transient-empty race no longer reports `1s`.
+    duration = int(round(time.monotonic() - started))
+
+    # Codex review (round 1, Major): once the resolver picks the final
+    # verdict, the script's exit code must reflect that verdict, not
+    # whatever gh returned from the initial `--watch` invocation. With
+    # the retry loop, gh can exit ``8`` ("Checks pending") on the first
+    # observation and then a later JSON probe surfaces the actual
+    # ``passed`` state — returning ``8`` to the caller would falsely
+    # signal "incomplete" to shell-script consumers checking `$?`. The
+    # mapping below mirrors :func:`_classify` (gh's documented codes:
+    # 0=passed, 2=canceled, 8=incomplete) and adds 1 for failed. The
+    # later merge-watch block can still override ``0`` → ``9`` when
+    # the post-CI loop itself fails.
+    exit_code = {
+        "passed": 0,
+        "failed": 1,
+        "canceled": 2,
+        "incomplete": 8,
+    }.get(status, exit_code)
+
+    _record_ci_completed(
+        db_path=db_path,
+        pr=pr,
+        repo=repo,
+        status=status,
+        duration=duration,
+        head=head_short,
+    )
+
+    # Issue #326: nudge secretary as soon as the CI verdict is recorded
+    # so it doesn't have to poll the DB. Best-effort — silent fallback
+    # in non-renga environments (RENGA_SOCKET unset). Issue #413: the
+    # peer notification, like the DB event, fires once per ci-watch
+    # round and only on the final verdict (the retry loop above already
+    # absorbed transient incomplete observations). Issue #636: the head
+    # tag lets the secretary distinguish a re-emitted CI_COMPLETED for a
+    # new head from the original one. If a progress channel is ever
+    # wanted, route it through a distinct event/message name (e.g.
+    # `ci_progress`) rather than overloading `CI_COMPLETED`.
+    _notify_peer(
+        f"CI_COMPLETED: PR #{pr} {status} "
+        f"(head={head_short or 'unknown'}, duration {duration}s, repo {repo})"
+    )
+
+    sys.stdout.write(
+        f"pr_watch: PR #{pr} {status} "
+        f"({duration}s, head={head_short or 'unknown'})\n"
+    )
+    return status, exit_code, head_oid
 
 
 def main(argv: "list[str] | None" = None) -> int:
@@ -594,114 +883,73 @@ def main(argv: "list[str] | None" = None) -> int:
         )
         return 2
 
-    cmd = [
-        "gh", "pr", "checks", str(args.pr),
-        "--repo", repo,
-        "--watch",
-        "--interval", str(args.interval),
-    ]
-    started = time.monotonic()
-    canceled = False
-    try:
-        completed = subprocess.run(cmd)
-        exit_code = completed.returncode
-    except KeyboardInterrupt:
-        # Normalize parent-side cancellation to gh's standard exit code 2
-        # so callers (and the journal status mapping) see a portable signal.
-        exit_code = 2
-        canceled = True
+    # Issue #636: ci-watch → merge-watch is now a loop, not a one-shot.
+    # Each round watches the PR's CI, records the head observed at verdict
+    # time, and (when --merge-watch is on and CI passed) polls for merge
+    # against that head. If the merge-watch loop observes the head move to
+    # a new commit, it returns "head_changed" and we loop back to ci-watch
+    # for the new head — so the secretary always sees a CI_COMPLETED for
+    # the *current* head and never approves a merge against a stale
+    # verdict. The merge-watch 24h timeout resets each round because
+    # _watch_for_merge recomputes its own deadline on entry (a moving head
+    # is a sign of active work, so resetting the human-intervention grace
+    # is correct — Issue #636 design note 6).
+    while True:
+        status, exit_code, head_oid = _run_ci_watch_phase(
+            pr=args.pr, repo=repo, interval=args.interval,
+            db_path=JOURNAL_PATH,
+        )
 
-    # gh's documented cancellation exit code is 2 (parent SIGINT or
-    # subprocess-side Ctrl-C). Honor it directly so we don't overwrite a
-    # genuine cancellation with whatever the JSON probe returns.
-    if canceled or exit_code == 2:
-        status = "canceled"
-    else:
-        # Issue #224: gh exit 1 from a transient watch-loop error must
-        # not be conflated with "CI failed". Issue #413: a freshly
-        # created PR may have no check rows yet when --watch returns,
-        # so an empty / pending JSON response is "still observing"
-        # rather than the final verdict. Drive the resolver until it
-        # returns a final verdict (or exhausts its retry budget).
-        status = _resolve_final_status(args.pr, repo, exit_code)
+        if status == "head_changed":
+            # The head moved while resolving this round's verdict; no
+            # verdict was recorded. Restart the full ci-watch for the new
+            # head (re-emitting CI_COMPLETED once it resolves stably).
+            continue
 
-    # Issue #413: duration is measured from the start of the watch to
-    # the moment we have a final verdict (post-retry), so a
-    # transient-empty race no longer reports `1s`.
-    duration = int(round(time.monotonic() - started))
+        # Issue #317: only enter merge-watch when CI actually passed and
+        # the caller explicitly opted in via --merge-watch. The default
+        # is off so pr_watch stays a "CI passed → return" command
+        # compatible with secretary's 2c/T6 review-feedback loop.
+        # Codex pre-design review (Minor 1): `run_complete_on_merge` is
+        # the downstream actor for the green-PR path and is invoked only
+        # when `status == "passed"`. `incomplete` / `failed` /
+        # `canceled` results never trigger merge-watch.
+        if not (status == "passed" and args.merge_watch
+                and not args.no_merge_watch):
+            return exit_code
 
-    # Codex review (round 1, Major): once the resolver picks the final
-    # verdict, the script's exit code must reflect that verdict, not
-    # whatever gh returned from the initial `--watch` invocation. With
-    # the retry loop, gh can exit ``8`` ("Checks pending") on the first
-    # observation and then a later JSON probe surfaces the actual
-    # ``passed`` state — returning ``8`` to the caller would falsely
-    # signal "incomplete" to shell-script consumers checking `$?`. The
-    # mapping below mirrors :func:`_classify` (gh's documented codes:
-    # 0=passed, 2=canceled, 8=incomplete) and adds 1 for failed. The
-    # later merge-watch block can still override ``0`` → ``9`` when
-    # the post-CI loop itself fails.
-    exit_code = {
-        "passed": 0,
-        "failed": 1,
-        "canceled": 2,
-        "incomplete": 8,
-    }.get(status, exit_code)
-
-    _record_ci_completed(
-        db_path=JOURNAL_PATH,
-        pr=args.pr,
-        repo=repo,
-        status=status,
-        duration=duration,
-    )
-
-    # Issue #326: nudge secretary as soon as the CI verdict is recorded
-    # so it doesn't have to poll the DB. Best-effort — silent fallback
-    # in non-renga environments (RENGA_SOCKET unset). Issue #413: the
-    # peer notification, like the DB event, fires once per pr_watch
-    # invocation and only on the final verdict (the retry loop above
-    # already absorbed transient incomplete observations). If a
-    # progress channel is ever wanted, route it through a distinct
-    # event/message name (e.g. `ci_progress`) rather than overloading
-    # `CI_COMPLETED`.
-    _notify_peer(
-        f"CI_COMPLETED: PR #{args.pr} {status} "
-        f"(duration {duration}s, repo {repo})"
-    )
-
-    sys.stdout.write(f"pr_watch: PR #{args.pr} {status} ({duration}s)\n")
-
-    # Issue #317: only enter merge-watch when CI actually passed and
-    # the caller explicitly opted in via --merge-watch. The default is
-    # off so pr_watch stays a "CI passed → return" command compatible
-    # with secretary's 2c/T6 review-feedback loop.
-    # Codex pre-design review (Minor 1): `run_complete_on_merge` is
-    # the downstream actor for the green-PR path and is invoked here
-    # only when `status == "passed"`. `incomplete` / `failed` /
-    # `canceled` results never trigger merge-watch, so callers can
-    # treat the `passed`-gated invocation as the contract.
-    if status == "passed" and args.merge_watch and not args.no_merge_watch:
         merge_result = _watch_for_merge(
             pr=args.pr,
             repo=repo,
             interval=args.interval,
             db_path=JOURNAL_PATH,
+            baseline_head=head_oid,
         )
+
+        if merge_result == "head_changed":
+            # A new commit landed on the PR branch during merge-watch.
+            # Loop back to ci-watch for the new head (re-emitting
+            # CI_COMPLETED for it). No exit-code mutation — the next
+            # round computes a fresh verdict.
+            continue
+
         # Codex Major: surface merge-watch failure modes via exit code
         # so callers can distinguish "CI passed but PR did not merge in
         # 24h" / "helper raised" from "CI passed and we successfully
         # transitioned the run". Don't override a non-zero CI exit
         # code — that already signaled trouble.
-        if exit_code == 0 and merge_result in ("timeout", "error", "no_run"):
+        if exit_code == 0 and merge_result in (
+            "timeout", "error", "no_run", MERGE_RESULT_HEAD_UNCONFIRMED,
+        ):
             # Codex round-2 Major: no_run means we observed a merge but
             # could not resolve the PR back to a runs row, so the
             # status flip didn't happen and the secretary needs to
-            # intervene. Surface that as exit 9 so callers don't treat
-            # it as success.
+            # intervene. Issue #636: merged_head_unconfirmed means the PR
+            # merged at a head whose CI we never confirmed. Surface both
+            # as exit 9 so callers don't treat them as success.
             exit_code = 9
 
-    return exit_code
+        return exit_code
 
 
 if __name__ == "__main__":

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -202,16 +202,21 @@ def _resolve_repo() -> str:
 def fetch_pr_view(pr: int, repo: str) -> dict:
     """Return the parsed `gh pr view` payload for the given PR.
 
-    Fields requested: ``number,url,state,mergedAt,mergeCommit,headRefName``.
-    Raises ``RuntimeError`` if gh fails or the JSON is unparseable —
-    callers (CLI / merge-watch) are expected to surface that and retry
-    or exit.
+    Fields requested:
+    ``number,url,state,mergedAt,mergeCommit,headRefName,headRefOid``.
+    Issue #636 added ``headRefOid`` so pr_watch's merge-watch loop can
+    detect a new commit pushed to the PR branch (the head moving) and
+    loop back to ci-watch instead of silently sitting on a stale CI
+    verdict. Raises ``RuntimeError`` if gh fails or the JSON is
+    unparseable — callers (CLI / merge-watch) are expected to surface
+    that and retry or exit.
     """
     proc = subprocess.run(
         [
             "gh", "pr", "view", str(pr),
             "--repo", repo,
-            "--json", "number,url,state,mergedAt,mergeCommit,headRefName",
+            "--json",
+            "number,url,state,mergedAt,mergeCommit,headRefName,headRefOid",
         ],
         capture_output=True, text=True, encoding="utf-8", check=False,  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
     )
@@ -308,6 +313,10 @@ def complete_on_merge(
 
     pr_url = pr_view.get("url") or ""
     head_ref = pr_view.get("headRefName")
+    # Issue #636: the head commit OID (PR branch tip at merge time). Distinct
+    # from the merge commit below — recorded short on the pr_merged event so
+    # the secretary can tell which head the merge corresponds to.
+    head_short = _short_sha(pr_view.get("headRefOid"))
     merge_commit = pr_view.get("mergeCommit") or {}
     commit_full = (merge_commit.get("oid") if isinstance(merge_commit, dict)
                    else None)
@@ -408,6 +417,8 @@ def complete_on_merge(
                     "repo": repo,
                     "pr_url": pr_url,
                     "merge_commit": commit_full,
+                    # Issue #636: short head sha (branch tip that was merged).
+                    "head": head_short,
                     "merged_at": merged_at,
                     "pattern": pattern,
                     "auto_completed": False,

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -891,6 +891,14 @@ class MergeWatchTests(unittest.TestCase):
                     and cmd[cmd.index("--json") + 1] == "number"):
                 seen_existence_probe["v"] = True
                 return mock.Mock(returncode=0, stdout="{}", stderr="")
+            # Issue #636 head probe: `gh pr view <pr> --json headRefOid`.
+            # Return an empty object so `_fetch_head_oid` resolves to None
+            # (no head-change detection) WITHOUT consuming a view_sequence
+            # entry — these legacy fixtures retain mergedAt-only behavior.
+            if (cmd[:3] == ["gh", "pr", "view"]
+                    and "--json" in cmd
+                    and cmd[cmd.index("--json") + 1] == "headRefOid"):
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
             # Merge-watch probe: `gh pr view <pr> --json number,url,...`
             if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
                 idx = view_idx["i"]
@@ -1185,6 +1193,7 @@ class PeerNotifyTests(unittest.TestCase):
                 "mergedAt": "2026-05-06T03:21:00Z",
                 "mergeCommit": {"oid": "f" * 40},
                 "headRefName": "feat/merge-watch",
+                "headRefOid": "c" * 40,
             }
             fake_run = mw_tests._build_run_with_view_sequence(
                 watch_exit=0, view_sequence=[view_merged],
@@ -1203,8 +1212,10 @@ class PeerNotifyTests(unittest.TestCase):
             # Expect both CI_COMPLETED and PR_MERGED in captured.
             self.assertTrue(any("CI_COMPLETED" in m for m in captured),
                             f"missing CI_COMPLETED: {captured}")
-            self.assertTrue(any("PR_MERGED: PR #777" in m for m in captured),
-                            f"missing PR_MERGED: {captured}")
+            # Issue #636: PR_MERGED carries the merged head's short sha.
+            self.assertTrue(
+                any("PR_MERGED: PR #777 (head=ccccccc)" in m for m in captured),
+                f"missing PR_MERGED w/ head: {captured}")
 
     def test_merge_watch_timeout_dispatches_peer_message(self) -> None:
         with TempDir() as tmp:
@@ -1214,6 +1225,7 @@ class PeerNotifyTests(unittest.TestCase):
                 "number": 555, "url": "https://github.com/octo/repo/pull/555",
                 "state": "OPEN", "mergedAt": None,
                 "mergeCommit": None, "headRefName": "feat/x",
+                "headRefOid": "d" * 40,
             }
             from tools.state_db import apply_schema, connect
             apply_schema(connect(db))
@@ -1230,14 +1242,20 @@ class PeerNotifyTests(unittest.TestCase):
             with mock.patch.object(pr_watch, "_notify_peer",
                                    side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                # Issue #636: baseline_head matches the polled headRefOid
+                # (no head change), so the loop times out and the message
+                # carries the short head sha.
                 result = pr_watch._watch_for_merge(
                     pr=555, repo="octo/repo", interval=0,
                     db_path=db, max_seconds=60,
                     sleeper=lambda _s: None,
                     monotonic=mock.Mock(side_effect=[0.0, 100.0, 100.0]),
+                    baseline_head="d" * 40,
                 )
             self.assertEqual(result, "timeout")
-            self.assertEqual(captured, ["PR_MERGE_WATCH_TIMEOUT: PR #555"])
+            self.assertEqual(
+                captured, ["PR_MERGE_WATCH_TIMEOUT: PR #555 (head=ddddddd)"]
+            )
 
     def test_no_run_dispatches_distinct_message(self) -> None:
         """When complete_on_merge returns no_run, pr-watch must NOT
@@ -1255,6 +1273,7 @@ class PeerNotifyTests(unittest.TestCase):
                 "mergedAt": "2026-05-06T03:21:00Z",
                 "mergeCommit": {"oid": "a" * 40},
                 "headRefName": "feat/x",
+                "headRefOid": "e" * 40,
             }
 
             def fake_run(cmd, *args, **kwargs):
@@ -1270,6 +1289,7 @@ class PeerNotifyTests(unittest.TestCase):
                                    side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
                 # No seeded run for PR #444 → complete_on_merge → no_run.
+                # Issue #636: the head sha comes from the merged view.
                 result = pr_watch._watch_for_merge(
                     pr=444, repo="octo/repo", interval=0,
                     db_path=db, max_seconds=60,
@@ -1277,7 +1297,9 @@ class PeerNotifyTests(unittest.TestCase):
                     monotonic=mock.Mock(side_effect=[0.0, 0.0, 100.0]),
                 )
             self.assertEqual(result, "no_run")
-            self.assertEqual(captured, ["PR_MERGED_NO_RUN: PR #444"])
+            self.assertEqual(
+                captured, ["PR_MERGED_NO_RUN: PR #444 (head=eeeeeee)"]
+            )
 
     def test_no_renga_socket_silent_fallback(self) -> None:
         """With RENGA_SOCKET unset, _notify_peer must return False
@@ -1305,6 +1327,477 @@ class PeerNotifyTests(unittest.TestCase):
                 rc = pr_watch.main(["--pr", "10", "--repo", "octo/repo"])
             self.assertEqual(rc, 0)
             self.assertEqual(_count_ci_events(db), 1)
+
+
+def _read_ci_events(db_path: Path) -> "list[dict]":
+    """Return all ci_completed events (payload dicts, ordered by id)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events WHERE kind = 'ci_completed' "
+            "ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+    return [json.loads(r["payload_json"]) if r["payload_json"] else {}
+            for r in rows]
+
+
+class HeadPollLoopbackTests(unittest.TestCase):
+    """Issue #636: merge-watch polls headRefOid and loops back to ci-watch
+    when the PR head moves, re-emitting CI_COMPLETED for the new head."""
+
+    HEAD_A = "a" * 40
+    HEAD_B = "b" * 40
+    PR_URL = "https://github.com/octo/repo/pull/636"
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    # -- direct _watch_for_merge unit coverage -----------------------------
+
+    def test_head_change_returns_head_changed(self) -> None:
+        """A new headRefOid (≠ baseline) makes _watch_for_merge return
+        ``head_changed`` without merging, timing out, or notifying."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            from tools.state_db import apply_schema, connect
+            apply_schema(connect(db))
+
+            view_a = {
+                "number": 636, "url": self.PR_URL, "state": "OPEN",
+                "mergedAt": None, "mergeCommit": None,
+                "headRefName": "feat/hp", "headRefOid": self.HEAD_A,
+            }
+            view_b = dict(view_a, headRefOid=self.HEAD_B)
+            views = [view_a, view_b]
+            idx = {"i": 0}
+
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    i = idx["i"]
+                    payload = views[i] if i < len(views) else views[-1]
+                    if i < len(views) - 1:
+                        idx["i"] = i + 1
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(payload), stderr="",
+                    )
+                raise AssertionError(f"unexpected cmd: {cmd}")
+
+            captured: list[str] = []
+            with mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                # poll0 = HEAD_A (no change), poll1 = HEAD_B (change).
+                result = pr_watch._watch_for_merge(
+                    pr=636, repo="octo/repo", interval=0,
+                    db_path=db, max_seconds=60,
+                    sleeper=lambda _s: None,
+                    monotonic=mock.Mock(side_effect=[0.0, 1.0, 2.0]),
+                    baseline_head=self.HEAD_A,
+                )
+            self.assertEqual(result, "head_changed")
+            # No peer notification on a head change (the ci-watch loopback
+            # re-emits CI_COMPLETED instead).
+            self.assertEqual(captured, [])
+            # And no timeout event was written.
+            conn = sqlite3.connect(str(db))
+            try:
+                cnt = conn.execute(
+                    "SELECT COUNT(*) FROM events "
+                    "WHERE kind = 'pr_merge_watch_timeout'"
+                ).fetchone()[0]
+            finally:
+                conn.close()
+            self.assertEqual(cnt, 0)
+
+    def test_none_baseline_disables_head_change_detection(self) -> None:
+        """Compat (Issue #636 #7): when baseline_head is None, a moving
+        headRefOid must NOT trigger head_changed — the loop falls through
+        to its pre-#636 mergedAt/timeout behavior (None-safe)."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            from tools.state_db import apply_schema, connect
+            apply_schema(connect(db))
+
+            view = {
+                "number": 636, "url": self.PR_URL, "state": "OPEN",
+                "mergedAt": None, "mergeCommit": None,
+                "headRefName": "feat/hp", "headRefOid": self.HEAD_B,
+            }
+
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(view), stderr="",
+                    )
+                raise AssertionError(f"unexpected cmd: {cmd}")
+
+            with mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                result = pr_watch._watch_for_merge(
+                    pr=636, repo="octo/repo", interval=0,
+                    db_path=db, max_seconds=60,
+                    sleeper=lambda _s: None,
+                    monotonic=mock.Mock(side_effect=[0.0, 100.0]),
+                    baseline_head=None,  # detection disabled
+                )
+            # Falls through to timeout rather than head_changed.
+            self.assertEqual(result, "timeout")
+
+    # -- end-to-end main() loopback ----------------------------------------
+
+    def test_main_loops_back_to_ci_watch_on_head_change(self) -> None:
+        """ci-watch → merge-watch → head moves → ci-watch loopback → second
+        CI_COMPLETED → merge. Proves the one-shot trap is fixed."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            # Seed a run so the final complete_on_merge resolves to MERGED.
+            MergeWatchTests()._seed_run_for_merge(db, pr_url=self.PR_URL)
+
+            head_calls = {"i": 0}
+            mw_calls = {"i": 0}
+            mw_seq = [
+                # round-1 merge-watch poll: head already moved to HEAD_B.
+                {"number": 636, "url": self.PR_URL, "state": "OPEN",
+                 "mergedAt": None, "mergeCommit": None,
+                 "headRefName": "feat/hp", "headRefOid": self.HEAD_B},
+                # round-2 merge-watch poll: merged at HEAD_B.
+                {"number": 636, "url": self.PR_URL, "state": "MERGED",
+                 "mergedAt": "2026-06-23T00:00:00Z",
+                 "mergeCommit": {"oid": "c" * 40},
+                 "headRefName": "feat/hp", "headRefOid": self.HEAD_B},
+            ]
+
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
+                    jval = cmd[cmd.index("--json") + 1]
+                    if jval == "number":
+                        return mock.Mock(returncode=0, stdout="{}", stderr="")
+                    if jval == "headRefOid":
+                        # Two head probes per ci-watch round (pre/post
+                        # resolution). Head sits at HEAD_A through round 1
+                        # (probes 0,1) and at HEAD_B through round 2
+                        # (probes 2,3) — stable within each round so no
+                        # spurious mid-resolution-advance is logged.
+                        i = head_calls["i"]
+                        head_calls["i"] = i + 1
+                        oid = self.HEAD_A if i < 2 else self.HEAD_B
+                        return mock.Mock(
+                            returncode=0,
+                            stdout=json.dumps({"headRefOid": oid}),
+                            stderr="",
+                        )
+                    # merge-watch poll (long --json field list).
+                    i = mw_calls["i"]
+                    payload = mw_seq[i] if i < len(mw_seq) else mw_seq[-1]
+                    if i < len(mw_seq) - 1:
+                        mw_calls["i"] = i + 1
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(payload), stderr="",
+                    )
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps(
+                            [{"name": "ci", "state": "COMPLETED",
+                              "bucket": "pass"}]
+                        ),
+                        stderr="",
+                    )
+                # The watched `gh pr checks --watch` run (both rounds pass).
+                return mock.Mock(returncode=0)
+
+            captured: list[str] = []
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 1.0, 2.0, 3.0]):
+                rc = pr_watch.main([
+                    "--pr", "636", "--repo", "octo/repo", "--interval", "1",
+                    "--merge-watch",
+                ])
+            self.assertEqual(rc, 0)
+
+            # Two CI_COMPLETED messages — one per head — re-emitted across
+            # the loopback. This is the core of the Issue #636 fix.
+            ci_msgs = [m for m in captured if m.startswith("CI_COMPLETED")]
+            self.assertEqual(len(ci_msgs), 2, f"captured={captured}")
+            self.assertIn("head=aaaaaaa", ci_msgs[0])
+            self.assertIn("head=bbbbbbb", ci_msgs[1])
+            # The merge is announced against the new head.
+            self.assertTrue(
+                any("PR_MERGED: PR #636 (head=bbbbbbb)" in m for m in captured),
+                f"captured={captured}")
+
+            # Two ci_completed events, each tagged with its head sha.
+            events = _read_ci_events(db)
+            self.assertEqual(len(events), 2)
+            self.assertEqual(events[0]["head"], "aaaaaaa")
+            self.assertEqual(events[1]["head"], "bbbbbbb")
+            self.assertEqual(events[0]["status"], "passed")
+            self.assertEqual(events[1]["status"], "passed")
+
+    def test_ci_completed_message_and_event_carry_head(self) -> None:
+        """Acceptance: the CI_COMPLETED peer message and the ci_completed
+        event both carry the short head sha (CI-only, no merge-watch)."""
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
+                jval = cmd[cmd.index("--json") + 1]
+                if jval == "number":
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if jval == "headRefOid":
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps({"headRefOid": self.HEAD_A}),
+                        stderr="",
+                    )
+            if "checks" in cmd and "--json" in cmd:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}]
+                    ),
+                    stderr="",
+                )
+            return mock.Mock(returncode=0)
+
+        captured: list[str] = []
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 5.0]):
+                rc = pr_watch.main(["--pr", "636", "--repo", "octo/repo"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(len(captured), 1)
+            self.assertIn("CI_COMPLETED: PR #636 passed", captured[0])
+            self.assertIn("head=aaaaaaa", captured[0])
+            rec = _read_ci_event(db)
+            self.assertEqual(rec["head"], "aaaaaaa")
+            self.assertEqual(rec["status"], "passed")
+
+    def test_merge_at_unconfirmed_head_is_distinct_signal_not_pr_merged(self) -> None:
+        """Codex review: if a PR merges at a head different from the last
+        CI-confirmed head (a push + merge slipped in before the next
+        merge-watch poll), pr_watch must NOT emit a clean PR_MERGED. The
+        merge is terminal (no loopback possible), so it emits a DISTINCT
+        prefix (PR_MERGED_HEAD_UNCONFIRMED — fails closed so the secretary
+        escalates instead of auto-advancing) and returns a sentinel main
+        maps to a non-zero exit."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            MergeWatchTests()._seed_run_for_merge(db, pr_url=self.PR_URL)
+
+            # Merged at HEAD_B while the CI baseline was HEAD_A.
+            view_merged = {
+                "number": 636, "url": self.PR_URL, "state": "MERGED",
+                "mergedAt": "2026-06-23T00:00:00Z",
+                "mergeCommit": {"oid": "c" * 40},
+                "headRefName": "feat/hp", "headRefOid": self.HEAD_B,
+            }
+
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(view_merged), stderr="",
+                    )
+                raise AssertionError(f"unexpected cmd: {cmd}")
+
+            captured: list[str] = []
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                result = pr_watch._watch_for_merge(
+                    pr=636, repo="octo/repo", interval=0,
+                    db_path=db, max_seconds=60,
+                    sleeper=lambda _s: None,
+                    monotonic=mock.Mock(side_effect=[0.0, 0.0, 100.0]),
+                    baseline_head=self.HEAD_A,  # CI was confirmed for HEAD_A
+                )
+            self.assertEqual(result, pr_watch.MERGE_RESULT_HEAD_UNCONFIRMED)
+            self.assertEqual(len(captured), 1)
+            msg = captured[0]
+            # Distinct prefix — NOT the clean "PR_MERGED: " consumers act on.
+            self.assertTrue(msg.startswith("PR_MERGED_HEAD_UNCONFIRMED: PR #636"))
+            self.assertIn("head=bbbbbbb", msg)
+            # Names the stale CI-confirmed head for the human.
+            self.assertIn("aaaaaaa", msg)
+
+    def test_unconfirmed_head_merge_exits_nonzero_through_main(self) -> None:
+        """End-to-end: a merge at an unconfirmed head makes main exit 9 (not
+        0), so shell callers don't treat it as a confirmed-CI success."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            MergeWatchTests()._seed_run_for_merge(db, pr_url=self.PR_URL)
+
+            head_calls = {"i": 0}
+            # ci-watch round confirms HEAD_A; merge-watch then observes a
+            # merge already at HEAD_B (push+merge slipped in).
+            view_merged = {
+                "number": 636, "url": self.PR_URL, "state": "MERGED",
+                "mergedAt": "2026-06-23T00:00:00Z",
+                "mergeCommit": {"oid": "c" * 40},
+                "headRefName": "feat/hp", "headRefOid": self.HEAD_B,
+            }
+
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
+                    jval = cmd[cmd.index("--json") + 1]
+                    if jval == "number":
+                        return mock.Mock(returncode=0, stdout="{}", stderr="")
+                    if jval == "headRefOid":
+                        # Both ci-watch head probes (pre/post) see HEAD_A.
+                        head_calls["i"] += 1
+                        return mock.Mock(
+                            returncode=0,
+                            stdout=json.dumps({"headRefOid": self.HEAD_A}),
+                            stderr="",
+                        )
+                    # merge-watch poll: merged at HEAD_B.
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(view_merged), stderr="",
+                    )
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps(
+                            [{"name": "ci", "state": "COMPLETED",
+                              "bucket": "pass"}]
+                        ),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=0)
+
+            captured: list[str] = []
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                rc = pr_watch.main([
+                    "--pr", "636", "--repo", "octo/repo", "--interval", "1",
+                    "--merge-watch",
+                ])
+            self.assertEqual(rc, 9)
+            self.assertTrue(
+                any(m.startswith("PR_MERGED_HEAD_UNCONFIRMED") for m in captured),
+                f"captured={captured}")
+            self.assertFalse(
+                any(m.startswith("PR_MERGED:") for m in captured),
+                f"clean PR_MERGED must not be sent: {captured}")
+
+    def test_merge_at_confirmed_head_has_no_warning(self) -> None:
+        """The flag fires ONLY on a head mismatch: merging at the same head
+        the CI baseline confirmed is a clean PR_MERGED with no warning."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            MergeWatchTests()._seed_run_for_merge(db, pr_url=self.PR_URL)
+
+            view_merged = {
+                "number": 636, "url": self.PR_URL, "state": "MERGED",
+                "mergedAt": "2026-06-23T00:00:00Z",
+                "mergeCommit": {"oid": "c" * 40},
+                "headRefName": "feat/hp", "headRefOid": self.HEAD_A,
+            }
+
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(view_merged), stderr="",
+                    )
+                raise AssertionError(f"unexpected cmd: {cmd}")
+
+            captured: list[str] = []
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                result = pr_watch._watch_for_merge(
+                    pr=636, repo="octo/repo", interval=0,
+                    db_path=db, max_seconds=60,
+                    sleeper=lambda _s: None,
+                    monotonic=mock.Mock(side_effect=[0.0, 0.0, 100.0]),
+                    baseline_head=self.HEAD_A,
+                )
+            self.assertEqual(result, "merged")
+            self.assertEqual(captured, ["PR_MERGED: PR #636 (head=aaaaaaa)"])
+
+    def test_head_advance_during_resolution_restarts_ci_watch(self) -> None:
+        """Codex review: if the branch advances during verdict resolution
+        (pre-resolution head != post-resolution head), pr_watch records NO
+        verdict for that round and restarts the full ci-watch for the new
+        head — so a new head whose CI is still pending is properly waited
+        on via `gh pr checks --watch`, not short-circuited to incomplete.
+        The recorded verdict/head is the stabilized HEAD_B."""
+        head_calls = {"i": 0}
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
+                jval = cmd[cmd.index("--json") + 1]
+                if jval == "number":
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if jval == "headRefOid":
+                    # Round 1: pre=HEAD_A (probe 0), post=HEAD_B (probe 1)
+                    # → advanced mid-resolution → head_changed → restart.
+                    # Round 2: pre=HEAD_B (probe 2), post=HEAD_B (probe 3)
+                    # → stable → record HEAD_B.
+                    i = head_calls["i"]
+                    head_calls["i"] = i + 1
+                    oid = self.HEAD_A if i == 0 else self.HEAD_B
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps({"headRefOid": oid}),
+                        stderr="",
+                    )
+            if "checks" in cmd and "--json" in cmd:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}]
+                    ),
+                    stderr="",
+                )
+            return mock.Mock(returncode=0)
+
+        captured: list[str] = []
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            # CI-only (no --merge-watch): even here a mid-resolution advance
+            # restarts ci-watch, so the recorded verdict is for a stable head.
+            # monotonic: round-1 consumes only `started` (head_changed returns
+            # before the duration calc); round-2 consumes started + duration.
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0, 5.0]):
+                rc = pr_watch.main(["--pr", "636", "--repo", "octo/repo"])
+            self.assertEqual(rc, 0)
+            # Exactly one ci_completed event — the head_changed round records
+            # nothing — tagged with the stabilized HEAD_B (never HEAD_A).
+            rec = _read_ci_event(db)
+            self.assertEqual(rec["head"], "bbbbbbb")
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(len(captured), 1)
+            self.assertIn("head=bbbbbbb", captured[0])
+            self.assertNotIn("aaaaaaa", captured[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

merge-watch が「CI 通過後は head が固定」と仮定した one-shot 設計で、PR ブランチに追加 commit が push されても新 CI を観測せず CI_COMPLETED を再送せず、窓口が古い green を根拠に誤マージを誘発しうる罠（#636）を根治する。pr_watch は ci-watch → merge-watch のループになり、head が動いたら新 head の CI を観測し直して CI_COMPLETED を再送する。

Closes #636

## 主要変更点

1. **merge-watch の head-poll 化** — 毎 iteration `headRefOid` を見て baseline と異なれば `head_changed` を返し ci-watch にループバック。merge-watch の 24h タイムアウトは head ごとリセット
2. **メッセージ / events への head 付与** — CI_COMPLETED / PR_MERGED / PR_MERGE_WATCH_TIMEOUT 本文に head 短縮 sha、ci_completed / pr_merge_watch_timeout / pr_merged の event payload にも `head` フィールド追加
3. **verdict と head の整合保証** — ci-watch フェーズ全体（`gh pr checks --watch` 開始前〜verdict 解決後）を head の前後読みで挟む。フェーズ中に head が動いたら verdict を記録せず full ci-watch を再開
4. **CI 未確認マージ終端の fail-closed 化** — push と merge が poll 間に同時に滑り込み CI 未確認 head でマージされた終端は loopback 不能のため、専用シグナル `PR_MERGED_HEAD_UNCONFIRMED` + exit 9 で fail-closed 通知（clean な PR_MERGED は出さない）

## 設計判断

- head は「watch 前」と「resolve 後」の両端ブラケットで一致要求（不一致なら full 再 watch）— 片側だけでは window をカバーできず stale 承認のリスクが残る
- マージ済み head 不一致は loopback せず distinct signal — merge は不可逆で再 watch 不能。`PR_MERGED_NO_RUN` と同じ fail-closed 流儀

## Test plan

- [x] `python3 -m unittest tools.test_pr_watch tools.test_run_complete_on_merge` — Ran 64 tests, OK (skipped=1)
- [x] 関連周辺含め 104 tests OK
- [x] `--help` 実端末スモーク OK（cp932 非互換文字なし）
- [x] Codex セルフレビュー（`codex exec review --base main -m gpt-5.5`）7 ラウンド clean 収束（各ラウンドが別個正当な並行性エッジで根治収束まで回したため 3 上限超）

## Follow-up

`PR_MERGED_HEAD_UNCONFIRMED` の org-pull-request SKILL への契約明文化（新シグナル受信時の人間確認 gate）は別 Issue で扱う。