### PR TITLE
feat(claude): Python src-layout プロジェクトの worker brief に PYTHONPATH=src 検証・editable install 禁止の定型規約を焼き込む

### DIFF
--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -55,6 +55,13 @@ REQUIRED_STRING_KEYS = {
     "paths": ("claude_org",),
 }
 
+# Issue #676: Python src-layout detection. A repo counts as "Python
+# src-layout" when it has a ``src/`` directory AND a Python packaging
+# marker at its root. The marker requirement keeps non-Python repos that
+# happen to use ``src/`` (Rust's Cargo layout, JS bundler conventions)
+# from tripping the brief rule.
+_PYTHON_PROJECT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg")
+
 _BLOCK_RE = re.compile(
     r"<!--BEGIN:(?P<name>[a-z_]+)-->(?P<body>.*?)<!--END:(?P=name)-->\n?",
     re.DOTALL,
@@ -103,6 +110,11 @@ def validate(config: dict[str, Any]) -> None:
         raise ConfigError("missing required key worker.self_edit")
     if not isinstance(config["worker"]["self_edit"], bool):
         raise ConfigError("worker.self_edit must be a boolean")
+
+    if "python_src_layout" in config["project"] and not isinstance(
+        config["project"]["python_src_layout"], bool
+    ):
+        raise ConfigError("project.python_src_layout must be a boolean")
 
     task = config["task"]
     if "issue_url" in task and not isinstance(task["issue_url"], str):
@@ -174,12 +186,57 @@ def _references_knowledge_block(items: list[str]) -> str:
     return "\n".join(f"- `{p}`" for p in items)
 
 
+def is_python_src_layout(repo_dir: Path) -> bool:
+    """True iff ``repo_dir`` looks like a Python src-layout project root.
+
+    Requires BOTH a ``src/`` directory and a Python packaging marker
+    (pyproject.toml / setup.py / setup.cfg) so Rust / JS repos that use a
+    ``src/`` directory don't match. Filesystem errors are treated as
+    "not detected" — the rule is a safety net, not a hard gate.
+    """
+    try:
+        if not (repo_dir / "src").is_dir():
+            return False
+        return any((repo_dir / m).is_file() for m in _PYTHON_PROJECT_MARKERS)
+    except OSError:
+        return False
+
+
+def _detect_python_src_layout(
+    worker_dir: Path, project_path: Optional[str]
+) -> bool:
+    """Probe the delegation's repo candidates for a Python src-layout.
+
+    Brief generation runs BEFORE the worktree is created, so the probe
+    targets are (any hit wins):
+
+    - ``<base>`` when worker_dir has the unified ``<base>/.worktrees/<task>``
+      shape (Pattern A/B on an existing clone — the claude-org-runtime case);
+    - ``worker_dir`` itself (Pattern A legacy direct on an existing clone,
+      Pattern C gitignored_repo_root where worker_dir IS the repo root);
+    - the registry row's path when it is a local directory (URL rows and
+      the ``-`` placeholder are skipped).
+
+    When none of the candidates exist on disk yet (first dispatch before
+    any clone), detection returns False and the brief simply omits the
+    rule — the pre-#676 status quo.
+    """
+    candidates: list[Path] = []
+    if worker_dir.parent.name == ".worktrees":
+        candidates.append(worker_dir.parent.parent)
+    candidates.append(worker_dir)
+    if project_path and project_path != "-" and "://" not in project_path:
+        candidates.append(Path(project_path))
+    return any(is_python_src_layout(c) for c in candidates)
+
+
 def _select_blocks(config: dict[str, Any]) -> dict[str, bool]:
     """Decide which optional <!--BEGIN:name--> blocks to keep."""
     task = config["task"]
     depth = task["verification_depth"]
     blocks = {
         "issue_url": bool(task.get("issue_url")),
+        "python_src_layout": bool(config["project"].get("python_src_layout")),
         "implementation": "implementation" in config
         and (
             config["implementation"].get("target_files")
@@ -371,6 +428,7 @@ def build_config_from_task(
     )
     project_name = project_slug
     project_description = project_description_override or ""
+    match = None
     if registry_for_meta.exists():
         rows = rwl.parse_projects(registry_for_meta)
         match = rwl.find_project(rows, project_slug)
@@ -420,6 +478,17 @@ def build_config_from_task(
     # --write-toml cleanly. Codex Round 2 Major.
     if layout.pattern_variant is not None:
         config["worker"]["pattern_variant"] = layout.pattern_variant
+    # Issue #676: Python src-layout projects (claude-org-runtime being the
+    # motivating case — 3 workers independently re-discovered the venv
+    # shadow trap) get a standing verification rule baked into the brief:
+    # pytest runs with PYTHONPATH=src, editable installs into the shared
+    # venv are forbidden. Added only when detected so the key stays out of
+    # the minimal [project] schema (mirrors pattern_variant above).
+    if _detect_python_src_layout(
+        Path(layout.worker_dir),
+        match.path if match is not None else None,
+    ):
+        config["project"]["python_src_layout"] = True
     if issue_url:
         config["task"]["issue_url"] = issue_url
     if closes_issue is not None:

--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -47,6 +47,15 @@ ${parallel_notes}
 ## ナレッジ参照
 ${references_knowledge_block}
 <!--END:references-->
+<!--BEGIN:python_src_layout-->
+
+## Python 検証規約（src-layout）
+
+このプロジェクトは Python の src-layout（パッケージ本体が `src/` 配下）である。venv に残った stale install が `src/` を shadow して古いコードを import する罠（phantom FAIL・新メソッドの AttributeError・「main が赤い」誤診断）を避けるため、以下を必ず守ること:
+
+- 検証（pytest 等）は `PYTHONPATH=src` を前置して実行する（例: `PYTHONPATH=src python -m pytest`）
+- 共有 venv への editable install（`pip install -e`）は禁止（venv の `.pth` に worktree 絶対パスが焼き込まれ、worktree 削除後に他ツールが ModuleNotFoundError で壊れる）
+<!--END:python_src_layout-->
 
 ## 権限
 - git commit: 可

--- a/tools/templates/worker_brief_self_edit.md
+++ b/tools/templates/worker_brief_self_edit.md
@@ -44,6 +44,11 @@ ${parallel_notes}
 ## ナレッジ参照
 ${references_knowledge_block}
 <!--END:references-->
+<!--BEGIN:python_src_layout-->
+
+## Python 検証規約（src-layout）
+検証（pytest 等）は `PYTHONPATH=src` を前置して実行する（例: `PYTHONPATH=src python -m pytest`。stale install の shadow による phantom FAIL 防止）。共有 venv への editable install（`pip install -e`）は禁止（worktree 削除後に venv 残骸の `.pth` が ModuleNotFoundError を起こす）。
+<!--END:python_src_layout-->
 
 ## 権限
 - git commit 可、push 不可、PR 不可、`rm -rf` 不可

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -153,6 +153,112 @@ class OptionalSections(unittest.TestCase):
         self.assertIn("guidance only", out)
 
 
+class PythonSrcLayoutRule(unittest.TestCase):
+    """Issue #676: Python src-layout projects carry the PYTHONPATH=src /
+    no-editable-install verification rule as a standing brief section."""
+
+    RULE_HEADER = "Python 検証規約（src-layout）"
+
+    def test_omitted_by_default(self):
+        cfg = _base_config(self_edit=False)
+        out = gwb.render(cfg)
+        self.assertNotIn(self.RULE_HEADER, out)
+        self.assertNotIn("PYTHONPATH=src", out)
+        self.assertNotIn("pip install -e", out)
+
+    def test_normal_brief_carries_rule_when_flagged(self):
+        cfg = _base_config(self_edit=False)
+        cfg["project"]["python_src_layout"] = True
+        out = gwb.render(cfg)
+        self.assertIn(self.RULE_HEADER, out)
+        self.assertIn("`PYTHONPATH=src` を前置", out)
+        self.assertIn("editable install（`pip install -e`）は禁止", out)
+        self.assertNotIn("<!--BEGIN:", out)
+
+    def test_self_edit_brief_carries_rule_when_flagged(self):
+        cfg = _base_config(self_edit=True)
+        cfg["project"]["python_src_layout"] = True
+        out = gwb.render(cfg)
+        self.assertIn(self.RULE_HEADER, out)
+        self.assertIn("`PYTHONPATH=src` を前置", out)
+        self.assertIn("editable install（`pip install -e`）は禁止", out)
+
+    def test_explicit_false_omits_rule(self):
+        cfg = _base_config(self_edit=False)
+        cfg["project"]["python_src_layout"] = False
+        out = gwb.render(cfg)
+        self.assertNotIn(self.RULE_HEADER, out)
+
+    def test_non_bool_flag_rejected(self):
+        cfg = _base_config(self_edit=False)
+        cfg["project"]["python_src_layout"] = "yes"
+        with self.assertRaises(gwb.ConfigError):
+            gwb.render(cfg)
+
+
+class PythonSrcLayoutDetection(unittest.TestCase):
+    """Filesystem detection helpers behind the Issue #676 rule."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.td = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _make_repo(self, name: str, *, src: bool, markers: tuple[str, ...]) -> Path:
+        repo = self.td / name
+        repo.mkdir(parents=True)
+        if src:
+            (repo / "src").mkdir()
+        for m in markers:
+            (repo / m).write_text("", encoding="utf-8")
+        return repo
+
+    def test_src_plus_pyproject_detected(self):
+        repo = self._make_repo("runtime", src=True, markers=("pyproject.toml",))
+        self.assertTrue(gwb.is_python_src_layout(repo))
+
+    def test_setup_py_and_setup_cfg_also_count(self):
+        for marker in ("setup.py", "setup.cfg"):
+            repo = self._make_repo(f"proj-{marker}", src=True, markers=(marker,))
+            self.assertTrue(gwb.is_python_src_layout(repo), marker)
+
+    def test_src_without_python_marker_not_detected(self):
+        # Rust-style layout: src/ + Cargo.toml, no Python packaging marker.
+        repo = self._make_repo("rusty", src=True, markers=("Cargo.toml",))
+        self.assertFalse(gwb.is_python_src_layout(repo))
+
+    def test_python_marker_without_src_not_detected(self):
+        # Flat-layout Python project — PYTHONPATH=src would be wrong advice.
+        repo = self._make_repo("flat", src=False, markers=("pyproject.toml",))
+        self.assertFalse(gwb.is_python_src_layout(repo))
+
+    def test_missing_dir_not_detected(self):
+        self.assertFalse(gwb.is_python_src_layout(self.td / "nope"))
+
+    def test_worktree_shaped_worker_dir_probes_base_clone(self):
+        # The unified <base>/.worktrees/<task>/ layout: the worktree does
+        # not exist yet at brief-gen time, so detection must probe <base>.
+        base = self._make_repo("base-clone", src=True, markers=("pyproject.toml",))
+        worker_dir = base / ".worktrees" / "task-1"  # intentionally not created
+        self.assertTrue(gwb._detect_python_src_layout(worker_dir, None))
+
+    def test_registry_local_path_probed_as_fallback(self):
+        repo = self._make_repo("registered", src=True, markers=("pyproject.toml",))
+        worker_dir = self.td / "workers" / "registered"  # does not exist
+        self.assertTrue(gwb._detect_python_src_layout(worker_dir, str(repo)))
+
+    def test_url_and_placeholder_registry_paths_skipped(self):
+        worker_dir = self.td / "workers" / "some-proj"  # does not exist
+        self.assertFalse(
+            gwb._detect_python_src_layout(
+                worker_dir, "https://github.com/example/some-proj"
+            )
+        )
+        self.assertFalse(gwb._detect_python_src_layout(worker_dir, "-"))
+
+
 class VerificationDepth(unittest.TestCase):
     def test_minimal_replaces_codex_section(self):
         cfg = _base_config(self_edit=False)
@@ -463,6 +569,115 @@ class FromTaskSubcommand(unittest.TestCase):
         self.assertIn("knowledge/curated/notes.md", text)
         self.assertIn("Closes #9", text)
         self.assertIn("https://example.com/issues/9", text)
+
+
+class FromTaskPythonSrcLayout(unittest.TestCase):
+    """Issue #676 end-to-end: the from-task path detects a Python
+    src-layout base clone (the claude-org-runtime deployment shape) and
+    bakes the PYTHONPATH=src / no-editable-install rule into the brief."""
+
+    RULE_HEADER = "Python 検証規約（src-layout）"
+
+    def setUp(self) -> None:
+        import subprocess as _sp
+        self._td = tempfile.TemporaryDirectory()
+        td = Path(self._td.name)
+        self.claude_org_root = td / "claude-org"
+        (self.claude_org_root / ".state").mkdir(parents=True)
+        (self.claude_org_root / "registry").mkdir()
+        _sp.run(["git", "init", "-q", str(self.claude_org_root)], check=True)
+        _sp.run(
+            ["git", "-C", str(self.claude_org_root), "remote", "add",
+             "origin", "https://github.com/suisya-systems/claude-org-ja.git"],
+            check=True,
+        )
+        (self.claude_org_root / "registry" / "org-config.md").write_text(
+            "## Workers Directory\nworkers_dir: ../workers\n",
+            encoding="utf-8",
+        )
+        # URL-only registry rows: claude-org-runtime (Python src-layout)
+        # and renga (Rust — src/ but no Python packaging marker).
+        (self.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| ランタイム | claude-org-runtime | "
+            "https://github.com/suisya-systems/claude-org-runtime | runtime | release |\n"
+            "| renga | renga | https://github.com/suisya-systems/renga "
+            "| TUI | 機能追加 |\n",
+            encoding="utf-8",
+        )
+        workers = td / "workers"
+        workers.mkdir()
+        # Base clone at workers/claude-org-runtime with matching origin URL
+        # (the trust gate find_workers_dir_clone requires) + src-layout.
+        runtime = workers / "claude-org-runtime"
+        (runtime / "src" / "claude_org_runtime").mkdir(parents=True)
+        (runtime / "pyproject.toml").write_text(
+            "[project]\nname = 'claude-org-runtime'\n", encoding="utf-8"
+        )
+        _sp.run(["git", "init", "-q", str(runtime)], check=True)
+        _sp.run(
+            ["git", "-C", str(runtime), "remote", "add", "origin",
+             "https://github.com/suisya-systems/claude-org-runtime.git"],
+            check=True,
+        )
+        # Rust-shaped clone: src/ + Cargo.toml only.
+        renga = workers / "renga"
+        (renga / "src").mkdir(parents=True)
+        (renga / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+        _sp.run(["git", "init", "-q", str(renga)], check=True)
+        _sp.run(
+            ["git", "-C", str(renga), "remote", "add", "origin",
+             "https://github.com/suisya-systems/renga.git"],
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _render(self, slug: str, task_id: str) -> str:
+        out = Path(self._td.name) / f"{task_id}-CLAUDE.md"
+        rc = gwb.main([
+            "from-task",
+            "--task-id", task_id,
+            "--project-slug", slug,
+            "--description", f"work on {slug}",
+            "--claude-org-root", str(self.claude_org_root),
+            "--out", str(out),
+        ])
+        self.assertEqual(rc, 0)
+        return out.read_text(encoding="utf-8")
+
+    def test_runtime_brief_carries_rule(self):
+        text = self._render("claude-org-runtime", "runtime-676")
+        self.assertIn(self.RULE_HEADER, text)
+        self.assertIn("`PYTHONPATH=src` を前置", text)
+        self.assertIn("editable install（`pip install -e`）は禁止", text)
+
+    def test_rust_src_dir_brief_has_no_rule(self):
+        text = self._render("renga", "renga-676")
+        self.assertNotIn(self.RULE_HEADER, text)
+        self.assertNotIn("PYTHONPATH=src", text)
+
+    def test_write_toml_round_trips_flag(self):
+        toml_path = Path(self._td.name) / "audit.toml"
+        out = Path(self._td.name) / "rt-CLAUDE.md"
+        rc = gwb.main([
+            "from-task",
+            "--task-id", "runtime-audit-676",
+            "--project-slug", "claude-org-runtime",
+            "--description", "work on runtime",
+            "--claude-org-root", str(self.claude_org_root),
+            "--out", str(out),
+            "--write-toml", str(toml_path),
+        ])
+        self.assertEqual(rc, 0)
+        body = toml_path.read_text(encoding="utf-8")
+        self.assertIn("python_src_layout = true", body)
+        # And the dumped TOML renders back to a brief with the rule.
+        cfg = gwb.load_config(toml_path)
+        self.assertIn(self.RULE_HEADER, gwb.render(cfg))
 
 
 class LegacyCLIPreserved(unittest.TestCase):


### PR DESCRIPTION
Closes #676

## 概要

venv shadow 罠（(a) stale install が src/ を shadow して phantom FAIL、(b) worker の editable install が共有 venv を汚し worktree 削除後に窓口ツールが ModuleNotFoundError）を、worker brief の定型 1 規約で両方向塞ぐ（curator 提案・2026-07-04 user 採用）。

- `tools/gen_worker_brief.py`: `is_python_src_layout()` 検出 helper を追加し、repo root に `src/` かつ Python packaging marker（pyproject.toml / setup.py / setup.cfg）の両方がある場合のみ `python_src_layout` ブロックを発火
- 検出 probe: base clone（`<base>/.worktrees/<task>` 形）→ worker_dir 自身 → registry ローカルパスの順（URL registry は skip）。brief 生成時点で worktree 未作成でも base clone を見るので確実に効く
- テンプレート（normal / self_edit 両方）: 「検証（pytest 等）は `PYTHONPATH=src` を前置」「共有 venv への editable install（`pip install -e`）は禁止」+ 両方向の理由各 1 行の条件ブロック
- legacy TOML 経由では `[project] python_src_layout = true` の明示指定も可能

**条件付きにした理由**: renga（Rust、src/ + Cargo.toml）や flat-layout Python では `PYTHONPATH=src` が誤った指示になるため、無条件焼き込みは不採用。marker 要件で Rust/JS の src/ 誤爆も遮断。

## 検証

- 新規テスト 3 クラス（render 層の載る/載らない/self_edit/型検証、検出 helper 単体 8 件、from-task end-to-end + TOML round-trip）
- 全体 green: tests/ 649 件 OK、tools/ 581 件 OK (skipped=2)
- Codex レビュー 1 ラウンド: Blocker/Major ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)