### PR TITLE
fix(claude): pr-watch.sh/.ps1 を自己 re-exec で cwd/引数/stdin の取り違えを吸収

### DIFF
--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -16,12 +16,80 @@ param(
     [switch]$MergeWatch,
 
     [Parameter(Mandatory = $false)]
-    [switch]$NoMergeWatch
+    [switch]$NoMergeWatch,
+
+    # Wrapper-only flag (Issue #641): run in the foreground instead of
+    # self-re-execing into a detached process. Used for tests / debugging.
+    [Parameter(Mandatory = $false)]
+    [switch]$NoDetach
 )
 
 $ErrorActionPreference = 'Stop'
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ScriptPath = Join-Path $ScriptDir 'pr_watch.py'
+
+# Detach behavior (Issue #641) — mirror of tools/pr-watch.sh.
+# ----------------------------------------------------------------------
+# By default, self-re-exec into an independent, hidden process and return
+# immediately so the watcher survives the parent session closing (the
+# Windows analogue of the POSIX SIGHUP trap: a closing console sends
+# CTRL_CLOSE to attached children). The child re-runs this script with
+# PR_WATCH_DETACHED=1 set, which routes it down the foreground branch. The
+# re-exec is idempotent, so an outer background launch becomes a no-op.
+#
+#   -NoDetach           Run in the foreground (tests / debugging).
+#   $env:PR_WATCH_LOG   Override the log path. Default:
+#                       <repo-root>\.state\pr-watch-<PR>.log
+#   $env:PR_WATCH_DETACHED  Internal re-entry guard set by the re-exec.
+if (-not $env:PR_WATCH_DETACHED -and -not $NoDetach) {
+    $RepoRoot = Split-Path -Parent $ScriptDir
+    if ($env:PR_WATCH_LOG) {
+        $LogPath = $env:PR_WATCH_LOG
+    }
+    else {
+        $LogPath = Join-Path (Join-Path $RepoRoot '.state') "pr-watch-$PR.log"
+    }
+    $LogDir = Split-Path -Parent $LogPath
+    if ($LogDir -and -not (Test-Path -LiteralPath $LogDir)) {
+        New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+    }
+
+    # Rebuild the child argument list, dropping -NoDetach (never re-passed).
+    $childArgs = @('-NoProfile', '-File', $PSCommandPath, '-PR', $PR)
+    if ($PSBoundParameters.ContainsKey('Repo') -and $Repo) {
+        $childArgs += @('-Repo', $Repo)
+    }
+    if ($PSBoundParameters.ContainsKey('Interval')) {
+        $childArgs += @('-Interval', $Interval)
+    }
+    if ($MergeWatch) { $childArgs += '-MergeWatch' }
+    if ($NoMergeWatch) { $childArgs += '-NoMergeWatch' }
+
+    # Resolve the running PowerShell host so the child uses the same engine.
+    $pwshExe = (Get-Process -Id $PID).Path
+    if (-not $pwshExe) { $pwshExe = 'pwsh' }
+
+    # The child inherits this env var and so takes the foreground branch.
+    $env:PR_WATCH_DETACHED = '1'
+    # Start-Process spawns an independent process that outlives this one;
+    # a hidden window detaches it from the parent console. stdout goes to
+    # the log; stderr goes to "<log>.err" because Start-Process refuses to
+    # point both streams at the same file.
+    $errPath = "$LogPath.err"
+    # Build one explicitly double-quoted command line: passing a string[]
+    # to -ArgumentList joins the elements with spaces WITHOUT re-quoting
+    # them, so a -File path containing spaces (e.g. C:\Users\First Last\..)
+    # would be split and the child would fail to launch while the parent
+    # still reports "detached".
+    $argLine = ($childArgs | ForEach-Object {
+        '"' + ([string]$_ -replace '"', '""') + '"'
+    }) -join ' '
+    $proc = Start-Process -FilePath $pwshExe -ArgumentList $argLine `
+        -WindowStyle Hidden -PassThru `
+        -RedirectStandardOutput $LogPath -RedirectStandardError $errPath
+    Write-Output "pr-watch detached: pid=$($proc.Id) log=$LogPath"
+    exit 0
+}
 
 # Probe interpreters by actually running `--version`, not just by checking
 # Get-Command. Some Windows boxes have a stale `py.exe` whose default 3.x

