### PR TITLE
feat(claude): runtime v0.1.32 paired pin bump (raw-key send_keys / herdr reap fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.31,<0.2",
+    "claude-org-runtime>=0.1.32,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,11 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.32 for the send_keys raw-key vocabulary (runtime #111):
+# org-delegate's intervention procedure assumes raw-key send_keys, so pin the
+# floor to the release that ships it. Also bundles the herdr reap fix
+# (runtime #112). No schema / DEFAULT_NOTIFY / attention change — pin-only
+# bump on the ja side. The earlier 0.1.31 floor (below) is subsumed.
 # Floor bumped to 0.1.31 for the backend-aware worker-capacity surface
 # (runtime #104): under broker the dispatcher's worker parallelism is gated by
 # a max_concurrent_workers policy (default 8, unlimited opt-in) that bypasses
@@ -65,7 +70,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.31,<0.2
+claude-org-runtime>=0.1.32,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
## 概要

runtime v0.1.32 (PyPI 反映済み) の paired pin floor bump。>=0.1.31 → >=0.1.32 (upper <0.2 据え置き)。

## 根拠

- send_keys raw-key vocabulary (runtime#111): org-delegate のワーカー介入手順 (Escape 中断) が前提とする挙動
- herdr reap fix (runtime#112) 同梱
- schema / DEFAULT_NOTIFY / attention 変更なしの pin-only bump (runtime CHANGELOG 0.1.32 の ja-side note に整合)

## 検証

- tests/ 全体 649 passed + 130 subtests。check_runtime_version exit 0。pin ハードコード箇所が他に無いことを rg 確認
- Codex review 1 round 指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)