### PR TITLE
fix(claude): peer_notify の broker send に ORG_BROKER_STATE_DIR を配線

### DIFF
--- a/.claude/skills/pr-watch-pane/SKILL.md
+++ b/.claude/skills/pr-watch-pane/SKILL.md
@@ -41,7 +41,10 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
 > **peer push は best-effort**: `pr_watch.py` は CI 確定・マージ時に窓口へ `CI_COMPLETED` /
 > `PR_MERGED` の peer message を送ろうとするが、これは `tools/peer_notify.py` 経由の
 > best-effort（broker send CLI 不在 / `ORG_TRANSPORT`・`RENGA_SOCKET` 未設定の pane では
-> no-op）。**待つべき正路は上記 events DB 行と可視ペイン**であり、push の到達を merge gate の
+> no-op）。daemon が非既定 state dir（herdr dogfood 等）で動く環境では、pane env に
+> `ORG_BROKER_STATE_DIR` が無いと broker send が既定 `.state/broker` を掴んで push が欠落する
+> （欠落しても canonical の events DB 行には影響しない）。**待つべき正路は上記 events DB 行と
+> 可視ペイン**であり、push の到達を merge gate の
 > 前提にしない（org-pull-request の CI/merge gate は events DB を一次ソースにする）。
 
 > **輸送層（transport）両系 — 既定 `broker` / opt-in `renga`**: 本ファイル（および各スキル）の peer message・pane 操作は `mcp__org-broker__*` で書いてあり、**`ORG_TRANSPORT` 無設定＝既定 `broker`** ではそのまま従えばよい。`ORG_TRANSPORT=renga`（opt-in、切戻し可）では MCP サーバー名が `renga-peers` になり、**完全修飾名が `mcp__org-broker__*` → `mcp__renga-peers__*`** に機械置換される（引数形・セマンティクスは同一なので操作の論理は変わらない）。輸送依存で手順が変わる差は次の 3 点:

--- a/.claude/skills/pr-watch-pane/SKILL.md.in
+++ b/.claude/skills/pr-watch-pane/SKILL.md.in
@@ -41,7 +41,10 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
 > **peer push は best-effort**: `pr_watch.py` は CI 確定・マージ時に窓口へ `CI_COMPLETED` /
 > `PR_MERGED` の peer message を送ろうとするが、これは `tools/peer_notify.py` 経由の
 > best-effort（broker send CLI 不在 / `ORG_TRANSPORT`・`RENGA_SOCKET` 未設定の pane では
-> no-op）。**待つべき正路は上記 events DB 行と可視ペイン**であり、push の到達を merge gate の
+> no-op）。daemon が非既定 state dir（herdr dogfood 等）で動く環境では、pane env に
+> `ORG_BROKER_STATE_DIR` が無いと broker send が既定 `.state/broker` を掴んで push が欠落する
+> （欠落しても canonical の events DB 行には影響しない）。**待つべき正路は上記 events DB 行と
+> 可視ペイン**であり、push の到達を merge gate の
 > 前提にしない（org-pull-request の CI/merge gate は events DB を一次ソースにする）。
 
 {{> dual-system-header-long }}