--- a/tools/pr-watch.sh
+++ b/tools/pr-watch.sh
@@ -1,6 +1,98 @@
 #!/usr/bin/env bash
 # Thin POSIX wrapper around tools/pr_watch.py.
-# Usage: tools/pr-watch.sh --pr <PR> [--repo OWNER/REPO] [--interval SEC]
+#
+# Usage:
+#   tools/pr-watch.sh <PR> [--repo OWNER/REPO] [--interval SEC] \
+#                          [--merge-watch] [--no-merge-watch] [--no-detach]
+#   tools/pr-watch.sh --pr <PR> [...]
+#
+# Detach behavior (Issue #641)
+# ----------------------------
+# By default this wrapper self-re-execs into a fully detached session
+# (setsid + nohup + stdin </dev/null + log redirect) and returns
+# immediately. This makes a bare
+#
+#   bash tools/pr-watch.sh <PR> --repo <owner/repo> --merge-watch
+#
+# survive the exit of a short-lived parent session (e.g. Claude Code's
+# Bash tool), which otherwise SIGHUPs the watcher within seconds. `disown`
+# alone does not help — it only drops the job from the shell's table, it
+# does not shield the child from the parent session's SIGHUP. The re-exec
+# is idempotent: the child runs with PR_WATCH_DETACHED=1 set and takes the
+# foreground branch, so an outer `nohup ... &` wrapper from an existing
+# caller becomes a harmless no-op.
+#
+# Wrapper-only options (consumed here, NOT forwarded to pr_watch.py):
+#   --no-detach   Run the watcher in the foreground (tests / debugging).
+#
+# Environment:
+#   PR_WATCH_LOG       Override the detached log path. Default:
+#                      <repo-root>/.state/pr-watch-<PR>.log
+#   PR_WATCH_DETACHED  Internal re-entry guard set by the re-exec. Do not
+#                      set this by hand.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$SCRIPT_DIR/pr_watch.py" "$@"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Split wrapper-only flags (--no-detach) out of the arguments forwarded to
+# pr_watch.py, which does not recognize them.
+no_detach=0
+forward_args=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-detach) no_detach=1 ;;
+    *) forward_args+=("$arg") ;;
+  esac
+done
+
+# Already detached, or the caller asked for foreground: run pr_watch.py in
+# place and let its exit code propagate.
+if [[ -n "${PR_WATCH_DETACHED:-}" || "$no_detach" == 1 ]]; then
+  exec python3 "$SCRIPT_DIR/pr_watch.py" ${forward_args[@]+"${forward_args[@]}"}
+fi
+
+# --- Detach path: self re-exec in a new, SIGHUP-immune session. ---
+
+# Best-effort PR label for the default log filename. Handles `--pr N`,
+# `--pr=N`, and a bare positional PR while skipping the values of other
+# value-taking flags, so e.g. `--repo owner/name` is not mistaken for it.
+pr_label="unknown"
+i=0
+n=${#forward_args[@]}
+while (( i < n )); do
+  a="${forward_args[i]}"
+  case "$a" in
+    --pr=*) pr_label="${a#--pr=}"; break ;;
+    --pr) if (( i + 1 < n )); then pr_label="${forward_args[i+1]}"; fi; break ;;
+    --repo|--interval) i=$((i + 2)) ;;
+    --repo=*|--interval=*|--merge-watch|--no-merge-watch) i=$((i + 1)) ;;
+    -*) i=$((i + 1)) ;;
+    *) pr_label="$a"; break ;;
+  esac
+done
+# Sanitize for filesystem safety (keep the log inside .state, never let a
+# stray arg escape the directory via slashes).
+pr_label="${pr_label//[^A-Za-z0-9._-]/_}"
+
+log_path="${PR_WATCH_LOG:-$REPO_ROOT/.state/pr-watch-${pr_label}.log}"
+mkdir -p "$(dirname "$log_path")"
+
+# Re-exec the script itself via bash (the file is not marked executable),
+# in a fresh session with no controlling terminal and SIGHUP ignored.
+#
+# setsid gives the watcher its own session (no controlling tty) — the
+# strongest SIGHUP shield — but it is not installed everywhere (notably
+# stock macOS). When it is absent, fall back to nohup-only detachment:
+# `nohup` ignores SIGHUP and `</dev/null` + the log redirect still detach
+# the child from the parent's stdio, which covers the common case.
+setsid_prefix=()
+if command -v setsid >/dev/null 2>&1; then
+  setsid_prefix=(setsid)
+fi
+${setsid_prefix[@]+"${setsid_prefix[@]}"} env PR_WATCH_DETACHED=1 nohup \
+  "${BASH:-bash}" "$0" ${forward_args[@]+"${forward_args[@]}"} \
+  </dev/null >"$log_path" 2>&1 &
+detached_pid=$!
+disown 2>/dev/null || true
+echo "pr-watch detached: pid=$detached_pid log=$log_path"
+exit 0


