### PR TITLE
fix(claude): curate 閾値カウントのコードフェンス誤マッチを解消 (Closes #666)

### DIFF
--- a/.claude/skills/skill-audit/SKILL.md
+++ b/.claude/skills/skill-audit/SKILL.md
@@ -36,8 +36,10 @@ skill 数増加そのものよりも「検索面のノイズ」が本丸。
 以下をいずれも満たさない場合は **即終了**（ログも残さない）。
 
 ```bash
-# 候補キュー pending エントリ数
-cand_count=$(grep -c '^- \*\*status\*\*: pending' knowledge/skill-candidates.md 2>/dev/null || echo 0)
+# 候補キュー pending エントリ数（コードフェンス内のテンプレ例文は数えない）
+cand_count=$(awk '/^(```|~~~)/ { fence = !fence; next }
+  !fence && /^- \*\*status\*\*: pending[ \t]*$/ { n++ }
+  END { print n + 0 }' knowledge/skill-candidates.md 2>/dev/null || echo 0)
 
 # work-skill 数（org-* は除外。ノイズ源となる work-skill 検索対象に合わせる）
 work_skill_count=$(find .claude/skills -maxdepth 2 -name SKILL.md \
@@ -52,10 +54,14 @@ work_skill_count=$(find .claude/skills -maxdepth 2 -name SKILL.md \
 `org-*` の増減は検索ノイズに直接影響しない。
 
 > **カウント定義の同期（重要）**: 上記 2 つのカウント定義（pending は
-> `^- \*\*status\*\*: pending` の行一致、work-skill は `find .claude/skills -maxdepth 2
+> `^- \*\*status\*\*: pending` の行一致 **かつコードフェンス外**（行頭 `` ``` `` /
+> `~~~` で開閉するブロック内は除外）、work-skill は `find .claude/skills -maxdepth 2
 > -name SKILL.md | grep -v '/org-'`）は、オンデマンド curator の起動判定
 > [`tools/check_curate_threshold.py`](../../../tools/check_curate_threshold.py) と
-> **完全一致**させること。どちらかを変更する場合は両方を更新する
+> **完全一致**させること。pending カウントのセマンティクスはさらに
+> [`knowledge/skill-candidates.md`](../../../knowledge/skill-candidates.md)
+> 冒頭の運用ルール記載と合わせた **3 者同期**（本 Step 1 / check_curate_threshold.py /
+> skill-candidates.md 冒頭）。いずれかを変更する場合は 3 箇所同時に更新する
 > （`tools/test_check_curate_threshold.py` の parity テストが drift を検出する）。
 
 ## Step 2: 廃止候補の洗い出し

--- a/.claude/skills/skill-audit/SKILL.md.in
+++ b/.claude/skills/skill-audit/SKILL.md.in
@@ -30,8 +30,10 @@ skill 数増加そのものよりも「検索面のノイズ」が本丸。
 以下をいずれも満たさない場合は **即終了**（ログも残さない）。
 
 ```bash
-# 候補キュー pending エントリ数
-cand_count=$(grep -c '^- \*\*status\*\*: pending' knowledge/skill-candidates.md 2>/dev/null || echo 0)
+# 候補キュー pending エントリ数（コードフェンス内のテンプレ例文は数えない）
+cand_count=$(awk '/^(```|~~~)/ { fence = !fence; next }
+  !fence && /^- \*\*status\*\*: pending[ \t]*$/ { n++ }
+  END { print n + 0 }' knowledge/skill-candidates.md 2>/dev/null || echo 0)
 
 # work-skill 数（org-* は除外。ノイズ源となる work-skill 検索対象に合わせる）
 work_skill_count=$(find .claude/skills -maxdepth 2 -name SKILL.md \
@@ -46,10 +48,14 @@ work_skill_count=$(find .claude/skills -maxdepth 2 -name SKILL.md \
 `org-*` の増減は検索ノイズに直接影響しない。
 
 > **カウント定義の同期（重要）**: 上記 2 つのカウント定義（pending は
-> `^- \*\*status\*\*: pending` の行一致、work-skill は `find .claude/skills -maxdepth 2
+> `^- \*\*status\*\*: pending` の行一致 **かつコードフェンス外**（行頭 `` ``` `` /
+> `~~~` で開閉するブロック内は除外）、work-skill は `find .claude/skills -maxdepth 2
 > -name SKILL.md | grep -v '/org-'`）は、オンデマンド curator の起動判定
 > [`tools/check_curate_threshold.py`](../../../tools/check_curate_threshold.py) と
-> **完全一致**させること。どちらかを変更する場合は両方を更新する
+> **完全一致**させること。pending カウントのセマンティクスはさらに
+> [`knowledge/skill-candidates.md`](../../../knowledge/skill-candidates.md)
+> 冒頭の運用ルール記載と合わせた **3 者同期**（本 Step 1 / check_curate_threshold.py /
+> skill-candidates.md 冒頭）。いずれかを変更する場合は 3 箇所同時に更新する
 > （`tools/test_check_curate_threshold.py` の parity テストが drift を検出する）。
 
 ## Step 2: 廃止候補の洗い出し

--- a/knowledge/skill-candidates.md
+++ b/knowledge/skill-candidates.md
@@ -18,16 +18,23 @@
 - **関連 raw ファイル**: {raw_files のパス列}
 - **呼び出し元**: {post_retro | curation}
 - **提案 skill 名**: {kebab-case 名}
-- **status**: pending
+- **status**: {pending | approved | rejected | merged-into-*}
 - **決定日**: 未定
 - **却下理由**: （status が `rejected` に遷移したとき記入、それ以外は省略）
 - **統合先**: （status が `merged-into-*` のとき記入、それ以外は省略）
 ```
 
 > **status 行の形式は厳守**: pending のカウントは `- **status**: pending` の**行形式
-> 完全一致**（`grep '^- \*\*status\*\*: pending'`）で行われる（`skill-audit` Step 1 /
-> `tools/check_curate_threshold.py`）。インデント・スペース数・大文字小文字を変える
-> とカウントから漏れ、skill-audit / オンデマンド curate が発火しなくなる。
+> 完全一致**で行われる（`skill-audit` Step 1 / `tools/check_curate_threshold.py`）。
+> インデント・スペース数・大文字小文字を変えるとカウントから漏れ、skill-audit /
+> オンデマンド curate が発火しなくなる。
+>
+> **コードフェンス内は数えない**: カウントはコードフェンス（行頭 `` ``` `` /
+> `~~~` で開閉するブロック）の**外側の行のみ**が対象。上の「エントリフォーマット」の
+> テンプレ例文が誤カウントされない防御であり、このセマンティクスは
+> `tools/check_curate_threshold.py` の `count_pending` / `skill-audit` Step 1 の
+> カウントコマンド / 本節の 3 者で完全一致させること（変更時は 3 箇所同時更新。
+> `tools/test_check_curate_threshold.py` の parity テストが drift を検出する）。
 
 ## status の遷移
 

--- a/tools/check_curate_threshold.py
+++ b/tools/check_curate_threshold.py
@@ -54,9 +54,15 @@ Counting rules (Codex review M4 / m9):
   Codex review B3: their mere existence fires the
   ``legacy_marker_sweep`` reason so the sweep can't starve).
 * ``skill_candidates_pending`` — lines matching exactly
-  ``- **status**: pending`` in ``knowledge/skill-candidates.md``
-  (the same ``grep -c '^- \\*\\*status\\*\\*: pending'`` the
-  skill-audit Step 1 uses).
+  ``- **status**: pending`` in ``knowledge/skill-candidates.md``,
+  **excluding lines inside code fences** (blocks opened/closed by a
+  line starting with three backticks or ``~~~``) so the entry-format
+  template example at the head of the file can never inflate the
+  count. This fence-excluding semantics is kept in three-way sync
+  with the skill-audit Step 1 count command and the operational note
+  at the head of ``knowledge/skill-candidates.md`` — change one,
+  change all three (``tools/test_check_curate_threshold.py`` asserts
+  parity).
 * ``work_skill`` — ``SKILL.md`` files at ``.claude/skills/*/SKILL.md``
   whose skill directory does **not** start with ``org-``. This matches
   skill-audit Step 1's
@@ -97,7 +103,13 @@ LEGACY_MARKER = "<!-- curated -->"
 # tolerates a BOM / leading blank line without reading whole files.
 _HEAD_BYTES = 256
 
-_PENDING_RE = re.compile(r"^- \*\*status\*\*: pending\s*$", re.MULTILINE)
+# Matched per line (not MULTILINE over the whole text) because fence
+# state is tracked line by line in count_pending.
+_PENDING_RE = re.compile(r"^- \*\*status\*\*: pending\s*$")
+# A code fence opens/closes on a line *starting* with ``` or ~~~
+# (three-way sync: skill-audit Step 1 awk command and the operational
+# note in knowledge/skill-candidates.md use the same rule).
+_FENCE_RE = re.compile(r"^(```|~~~)")
 
 
 def _has_legacy_marker(path: Path) -> bool:
@@ -146,6 +158,12 @@ def count_raw(root: Path) -> tuple[int, int]:
 def count_pending(root: Path) -> int:
     """Count ``- **status**: pending`` lines in skill-candidates.md.
 
+    Lines inside code fences (blocks delimited by lines starting with
+    ``` or ``~~~``) are excluded: the entry-format template example at
+    the head of the file must never count as a real pending entry
+    (it once did, spuriously spawning the on-demand curator on every
+    worker close).
+
     A missing file counts as 0 (normal in fresh checkouts); any other
     read error propagates so ``main`` reports ``status=error`` / exit 2
     rather than masking a real queue behind a false 0.
@@ -155,7 +173,15 @@ def count_pending(root: Path) -> int:
         text = candidates.read_text(encoding="utf-8")
     except FileNotFoundError:
         return 0
-    return len(_PENDING_RE.findall(text))
+    count = 0
+    in_fence = False
+    for line in text.splitlines():
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence and _PENDING_RE.match(line):
+            count += 1
+    return count
 
 
 def count_work_skills(root: Path) -> int:

--- a/tools/test_check_curate_threshold.py
+++ b/tools/test_check_curate_threshold.py
@@ -9,7 +9,9 @@ pane close, and org-curate consumes its ``reasons[]``. It must:
 * fire ``legacy_marker_sweep`` when any ``<!-- curated -->`` remnant
   sits directly under ``knowledge/raw/`` (B3)
 * fire ``skill_candidates_pending`` on >= 5 ``- **status**: pending``
-  lines, matching skill-audit's grep exactly (m9)
+  lines **outside code fences** (the entry-format template example in
+  the fenced block at the head of skill-candidates.md must never
+  count), matching skill-audit Step 1's count command exactly (m9)
 * fire ``work_skill_count`` with the same count skill-audit Step 1
   computes — parity asserted against the literal shell pipeline (M4)
 * exit 0 / 10 so the dispatcher can branch without JSON parsing (m8)
@@ -34,6 +36,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import check_curate_threshold as cct  # noqa: E402
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The pending-count command skill-audit Step 1 documents, verbatim
+# (three-way sync: check_curate_threshold.count_pending / skill-audit
+# Step 1 / the operational note in knowledge/skill-candidates.md).
+_SKILL_AUDIT_PENDING_AWK = (
+    "awk '/^(```|~~~)/ { fence = !fence; next }\n"
+    "  !fence && /^- \\*\\*status\\*\\*: pending[ \\t]*$/ { n++ }\n"
+    "  END { print n + 0 }' knowledge/skill-candidates.md 2>/dev/null"
+    " || echo 0"
+)
 
 
 class _TreeCase(unittest.TestCase):
@@ -162,6 +174,117 @@ class TestPendingCandidates(_TreeCase):
     def test_missing_file_counts_zero(self):
         _, out = self.run_main(self.root)
         self.assertEqual(out["counts"]["skill_candidates_pending"], 0)
+
+    def test_fenced_template_is_not_counted(self):
+        # The head of the real skill-candidates.md carries an
+        # entry-format template inside a fenced block. A literal
+        # `- **status**: pending` line in there (as the template read
+        # before its defusal) must not inflate the count: 4 real
+        # entries count as 4, not 5.
+        real_entries = "".join(
+            f"### 2026-07-03 pat-{i}\n- **status**: pending\n"
+            for i in range(4)
+        )
+        (self.root / "knowledge" / "skill-candidates.md").write_text(
+            "# queue\n"
+            "\n"
+            "```markdown\n"
+            "### {YYYY-MM-DD} {pattern-name}\n"
+            "- **status**: pending\n"
+            "```\n"
+            "\n" + real_entries,
+            encoding="utf-8",
+        )
+        code, out = self.run_main(self.root)
+        self.assertEqual(out["counts"]["skill_candidates_pending"], 4)
+        self.assertEqual(code, cct.EXIT_BELOW_THRESHOLD)
+
+    def test_tilde_fences_also_excluded(self):
+        (self.root / "knowledge" / "skill-candidates.md").write_text(
+            "~~~\n"
+            "- **status**: pending\n"
+            "~~~\n"
+            "- **status**: pending\n",
+            encoding="utf-8",
+        )
+        _, out = self.run_main(self.root)
+        self.assertEqual(out["counts"]["skill_candidates_pending"], 1)
+
+    def test_pending_after_closed_fence_counts_again(self):
+        # Fence state must toggle closed, not stick open forever.
+        (self.root / "knowledge" / "skill-candidates.md").write_text(
+            "- **status**: pending\n"
+            "```bash\n"
+            "- **status**: pending\n"
+            "```\n"
+            "- **status**: pending\n",
+            encoding="utf-8",
+        )
+        _, out = self.run_main(self.root)
+        self.assertEqual(out["counts"]["skill_candidates_pending"], 2)
+
+    def test_repo_template_head_has_no_countable_pending(self):
+        """The committed skill-candidates.md head (format template +
+        operational notes, i.e. everything above the entry list) must
+        contribute 0 to the count — both template defusal (the example
+        line no longer reads ``- **status**: pending``) and fence
+        exclusion defend this."""
+        real = (
+            _REPO_ROOT / "knowledge" / "skill-candidates.md"
+        ).read_text(encoding="utf-8")
+        head = real.split("## エントリ一覧")[0]
+        (self.root / "knowledge" / "skill-candidates.md").write_text(
+            head, encoding="utf-8"
+        )
+        _, out = self.run_main(self.root)
+        self.assertEqual(out["counts"]["skill_candidates_pending"], 0)
+
+    def test_parity_with_skill_audit_count_command(self):
+        """Three-way sync (fence-excluding semantics): the literal awk
+        command skill-audit Step 1 documents must (a) appear verbatim
+        in the committed SKILL.md and (b) produce the same count as
+        ``count_pending`` on a fixture exercising fences + real
+        entries."""
+        skill_md = (
+            _REPO_ROOT / ".claude" / "skills" / "skill-audit" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            _SKILL_AUDIT_PENDING_AWK,
+            skill_md,
+            "skill-audit Step 1 count command drifted from the one "
+            "this parity test runs — update both together",
+        )
+        fixture = (
+            "```markdown\n"
+            "- **status**: pending\n"
+            "```\n"
+            "- **status**: pending\n"
+            "- **status**: pending  \n"  # trailing spaces still match
+            "- **status**: approved\n"
+            "~~~\n"
+            "- **status**: pending\n"
+            "~~~\n"
+            "- **status**: pending\n"
+        )
+        (self.root / "knowledge" / "skill-candidates.md").write_text(
+            fixture, encoding="utf-8"
+        )
+        if not shutil.which("bash"):
+            self.skipTest("bash not on PATH — shell parity untestable")
+        try:
+            proc = subprocess.run(
+                ["bash", "-c", _SKILL_AUDIT_PENDING_AWK],
+                cwd=self.root,
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                check=True,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            self.skipTest(f"bash unusable here ({exc!r}) — parity skipped")
+        self.assertEqual(cct.count_pending(self.root), int(proc.stdout.strip()))
+        self.assertEqual(cct.count_pending(self.root), 3)
 
 
 class TestWorkSkillCount(_TreeCase):


### PR DESCRIPTION
## 概要

`check_curate_threshold.py` の skill_candidates_pending カウントが `knowledge/skill-candidates.md` 冒頭のコードフェンス内テンプレート例文を誤マッチし、実 pending 4 件を 5 件と誤カウント → worker クローズごとに curator が誤 spawn される問題の修正 (skill-audit 2026-07-03 で発見)。

## 変更点 (curator 提案の両案併用 + 3 者同期)

- テンプレ例文を `- **status**: {pending | approved | rejected | merged-into-*}` に変更 (regex 不一致化) + 運用ルールに「コードフェンス内は数えない」を明文化
- `count_pending` を行頭 `\`\`\`` / `~~~` トグルのフェンス除外に強化
- skill-audit SKILL.md (.in + 生成物) の Step 1 grep を同一セマンティクスに追従、同期注記を 3 者同期に拡張
- parity テスト 5 本追加 (フェンス内非カウント / ~~~ / フェンス閉後再カウント / 実ファイル先頭部 0 寄与 / skill-audit Step 1 コマンドとの verbatim + 実行 parity)

## 検証

- 旧版: 現行リポジトリで 5 / curate_needed (誤発火の再現) → 修正版: 4 / below_threshold (解消)
- tools/ スイート 561 passed, 4 skipped。drift check green。Codex 1 round 指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)