### PR TITLE
fix(claude): テスト実行のライブ broker 送信漏れをパッケージ level の hermetic env ガードで構造遮断

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,13 @@
+"""``tests`` package marker + Issue #683 hermetic env guard.
+
+This package is imported only by the test runner, so the live
+broker/renga transport env vars are scrubbed unconditionally here (no
+runner detection needed). Keeps tests under ``tests/`` from reaching a
+live daemon, mirroring the gated guard in ``tools/__init__.py``. See
+``tools/_hermetic_env.py`` for the full rationale.
+"""
+import os
+
+for _name in ("ORG_BROKER_STATE_DIR", "ORG_TRANSPORT", "RENGA_SOCKET"):
+    os.environ.pop(_name, None)
+del _name

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,21 @@
+"""``tools`` package marker.
+
+Kept intentionally minimal. Its only behaviour is a *test-only* env guard
+(Issue #683): when the ``tools`` package is imported by a test runner
+(``unittest`` / ``pytest`` / a directly executed ``test_*.py``), any live
+broker/renga transport env vars inherited from a real org session are
+scrubbed from ``os.environ`` *before any test runs*, so neither in-process
+peer emits nor subprocess-spawning tests can reach the live daemon. Under
+normal production imports (``python tools/pr_watch.py`` and friends) the
+guard is a no-op, so real peer delivery is unaffected.
+
+Under ``python -m unittest discover -s tools`` this module is imported at
+the very start of discovery, so the scrub lands before the first test
+module is loaded. See ``tools/_hermetic_env.py`` for the full rationale.
+"""
+from __future__ import annotations
+
+from ._hermetic_env import running_under_test, scrub_live_transport_env
+
+if running_under_test():
+    scrub_live_transport_env()

--- a/tools/_hermetic_env.py
+++ b/tools/_hermetic_env.py
@@ -1,0 +1,87 @@
+"""Test-only guard: scrub live broker/renga transport env vars (Issue #683).
+
+Background
+----------
+The runtime launcher injects ``ORG_BROKER_STATE_DIR`` / ``ORG_TRANSPORT``
+into pane envs so the *real* CLI helpers reach the live broker daemon
+(paired contract, claude-org-runtime #122/#127). That is correct for
+production. It is dangerous for tests: several tool tests drive
+``pr_watch.main`` / ``notify_peer`` end-to-end — either in-process or by
+spawning ``python tools/pr_watch.py`` with ``env={**os.environ}`` — so a
+suite run inside a live org session leaks fixture peer messages (observed:
+``x`` and ``CI_COMPLETED: PR #4242 ... repo octo/repo``) onto the live
+secretary channel.
+
+The pre-existing guard lived in ``tools/conftest.py`` as a *pytest-only*
+autouse fixture, but CI and workers run the suite with
+``python -m unittest discover`` — where conftest never fires — and it only
+scrubbed the renga vars, so the broker path (``ORG_TRANSPORT=broker`` +
+``ORG_BROKER_STATE_DIR``) leaked regardless. Per-file ``setUpModule``
+hooks (e.g. ``tools/test_pr_watch.py``) papered over one module at a time
+and were renga-only. This module is the runner-agnostic replacement.
+
+Design
+------
+* :func:`running_under_test` returns True only when the interpreter was
+  started as a test runner (``python -m unittest``, ``pytest``, or a
+  directly executed ``test_*.py``). Production tool invocations
+  (``python tools/pr_watch.py`` etc.) return False, so live peer delivery
+  is never disturbed.
+* :func:`scrub_live_transport_env` removes the transport-routing vars from
+  ``os.environ`` process-wide. Doing it once, early, protects both the
+  in-process path *and* any child spawned with an inherited environment.
+
+``tools/__init__.py`` calls the pair at package-import time (gated), which
+under ``unittest discover -s tools`` runs before any test module is even
+imported. ``tests/__init__.py`` scrubs unconditionally (that package is
+imported only by the test runner).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+# Env vars that route peer_notify / the broker CLI at a *live* daemon.
+# Scrubbing all three forces the hermetic no-op path: peer_notify falls
+# back to the renga branch (no ORG_TRANSPORT=broker) which then
+# short-circuits because RENGA_SOCKET is gone too.
+LIVE_TRANSPORT_ENV = ("ORG_BROKER_STATE_DIR", "ORG_TRANSPORT", "RENGA_SOCKET")
+
+
+def scrub_live_transport_env() -> None:
+    """Remove live broker/renga transport env vars from ``os.environ``.
+
+    Idempotent and process-wide: children spawned afterwards with an
+    inherited environment start clean too.
+    """
+    for name in LIVE_TRANSPORT_ENV:
+        os.environ.pop(name, None)
+
+
+def running_under_test() -> bool:
+    """True iff this interpreter was launched as a test runner.
+
+    Detection is deliberately conservative so it never fires for a
+    production tool invocation:
+
+    * ``python -m unittest ...`` -> ``sys.argv[0]`` is the unittest
+      ``__main__.py`` path (contains ``"unittest"``).
+    * ``pytest`` / ``python -m pytest`` -> ``sys.argv[0]`` contains
+      ``"pytest"``, or pytest exports ``PYTEST_CURRENT_TEST`` /
+      ``PYTEST_VERSION``.
+    * ``python tools/test_foo.py`` -> the script basename starts with
+      ``test``.
+
+    Real tools (``pr_watch.py``, ``journal_append.py``,
+    ``check_role_configs.py``, ...) match none of these, so the guard is a
+    no-op for them.
+    """
+    argv0 = sys.argv[0] if sys.argv else ""
+    if "unittest" in argv0 or "pytest" in argv0:
+        return True
+    base = os.path.basename(argv0)
+    if base.startswith("test"):
+        return True
+    if os.environ.get("PYTEST_CURRENT_TEST") or os.environ.get("PYTEST_VERSION"):
+        return True
+    return False

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -1,44 +1,39 @@
 """pytest fixtures shared across tools/ test modules.
 
