### PR TITLE
feat(claude): runtime v0.1.34 の paired pin bump (herdr workspace layout policy #117)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.33,<0.2",
+    "claude-org-runtime>=0.1.34,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,11 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.34 for the herdr workspace layout policy (runtime #117,
+# Closes runtime #110): herdr now isolates each org into its own workspace,
+# routes panes by space, and generationally reaps stale panes, so pin the floor
+# to the release that ships it. No schema / DEFAULT_NOTIFY / attention change —
+# pin-only bump on the ja side. The earlier 0.1.33 floor (below) is subsumed.
 # Floor bumped to 0.1.33 for the herdr agent.start placement/liveness fix
 # (runtime #115, Closes runtime #114): herdr's focus-driven pane placement
 # collapsed spawn isolation and false-reaped live bindings, so pin the floor to
@@ -75,7 +80,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.33,<0.2
+claude-org-runtime>=0.1.34,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
## 概要

runtime v0.1.34 (PyPI 反映済み) の paired pin floor bump。>=0.1.33 → >=0.1.34 (upper <0.2 据え置き)。

## 根拠

- herdr workspace レイアウトポリシー実装 (runtime#117、Closes runtime#110): multi-space isolation (owned set / liveness registry 分離 + self-ownership ゲート)・role/project ベースの space ルーティング・世代識別ラベル + 起動時 stale 掃除。ja の herdr dogfood 経路が前提とする
- schema / DEFAULT_NOTIFY / attention 変更なしの pin-only bump (check_runtime_schema_drift で 0.1.34 bundled schema の一致を機械確認済み)。earlier 0.1.33 floor is subsumed

## 検証

- tests/ + tools/ フルスイート: 1210 passed, 4 skipped
- check_runtime_schema_drift OK / check_role_configs OK / check_runtime_version.py exit 0 (installed=0.1.34)
- pin ハードコード箇所が他に無いことを rg 確認
- Codex review round 1 指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwC5hmxBZ2LtyRWhVqSLSj