--- a/tools/peer_notify.py
+++ b/tools/peer_notify.py
@@ -96,12 +96,23 @@ def _notify_peer_broker(
 
         claude-org-runtime broker send --to <to_id> --message <message>
 
+    When ``ORG_BROKER_STATE_DIR`` is set and non-empty (the runtime
+    launcher injects it into pane envs when the daemon runs on a
+    non-default state dir — paired contract, claude-org-runtime #122),
+    ``--state-dir <value>`` is appended so the CLI talks to the live
+    daemon instead of picking up a stale default ``.state/broker``.
+    Unset / empty keeps the historical argv, so this stays safe against
+    runtimes that predate the flag.
+
     Returns ``True`` iff the subprocess exits 0. ``FileNotFoundError``
     (CLI not installed — the common case until runtime#93 ships),
     non-zero exit, timeout, and any other exception all map to ``False``.
     Never raises.
     """
     cmd = [runtime_bin, "broker", "send", "--to", to_id, "--message", message]
+    state_dir = os.environ.get("ORG_BROKER_STATE_DIR")
+    if state_dir:
+        cmd += ["--state-dir", state_dir]
     try:
         proc = subprocess.run(cmd, capture_output=True, timeout=timeout)
     except Exception:  # noqa: BLE001 — best-effort; CLI absent, timeout, etc.

--- a/tools/test_peer_notify.py
+++ b/tools/test_peer_notify.py
@@ -269,9 +269,13 @@ class NotifyPeerBrokerTests(unittest.TestCase):
     """ORG_TRANSPORT=broker branch — shells out to the runtime CLI."""
 
     def setUp(self) -> None:
-        self._env = mock.patch.dict(
-            os.environ, {"ORG_TRANSPORT": "broker"}, clear=False,
-        )
+        # Pin ORG_TRANSPORT=broker and drop any ORG_BROKER_STATE_DIR
+        # leaking in from a real broker session env so the frozen-argv
+        # tests exercise the default (no --state-dir) command shape.
+        env = {k: v for k, v in os.environ.items()
+               if k != "ORG_BROKER_STATE_DIR"}
+        env["ORG_TRANSPORT"] = "broker"
+        self._env = mock.patch.dict(os.environ, env, clear=True)
         self._env.start()
 
     def tearDown(self) -> None:
@@ -314,6 +318,41 @@ class NotifyPeerBrokerTests(unittest.TestCase):
             ["claude-org-runtime", "broker", "send",
              "--to", "secretary", "--message", "a message"],
         )
+
+    def test_state_dir_env_appends_flag(self) -> None:
+        """ORG_BROKER_STATE_DIR set + non-empty → `--state-dir <value>`
+        is appended so the CLI reaches a daemon on a non-default state
+        dir (paired contract, claude-org-runtime #122)."""
+        with mock.patch.dict(
+            os.environ,
+            {"ORG_BROKER_STATE_DIR": "/abs/.state/broker-herdr-dogfood-33"},
+            clear=False,
+        ), self._patch_run(return_value=_FakeCompleted(0)) as run:
+            self.assertTrue(peer_notify.notify_peer("secretary", "hi"))
+        argv = run.call_args.args[0]
+        self.assertEqual(
+            argv,
+            ["claude-org-runtime", "broker", "send",
+             "--to", "secretary", "--message", "hi",
+             "--state-dir", "/abs/.state/broker-herdr-dogfood-33"],
+        )
+
+    def test_state_dir_env_unset_keeps_legacy_argv(self) -> None:
+        """No ORG_BROKER_STATE_DIR → historical argv, no --state-dir
+        (backward compatible with runtimes that predate the flag)."""
+        with self._patch_run(return_value=_FakeCompleted(0)) as run:
+            self.assertTrue(peer_notify.notify_peer("secretary", "hi"))
+        argv = run.call_args.args[0]
+        self.assertNotIn("--state-dir", argv)
+
+    def test_state_dir_env_empty_keeps_legacy_argv(self) -> None:
+        """Empty ORG_BROKER_STATE_DIR is treated as unset."""
+        with mock.patch.dict(
+            os.environ, {"ORG_BROKER_STATE_DIR": ""}, clear=False,
+        ), self._patch_run(return_value=_FakeCompleted(0)) as run:
+            self.assertTrue(peer_notify.notify_peer("secretary", "hi"))
+        argv = run.call_args.args[0]
+        self.assertNotIn("--state-dir", argv)
 
     def test_broker_branch_does_not_spawn_renga(self) -> None:
         """ORG_TRANSPORT=broker must never reach the renga Popen path,


### PR DESCRIPTION
Closes #674

## 概要

- `tools/peer_notify.py` の broker 経路で、環境変数 `ORG_BROKER_STATE_DIR` が set かつ非空なら `claude-org-runtime broker send` に `--state-dir <値>` を付与する。未 set / 空文字は従来 argv のまま（後方互換、best-effort 契約不変）
- テスト 3 本追加（env 有り / 無し / 空文字での argv 固定）+ setUp で実環境からの env リーク遮断
- `.claude/skills/pr-watch-pane/SKILL.md.in` の「peer push は best-effort」注記に、非既定 state dir 環境での push 欠落条件を追記（生成器で SKILL.md 再 render 済み）

## 背景

herdr dogfood 等で daemon が非既定 `--state-dir` で動いていると、send CLI が既定 `.state/broker` の残骸 sidecar を掴んで配送失敗し、CI_COMPLETED / PR_MERGED push が silent 欠落する（2026-07-04 に runtime PR #121 の CI 監視で実発火）。runtime 側の env 注入（runtime#122)と対の消費側 fix。env 不在時は現状維持なので runtime リリースを待たず land 可能。

## 検証

- `tools.test_peer_notify` 21/21 OK、CI 同形 full suite green（tools 565 / tests 649）、`gen_skill_prose.py --check` drift なし
- Codex レビュー 1 ラウンドで Blocker/Major/Minor ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)