### PR TITLE
fix(claude): /pr-watch-pane skill に --no-detach を付与して watcher 孤児化を防ぐ

### DIFF
--- a/.claude/skills/pr-watch-pane/SKILL.md
+++ b/.claude/skills/pr-watch-pane/SKILL.md
@@ -123,7 +123,7 @@ mcp__org-broker__spawn_pane(
   role="watcher",
   name="pr-watch-<PR>",
   cwd="<JA_ROOT 絶対パス>",
-  command="mkdir -p .state; bash tools/pr-watch.sh <PR> --repo <OWNER/REPO> --merge-watch 2>&1 | tee -a .state/pr-watch-<PR>.log; tmux kill-pane 2>/dev/null || true"
+  command="mkdir -p .state; bash tools/pr-watch.sh <PR> --repo <OWNER/REPO> --merge-watch --no-detach 2>&1 | tee -a .state/pr-watch-<PR>.log; tmux kill-pane 2>/dev/null || true"
 )
 ```
 
@@ -135,6 +135,11 @@ mcp__org-broker__spawn_pane(
   は spawn 時に固定で、role ラベルは tier を変えない — Surface 8）。
 - `cwd`: **Step 1 で解決した JA_ROOT 絶対パス**。これにより pane 内の `tools/pr-watch.sh` /
   `.state/pr-watch-<PR>.log` が ja-root 基点で resolve される（cwd trap 吸収）。
+- **`--no-detach` 必須（Issue #650）**: `tools/pr-watch.sh` は Issue #641 対策で既定
+  setsid + nohup の自己 detach をするため、`--no-detach` を付けないと spawn 直後に親 bash が
+  exit して broker pane が即時掃除され、watcher が孤児化する（pane が無いので `/org-attach` /
+  `Ctrl-b s` でも覗けない）。`--no-detach` で前景動作させ、`tee` と末尾 `tmux kill-pane` の
+  自己終了サイクルを成立させる。
 - `command`: pr-watch を前景実行し、stdout/stderr を `.state/pr-watch-<PR>.log` に `tee -a`
   （tmux スクロールバッファにも出る二段）。先頭 `mkdir -p .state` で fresh clone でも tee の
   出力先を確保する。pr-watch 終了後に `tmux kill-pane` で **ペインを自己 close**（監視終了で

--- a/.claude/skills/pr-watch-pane/SKILL.md.in
+++ b/.claude/skills/pr-watch-pane/SKILL.md.in
@@ -117,7 +117,7 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
   role="watcher",
   name="pr-watch-<PR>",
   cwd="<JA_ROOT 絶対パス>",
-  command="mkdir -p .state; bash tools/pr-watch.sh <PR> --repo <OWNER/REPO> --merge-watch 2>&1 | tee -a .state/pr-watch-<PR>.log; tmux kill-pane 2>/dev/null || true"
+  command="mkdir -p .state; bash tools/pr-watch.sh <PR> --repo <OWNER/REPO> --merge-watch --no-detach 2>&1 | tee -a .state/pr-watch-<PR>.log; tmux kill-pane 2>/dev/null || true"
 )
 ```
 
@@ -129,6 +129,11 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
   は spawn 時に固定で、role ラベルは tier を変えない — Surface 8）。
 - `cwd`: **Step 1 で解決した JA_ROOT 絶対パス**。これにより pane 内の `tools/pr-watch.sh` /
   `.state/pr-watch-<PR>.log` が ja-root 基点で resolve される（cwd trap 吸収）。
+- **`--no-detach` 必須（Issue #650）**: `tools/pr-watch.sh` は Issue #641 対策で既定
+  setsid + nohup の自己 detach をするため、`--no-detach` を付けないと spawn 直後に親 bash が
+  exit して broker pane が即時掃除され、watcher が孤児化する（pane が無いので `/org-attach` /
+  `Ctrl-b s` でも覗けない）。`--no-detach` で前景動作させ、`tee` と末尾 `tmux kill-pane` の
+  自己終了サイクルを成立させる。
 - `command`: pr-watch を前景実行し、stdout/stderr を `.state/pr-watch-<PR>.log` に `tee -a`
   （tmux スクロールバッファにも出る二段）。先頭 `mkdir -p .state` で fresh clone でも tee の
   出力先を確保する。pr-watch 終了後に `tmux kill-pane` で **ペインを自己 close**（監視終了で


### PR DESCRIPTION
## Summary

- `/pr-watch-pane` Step 3 の spawn_pane 例に `--no-detach` を追加
- `tools/pr-watch.sh` は Issue #641 対策で**既定 setsid + nohup の自己 detach** をするため、`--no-detach` を付けないと spawn 直後に親 bash が exit → broker pane が即時掃除 → watcher が孤児化していた（pane が無いので `org-dispatcher-view.sh` / `Ctrl-b s` でも覗けない）
- `--no-detach` で前景動作させ、`tee` + 末尾 `tmux kill-pane` の自己終了サイクルが正しく成立する
- Step 3 内に「なぜ `--no-detach` 必須か」の rationale 注記も新規 bullet で追加

Closes #650

## Scope

- `.claude/skills/pr-watch-pane/SKILL.md` のみ、+6/-1
- `tools/pr-watch.sh` 本体・他 skill・README 等は触らない

## Test plan

- [ ] Step 3 の `command` 例に `--no-detach` が含まれている
- [ ] 「なぜ `--no-detach` 必須か」の 1〜2 文の注記が Step 3 内に追加されている
- [ ] その他のステップ（Step 0/1/2/4/5）、輸送層注記、冪等チェック、エラー分岐表、Step 5 手動 close は無変更
- [ ] 実走確認は本 PR merge 後の次回 `/pr-watch-pane` 呼び出しで pane が即消滅せず broker registry に残り、`org-dispatcher-view.sh` の `Ctrl-b s` で表示できることを実機検証