### PR TITLE
feat(claude): worker brief テンプレートに「完了報告前 rebase」を焼き込む

### DIFF
--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -94,6 +94,18 @@ probe / 検証 / fuzzing 系タスク（sandbox 探索・hook 動作確認・フ
 
 背景: 過去に生成物 prose を直接編集して生成元との drift を生む事故を複数回踏んでいる。生成元から render し直して `--check` で照合することで再発を防ぐ。
 
+## 完了報告前の rebase（必須・`full` 限定、`minimal` では不要）
+
+完了報告（および下記 Codex セルフレビュー）の前に、以下を必ず実行する（検証深度 `minimal` の trivial fix には過剰なので適用外）:
+
+1. `git fetch origin main`
+2. `git rebase origin/main`（branch policy が merge 運用なら `git merge origin/main`。既定は rebase）
+3. Conflict があれば worker が解決する（他の並列 PR が同じ integration point = registry / CLI --source routing / `pyproject.toml` extras・markers / README / docs を触った結果）。conflict resolution 中もローカルテスト（`pytest` / `make demo` / `make test-local` 等リポジトリで定義された検証）が引き続き green を維持することを確認する
+4. Rebase 後、branch が `origin/main` の descendant で clean（behind=0）であることを確認する: `git rev-list --count HEAD..origin/main` が `0`
+5. 完了報告に「rebase clean: HEAD=`<sha>` on top of origin/main `<sha>`」の 1 行を含める
+
+背景（Refs: 2026-07-08 kura conveyor PR #46/#47 conflict fest）: 並列 dispatch で複数 worker が dispatch 時点の main から同じ integration point（`source/__init__.py` registry / CLI `--source` routing / `pyproject.toml` extras・markers / README / docs）を編集すると、先に merge した方が勝ち残りは GitHub 上で CONFLICTING になり CI すら起動しない。worker 段階で rebase → conflict 解決 → clean push まで済ませることで、窓口側の rebase コスト（意味的マージが worker context 無しに解けず二度手間になる）と、CI 未起動による遅延を防ぐ。
+
 ## Codex セルフレビュー手順
 
 派遣指示に**必ず含まれる「検証深度」行**（`full` または `minimal`）に従うこと。指示に値が無い・不明瞭な場合は勝手に決めず窓口（`secretary`）に確認すること。
@@ -163,6 +175,7 @@ done: {commit SHA 短縮形} {変更ファイル名}
    - **フォールバック**: `to_id="secretary"` が `[pane_not_found]` で返る場合は、`renga --layout ops` 以外の経路で窓口ペインが起動された可能性がある。その場合は DELEGATE メッセージ本文で指定された numeric pane id（例: `to_id="1"`）を使って送信する。窓口側で `/org-start` Step 0 の `set_pane_identity` 自動修復が走れば、以降は `to_id="secretary"` が使える
    - 何を完了したか
    - 作成したファイル、コミット、PR等の成果物
+   - **rebase clean 確認（必須）**: 上記「完了報告前の rebase」で確認した「rebase clean: HEAD=`<sha>` on top of origin/main `<sha>`」の 1 行（`behind=0` である旨）
    - 残作業や注意点があれば
    - **人間向け理解サマリ（必須）**: 窓口がコードを精読せずに「何を承認しようとしているか」を把握し、そのままユーザーへの承認提示に使えるよう、完了報告に以下 3 点を必ず含める。これは完了報告が起こす `awaiting_review` (REVIEW) 遷移・`worker_completed` の入力であり、報告フォーマットを拡張するもの（lifecycle の不変条件は変えない）:
      1. **最重要の変更点（N 個）**: このタスクで実際に変えたことを効果の大きい順に N 個（目安 3〜5 個）。1 項目 1〜2 行で、diff を開かなくても要旨が掴めるように書く

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -96,12 +96,14 @@ probe / 検証 / fuzzing 系タスク（sandbox 探索・hook 動作確認・フ
 
 ## 完了報告前の rebase（必須・`full` 限定、`minimal` では不要）
 
+**適用範囲**: この節は「既存リポジトリで `origin/main`（= このブランチの PR ベース）を親に PR を出す `full` タスク」に適用する。上記「正しい作業手順」の `git init` 新規プロジェクトや、`origin` remote が無い / PR のベースが `origin/main` 以外（`origin/develop` 等）のリポジトリでは、`origin/main` を**そのブランチの実際のベース upstream** に読み替える。upstream remote 自体が存在しない（`git remote` が空）場合はこの rebase ゲート自体が適用外（skip して次の Codex セルフレビューに進む）。以下は既定ケース（ベース = `origin/main`）の手順:
+
 完了報告（および下記 Codex セルフレビュー）の前に、以下を必ず実行する（検証深度 `minimal` の trivial fix には過剰なので適用外）:
 
