### PR TITLE
fix(claude): segment-split.sh の core-harness 解決に repo .venv フォールバックを追加 — venv 非継承ペインの全 Bash fail-closed を恒久解消

### DIFF
--- a/.hooks/lib/segment-split.sh
+++ b/.hooks/lib/segment-split.sh
@@ -27,26 +27,72 @@ export CORE_HARNESS_BLOCK_PREFIX="${CORE_HARNESS_BLOCK_PREFIX:-ブロック: }"
 # importable we fail closed (echo + exit 2) — same pattern as the
 # pre-extraction "missing jq/awk" guard, so behaviour is unchanged
 # for misconfigured environments.
+#
+# Sets two globals rather than printing to stdout so the accumulated
+# interpreter-attempt list survives into the rejection message (a
+# command-substitution subshell would discard it):
+#   __CORE_HARNESS_LIB_DIR  — resolved lib dir on success, "" otherwise
+#   __CORE_HARNESS_TRIED    — interpreters attempted, for diagnostics
 __core_harness_resolve_lib() {
+  __CORE_HARNESS_LIB_DIR=""
+  __CORE_HARNESS_TRIED=()
+  local prog='import core_harness.hooks, sys; sys.stdout.write(str(core_harness.hooks.lib_path()))'
+
+  # Repo-local virtualenv first (Issue #679). requirements.txt exact-pins
+  # core-harness into <repo_root>/.venv, and that install is reachable from
+  # this shim's own location even in panes that did NOT inherit VIRTUAL_ENV
+  # or .venv/bin on PATH — runtime-spawned panes rebuild PATH through a
+  # login shell and drop the venv, so the on-PATH `python3` cannot import
+  # core_harness and every Bash call fails closed. Deriving <repo_root> from
+  # $BASH_SOURCE keeps this independent of the caller's CWD. Trying the venv
+  # first also keeps the healthy path at a single interpreter spawn (no perf
+  # regression vs. the previous python3-first order, since the venv resolves
+  # on the first attempt when present).
+  local script_dir repo_root venv_py
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || script_dir=""
+  if [[ -n "$script_dir" ]]; then
+    repo_root="$(cd "$script_dir/../.." 2>/dev/null && pwd)" || repo_root=""
+    if [[ -n "$repo_root" ]]; then
+      for venv_py in "$repo_root/.venv/bin/python3" "$repo_root/.venv/Scripts/python.exe"; do
+        if [[ -x "$venv_py" ]]; then
+          __CORE_HARNESS_TRIED+=("$venv_py")
+          # Accept only on a clean exit (assignment status == interpreter
+          # status) AND non-empty output, so a noisy interpreter that writes
+          # to stdout then fails does not masquerade as a resolved lib path.
+          if __CORE_HARNESS_LIB_DIR="$("$venv_py" -c "$prog" 2>/dev/null)" && [[ -n "$__CORE_HARNESS_LIB_DIR" ]]; then
+            return 0
+          fi
+        fi
+      done
+    fi
+  fi
+
   # Detection order aligned with tools/journal_append.sh (cross-review
   # Minor 5): try the Windows `py -3` launcher first, then `python3`,
   # then `python`, so Git-for-Windows shells without python3 on PATH
   # still resolve the lib.
   if command -v py >/dev/null 2>&1; then
-    py -3 -c 'import core_harness.hooks, sys; sys.stdout.write(str(core_harness.hooks.lib_path()))' 2>/dev/null && return 0
+    __CORE_HARNESS_TRIED+=("py -3")
+    if __CORE_HARNESS_LIB_DIR="$(py -3 -c "$prog" 2>/dev/null)" && [[ -n "$__CORE_HARNESS_LIB_DIR" ]]; then
+      return 0
+    fi
   fi
   local py
   for py in python3 python; do
     if command -v "$py" >/dev/null 2>&1; then
-      "$py" -c 'import core_harness.hooks, sys; sys.stdout.write(str(core_harness.hooks.lib_path()))' 2>/dev/null && return 0
+      __CORE_HARNESS_TRIED+=("$py")
+      if __CORE_HARNESS_LIB_DIR="$("$py" -c "$prog" 2>/dev/null)" && [[ -n "$__CORE_HARNESS_LIB_DIR" ]]; then
+        return 0
+      fi
     fi
   done
+  __CORE_HARNESS_LIB_DIR=""
   return 1
 }
 
