### PR TITLE
docs(claude): dispatcher /loop 監視の「宣言ではなく実 invoke」を org-start 裏取り手順と dispatcher-resume 強調で明文化 (Closes #662)

### DIFF
--- a/.claude/skills/dispatcher-resume/SKILL.md
+++ b/.claude/skills/dispatcher-resume/SKILL.md
@@ -214,7 +214,10 @@ secretary に **報告して** 判断を仰ぐ（勝手に再 spawn / status 変
    （1 の再生成分を含む。オンデマンド curate の完了監視が引き継ぎ対象。
    `.dispatcher/references/worker-monitoring.md` Step 5.3）のいずれかを満たせば
    下記の monitoring 専用ディレクティブを渡して `/loop 3m` で worker monitoring を
-   再開する（**prompt を省略しない**）:
+   再開する（**prompt を省略しない**）。この再開は「/loop で監視を再開します」と
+   **宣言するだけでは武装されない** — 宣言はターン終了と同時に失効するため、必ず
+   本ターン内で `/loop` を実 invoke すること（窓口側も `inspect_pane` で実行痕跡を
+   裏取りし、無ければ `send_keys` で再点火する運用である）:
 
 <!--
 INVARIANT(loop-prompt): `/loop` の prompt 引数に skill 自身（`/dispatcher-resume`）や

--- a/.claude/skills/dispatcher-resume/SKILL.md.in
+++ b/.claude/skills/dispatcher-resume/SKILL.md.in
@@ -208,7 +208,10 @@ secretary に **報告して** 判断を仰ぐ（勝手に再 spawn / status 変
    （1 の再生成分を含む。オンデマンド curate の完了監視が引き継ぎ対象。
    `.dispatcher/references/worker-monitoring.md` Step 5.3）のいずれかを満たせば
    下記の monitoring 専用ディレクティブを渡して `/loop 3m` で worker monitoring を
-   再開する（**prompt を省略しない**）:
+   再開する（**prompt を省略しない**）。この再開は「/loop で監視を再開します」と
+   **宣言するだけでは武装されない** — 宣言はターン終了と同時に失効するため、必ず
+   本ターン内で `/loop` を実 invoke すること（窓口側も `inspect_pane` で実行痕跡を
+   裏取りし、無ければ `send_keys` で再点火する運用である）:
 
 <!--
 INVARIANT(loop-prompt): `/loop` の prompt 引数に skill 自身（`/dispatcher-resume`）や

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -271,6 +271,10 @@ curator の spawn / boot 失敗モードは org-start には存在しない（sp
 | Stage A+B 後 | 上に加え、Step 0 完了直後に Block A の spawn を発火、Block B (state 復元) / Block C (dashboard 起動) と並列に Claude の boot wait を overlap | 〜35s |
 | curator オンデマンド化後 | 起動対象は dispatcher のみ（curator の spawn / Enter / poll / greet が消滅） | さらに短縮 |
 
+### 起動後の裏取り: dispatcher の /loop 監視宣言は実 invoke を打鍵で確認する
+
+dispatcher は初回 DELEGATE 完了報告で「/loop 3m で監視します」と宣言したまま実 invoke せず idle に落ちることがある（宣言はターン終了と同時に失効し、次の契機がなければ実行されない）。窓口は初回 DELEGATE 完了報告や監視宣言を信用せず、使用中 transport の `inspect_pane(target="dispatcher")` で /loop の実行痕跡（loop 予約 / 監視サイクル出力）を確認し、無ければ `send_keys` で `/loop 3m <監視ディレクティブ>` を user turn として打鍵し再点火する。打鍵は text と Enter を**別呼び出し**に分ける 2 段（`send_keys(target="dispatcher", text="/loop 3m ...")` → `inspect_pane` で入力欄に乗ったことを確認 → `send_keys(target="dispatcher", enter=true)`。text+enter 同時送は draft 残りで未武装が再発しやすい。[`.dispatcher/references/spawn-flow.md`](../../../.dispatcher/references/spawn-flow.md) 3-5a と同じ手順）で行う（いずれも Step 0 で判定した transport の完全修飾名で呼ぶ。監視ディレクティブは placeholder のまま打鍵せず、[`.claude/skills/dispatcher-resume/SKILL.md`](../dispatcher-resume/SKILL.md) Step 5 のコードブロック正文をそのまま使う。手順詳細は [`.dispatcher/references/worker-monitoring.md`](../../../.dispatcher/references/worker-monitoring.md)）。`send_message` / `check_messages` 経由の指示では武装しない — 打鍵による user turn 注入が確実な武装手段である（ultracode 武装と同型の構造）。
+
 ## Step 4: 準備完了の報告
 
 人間に簡潔に報告する。起動するのはディスパッチャーのみ（キュレーターはオンデマンド）。


### PR DESCRIPTION
## 概要

dispatcher が「/loop 3m で監視します」と宣言したまま実 invoke せず idle に落ちる再発問題 (2026-07-03 実運用で再発、ユーザーが先に検知) への再発防止。curator 改善提案をユーザー承認 (2026-07-03) の上で反映。

## 変更点

- **org-start**: Step 4 直前に「起動後の裏取り」節を追加 — 窓口が inspect_pane で /loop 実行痕跡を確認し、無ければ send_keys の 2 段打鍵 (text → inspect_pane 確認 → 別 Enter) で /loop 3m を user turn として再点火する
- **dispatcher-resume (.in + 生成物)**: Step 5 の /loop 3m 再開に「宣言はターン終了と同時に失効、本ターン内の実 invoke 必須」を追記

## 検証

- gen_skill_prose drift check exit 0 / pytest 711 passed + 142 subtests / link audit 新規指摘なし
- Codex レビュー 3 round (R1: transport 直書き不整合と placeholder 打鍵余地を修正 / R2: text+enter 同時送の draft 残り再発リスクを 2 段打鍵に修正 / R3: Blocker/Major ゼロ)

## 参照

- knowledge/raw/2026-07-03-delegation-dispatcher-loop-arming-verify.md
- knowledge/curated/dispatcher-monitoring.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)