-1. `git fetch origin main`
-2. `git rebase origin/main`（branch policy が merge 運用なら `git merge origin/main`。既定は rebase）
+1. `git fetch origin`（`git fetch origin main` は `FETCH_HEAD` に取るだけで `origin/main` 追跡 ref を確実には更新せず、stale な `origin/main` に対して behind=0 と誤判定しうる。remote 名 / ベースが異なる場合は該当 upstream を fetch する）
+2. `git rebase origin/main`（branch policy が merge 運用なら `git merge origin/main`。既定は rebase。ベースが異なる場合は該当 upstream に読み替える）
 3. Conflict があれば worker が解決する（他の並列 PR が同じ integration point = registry / CLI --source routing / `pyproject.toml` extras・markers / README / docs を触った結果）。conflict resolution 中もローカルテスト（`pytest` / `make demo` / `make test-local` 等リポジトリで定義された検証）が引き続き green を維持することを確認する
-4. Rebase 後、branch が `origin/main` の descendant で clean（behind=0）であることを確認する: `git rev-list --count HEAD..origin/main` が `0`
+4. Rebase 後、branch が `origin/main`（= ベース upstream）の descendant で clean（behind=0）であることを確認する: `git rev-list --count HEAD..origin/main` が `0`
 5. 完了報告に「rebase clean: HEAD=`<sha>` on top of origin/main `<sha>`」の 1 行を含める
 
 背景（Refs: 2026-07-08 kura conveyor PR #46/#47 conflict fest）: 並列 dispatch で複数 worker が dispatch 時点の main から同じ integration point（`source/__init__.py` registry / CLI `--source` routing / `pyproject.toml` extras・markers / README / docs）を編集すると、先に merge した方が勝ち残りは GitHub 上で CONFLICTING になり CI すら起動しない。worker 段階で rebase → conflict 解決 → clean push まで済ませることで、窓口側の rebase コスト（意味的マージが worker context 無しに解けず二度手間になる）と、CI 未起動による遅延を防ぐ。


### PR DESCRIPTION
## 概要
worker brief テンプレート (`.claude/skills/org-delegate/references/worker-claude-template.md`) に **「完了報告前の rebase」** を焼き込む。並列 dispatch で複数 worker が `main-at-when-dispatched` から同じ integration point (registry / cli / pyproject / README / docs) を編集し、先に merge した方が勝ち残りは CONFLICTING で CI すら起動しない **conflict 連鎖** を予防する。

## 背景 (2026-07-08 kura conveyor の実運用反省)
kura aggregation conveyor で並列 dispatch した #26 Slack / #27 SF が続けて #45 Drive merge 後の main と conflict、CI 起動せず → worker に戻して手動 rebase → force-push という無駄工程が **2 回連続で発生**。原因は brief に「完了報告前 rebase」を書いておらず worker が確認しないため。テンプレートに焼き込めば `--impl-guidance` で毎回書かなくても既定で反映される。

## 変更ファイル (1 file, +15 lines)
- `.claude/skills/org-delegate/references/worker-claude-template.md`

## 変更内容

### 1. 新 subsection: 「完了報告前の rebase (必須・full 限定、minimal では不要)」
「`## Codex セルフレビュー手順`」の直前に配置し、論理順 **rebase → codex → 完了報告** に整合。5 手順:
1. `git fetch origin`
2. `git rebase origin/main`
3. Conflict があれば worker が解決 (他の並列 PR が同じ integration point を触った結果)
4. Rebase 後、branch が origin/main の descendant で clean rebase (behind=0) を確認
5. 完了報告に「rebase clean: HEAD=<sha> on top of origin/main <sha>」の 1 行を含める

### 2. 適用範囲ガード (Codex R1 の指摘反映)
`git init` 新規プロジェクトや `origin/main` 以外がベースのリポジトリでは該当 upstream に読み替え、upstream 不在なら rebase ゲート自体を skip。テンプレが明示サポートする「新規プロジェクト」パスと非衝突。

### 3. 完了報告フォーマットに 1 行追記
「rebase clean 確認 (必須): behind=0」の要求。

## 主要な設計判断
- **`git fetch origin` (main 明示なし)**: Codex R1 P2 指摘。`git fetch origin main` は FETCH_HEAD に取るだけで `origin/main` 追跡 ref を確実に更新せず、stale ref に対し behind=0 と誤判定して本ゲート素通りしうる。remote 全追跡 ref を更新する `git fetch origin` に変更
- **無条件適用でなく適用範囲ガード追加**: Codex R1 P2 指摘。テンプレは `git init` 新規プロジェクトも明示サポートするため、全 full タスクへの無条件 rebase は origin/main 不在で破綻する
- **却下**: 別ファイル参照に切り出す案 → subsection 1 個で足りる最小スコープのためインラインで完結

## 検証
- `gen_skill_prose --check`: drift ゼロ (exit 0)
- `audit_link_paths`: 追加分 flagged なし
- `pytest` full: **1278 passed / 13 skipped**
- **Codex full (gpt-5.5 medium) 2 rounds**: R1 で P2×2 → 修正 → R2 clean (no findings)。**Blocker/Major ゼロ**

## dogfooding
本 PR の worker 自身が「rebase clean: HEAD=9e78c8d on top of origin/main 2670ce3」の完了報告を返した — テンプレートに焼き込む手順そのものを実践している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)