### PR DESCRIPTION
## Summary

`tools/pr-watch.sh` と `tools/pr-watch.ps1` の冒頭に **自己 re-exec による detach 内部化** を入れ、呼び出し側が cwd / 引数 / stdin redirect の 3 要素を毎回揃える運用負荷を排除する。

**位置づけ (重要):** 本修正は cwd / 引数 / stdin 取り違えを wrapper 側で吸収する **規律強化** であり、Claude Code Bash tool sandbox 由来の prog group kill は wrapper レイヤでは超えられないため **CI 監視永続化の根治ではない**。CI 監視永続化の根治は別 Issue #642 (tmux pane skill) で扱う。

Closes #641

## 主要変更点 (5)

1. **`pr-watch.sh` 冒頭の `PR_WATCH_DETACHED` 再入ガード** — 未セットなら setsid + nohup + stdin `</dev/null` + log redirect で自己 re-exec し `pr-watch detached: pid=N log=PATH` を出力して exit 0。再 exec 子は guard が立つので foreground 分岐で `pr_watch.py` を実行。冪等で外側 nohup は no-op
2. **`setsid` 不在環境のグレースフルフォールバック** — stock macOS 等で setsid 無しのときは nohup-only にフォールバック (Codex P2 指摘の移植性回帰修正)
3. **log path は `PR_WATCH_LOG` env で上書き可、default は `<repo-root>/.state/pr-watch-<PR>.log`** (state.db と同じ repo-root 相対)。PR ラベルは `--pr N` / `--pr=N` / 位置引数を解釈し `--repo` / `--interval` の値と取り違えず抽出・サニタイズ
4. **`--no-detach` フラグ** で foreground 実行 (pr_watch.py には転送しない wrapper 専用)
5. **`pr-watch.ps1` も等価動作** (`-NoDetach` / `$env:PR_WATCH_DETACHED` / `Start-Process -WindowStyle Hidden`)。スペース込みパスで `-File` が分割されないよう引数を明示クォート (Codex P2 修正)

不変条件 (CI_COMPLETED / PR_MERGED / PR_MERGE_WATCH_TIMEOUT メッセージ / event payload / log 規約) は不変更。

## Test plan

- [x] 実 PR #640 で detach 後 PID がセッションリーダー (setsid 成立)、spawning subshell 終了後も生存、log path 正、"detached" 出力 OK
- [x] 副作用ゼロ fake python3 stub で: `--no-detach` foreground / `--pr` ラベル抽出 / `PR_WATCH_LOG` 上書き / 再入ガード冪等 / setsid 不在フォールバック をすべて確認
- [x] Codex full レビュー (`gpt-5.5`, effort medium) 2 ラウンド、P2 × 2 (setsid 移植性 / ps1 引数クォート) 修正、round 2 クリーン
- [x] `python3 -m unittest` 48 pass (pwsh probe のみ skip)

## Follow-up

CI 監視永続化の根治は別 Issue #642 (tmux pane skill `/pr-watch-pane`) で実装中。本 PR は wrapper 規律強化として独立に成立する。

## Spurious DB rows cleanup

detach 検証で `.state/state.db` に spurious `ci_completed` 行が 3 件 (id 1581 pr=640, id 1584/1585 pr=999999) 残ったため、merge 前に窓口側で削除済み。journal に `spurious_event_cleanup ci_event_ids=1581,1584,1585` を 1 行記録。