-__CORE_HARNESS_LIB_DIR="$(__core_harness_resolve_lib || true)"
+__core_harness_resolve_lib || true
 if [[ -z "$__CORE_HARNESS_LIB_DIR" || ! -f "$__CORE_HARNESS_LIB_DIR/core_harness_hooks.sh" ]]; then
-  echo "ブロック: core-harness パッケージが見つかりません (pip install -e . が必要)。" >&2
+  echo "ブロック: core-harness パッケージが見つかりません (pip install -e . または <repo>/.venv の作成が必要)。試行した interpreter: ${__CORE_HARNESS_TRIED[*]:-none}" >&2
   exit 2
 fi
 


### PR DESCRIPTION
## 概要

venv 非継承ペイン（broker/herdr spawn の dispatcher / worker）で PreToolUse フックが core-harness を解決できず、**コマンド内容に関わらず全 Bash 呼び出しを exit 2 で fail-closed ブロック**する障害（2026-07-04 実発生）の恒久修正。

Closes #679

## 変更内容（.hooks/lib/segment-split.sh のみ、1 ファイル）

1. **repo .venv フォールバックを解決順の最優先に追加**: `$BASH_SOURCE` から repo root を導出し `<repo>/.venv/bin/python3`（Windows: `<repo>/.venv/Scripts/python.exe`）で core_harness を解決。venv 非継承ペインでも Bash が通るようになる
2. **性能中立**: venv を先頭に置いても healthy path の interpreter spawn は従来どおり 1 回（フックは全 Bash 呼び出しで走るため重要）。venv 不在環境では `-x` テスト即失敗で従来の `py -3` → `python3` → `python` 探索へ素通り（後方互換）
3. **Codex 指摘修正**: 候補採否を「exit 0 かつ出力非空」で判定し、stdout に書いてから異常終了する noisy interpreter の誤解決を防止
4. **診断性向上**: 拒否メッセージに試行した interpreter 一覧を付加

## 検証（full）

- クリーン環境（`env -i` / `PATH=/usr/bin:/bin` / `PYTHONNOUSERSITE=1`）で実再現→修正確認:
  - CASE1（venv 無し）: exit 2 の fail-closed を再現（クリーン環境が本当に core_harness を欠くことを確認）
  - CASE2（repo .venv 有り）: 解決成功・exit 0（修正が効いている）
  - CASE3（偽 venv python: stdout に bogus パスを書いて exit 3）: 正しくスキップし後続 python3 で実解決
- 既存フックテスト全通過: test-unwrap-eval-bashc 14/14・test-block-pretooluse-hooks 173/173・test-block-dangerous-git 69/69
- Codex ゲート: round 2 clean（Blocker/Major ゼロ）

## 切り分け調査の結論（Issue #679 スコープ 2）

根因は「spawn されたペインが新規 login shell で PATH をゼロから再構築し、親（venv-active な broker/secretary）の `VIRTUAL_ENV` / `.venv/bin` を継承しない」こと。runtime 側の spawn env で workspace venv を再活性化する根本修正が別途妥当（claude-org-runtime に英語 Issue を起票し #679 コメントから参照）。本 PR はその手前の org 側 defense-in-depth。

## Human Understanding Summary

worker 完了報告の要約は Issue #679 の完了コメントと `.state/workers/` の Progress Log を参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCpf5WFSyQoiy6VkeLEWci
