### PR TITLE
feat(claude): runtime v0.1.35 の paired pin floor bump (broker delivery fixes)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.34,<0.2",
+    "claude-org-runtime>=0.1.35,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,14 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.35 for three broker/herdr delivery fixes: native Windows
+# fail-fast for `org up --backend herdr` (runtime #120, PR #121);
+# session-scoped delivery credential fencing so fork-spawned duplicate sidecars
+# no longer swallow messages (runtime #125, PR #126); and ORG_BROKER_STATE_DIR
+# pane-env wiring so broker sends reach daemons on a non-default state dir
+# (runtime #122, PR #127) — the ja-side consumer (tools/peer_notify.py) becomes
+# effective with this release. No schema / DEFAULT_NOTIFY / attention change —
+# pin-only bump on the ja side. The earlier 0.1.34 floor (below) is subsumed.
 # Floor bumped to 0.1.34 for the herdr workspace layout policy (runtime #117,
 # Closes runtime #110): herdr now isolates each org into its own workspace,
 # routes panes by space, and generationally reaps stale panes, so pin the floor
@@ -80,7 +88,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.34,<0.2
+claude-org-runtime>=0.1.35,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
runtime v0.1.35（PyPI 反映済み）の paired pin floor bump。`>=0.1.34` → `>=0.1.35`（upper `<0.2` 据え置き）。

## 根拠（v0.1.35 の内容）

- `org up --backend herdr` の native Windows fail-fast（runtime#120 / runtime PR #121）— 20 秒無情報タイムアウトを即時 actionable エラー化
- session-scoped delivery credential fencing（runtime#125 / runtime PR #126）— セッション fork 由来の二重 sidecar による secretary 宛メッセージ silent 消失の修正
- `ORG_BROKER_STATE_DIR` の pane env 配線（runtime#122 / runtime PR #127）— 非既定 state dir daemon への broker send 到達。ja 側消費部（tools/peer_notify.py、#674 / PR #675 マージ済み）がこれで実効化する

schema / DEFAULT_NOTIFY / attention テンプレの変更は無く、pin-only bump（paired sync 4 系統は非該当）。

## 検証

- pin 関連テスト 40 passed + 28 subtests（test_check_runtime_version / test_update_runtime / test_runtime_schema_drift_semantic）
- `rg` で他の pin ハードコード箇所なし（requirements.txt の floor 履歴コメントの旧版数は歴史記述として意図的保持）
- Codex レビュー 1 ラウンド: Blocker/Major ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)