### PR TITLE
feat(claude): runtime v0.1.36 の paired pin floor bump (observer lease / Herdr pane id / pane venv inheritance)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.35,<0.2",
+    "claude-org-runtime>=0.1.36,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,16 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.36 for three broker/herdr delivery fixes: broker observer
+# lease so a background-hosted duplicate sidecar no longer claims-then-drops
+# messages, exposing per-agent receive_mode via list_peers (runtime #132);
+# Herdr pane-id parsing hardening (runtime #134); and pane venv inheritance so
+# spawned panes resolve the org's interpreter/venv (runtime #135, #137). No
+# schema / DEFAULT_NOTIFY / classifier-vocabulary / attention change — pin-only
+# bump on the ja side (list_peers.receive_mode is now per-agent runtime state
+# rather than a constant "push", and new journal event kinds such as
+# delivery_suppressed_bg_hosted may appear; ja asserts neither as a closed set).
+# The earlier 0.1.35 floor (below) is subsumed.
 # Floor bumped to 0.1.35 for three broker/herdr delivery fixes: native Windows
 # fail-fast for `org up --backend herdr` (runtime #120, PR #121);
 # session-scoped delivery credential fencing so fork-spawned duplicate sidecars
@@ -88,7 +98,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.35,<0.2
+claude-org-runtime>=0.1.36,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
## 概要

claude-org-runtime v0.1.36 の PyPI 発行を受けた paired pin floor bump。`pyproject.toml` / `requirements.txt` の依存制約を `>=0.1.36,<0.2` へ引き上げる（両ファイルは同期保持 pin）。

同梱 3 件（Refs runtime#132 / runtime#134 / runtime#135 / runtime#137）:
- **broker observer lease**: 配信を人間が観測しているセッションに束縛（fork/resume takeover と bg-hosted 破壊の修正）
- **Herdr pane id parsing**: delegate-plan helper が `w<workspace>:p<pane>` handle を受理
- **pane venv inheritance**: spawn ペインで workspace .venv を再活性化

## 非影響の確認（paired sync 4 系統）

DEFAULT_NOTIFY / classifier vocabulary / org_extension_schema / attention テンプレのいずれにも触れないリリースのため 4 系統同期は不要。加えて (1) receive_mode の per-agent 化を固定期待するテスト無し（grep 0 hit）、(2) 新 journal event 種は importer が任意 kind 受理のため閉集合検証に非抵触、を確認済み。schema drift check も 0.1.36 bundled schema と一致で green。

## 検証（full、.venv に claude-org-runtime==0.1.36）

tests/ 685 OK / tools/ 581 OK / shell hooks 412 passed / check_runtime_schema_drift OK / check_role_configs OK / state-db drift round-trip OK。Codex review round 1 で指摘ゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCpf5WFSyQoiy6VkeLEWci