### PR TITLE
feat(claude): claude-org-runtime pin floor を 0.1.36 へ bump (herdr delegate-plan pane-id fix #133/#134 取り込み)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.34,<0.2",
+    "claude-org-runtime>=0.1.36,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,11 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.36 for the herdr delegate-plan pane-id parse fix
+# (runtime #133 / #134): herdr previously rejected `w<N>:p<N>` delegate-plan
+# pane ids (runtime #119, closed as a duplicate of #133), so pin the floor to
+# the release that fixes it. No schema / DEFAULT_NOTIFY / attention change —
+# pin-only bump on the ja side. The earlier 0.1.34 floor (below) is subsumed.
 # Floor bumped to 0.1.34 for the herdr workspace layout policy (runtime #117,
 # Closes runtime #110): herdr now isolates each org into its own workspace,
 # routes panes by space, and generationally reaps stale panes, so pin the floor
@@ -80,7 +85,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.34,<0.2
+claude-org-runtime>=0.1.36,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
## 概要
`claude-org-runtime` の pin floor を `>=0.1.34` → `>=0.1.36` へ bump する pin-only の bump。

## 背景
runtime 0.1.36 に herdr `delegate-plan` の pane-id パース修正（suisya-systems/claude-org-runtime#133 / #134）が入っており、herdr backend で `w<N>:p<N>` 形式が拒否され delegate-plan CLI が exit 1 になる事象を根治する。この事象は元々 runtime#119 として起票されていたが、#133 の重複として close 済み。ja の venv は既に 0.1.36 へ更新済みで、pin をそれに一致させて runtime drift 検出をクリーンに保つ。

## 変更
- `pyproject.toml`: `claude-org-runtime>=0.1.34,<0.2` → `>=0.1.36,<0.2`
- `requirements.txt`: 同上 + 走行履歴コメント（#672 の慣習に倣い根拠ブロックを prepend）
- upper bound `<0.2` は据え置き。pin-only（スキーマ / 挙動への影響なし）。

## 検証
- Codex full レビュー 2 round: **Blocker/Major ゼロ**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)