### PR TITLE
feat(claude): /org-conveyor 承認スコープ内自走ループ skill を追加

### DIFF
--- a/.claude/skills/org-conveyor/SKILL.md
+++ b/.claude/skills/org-conveyor/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: org-conveyor
+description: >
+  窓口が人間から「承認スコープの輪郭」を受けて、その内側で triage → worker 派遣 →
+  iteration → verify → push → PR 作成 → CI 監視 を完了駆動で自走し、PR ごとに
+  merge gate で必ず停止するベルトコンベア。/work-discovery + /org-delegate + verify +
+  /org-pull-request + /org-escalation を呼ぶ薄い orchestrator。
+  発動条件: 人間が「この範囲は自走してよい」というスコープ承認を明示し、複数候補を
+  完了駆動で順次流したいとき（例「triage 上位の S 級バグ修正を空き pane 分まで自走、
+  merge は都度わたしが判断」）。起動主体は窓口に限定。スコープ外候補・判断境界・退出条件に
+  触れたら必ず halt する。merge 自動化はしない。
+effort: medium
+allowed-tools:
+  - Read
+  - Write # .state/conveyor/scope-contract.md の初回書き出し（Step 1）
+  - Edit # スコープ契約の更新（再承認による拡大・早期停止）
+  - Skill
+  - TaskCreate # Claude Code 組込みの task-list（todo）ツール。観測可能性 backbone。repo 定義ではなくハーネス提供
+  - TaskUpdate
+  - TaskList
+  - Bash(python3 tools/work_discovery_scan.py:*)
+  - Bash(py -3 tools/work_discovery_scan.py:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(git diff:*) # verify applicability classifier の touch-domain 裏取り（read-only。worker branch が local に在るとき）
+  - Bash(mkdir -p .state/conveyor:*) # Step 1 のスコープ契約書き出し先ディレクトリ確保（fresh checkout 対策）
+  # 直接の transport 面は active transport（コード既定 broker）のみ列挙する。broker + renga の
+  # union は非アクティブ transport のツールまで認可し per-transport auth モデルを迂回するため不可
+  # （設計 SoT: notes/broker-skill-generator-design.md #9。union 却下）。送受信機構はサブスキルへ委譲し、
+  # conveyor 自身が直接使うのは free-pane 会計（list_panes）とループ event のドレイン（check_messages）だけ。
+  - mcp__org-broker__list_panes # free-pane 会計（バックプレッシャー）
+  - mcp__org-broker__check_messages # broker pull フォールバック時の semantic event ドレイン
+---
+
+# org-conveyor: 承認スコープ内自走ループ（ベルトコンベア）
+
+窓口が人間から **承認スコープの輪郭** を受け取り、それを機械契約として articulate したうえで、
+その内側を `triage → /org-delegate → worker iteration → Codex round → verify（applicable なら必須）→
+push → gh pr create → pr-watch CI 監視 → CI green` まで **完了駆動で自走** し、**PR ごとに
+merge gate で必ず停止** する。人間は「レビュー待ち PR のキュー」を順次 merge するだけになる。
+
+本スキルは **薄い orchestrator** であって、実作業の機構は既存スキルに委譲する。本スキルが固有に持つのは
+**(1) 承認スコープ契約の articulate と gate、(2) 完了駆動ループとバックプレッシャー、(3) 観測可能性、
+(4) 機械的退出条件** の 4 つだけ。受信モデル・ack・push/PR/CI・escalation の機構は下記スキルを呼ぶ:
+
+- triage: [`/work-discovery`](../work-discovery/SKILL.md)（propose-only / 候補生成）
+- 派遣: [`/org-delegate`](../org-delegate/SKILL.md)（Step 0〜、レーン選択・派遣・受信モデル・ack・監視）
+- 検証: `/verify`（Claude Code **組込みスキル**。app を起動して実行ビヘイビアを観測する。app + 変更が居る **worker の worktree 内で worker が実行**する）+ [`.claude/skills/org-conveyor/references/verify-evidence.md`](references/verify-evidence.md)（conveyor 側の applicability classifier + エビデンス転記）
+- PR: [`/org-pull-request`](../org-pull-request/SKILL.md)（push / PR / CI 監視 / レビューループ / マージ後クローズ）
+- 判断仰ぎ: [`/org-escalation`](../org-escalation/SKILL.md)（worker escalation を人間へ）
+
+## 位置づけ（他ループ系との差分）
+
+| skill | 駆動 | 停止条件 | 人間ゲート |
+|---|---|---|---|
+| `/loop` | 時間駆動 | なし（間隔ごとに再実行） | なし |
+| `/work-discovery` | イベント / 手動 | 候補提示で hard stop（propose-only） | 候補ごとに人間が番号選択 |
+| `/org-delegate` | 単発委譲 | escalation 境界で人間に戻る | 派遣ごと / escalation ごと |
+| **`/org-conveyor`** | **完了駆動ループ** | **PR ごとに merge gate で halt / 退出条件** | **起動時のスコープ承認（1 回）+ merge ごと** |
+
+`/org-conveyor` は `/work-discovery` の per-candidate 人間選択を、**起動時に 1 回だけ取る「承認スコープ契約」**
+へ畳み込んだものである。スコープ契約の内側では候補を再質問なしで自動投入し、**スコープ外の候補は scope 縁として
+投入せず halt** する。これが propose-only / hard-stop の `/work-discovery` との本質的な差分。
+
+## 不変条件（非交渉 / 破ってはならない）
+
+- **INV-1 merge 承認は人間 gate**: スコープ契約は dispatch〜CI 監視を事前承認できるが、**merge は決して事前承認できない**。
+  CI green に到達したら必ず停止し、PR を人間へ提示して merge を仰ぐ（`feedback-merge-approval` / `feedback-no-overgate-after-decision`
+  の「不可逆点でのみ再承認」）。bare「OK」を merge 承認と解釈しない。
+- **INV-2 scope 境界に触れたら必ず halt**: スコープ契約の述語に合致しない候補・判断・差分が現れたら、自走を止めて
+  [`/org-escalation`](../org-escalation/SKILL.md) 経由で人間に上げる（`feedback-no-stopgap` / 場当たり継続をしない）。
+- **INV-3 worker からの judgment escalation は人間へ**: worker の「判断仰ぎ」「承認を仰ぎ」「スコープ拡張」「ブロッカー」は
+  窓口が一次承認せず [`/org-escalation`](../org-escalation/SKILL.md) で人間へ。conveyor は escalation を自動判断しない。
+- **INV-4 propose-only の継承**: 候補生成は [`/work-discovery`](../work-discovery/SKILL.md)（決定的ツール）に委ね、conveyor は
+  その出力をスコープ契約で gate するだけ。候補の中身を自前調査・実装しない。
+- **INV-5 起動主体は窓口のみ**: 委譲済み worker は本スキルを起動しない（「1 worker = 1 task = 1 scope」原則。[`CLAUDE.md`](../../../CLAUDE.md)「役割の境界」）。
+- **INV-6 merge 自動化・escalation 自動判断・`/loop` 置換をしない**（Non-goals 節）。
+
+## 輸送層（transport）両系
+
+**per-transport 認可（union 不可）**: 本スキルが直接使う transport ツールは free-pane 会計の `list_panes` だけで、
+allowed-tools には **その deployment で active な単一 transport の面のみ** を列挙する（broker + renga を union で並べると
+非アクティブ transport のツールまで認可され per-transport auth モデルを迂回するため。設計 SoT:
+notes/broker-skill-generator-design.md #9。union 却下）。本リポジトリの active transport は **`broker`**（コード既定
+`DEFAULT_TRANSPORT=broker`、`org-broker-channel` 稼働中）なので allowlist は broker 面で render してある。`renga` で運用する
+deployment（opt-in 切戻し）では、この surface を renga 面へ **per-transport 再生成** する（`mcp__org-broker__*` →
+`mcp__renga-peers__*`、引数形・セマンティクスは同一。settings.local.json の per-transport 生成と同じ境界。フル per-transport
+render が要るなら他の transport 参照スキルと同じく `.md.in` + manifest 化が follow-up 候補）。送受信機構（ack・relay・escalation・
+push / PR）の輸送依存差・二フレーム関係・spawn 儀式・エラー分岐は本スキルが呼ぶ各スキルが per-transport に持つので、総説
+[`CLAUDE.md`](../../../CLAUDE.md)「輸送層（transport）両系」節とフル版注記 [`/org-escalation`](../org-escalation/SKILL.md) 冒頭の
+同名 note を一次参照する（本スキルは重複コピーを置かない）。
+
+**受信は transport ツールに依存しない**: conveyor 固有の輸送依存は **完了 / CI 遷移の受信** に集約されるが、ここは
+worker 報告・pr-watch の `CI_COMPLETED` / `PR_MERGED` が **in-band push で注入される**（broker は channel sidecar、renga は
+`<channel source="renga-peers">`。pr-watch の `tools/peer_notify.py: notify_peer` は raw env 判定で active transport を選ぶ）。
+in-band 注入の受信に tool 呼び出しは要らず、push 失効時の最終フォールバックは **events テーブルのポーリング**（Read / Bash、
+transport 非依存）なので、**broker の `check_messages` 単独待受や固定 sleep ポーリングに依存しない**。したがって conveyor は
+「`CI_COMPLETED` / `PR_MERGED` / worker 報告という semantic event が届いたこと」を契機にループを 1 周進める。受信機構の
+per-transport 詳細（pr-watch の二フレーム受信注記）は呼び先の [`/org-pull-request`](../org-pull-request/SKILL.md) 2b-i に委ねる。
+
+## Step 1: 承認スコープ契約を articulate する（起動時・人間ゲート）
+
+ループを回す **前に**、人間から受けた承認の輪郭を機械契約として articulate し、人間に確認を取る。
+スコープ契約は `/work-discovery` の per-candidate 選択の代わりに置かれる **唯一の事前人間ゲート** であり、
+この確認なしにループを開始してはならない。
+
+- テンプレート・フィールド定義・「何を事前承認し / 何を絶対に承認しないか」の境界は
+  [`.claude/skills/org-conveyor/references/scope-contract.md`](references/scope-contract.md) を一次参照する。
+- 確定した契約は `.state/conveyor/scope-contract.md` に書き出す（ループ中の gate 判定で読み戻す SoT）。書き出し前に
+  `mkdir -p .state/conveyor` で親ディレクトリを確保する（`.state/` は gitignore 配下で fresh checkout には `conveyor/`
+  サブディレクトリが無いため。idempotent）。
+- **契約が事前承認する範囲**: スコープ述語に合致する候補に対する `triage 投入 → /org-delegate 派遣 →
+  worker iteration → verify → push → gh pr create → pr-watch CI 監視`。push / PR 作成の「ユーザー明示承認」
+  前提（[`/org-pull-request`](../org-pull-request/SKILL.md) 2b-i）は、**この起動時スコープ承認が満たす**
+  （bare な per-PR OK ではなく、人間が明示した持続的スコープ承認の記録）。
+- **契約が決して承認しない範囲**: **merge**（INV-1）。merge は常に PR ごとの独立人間ゲート。CI green で halt し提示する。
+- スコープ述語は機械的に判定できる形で書く（例: `label:bug AND size:S`、`#637 の follow-up に限る`、
+  `PR #635 の review feedback round を ≤6 まで`）。判定不能な候補は scope 縁として扱い投入しない（INV-2）。
+- 並列上限は **起動時の free pane 数**（バックプレッシャー節）。退出予算（Codex round 上限 / 連続 false-positive
+  閾値 / 時間予算 / 最大反復数）も契約に明記する（[`.claude/skills/org-conveyor/references/exit-conditions.md`](references/exit-conditions.md)）。
+
+## Step 2: 完了駆動ループ本体（ベルトコンベア）
+
+スコープ契約確定後、以下を **完了駆動** で回す。各反復は「空き pane を埋める → 完了/CI 遷移を待つ →
+進んだ分だけ次を投入する」の 1 周。**固定 sleep でポーリングしない**（state transition の到着を契機にする）。
+
+1. **観測可能性サマリを出力**（反復開始時。「観測可能性」節）。
+2. **triage**: [`/work-discovery`](../work-discovery/SKILL.md) を起動する。conveyor 文脈では
+   `tools/work_discovery_scan.py --trigger post_merge --free-panes <空き pane 数>` 相当で候補 JSON を得る
+   （空き枠があると `parallelizable` 候補のランクが上がりベルトを埋めやすい）。候補生成は決定的ツールに委ねる（INV-4）。
+3. **scope gate**: 各候補をスコープ契約の述語に照合する。
+   - **合致 + 空き pane あり** → 投入対象。合致候補に対する派遣は契約で事前承認済みなので、per-candidate の
+     人間確認は **しない**（ここが `/work-discovery` の hard-stop との差分）。
+   - **非合致 / 判定不能** → **投入しない**。ベルトがその候補に触れざるを得ない（= スコープを使い切って外側しか残っていない等）
+     状況なら、自走を止め [`/org-escalation`](../org-escalation/SKILL.md) で人間に上げて halt する（INV-2）。
+4. **派遣**: 投入対象を空き pane 数まで [`/org-delegate`](../org-delegate/SKILL.md) の Step 0 から回す。レーン選択
+   （軽量 / 重量）・brief 生成・ディスパッチャー経由派遣は org-delegate に委ねる。project 文脈はスコープ契約に
+   pre-resolve 済みとし、org-delegate が **人間入力を要するチェック項目（曖昧用語・OS 前提・incorporation 戦略等）に
+   当たったらそれは scope 縁** として halt する（自動で人間質問を埋めない）。
+5. **worker iteration**: worker が走り、受信モデル（push 一次 / pull フォールバック）で報告する。ack・進捗 Progress Log・
+   完了 REVIEW 遷移・監視/介入は [`/org-delegate`](../org-delegate/SKILL.md) Step 5 に委ねる。判断仰ぎ/ブロッカーは
+   [`/org-escalation`](../org-escalation/SKILL.md) へ（INV-3）。**本スキルはこれらの機構を再規定しない**。
+6. **verify（条件付き必須）**: worker 完了時、conveyor は [`.claude/skills/org-conveyor/references/verify-evidence.md`](references/verify-evidence.md) の
+   applicability classifier を適用する。app code に触れていれば **worker が worktree 内で `/verify`（Claude Code 組込みスキル）
+   または同等の app 起動を必須実行**し（実作業は worker に委譲＝conveyor 自身は app を起動しない）、conveyor はその実行有無を gate し、
+   worker が返した再現コマンド + 出力 / スクショパスを **エビデンスとして PR 本文 `## Test plan` へ転記** する。判定不能 = scope 縁として halt（INV-2）。
+   並列 verify のポート衝突は [`.claude/skills/org-conveyor/references/dynamic-ports.md`](references/dynamic-ports.md) の動的ポート割当規律で避ける。
+7. **push / PR / CI 監視**: [`/org-pull-request`](../org-pull-request/SKILL.md) 2b-i を発動する（push → `gh pr create` →
+   `pr-watch`）。前提の「ユーザー明示承認」はスコープ契約の事前承認が満たす（Step 1）。`CI_COMPLETED` の到着で次へ。
+8. **CI green → merge gate で HALT**: CI green に達したら **merge せず停止** する。awaiting_user を emit
+   （`gate=ci_green_merge_gate`、[`/org-pull-request`](../org-pull-request/SKILL.md) 2b-i / [`/org-escalation`](../org-escalation/SKILL.md)
+   と同じ canonical emit）し、人間向け理解サマリ（full タスク）と PR を提示して merge を仰ぐ（INV-1）。
+   conveyor はこの PR についてここで停止する（ベルト全体は停止しない）。
+9. **バックプレッシャー**: 人間が merge し post-merge cleanup（[`/org-pull-request`](../org-pull-request/SKILL.md) 2b-ii）で
+   pane が解放されたら、**解放枠に triage の次候補を即時投入**する（2 へ戻る）。**PR キューに上限は設けない**
+   （未 merge PR が N 件溜まっても新規 triage を止めない）。**人間の merge が自然なバックプレッシャー（natural gate）** であり、
+   人間が merge を止めれば pane が解放されずベルトが自然に詰まって停止する。
+10. **state transition 直後に観測可能性サマリを再出力**（「観測可能性」節）。
+11. **退出条件チェック**（[`.claude/skills/org-conveyor/references/exit-conditions.md`](references/exit-conditions.md)）。いずれか該当で halt。
+
+> **再入と引き継ぎ**: 窓口 context が長くなったら [`/secretary-handover`](../secretary-handover/SKILL.md) →
+> `/clear` → [`/secretary-resume`](../secretary-resume/SKILL.md) で引き継ぐ。スコープ契約 `.state/conveyor/scope-contract.md`
+> と TaskList が SoT なので、resume 後は契約を読み戻してベルトを継続できる（ループ状態をメモリに依存させない）。
+
+## 観測可能性（必須・能動出力）
+
+ベルトコンベアの稼働状況を **人間が一目で読めるタスクリスト要約** として能動出力する。これは任意の運用習慣ではなく
+**skill 契約**であり、ベルト稼働中は省略しない（人間が「いまどこまで進んだか」を催促なしで把握できる状態を保つ）。
+
+- **状態 backbone は `TaskCreate` / `TaskUpdate` / `TaskList`**（Claude Code 組込みの task-list / todo ツール。repo 定義ではなく
+  ハーネスが窓口セッションに提供する標準ツールで、`status` は `pending` / `in_progress` / `completed` を取る）: ベルト上の各候補を
+  1 タスクとして起こし、state transition ごとに `TaskUpdate` で `status` を遷移させる（`pending` → `in_progress` → `completed`）。これは窓口の標準 UI なので
+  人間の認知負荷ゼロで、native 出力をそのまま人間向け窓に流せる。スコープ契約に紐づく conveyor 自身の制御タスク
+  （triage / 派遣 / verify / PR）と、候補ごとのタスクの両方をこの backbone に乗せてよい。
+- **要求フォーマット**（`TaskList` 由来の状態を 1 枚に整形）:
+  ```
+  3 tasks (1 done, 1 in progress, 1 open)
+  ✔ Issue #637 にコメントで決定事項を追記
+  ◼ /org-delegate で worker を派遣して SKILL.md を起…
+  ◻ worker 完了報告 → push → PR 作成 → CI 監視 → mer…
+  ```
+  - 1 行サマリ: `N tasks (X done, Y in progress, Z open)`（`X`=completed / `Y`=in_progress / `Z`=pending）。
+  - 各タスク 1 行: 状態記号 + タイトル。**状態記号**は `✔` = completed / `◼` = in_progress / `◻` = pending。
+  - タイトルが長ければ末尾を `…` で省略する（1 行に収める）。
+- **出力タイミング**（skill 契約として明文化）:
+  1. **ループ反復開始時**（新規 triage 投入後）。
+  2. **state transition 直後**（worker 派遣 / verify 完了 / CI green / PR merged / pane 解放 等の遷移ごと）。
+  3. **長時間 verify / CI watch の最中、一定間隔で**（例: 5 分毎）。**ただし前回出力から状態に変化が無ければ抑制する**
+     （無変化の定期出力で人間の通知疲労を作らない）。
+- halt（merge gate / 退出条件 / scope 縁）に入るときも、停止直前にこのサマリを出して「いまベルトのどこで止まったか」を残す。
+
+## verify 統合（条件付き必須）
+
+- **applicability classifier**: worker が diff の touch domain（app code / docs / config / fixture）を判定し、
+  **app code に触れている場合のみ `/verify` を必須** とする。**判定不能 = scope 縁扱いで停止**（INV-2）。
+- **エビデンス転記**: 完了報告に再現コマンド + 出力 / スクショパスを含め、PR 本文 `## Test plan` へ自動転記する。
+- **ポート衝突**: worktree 並列 verify で固定ポート前提のアプリ（Next.js / broker サーバー等）が衝突するため、
+  **動的ポート割り当て**（worker / app 側に env で port を受け取らせる規律）で避ける。
+- 詳細は [`.claude/skills/org-conveyor/references/verify-evidence.md`](references/verify-evidence.md) と [`.claude/skills/org-conveyor/references/dynamic-ports.md`](references/dynamic-ports.md) を一次参照。
+
+## 退出条件（機械的）
+
+以下のいずれかに該当したら自走を止め、観測可能性サマリ + 理由を人間へ提示して halt する。詳細・閾値の決め方・
+halt 後の扱いは [`.claude/skills/org-conveyor/references/exit-conditions.md`](references/exit-conditions.md) を一次参照する。
+
+- **Codex round 最大数到達** → 停止
+- **連続 false-positive 数が閾値到達** → 停止
+- **時間予算超過 / 最大反復数到達** → 停止
+- **worker escalation** → 停止（[`/org-escalation`](../org-escalation/SKILL.md) 経由、INV-3）
+- **scope 縁検知**（非合致候補 / org-delegate チェック項目で人間入力要求 / verify 判定不能）→ 停止（INV-2）
+
+## やらないこと（Non-goals）
+
+- **merge 自動化はしない**（INV-1。CI green で必ず人間へ）。
+- **escalation の自動判断はしない**（[`/org-escalation`](../org-escalation/SKILL.md) に委譲、INV-3）。
+- **`/loop` の置換ではない**（時間駆動ではなく完了駆動。間隔ポーリングをしない）。
+- **スコープ外候補の自動投入をしない**（INV-2 / INV-4）。
+- **worker 作業の代行をしない**（ファイル編集 / commit / テストは worker。窓口は司令塔）。
+- **PR キュー上限を設けない**（人間 merge が natural gate）。
+
+## 起動主体とパス解決
+
+- **起動主体は窓口だけ**（INV-5）。worker / dispatcher / curator は起動しない。
+- 本スキル中の `tools/...` / `docs/...` / `.state/...` 表記はリポジトリルート相対。窓口セッションの CWD は
+  リポジトリルートなのでそのまま実行できる。Windows では `python3` を `py -3` に読み替える（allowed-tools に両形登録済み）。
+- references へのリンク（`references/...`）は本 SKILL.md からの document-relative。表記規約は
+  [`docs/contributing/markdown-conventions.md`](../../../docs/contributing/markdown-conventions.md) に従う。

--- a/.claude/skills/org-conveyor/references/dynamic-ports.md
+++ b/.claude/skills/org-conveyor/references/dynamic-ports.md
@@ -1,0 +1,47 @@
+# 動的ポート割当規律（並列 verify のポート衝突回避）
+
+[`/org-conveyor`](../SKILL.md) はバックプレッシャーで **複数 worker を空き pane 分まで並列** に走らせる。各 worker は
+別 worktree で verify を回すため、**固定ポート前提のアプリ**（Next.js dev server `:3000` / broker サーバー / ローカル
+HTTP サービス等）を立てると **ポートが衝突** し、後から起動した verify が `EADDRINUSE` で落ちる・別 worker の
+プロセスに当たって誤判定する。
+
+Issue #637 の確定方針はこれを **動的ポート割り当て** で解く（serial verify レーン化は採らない＝並列性を殺さないため）。
+規律は一語で言うと **「ポートを固定で書かない。env で受け取る」**。
+
+## 規律
+
+1. **app / サーバーは listen ポートを env から受け取る**。固定ポートをコードに焼かない。
+   - 既定 env 名は `PORT`（多くのフレームワークの慣習）。アプリ固有の env があればそれに従う（例: Next.js は `PORT`、
+     broker サーバーは自身の port env）。verify policy（[`.claude/skills/org-conveyor/references/scope-contract.md`](scope-contract.md)）に env 名を明記する。
+2. **conveyor / worker は verify ごとに空きポートを動的確保し、env で app と検査側の両方へ渡す**。
+   ポート番号をハードコードした再現コマンドを書かない。
+3. **再現コマンドにも env 経由のポートを反映**して PR `## Test plan` に転記する（[`.claude/skills/org-conveyor/references/verify-evidence.md`](verify-evidence.md)）。
+   ポート番号は実行ごとに変わるので、Test plan には **env 名で示し具体値を焼かない**（追試者が同じ規律で再確保できる）。
+
+## 空きポートの確保（portable）
+
+OS にエフェメラルポートを割り当てさせる（`:0` に bind して即 close、得た番号を使う）。repo 固有ツールに依存しない:
+
+```bash
+# 空きポートを 1 つ確保して env に入れる
+PORT=$(python3 -c 'import socket;s=socket.socket();s.bind(("",0));print(s.getsockname()[1]);s.close()')
+# app と検査の双方へ同じ env を渡す
+PORT="$PORT" tools/run.sh &          # app は PORT を listen
+curl -s "localhost:$PORT/health"     # 検査も同じ PORT を叩く
+```
+
+> bind→close→使用の間に他プロセスが同じポートを取る競合は理論上ありうるが、エフェメラル域はレンジが広く
+> 並列数（= 空き pane 数、せいぜい数本）では実害が出にくい。確実性が要るアプリは「起動直後にポートを stdout へ
+> 出させてそれを掴む」方式（フレームワークが対応していれば）に切り替えてよい。
+
+## worker brief への載せ方
+
+- 並列 verify を伴う重量レーン委譲では、[`/org-delegate`](../../org-delegate/SKILL.md) の `--impl-guidance` 等で
+  「固定ポート禁止 / `PORT` env で受け取る / 再現コマンドは env 経由で書く」を brief に明記する。
+- verify policy（スコープ契約）に env 名と確保方式を 1 行で残し、conveyor が複数 worker を投入する前提を固定する。
+
+## 不採用案（serial verify レーン化）
+
+verify を 1 本ずつ直列化すれば固定ポートでも衝突しないが、**ベルトの並列性（バックプレッシャー）を殺す**ため
+Issue #637 では採らない。動的ポートなら並列のまま衝突を避けられる。どうしても直列必須なアプリ（共有 DB の
+排他ロック等、ポート以外の資源競合）が出たら、それは scope 縁としてスコープ契約に明記し人間判断を仰ぐ。

--- a/.claude/skills/org-conveyor/references/exit-conditions.md
+++ b/.claude/skills/org-conveyor/references/exit-conditions.md
@@ -1,0 +1,61 @@
+# 機械的退出条件（exit conditions）まとめ
+
+[`/org-conveyor`](../SKILL.md) は完了駆動で自走するが、**5 つの機械的退出条件** のいずれかに該当したら
+自走を止めて人間へ戻す。退出は失敗ではなく **安全装置**: 自動判断の射程を超えた状況（churn / 想定外 /
+スコープの縁）を機械的に検出し、ベルトを止めて人間の目を入れる。退出予算はスコープ契約
+（[`.claude/skills/org-conveyor/references/scope-contract.md`](scope-contract.md)）に明記し、引き継ぎ後も読み戻せるようにする。
+
+## 退出条件一覧
+
+| # | 条件 | 既定閾値 | 何を見るか |
+|---|---|---|---|
+| 1 | **Codex round 最大数到達** | `codex_round_max`（既定 3） | ある PR の Codex セルフレビュー fix が上限ラウンドに達しても Blocker/Major が収束しない |
+| 2 | **連続 false-positive 数到達** | `false_positive_streak_max`（既定 2） | CI red / Codex Blocker / verify 失敗を追ったが、いずれも変更起因の実欠陥でなかった（flaky / benign）回が連続 |
+| 3 | **時間予算超過 / 最大反復数到達** | `time_budget` / `max_iterations` | ベルト稼働の経過時間 / ループ反復回数が契約の予算を超えた |
+| 4 | **worker escalation** | 即時 | worker から「判断仰ぎ」「承認を仰ぎ」「スコープ拡張」「ブロッカー」「想定外」「runbook 逸脱」が来た |
+| 5 | **scope 縁検知** | 即時 | スコープ述語に非合致 / 判定不能の候補・差分、または org-delegate チェック項目が人間入力を要求、verify 判定不能 |
+
+## 各条件の詳細
+
+### 1. Codex round 最大数到達
+
+- worker の Codex セルフレビューは Blocker/Major ゼロまで回すが上限 3 ラウンド（[`/org-delegate`](../../org-delegate/SKILL.md)
+  「ワーカー監視と介入判定」: Codex 4 ラウンド目以降は介入トリガー）。conveyor はこれを **ベルト退出条件としても扱う**:
+  ある PR が上限ラウンドで収束しないなら、その候補はベルトから外し人間へ上げる（残りの候補のベルトは続けてよい）。
+- 「収束しない」を機械的に: 同一 PR で Codex round が `codex_round_max` 回を超えても Blocker/Major が残る。
+
+### 2. 連続 false-positive 数到達
+
+- conveyor の自動 gate（CI 解釈 / Codex Blocker / verify 失敗）が **halt 候補シグナルを出したが、追ったら変更起因の
+  実欠陥ではなかった**（flaky CI / benign な Codex 指摘 / 環境起因の verify 失敗）回を **false-positive** と数える。
+- 実欠陥を 1 つでも掴んだら連続カウンタはリセット。**連続**して `false_positive_streak_max` 回 false-positive が続いたら、
+  自動 gate のシグナルが信頼できない状態なので halt（誤シグナルで churn し続けない / `feedback-no-stopgap`）。
+- カウンタは TaskList のメタや conveyor 制御タスクに紐づけて引き継げる形で持つ（観測可能性節）。
+
+### 3. 時間予算超過 / 最大反復数到達
+
+- `time_budget`（壁時計）または `max_iterations`（ループ周回数）の超過で halt。長時間の無人自走を青天井にしない。
+- 経過の起点はスコープ契約の `approved_at`（または最初の反復開始時）。反復数は観測可能性サマリの出力回数に一致させると数えやすい。
+
+### 4. worker escalation
+
+- worker からの judgment escalation / scope 拡張 / ブロッカーは **即 halt** し、conveyor が一次承認せず
+  [`/org-escalation`](../../org-escalation/SKILL.md) の正準フロー（ack → 3 層状態保存 → 人間伝達 → 返答転送）へ渡す（INV-3）。
+- 該当 worker のベルト枠は人間判断が返るまで保留。他候補のベルトは独立に続けてよい。
+
+### 5. scope 縁検知
+
+- 以下はすべて scope 縁 → halt（INV-2）:
+  - triage 候補がスコープ述語に **非合致 / 判定不能**（[`.claude/skills/org-conveyor/references/scope-contract.md`](scope-contract.md)）。
+  - [`/org-delegate`](../../org-delegate/SKILL.md) の委譲前チェック（曖昧用語 / OS 前提 / incorporation 戦略等）が
+    **人間入力を要求**した（conveyor が代わりに埋めない）。
+  - verify の applicability classifier が **判定不能**（[`.claude/skills/org-conveyor/references/verify-evidence.md`](verify-evidence.md)）。
+- スコープを使い切り、残り候補が外側しか無いなら、それも「これ以上自走できる範囲が無い」= 正常退出として人間へ報告する。
+
+## halt 時の共通挙動
+
+- 自走を止め、**観測可能性サマリ（[`.claude/skills/org-conveyor/SKILL.md`](../SKILL.md)「観測可能性」節）+ 退出理由 + 該当 PR/候補** を人間へ提示する。
+  「ベルトのどこで何が起きて止まったか」を 1 枚で残す。
+- **退出条件は自動解決しない**（INV-3 / INV-6）。merge / scope 拡張 / escalation の解消はすべて人間ゲート。
+- 進行中の他 worker・未 merge の PR キューは halt しても消えない（人間が個別に merge / 対応できる）。
+- 人間がスコープを更新（拡大は再承認、[`.claude/skills/org-conveyor/references/scope-contract.md`](scope-contract.md)）すればベルトを再開できる。

--- a/.claude/skills/org-conveyor/references/scope-contract.md
+++ b/.claude/skills/org-conveyor/references/scope-contract.md
@@ -1,0 +1,84 @@
+# 承認スコープ契約（scope contract）テンプレートと規律
+
+[`/org-conveyor`](../SKILL.md) の **唯一の事前人間ゲート**。`/work-discovery` が候補ごとに取る人間選択を、
+**起動時に 1 回だけ取る機械契約** に畳み込んだもの。この契約の内側でだけ conveyor は再質問なしに自走し、
+契約の外側に触れたら必ず halt する（[`.claude/skills/org-conveyor/SKILL.md`](../SKILL.md) INV-1〜INV-4）。
+
+## なぜ機械契約として articulate するのか
+
+「PR #635 round 6 まで自走可」「triage 上位 S 級を空き pane 分だけ自走」のような承認は、口頭では
+輪郭が曖昧で、conveyor が「どこまでが承認内か」を機械的に判定できない。曖昧なまま回すと、
+スコープ外への踏み込み（自動 merge / 別件混入 / 想定外作業の自己承認）が起きうる。そこで承認の輪郭を
+**機械的に判定できる述語 + 予算** として書き下し、人間に確認を取ってから回す。これにより:
+
+- conveyor は各候補・各 state transition を契約に照合して **投入可否を決定的に判定** できる。
+- スコープの縁（contract の述語に合致しない / 判定不能）が **検出可能** になり、halt 契機が機械化される。
+- 引き継ぎ（[`/secretary-resume`](../../secretary-resume/SKILL.md)）後も契約を読み戻せば同じ判定を再現でき、
+  ループ状態をメモリに依存させない。
+
+## 何を事前承認し / 何を絶対に承認しないか（境界・非交渉）
+
+| 範囲 | 事前承認 | 根拠 |
+|---|---|---|
+| triage 投入（スコープ述語に合致する候補のみ） | ✅ する | 完了駆動ループの入口 |
+| `/org-delegate` 派遣（合致候補・空き pane 内） | ✅ する | per-candidate 人間選択を契約へ畳み込み |
+| worker iteration / verify | ✅ する | スコープ内作業 |
+| **push / `gh pr create` / `pr-watch` CI 監視** | ✅ する | 起動時スコープ承認が [`/org-pull-request`](../../org-pull-request/SKILL.md) 2b-i の「ユーザー明示承認」前提を満たす |
+| **merge** | ❌ **決して承認しない** | 不可逆点。常に PR ごとの独立人間ゲート（`feedback-merge-approval` / `feedback-no-overgate-after-decision`） |
+| スコープ外候補の投入 | ❌ しない | scope 縁 → halt（INV-2 / INV-4） |
+| worker escalation の一次承認 | ❌ しない | [`/org-escalation`](../../org-escalation/SKILL.md) 経由で人間へ（INV-3） |
+
+> **push/PR を事前承認できる理由（merge と区別する）**: 人間が「この範囲は自走してよい」と明示した
+> **持続的スコープ承認** が、in-scope な PR 作成までの mechanical pipeline を覆う（`feedback-no-overgate-after-decision`
+> 「ユーザー判断確定後は不可逆点でのみ再承認」）。merge は不可逆点なので **この承認の射程外**に明示的に置き、
+> 都度ゲートする。conveyor は bare な per-PR「OK」を merge 承認に流用しない。
+
+## テンプレート
+
+確定した契約を `.state/conveyor/scope-contract.md` に書き出す（ループ中の gate 判定で読み戻す SoT）。
+
+```markdown
+# Conveyor scope contract
+
+- contract_id: <YYYY-MM-DD>-<topic>            # 例: 2026-06-23-bugfix-belt
+- approved_by: human (窓口経由)                 # 承認した人間・経路
+- approved_at: <YYYY-MM-DD HH:MM>              # スコープ承認を受けた時刻
+- repo: <OWNER/REPO>                           # 対象リポジトリ（gh カレント解決でも可）
+
+## scope predicate（機械的に判定できる述語）
+- include: <述語>        # 例: label:bug AND size:S / #637 の follow-up に限る / PR #635 の review round
+- exclude: <述語>        # 例: label:needs-design / 多ファイル設計判断を含むもの
+- 判定不能候補の扱い: scope 縁として投入しない（halt）
+
+## project context（pre-resolve 済み・org-delegate の Step 0 人間質問を回避するため）
+- project: <registry/projects.md の通称>
+- branch 規約: <feat/... 等>
+- verify policy: <app code 変更時 /verify 必須 / docs-only は skip 等。references/verify-evidence.md 準拠>
+
+## 並列・予算（退出条件 / バックプレッシャー）
+- max_parallel: <起動時 free pane 数>          # references/exit-conditions.md
+- codex_round_max: <既定 3>
+- false_positive_streak_max: <既定 2>
+- time_budget: <例: 2h>  /  max_iterations: <例: 10>
+- PR キュー上限: なし（人間 merge が natural gate）
+
+## merge gate（非交渉）
+- merge は事前承認しない。CI green で halt し PR ごとに人間へ提示する。
+```
+
+> フィールドは固定キー（`label:` 等の述語はそのまま grep / gh フィルタに渡せる形）で書く。markdown だが
+> conveyor が読み戻す **構造化契約** なのでキー名を勝手に変えない。
+
+## 人間確認の手順（起動時 1 回）
+
+1. 人間から受けたスコープ承認を上記テンプレートに articulate する。
+2. **人間に読み返して確認を取る**（「この輪郭で自走します。merge は都度あなたが判断します」を含める）。
+   確認が取れるまでループを開始しない。
+3. 確認後 `.state/conveyor/scope-contract.md` に書き出し、[`.claude/skills/org-conveyor/SKILL.md`](../SKILL.md) Step 2 のループへ入る。
+
+## 契約の拡大・変更（再確認が必要）
+
+- スコープを **広げる**（include 述語の拡張 / 別 label の追加 / 予算の増額）のは **必ず人間の再承認** を経る。
+  conveyor が自走中に「ついでにこれも」と契約を自己拡張してはならない（worker のスコープ拡張提案を一次承認しないのと同じ規律。
+  [`CLAUDE.md`](../../../../CLAUDE.md)「worker への追加依頼の境界」と整合）。
+- スコープを **狭める / 早期停止** は人間がいつでも指示できる（merge を止めれば pane が解放されずベルトが自然に詰まる）。

--- a/.claude/skills/org-conveyor/references/verify-evidence.md
+++ b/.claude/skills/org-conveyor/references/verify-evidence.md
@@ -1,0 +1,80 @@
+# verify 統合: applicability classifier + エビデンス転記
+
+[`/org-conveyor`](../SKILL.md) Step 2-6 の verify 統合の詳細。verify を **条件付き必須** にする判定（applicability
+classifier）と、その結果を PR 本文 `## Test plan` へ機械転記する規律を定める。狙いは「app code を触ったのに
+動作未確認のまま PR を流す」ことを防ぎつつ、docs / config だけの差分に無意味な verify を強制しないこと。
+
+> **実行主体（重要）**: `/verify` は Claude Code の **組込みスキル**（app を起動して実行ビヘイビアを観測する）。
+> verify を **実行するのは worker** であり、**app + 当該変更が居る worker の worktree 内**で走らせる。conveyor（窓口
+> セッション・リポジトリルートで worker 変更を持たない）は **app を起動しない** — conveyor の責務は (1) applicability
+> classifier で verify 要否を gate、(2) worker が返したエビデンスを PR `## Test plan` へ転記、の 2 つだけ。組込み `/verify` が
+> app 形態に合わない場合は、worker が同等の app 起動コマンドを直接叩いて証跡を残す（[`.claude/skills/org-conveyor/SKILL.md`](../SKILL.md) Step 2-6）。
+
+## applicability classifier（diff touch domain で判定）
+
+worker は完了報告に **diff の touch domain** を、自身の worktree で得た `git diff --name-only <base>..HEAD` の出力ごと
+申告する（worker 側が一次ソース。HEAD が worker のブランチに在るのは worker のみ）。conveyor はその申告ファイル一覧を
+パス分類して `/verify` 必須かを決定的に判定する。worker のブランチが窓口セッションから local に見える場合
+（object store 共有の Pattern B worktree 等）は conveyor 自身も `git diff --name-only <base>..<branch>` を再実行して
+申告と突き合わせる（read-only の裏取り）。local に見えない場合（別 clone・push 前等）は PR 作成後の変更ファイル一覧
+（`gh pr view --json files`、[`/org-pull-request`](../../org-pull-request/SKILL.md) 経由）で突き合わせる。
+
+| touch domain | 例 | `/verify` |
+|---|---|---|
+| **app code** | アプリ実装・ランタイム挙動を変える source（`*.py` / `*.ts` の実装・CLI・サーバー・ツール本体・hook 等） | **必須** |
+| **docs** | `*.md` / `docs/` / コメントのみ | 不要 |
+| **config** | 設定値・lint / CI 設定・依存ピン（挙動を変えないもの） | 不要（挙動を変える config は app code 扱い） |
+| **fixture / test data** | golden / fixture / サンプルデータ更新のみ | 不要（テスト本体のロジック変更は app code 扱い） |
+
+判定規律:
+
+- **混在（app code + docs/config/fixture）** → app code の存在が支配的。**`/verify` 必須**。
+- **app code が無く docs / config / fixture のみ** → `/verify` 不要（理由を Test plan に 1 行記す: 例「docs-only、ビヘイビア変更なし」）。
+- **判定不能**（touch domain がパス分類と食い違う / どちらに倒すべきか機械的に決まらない / app code か config か曖昧）
+  → **scope 縁として halt**（[`.claude/skills/org-conveyor/SKILL.md`](../SKILL.md) INV-2）。誤って verify を skip して挙動退行を見逃すより、人間に上げる。
+- 本スキル（claude-org 自身の `.claude/` 編集）のような **実行可能アプリを持たない skill/docs タスク**は docs 扱いになりうるが、
+  その場合 verify policy（[`.claude/skills/org-conveyor/references/scope-contract.md`](scope-contract.md) の `verify policy`）に明記し、Test plan には
+  「skill prose のみ・実行ビヘイビアなし」等の不要理由を残す。
+
+> classifier はパスベースの決定的判定を一次に置き、worker の申告と食い違ったら **食い違い自体を halt 契機**にする
+> （申告を鵜呑みにしない / パス分類を鵜呑みにしない、の二重チェック）。
+
+## エビデンス転記（PR `## Test plan` へ自動転記）
+
+`/verify` を実行した（または不要と判定した）ら、再現可能な証跡を完了報告に含め、[`/org-pull-request`](../../org-pull-request/SKILL.md)
+2b-i の PR 作成時に PR 本文 `## Test plan` セクションへ **そのまま転記** する。窓口がコードを精読せずに、また将来の
+レビュアーが追試できるように、**再現コマンドと観測結果** を残すのが要件。
+
+完了報告に含めるエビデンス（worker が用意し、conveyor が転記）:
+
+- **再現コマンド**: verify で実際に叩いたコマンド（動的ポートは env 名で示す。[`.claude/skills/org-conveyor/references/dynamic-ports.md`](dynamic-ports.md)）。
+- **観測結果**: コマンド出力の要点 / 終了コード / スクリーンショットの保存パス（UI verify の場合）。
+- **applicability 判定**: app code 触れ有無と classifier の結論（必須実行 or 不要理由）。
+
+PR 本文へ転記する形（`## Test plan`）:
+
+````markdown
+## Test plan
+
+- applicability: app code を変更（`tools/foo.py`）→ /verify 必須
+- repro:
+  ```
+  PORT=$(python3 -c 'import socket;s=socket.socket();s.bind(("",0));print(s.getsockname()[1]);s.close()')
+  PORT="$PORT" tools/run.sh &       # 動的ポート（references/dynamic-ports.md）
+  curl -s "localhost:$PORT/health"  # → {"status":"ok"}
+  ```
+- result: health 200 / 終了コード 0 / 退行なし
+- screenshot: .state/conveyor/evidence/<task_id>/health.png   # UI の場合
+````
+
+docs / config / fixture のみで verify 不要だった場合も、Test plan に **不要理由を 1 行** 残す（空欄にしない）:
+
+```markdown
+## Test plan
+
+- applicability: docs-only（`.claude/skills/**/*.md` のみ）→ 実行ビヘイビア変更なし、/verify 不要
+```
+
+> 転記は **machine transcription**（worker が出した証跡を窓口が整形・貼付する）であって、窓口がエビデンスを
+> 自作・補完することではない。エビデンスが欠落していたら通常の review-feedback として worker に補完を依頼する
+> （[`/org-pull-request`](../../org-pull-request/SKILL.md) 2c）。


### PR DESCRIPTION
## Summary

承認スコープを機械契約として articulate し、その内側で triage → 派遣 → iteration → verify → push → PR → CI 監視 を完了駆動で自走、PR ごとに merge gate で必ず halt するベルトコンベア orchestrator を新規追加する。

既存のループ系 skill (`/loop` = 時間駆動 / `/work-discovery` = propose-only / `/org-delegate` = single worker) とは別の責務を担う薄い orchestrator として、既存 skill を組合せる形で実装。

Closes #637

## 変更ファイル (5 / +499 行・新規のみ)

- `.claude/skills/org-conveyor/SKILL.md` — 本体
- `.claude/skills/org-conveyor/references/scope-contract.md` — 承認スコープ契約テンプレ
- `.claude/skills/org-conveyor/references/verify-evidence.md` — applicability classifier + エビデンス転記
- `.claude/skills/org-conveyor/references/dynamic-ports.md` — 並列 verify の動的ポート割当
- `.claude/skills/org-conveyor/references/exit-conditions.md` — 5 つの機械的退出条件

## 設計確定事項 (Issue #637 Open questions より)

| 項目 | 決定 |
|------|------|
| skill 名 | `/org-conveyor` |
| verify ポート衝突 | 動的ポート割り当て (worker / app 側に env で port を受け取る規律) |
| バックプレッシャー上限 | 入れない (人間の merge が natural gate) |
| skill 構造 | orchestrator (`/work-discovery` + `/org-delegate` + `verify` を呼ぶ薄い skill) |

## 不変条件 (非交渉)

- merge 承認は人間 gate (`feedback-merge-approval`)
- scope 境界に触れたら必ず halt (`feedback-no-stopgap` / `org-escalation` 経由)
- worker 判断仰ぎは人間に上げる (一次承認しない)

## 観測可能性 (窓口要求)

`TaskCreate` / `TaskUpdate` / `TaskList` を状態 backbone とし、`N tasks (X done, Y in progress, Z open)` + ✔/◼/◻ の各タスク 1 行サマリを以下のタイミングで能動出力:
1. ループ反復開始時 (新規 triage 投入後)
2. state transition 直後 (worker 派遣 / CI green / PR merged 等)
3. 長時間 verify / CI watch 中の一定間隔 (無変化抑制)

## 退出条件 (機械的)

Codex round 上限 / 連続 false-positive / 時間予算 / worker escalation / scope 縁検知。

## Test plan

- [x] `tools/audit_link_paths.py`: org-conveyor 起点 broken link なし
- [x] 非ASCII 混入スキャン: stray なし
- [x] skill 登録確認: `/org-conveyor` がスキル一覧に出現
- [x] Codex セルフレビュー (`codex exec review --base main`) 5 ラウンド clean 収束
- [x] Codex 指摘 P1 (×2) / P2 (×4) / P3 (×1) は全て修正、残置 2 件は明文の見送り判断 (TaskCreate 系は実在ツール / transport allowlist は active 単一面採用)

## Follow-up

`.md.in` + manifest 化による per-transport full 対応は active transport が broker にフリップ済みのため現状維持。後日必要になったら別 Issue を起票する。