### PR TITLE
feat(claude): runtime v0.1.33 の paired pin bump (herdr isolation/false-reap fix #115)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.32,<0.2",
+    "claude-org-runtime>=0.1.33,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,11 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.33 for the herdr agent.start placement/liveness fix
+# (runtime #115, Closes runtime #114): herdr's focus-driven pane placement
+# collapsed spawn isolation and false-reaped live bindings, so pin the floor to
+# the release that fixes it. No schema / DEFAULT_NOTIFY / attention change —
+# pin-only bump on the ja side. The earlier 0.1.32 floor (below) is subsumed.
 # Floor bumped to 0.1.32 for the send_keys raw-key vocabulary (runtime #111):
 # org-delegate's intervention procedure assumes raw-key send_keys, so pin the
 # floor to the release that ships it. Also bundles the herdr reap fix
@@ -70,7 +75,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.32,<0.2
+claude-org-runtime>=0.1.33,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
## 概要

runtime v0.1.33 (PyPI 反映済み) の paired pin floor bump。>=0.1.32 → >=0.1.33 (upper <0.2 据え置き)。

## 根拠

- herdr agent.start の focus 駆動ペイン配置が spawn isolation を崩壊させ、agent_registered 済みの生存ペインを false-reap していた不具合の修正 (runtime#115、Closes runtime#114) を ja の herdr dogfood 経路が前提とするため
- schema / DEFAULT_NOTIFY / attention 変更なしの pin-only bump (runtime CHANGELOG 0.1.33 に整合)。earlier 0.1.32 floor is subsumed

## 検証

- tests/ 649 + tools/ 562 OK (skipped=11)。check_runtime_schema_drift OK / check_role_configs OK / state-db drift fixture OK
- check_runtime_version.py exit 0 (PyPI 0.1.33 published を直接確認、pin satisfiable)
- pin ハードコード箇所が他に無いことを rg 確認
- Codex review round 1 指摘ゼロ
- 注記: shell hook テスト 1 件 (test-block-foreground-subagent.sh "empty stdin is blocked") の失敗は変更前 base (113b927) で再現する pre-existing・ローカル WSL 環境固有で、本変更と無関係 (CI では pass する)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwC5hmxBZ2LtyRWhVqSLSj