-Issue #398 follow-up: several tool tests exercise `pr_watch.main()` end-to-end,
-which calls `_notify_peer` -> `tools.peer_notify.notify_peer` -> spawns
-`renga mcp-peer` when ``RENGA_SOCKET`` is set. Inside a live Claude Code /
-renga session that environment variable is set, so test runs with a real
-`renga` binary on PATH leak fake CI / merge messages onto the production
-peer channel. The existing tests didn't notice this because CI runners
-have neither the env var nor the binary.
+Issue #398 follow-up / Issue #590 / Issue #683: several tool tests
+exercise ``pr_watch.main()`` end-to-end, which calls ``_notify_peer`` ->
+``tools.peer_notify.notify_peer``. Inside a live Claude Code / renga
+session ``RENGA_SOCKET`` is set, and inside a live broker session
+``ORG_TRANSPORT=broker`` + ``ORG_BROKER_STATE_DIR`` are set; either lets a
+test run leak fake CI / merge messages onto the production peer channel.
+CI runners have none of these so they never noticed.
 
-Issue #590 makes ``notify_peer`` transport-neutral: with
-``ORG_TRANSPORT=broker`` it instead shells out to
-``claude-org-runtime broker send``. A test run inside a live broker
-session would leak the same fake messages onto the broker channel, so we
-scrub ``ORG_TRANSPORT`` too — forcing the renga branch, which then
-no-ops immediately because ``RENGA_SOCKET`` is also scrubbed.
-
-This autouse fixture scrubs ``RENGA_SOCKET`` and ``ORG_TRANSPORT`` for
-the duration of every test in ``tools/``. Tests that explicitly want to
-test peer-emit behaviour should mock ``tools.peer_notify.notify_peer``
-(or set the env vars themselves) instead.
+This autouse fixture is the pytest arm of the guard. The runner-agnostic
+arm — which also covers ``python -m unittest discover`` (the CI /worker
+path, where conftest never fires) and directly executed ``test_*.py`` —
+lives in ``tools/__init__.py`` + ``tools/_hermetic_env.py`` and scrubs at
+package-import time. Both scrub the same var set
+(``tools._hermetic_env.LIVE_TRANSPORT_ENV``). Tests that explicitly want
+to exercise peer-emit behaviour should mock
+``tools.peer_notify.notify_peer`` (or set the env vars themselves).
 """
 from __future__ import annotations
 
-import os
-
 import pytest
+
+from tools._hermetic_env import LIVE_TRANSPORT_ENV
 
 
 @pytest.fixture(autouse=True)
-def _scrub_renga_socket(monkeypatch):
+def _scrub_live_transport_env(monkeypatch):
     """Disable peer-emit fall-through (both transports) for the test.
 
-    `peer_notify.notify_peer` returns False immediately when
-    ``RENGA_SOCKET`` is unset, which short-circuits the renga subprocess
-    handshake. Scrubbing ``ORG_TRANSPORT`` keeps the dispatch on the
-    renga branch so a live broker session can't shell out to
-    ``claude-org-runtime broker send``. Together that is exactly the
-    hermetic behaviour we want for tests not asserting on the peer
-    channel.
+    ``peer_notify.notify_peer`` short-circuits to a no-op when
+    ``ORG_TRANSPORT`` is not ``broker`` and ``RENGA_SOCKET`` is unset;
+    scrubbing ``ORG_BROKER_STATE_DIR`` additionally keeps a stray
+    ``--state-dir`` from pointing the broker CLI at a live daemon. Using
+    ``monkeypatch`` restores any real values after the test.
     """
-    monkeypatch.delenv("RENGA_SOCKET", raising=False)
-    monkeypatch.delenv("ORG_TRANSPORT", raising=False)
+    for name in LIVE_TRANSPORT_ENV:
+        monkeypatch.delenv(name, raising=False)
     yield

--- a/tools/test_hermetic_env.py
+++ b/tools/test_hermetic_env.py
@@ -1,0 +1,189 @@
+"""Issue #683: tests must never reach a live broker/renga daemon.
+
+Covers the package-level hermetic env guard
+(``tools/__init__.py`` + ``tools/_hermetic_env.py``) that scrubs
+``ORG_BROKER_STATE_DIR`` / ``ORG_TRANSPORT`` / ``RENGA_SOCKET`` whenever
+the process is a test runner, so a worker running the suite inside a live
+org session cannot leak fixture peer messages (observed:
+``CI_COMPLETED: PR #4242 ... repo octo/repo``) onto the live channel.
+
+The integration test encodes the acceptance criterion directly: with a
+live ``ORG_BROKER_STATE_DIR`` exported and a fake ``claude-org-runtime``
+recording broker sends, a ``python -m unittest`` run of a peer-emitting
+probe adds zero lines to the daemon queue — while a bypass control proves
+the probe really would leak absent the guard.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tools import _hermetic_env  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class ScrubUnitTests(unittest.TestCase):
+    def test_scrub_removes_all_live_transport_env(self) -> None:
+        with mock.patch.dict(os.environ, {
+            "ORG_BROKER_STATE_DIR": "/live/.state/broker",
+            "ORG_TRANSPORT": "broker",
+            "RENGA_SOCKET": "/tmp/renga.sock",
+            "UNRELATED_KEEP": "keep",
+        }, clear=False):
+            _hermetic_env.scrub_live_transport_env()
+            self.assertNotIn("ORG_BROKER_STATE_DIR", os.environ)
+            self.assertNotIn("ORG_TRANSPORT", os.environ)
+            self.assertNotIn("RENGA_SOCKET", os.environ)
+            self.assertEqual(os.environ.get("UNRELATED_KEEP"), "keep")
+
+    def test_scrub_is_idempotent_when_unset(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            for name in _hermetic_env.LIVE_TRANSPORT_ENV:
+                os.environ.pop(name, None)
+            _hermetic_env.scrub_live_transport_env()  # must not raise
+
+    def test_running_under_test_detects_runners(self) -> None:
+        argv0s = [
+            "/usr/lib/python3.11/unittest/__main__.py",   # python -m unittest
+            "/venv/bin/pytest",                            # pytest console script
+            "/venv/lib/site-packages/pytest/__main__.py",  # python -m pytest
+            "tools/test_state_db_discover.py",             # direct execution
+        ]
+        for argv0 in argv0s:
+            with mock.patch.object(sys, "argv", [argv0]), \
+                    mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("PYTEST_CURRENT_TEST", None)
+                os.environ.pop("PYTEST_VERSION", None)
+                self.assertTrue(_hermetic_env.running_under_test(), argv0)
+
+    def test_running_under_test_true_via_pytest_env(self) -> None:
+        with mock.patch.object(sys, "argv", ["tools/pr_watch.py"]), \
+                mock.patch.dict(
+                    os.environ,
+                    {"PYTEST_CURRENT_TEST": "x::y (call)"},
+                    clear=False):
+            self.assertTrue(_hermetic_env.running_under_test())
+
+    def test_running_under_test_false_for_production(self) -> None:
+        for argv0 in [
+            "tools/pr_watch.py",
+            "tools/journal_append.py",
+            "tools/check_role_configs.py",
+            "tools/run_complete_on_merge.py",
+            "",
+        ]:
+            with mock.patch.object(sys, "argv", [argv0]), \
+                    mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("PYTEST_CURRENT_TEST", None)
+                os.environ.pop("PYTEST_VERSION", None)
+                self.assertFalse(_hermetic_env.running_under_test(), argv0)
+
+
+class LiveDaemonHermeticIntegrationTests(unittest.TestCase):
+    """Acceptance (Issue #683): a unittest run under a live
+    ``ORG_BROKER_STATE_DIR`` must not enqueue anything to the daemon queue.
+    """
+
+    def setUp(self) -> None:
+        if sys.platform == "win32":
+            self.skipTest("bash claude-org-runtime shim is POSIX-only")
+        self.tmp = Path(tempfile.mkdtemp(prefix="ja683-"))
+        self.state_dir = self.tmp / "broker-live"
+        self.state_dir.mkdir()
+        self.queue = self.state_dir / "queue.jsonl"
+        # Fake `claude-org-runtime`: record every `broker send` to the
+        # queue so any leak is observable. Prepended to PATH so it wins
+        # over a real runtime installed by `pip install -e .`.
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+        shim = self.bin / "claude-org-runtime"
+        shim.write_text(textwrap.dedent(f'''
+            #!/usr/bin/env bash
+            if [[ "$1 $2" == "broker send" ]]; then
+              echo "$*" >> "{self.queue}"
+            fi
+            exit 0
+        ''').lstrip())
+        shim.chmod(0o755)
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _live_env(self) -> dict:
+        return {
+            **os.environ,
+            "PATH": f"{self.bin}:{os.environ.get('PATH', '')}",
+            "ORG_TRANSPORT": "broker",
+            "ORG_BROKER_STATE_DIR": str(self.state_dir),
+        }
+
+    def _queue_lines(self) -> list:
+        if not self.queue.exists():
+            return []
+        return [ln for ln in self.queue.read_text().splitlines() if ln.strip()]
+
+    def test_negative_control_leaks_without_guard(self) -> None:
+        """Sanity: bypassing the guard (bare ``peer_notify`` import, non-test
+        argv) DOES leak — proves the probe + shim actually exercise the
+        broker send path, so the hermetic assertion below is meaningful."""
+        code = (
+            "import sys; sys.path.insert(0, %r); import peer_notify; "
+            "assert peer_notify.notify_peer('secretary', 'LEAKPROBE')"
+            % str(REPO_ROOT / "tools")
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            env=self._live_env(), cwd=str(REPO_ROOT),
+            capture_output=True, text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(
+            len(self._queue_lines()), 1,
+            f"control must leak exactly one send; queue={self._queue_lines()}",
+        )
+
+    def test_unittest_run_is_hermetic(self) -> None:
+        """A ``python -m unittest`` run of a peer-emitting probe adds nothing
+        to the live queue: ``tools/__init__`` scrubs the transport env at
+        import, so ``notify_peer`` no-ops."""
+        probe_dir = self.tmp / "probe"
+        probe_dir.mkdir()
+        (probe_dir / "test_leak_probe.py").write_text(textwrap.dedent(f'''
+            import sys, unittest
+            sys.path.insert(0, {str(REPO_ROOT)!r})
+            from tools.peer_notify import notify_peer  # triggers tools/__init__
+
+            class LeakProbe(unittest.TestCase):
+                def test_emit(self):
+                    # Env is scrubbed by the guard -> renga branch, no
+                    # RENGA_SOCKET -> no-op -> returns False, no send.
+                    notify_peer("secretary", "LEAKPROBE")
+        '''))
+        proc = subprocess.run(
+            [sys.executable, "-m", "unittest", "discover",
+             "-s", str(probe_dir), "-p", "test_*.py"],
+            env=self._live_env(), cwd=str(REPO_ROOT),
+            capture_output=True, text=True,
+        )
+        combined = proc.stdout + proc.stderr
+        self.assertIn("OK", combined, f"probe did not run cleanly: {combined}")
+        self.assertEqual(
+            self._queue_lines(), [],
+            f"LEAK: queue grew under unittest run: {self._queue_lines()!r}; "
+            f"runner output={combined!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

worker ペインでのテスト実行が、継承された ORG_BROKER_STATE_DIR / ORG_TRANSPORT 経由でライブ broker daemon へテスト由来メッセージ(octo/repo PR#4242 等)を送信してしまう問題を構造的に遮断する。

Closes #683

## 根因

既存の env サニタイズは tools/conftest.py の pytest autouse fixture のみで、CI・ワーカーの実際の実行経路である `python -m unittest discover` では一切発火しない dead code だった(かつ ORG_BROKER_STATE_DIR は未スクラブ)。さらにサブプロセス起動テストが `env={**os.environ}` で live env を素通ししていた。

## 変更内容

- `tools/_hermetic_env.py`(新規): broker/renga 関連 env を process-wide にスクラブ + テストランナー判定(本番ツール起動では no-op)
- `tools/__init__.py`(新規): パッケージ import 時に runner gated でスクラブ。全テスト実行前に発火し、サブプロセスへの env 素通しも親側で遮断
- `tools/test_hermetic_env.py`(新規): 受入条件の回帰テスト(negative control 込み)
- conftest 側にも ORG_BROKER_STATE_DIR スクラブを追加

## 検証

- 全 suite green: tools 600 / tests 685 OK
- 受入実測: live 相当 env + 送信記録 fake runtime でフル suite 実行 → daemon queue への enqueue 0 件
- setuptools auto-discovery への影響なし(pyproject の py-modules=[] を実測確認)
- Codex レビュー round 1 収束、Blocker/Major ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)