### PR TITLE
fix(claude): pr_watch を gh --watch 非依存の自前ポーリングに置換 (Closes #695)

### DIFF
--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -918,7 +918,33 @@ def _run_ci_watch_phase(
         # Issue #695: self-poll replaces the blocking `gh pr checks
         # --watch` subprocess. Raises KeyboardInterrupt on SIGINT, same
         # as the previous blocking subprocess.run(cmd) did.
-        verdict = _self_poll_watch(pr, repo, interval)
+        #
+        # `_self_poll_watch` polls unbounded while genuinely pending, but
+        # bails out (returns None) on an *inconclusive* observation (an
+        # empty check list / an unparseable probe — the Issue #413
+        # freshly-created-PR race), handing off to
+        # `_resolve_final_status`'s bounded retry/backoff. That resolver
+        # applies the SAME bounded budget to any `incomplete` verdict it
+        # sees, including a REAL pending check that appears mid-budget
+        # (Codex review, Issue #695 round 1 P1): without the loop below,
+        # a PR whose checks start out invisible and then take longer
+        # than the budget to finish would be wrongly declared
+        # `incomplete` instead of watched to completion. So: only accept
+        # the resolver's `incomplete` verdict as final when it reflects
+        # the empty-race itself (`total_checks` is 0 / unknown); once
+        # real, still-pending check rows are observed
+        # (`total_checks > 0`), hand control back to the unbounded
+        # self-poll loop instead of giving up.
+        while True:
+            verdict = _self_poll_watch(pr, repo, interval)
+            if verdict is not None:
+                break
+            verdict = _resolve_final_status(pr, repo, exit_code=8)
+            if verdict["status"] == "incomplete" and verdict["total_checks"]:
+                # Real, still-pending checks exist -- not an empty-race
+                # artifact. Resume unbounded polling for them.
+                continue
+            break
     except KeyboardInterrupt:
         canceled = True
 
@@ -941,18 +967,13 @@ def _run_ci_watch_phase(
         # pairing note above). Issue #413: a freshly created PR may have
         # no check rows yet, so an empty / unparseable JSON response is
         # "still observing" rather than the final verdict.
-        # Issue #695: `_self_poll_watch` already returns a decided verdict
-        # directly when it observed one (no gh exit code involved
-        # anymore); it only returns `None` on an inconclusive
-        # observation (empty list / unparseable probe), in which case
-        # `_resolve_final_status` drives its bounded retry/backoff.
-        # `exit_code=8` is a neutral "Checks pending" placeholder: there
-        # is no longer a real `gh --watch` exit code to consult, so on
-        # total probe exhaustion this degrades to `indeterminate`
-        # (Issue #685 intent) rather than fabricating a passed/failed
-        # guess.
-        if verdict is None:
-            verdict = _resolve_final_status(pr, repo, exit_code=8)
+        # Issue #695: the loop above already drove `verdict` to a
+        # decided, non-None result — either directly from
+        # `_self_poll_watch`, or from `_resolve_final_status` (whose
+        # `exit_code=8` neutral "Checks pending" placeholder degrades a
+        # totally-unparseable probe to `indeterminate` rather than
+        # fabricating a passed/failed guess, per Issue #685 intent).
+        assert verdict is not None
         status = verdict["status"]
         fail_count = verdict["fail_count"]
         pending_count = verdict["pending_count"]

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -2,7 +2,7 @@
 """Watch GitHub PR CI checks and emit a journal event when finished.
 
 Cross-platform helper for the secretary role: after creating a PR,
-invoke this script to block on ``gh pr checks --watch`` and record a
+invoke this script to block until CI resolves and record a
 ``ci_completed`` event in ``.state/state.db`` (events table).
 
 Usage::
@@ -13,15 +13,31 @@ Behavior:
 
 * Resolves the repo via ``gh repo view --json nameWithOwner`` when
   ``--repo`` is omitted.
-* Spawns ``gh pr checks <PR> --watch --interval <SEC>`` and forwards
-  its stdout/stderr.
-* After the watch loop returns, queries
-  ``gh pr checks <PR> --json bucket,state,name`` for per-check
-  ``bucket`` (gh's documented bucket values are
-  ``{pass, fail, pending, skipping, cancel}``) so the journal status
-  reflects what CI actually decided rather than just the gh process'
-  exit code (gh exits non-zero on a transient watch error too, and
-  exit 8 specifically means "Checks pending", not "failed").
+* Issue #695: watches CI via a **self-poll loop** over
+  ``gh pr checks <PR> --json bucket,state,name`` (:func:`_fetch_checks`
+  / :func:`_self_poll_watch`) at ``--interval`` cadence, instead of
+  shelling out to ``gh pr checks --watch``. ``gh``'s own ``--watch``
+  loop does not treat the ``skipping`` bucket as terminal, so a PR
+  whose checks are entirely ``pass``/``skipping`` (no ``pending``) —
+  e.g. 4 passed + 2 skipped, 0 pending — never made ``--watch``
+  return, and ``ci_completed`` was never recorded (observed on kura
+  PR #38). The self-poll loop instead stops as soon as every check's
+  ``bucket`` is outside :data:`_PENDING_BUCKETS`
+  (``pass``/``skipping``/``fail``/``cancel``), matching what
+  :func:`_classify_from_checks` already treats as decided. gh's
+  documented ``bucket`` values are ``{pass, fail, pending, skipping,
+  cancel}``.
+* Once the self-poll loop observes a decided verdict, or bails out on
+  an inconclusive observation (an empty check list / an unparseable
+  probe — the Issue #413 freshly-created-PR race), the result is
+  classified via :func:`_classify_from_checks` /
+  :func:`_resolve_final_status` so the journal status reflects what CI
+  actually decided. :func:`_resolve_final_status`'s bounded
+  retry-with-backoff absorbs that inconclusive-observation race;
+  genuinely still-running checks (a real ``pending`` bucket) are
+  instead polled unbounded by the self-poll loop itself, at
+  ``--interval`` cadence — mirroring ``gh --watch``'s own indefinite
+  block while CI is actually running.
   Classifies as ``passed`` (all pass/skipping), ``failed``
   (≥1 fail/cancel), ``incomplete`` (checks parseable but at least one
   still pending / unknown bucket / empty list), ``indeterminate``
@@ -38,11 +54,11 @@ Behavior:
   (Issue #413 / Codex round-1 Major): ``passed``→0, ``failed``→1,
   ``canceled``→2, ``incomplete``→8, ``indeterminate``→8 (Issue #685:
   like ``incomplete`` it is not a clean pass/fail for ``$?`` callers).
-  The original ``gh`` exit code
-  is intentionally NOT propagated, because the resolver may upgrade
-  ``gh exit 8`` ("Checks pending") to a final ``passed`` verdict
-  via retry — returning 8 in that case would mislead shell callers
-  inspecting ``$?``. The post-CI merge-watch helper may further
+  Issue #695: since there is no longer a ``gh pr checks --watch``
+  subprocess exit code to consult, ``indeterminate`` (probe never
+  parsed at all) is the only fallback verdict when nothing could be
+  read — the resolver no longer has a raw gh exit code to upgrade into
+  an optimistic ``passed``. The post-CI merge-watch helper may further
   override 0 → 9 on its own failure modes (timeout / no_run /
   helper exception).
 
@@ -332,7 +348,11 @@ def _classify(exit_code: int) -> str:
     as merely pending when its probe happened to fail transiently.
 
     SIGINT raised in the parent (Python ``KeyboardInterrupt``) is
-    normalized to 2 in :func:`main` before reaching this function.
+    handled directly in :func:`_run_ci_watch_phase` as a ``canceled``
+    verdict and never reaches this function (Issue #695: there is no
+    longer a real gh process exit code carrying that signal — the
+    caller always passes the neutral ``8`` placeholder here on the
+    non-cancellation path).
 
     Note: as of Issue #224 the primary classifier is
     :func:`_classify_from_checks`, which inspects per-check JSON. This
@@ -458,13 +478,21 @@ def _resolve_final_status(
 ) -> dict:
     """Drive `_fetch_checks` until a final CI verdict is observed.
 
-    Issue #413: ``gh pr checks --watch`` occasionally returns
-    immediately when invoked on a freshly created PR — before any
-    check-run row has propagated. The first :func:`_fetch_checks`
-    response is then ``[]`` (transient empty), and the legacy code
+    Issue #413: on a freshly created PR, the very first
+    :func:`_fetch_checks` response can be ``[]`` (transient empty,
+    before any check-run row has propagated), and the legacy code
     classified that as ``incomplete`` and wrote it as the *final*
     ``ci_completed`` event with ``duration_sec=1`` (e.g. PRs #411 /
     #14 / #15 / #416 in a single session).
+
+    Issue #695: this function is now called only when
+    :func:`_self_poll_watch` (the self-poll loop that replaced the
+    blocking ``gh pr checks --watch`` subprocess) bails out on such an
+    inconclusive observation. ``exit_code`` is therefore a caller-
+    supplied placeholder (``8``, "Checks pending") rather than a real
+    gh process exit code — it is consulted only in the final fallback
+    branch below, when the JSON probe never parses at all within the
+    budget.
 
     Final-verdict semantics:
 
@@ -583,6 +611,70 @@ def _resolve_final_status(
         "total_checks": last_summary[3],
         "probe_attempts": probe_attempts,
     }
+
+
+def _self_poll_watch(pr: int, repo: str, interval: int) -> "dict | None":
+    """Replace the blocking ``gh pr checks --watch`` subprocess (Issue #695).
+
+    ``gh``'s own ``--watch`` loop does not treat the ``skipping`` bucket
+    as terminal, so a PR whose checks are entirely ``pass``/``skipping``
+    (0 pending, e.g. 4 passed + 2 skipped) never made ``--watch``
+    return — ``ci_completed`` was never recorded (observed on kura PR
+    #38, the auto-merge gate never fired). This polls
+    :func:`_fetch_checks` directly at ``interval`` cadence and applies
+    the same terminal-bucket rule :func:`_classify_from_checks` already
+    uses (``pass``/``skipping``/``fail``/``cancel`` are all decided;
+    only :data:`_PENDING_BUCKETS` — or an unrecognized bucket — means
+    "still running").
+
+    Two distinct "not decided yet" observations are handled
+    differently:
+
+    * A non-empty checks list with at least one genuinely pending (or
+      unrecognized) bucket means CI is still running. This case loops
+      here, unbounded, at ``interval`` cadence — mirroring the
+      indefinite block ``gh --watch`` performed while checks were
+      pending, so a CI run that legitimately takes many minutes is
+      never prematurely declared ``incomplete``.
+    * An empty list (no check rows visible yet) or an unparseable probe
+      (:func:`_fetch_checks` returns ``None`` — a gh/network hiccup) is
+      inconclusive rather than "still running": this function returns
+      ``None`` immediately so the caller's existing
+      :func:`_resolve_final_status` bounded retry-with-backoff (Issue
+      #413 / #685) reconciles it, exactly as it did for the
+      post-``--watch`` race it was originally built for.
+
+    Returns a verdict dict shaped like :func:`_resolve_final_status`'s
+    return value (``status`` / ``fail_count`` / ``pending_count`` /
+    ``total_checks`` / ``probe_attempts``) once a decided verdict is
+    observed, or ``None`` to signal "inconclusive, hand off". May raise
+    ``KeyboardInterrupt`` (propagated from ``time.sleep`` or the
+    ``gh`` subprocess on SIGINT) — the caller treats that as
+    cancellation, matching the previous ``gh --watch`` Ctrl-C behavior.
+    """
+    probe_attempts = 0
+    while True:
+        checks = _fetch_checks(pr, repo)
+        probe_attempts += 1
+        if checks:
+            status, fail_count, pending_count, total = _summarize_checks(checks)
+            if status != "incomplete":
+                return {
+                    "status": status,
+                    "fail_count": fail_count,
+                    "pending_count": pending_count,
+                    "total_checks": total,
+                    "probe_attempts": probe_attempts,
+                }
+            # Non-empty but still pending (or an unrecognized bucket):
+            # genuinely still running. Fall through to the unbounded
+            # interval-cadence poll below.
+        else:
+            # checks is None (unparseable probe) or [] (no check rows
+            # visible yet) -- inconclusive; the bounded resolver is
+            # better suited to this than unbounded polling here.
+            return None
+        time.sleep(interval)
 
 
 def _watch_for_merge(
@@ -784,31 +876,32 @@ def _run_ci_watch_phase(
 ) -> "tuple[str, int, str | None]":
     """Run one ci-watch round and record/emit its verdict (Issue #636).
 
-    Blocks on ``gh pr checks --watch`` for ``pr``, resolves the final
-    verdict, appends a single ``ci_completed`` event and emits one
-    ``CI_COMPLETED`` peer message — both tagged with the short head sha
-    so the secretary can tell which head the verdict belongs to.
-    Returns ``(status, exit_code, head_oid)`` where ``head_oid`` is the
-    full head OID observed at verdict time (or ``None``).
+    Self-polls (:func:`_self_poll_watch`, Issue #695) until a decided CI
+    verdict for ``pr`` is observed, resolves the final verdict, appends a
+    single ``ci_completed`` event and emits one ``CI_COMPLETED`` peer
+    message — both tagged with the short head sha so the secretary can
+    tell which head the verdict belongs to. Returns
+    ``(status, exit_code, head_oid)`` where ``head_oid`` is the full head
+    OID observed at verdict time (or ``None``).
 
     Returns ``("head_changed", 0, head)`` instead when the branch advances
     while we are resolving the verdict (see below); the caller treats that
     like the merge-watch loop-back and re-runs a fresh ci-watch round.
 
-    Head/verdict pairing (Codex review, rounds 1-6): both
-    ``gh pr checks --watch`` and ``_resolve_final_status``'s
-    ``gh pr checks --json`` observe the PR's *live* head, so a branch that
-    advances any time between the start of the watch and the end of
-    resolution can yield a verdict describing a different commit than the
-    one we tag. We bracket the *entire* watch+resolve phase with a head
-    read taken before the watch starts and one taken after the verdict
-    resolves: if they differ, we do NOT record a (possibly stale or
-    transiently-incomplete) verdict — we return ``head_changed`` so
-    :func:`main` restarts the *full* ci-watch (``gh pr checks --watch``
-    blocks until the new head's CI actually completes) rather than tagging
-    a verdict to a head it doesn't describe or short-circuiting on the
-    bounded JSON resolver. When the head is stable across the whole phase,
-    the recorded head is exactly the one whose checks the verdict describes.
+    Head/verdict pairing (Codex review, rounds 1-6): both the self-poll
+    loop and ``_resolve_final_status``'s ``gh pr checks --json`` observe
+    the PR's *live* head, so a branch that advances any time between the
+    start of the watch and the end of resolution can yield a verdict
+    describing a different commit than the one we tag. We bracket the
+    *entire* watch+resolve phase with a head read taken before the watch
+    starts and one taken after the verdict resolves: if they differ, we do
+    NOT record a (possibly stale or transiently-incomplete) verdict — we
+    return ``head_changed`` so :func:`main` restarts the *full* ci-watch
+    (self-poll blocks until the new head's CI actually completes) rather
+    than tagging a verdict to a head it doesn't describe or
+    short-circuiting on the bounded JSON resolver. When the head is stable
+    across the whole phase, the recorded head is exactly the one whose
+    checks the verdict describes.
 
     Factored out of :func:`main` so the head-poll loop (Issue #636) can
     re-run a fresh ci-watch round — re-emitting ``CI_COMPLETED`` — when the
@@ -818,26 +911,17 @@ def _run_ci_watch_phase(
     # advance *during* the watch is caught when compared to the
     # post-resolution head below (Codex review round 6).
     head_before = _fetch_head_oid(pr, repo)
-    cmd = [
-        "gh", "pr", "checks", str(pr),
-        "--repo", repo,
-        "--watch",
-        "--interval", str(interval),
-    ]
     started = time.monotonic()
     canceled = False
+    verdict: "dict | None" = None
     try:
-        completed = subprocess.run(cmd)
-        exit_code = completed.returncode
+        # Issue #695: self-poll replaces the blocking `gh pr checks
+        # --watch` subprocess. Raises KeyboardInterrupt on SIGINT, same
+        # as the previous blocking subprocess.run(cmd) did.
+        verdict = _self_poll_watch(pr, repo, interval)
     except KeyboardInterrupt:
-        # Normalize parent-side cancellation to gh's standard exit code 2
-        # so callers (and the journal status mapping) see a portable signal.
-        exit_code = 2
         canceled = True
 
-    # gh's documented cancellation exit code is 2 (parent SIGINT or
-    # subprocess-side Ctrl-C). Honor it directly so we don't overwrite a
-    # genuine cancellation with whatever the JSON probe returns.
     head_oid: "str | None" = None
     # Issue #685: per-bucket counts (parseable probe) and probe attempts,
     # threaded into the payload / peer message below. Stay None for the
@@ -846,7 +930,7 @@ def _run_ci_watch_phase(
     pending_count: "int | None" = None
     total_checks: "int | None" = None
     probe_attempts = 0
-    if canceled or exit_code == 2:
+    if canceled:
         status = "canceled"
         # Skip the head probe on cancellation: the user is aborting, so a
         # second SIGINT during an extra subprocess would surface an ugly
@@ -854,13 +938,21 @@ def _run_ci_watch_phase(
         # on). head_oid stays None → "unknown".
     else:
         # Resolve the verdict against a stable head (see the head/verdict
-        # pairing note above). Issue #224: gh exit 1 from a transient
-        # watch-loop error must not be conflated with "CI failed". Issue
-        # #413: a freshly created PR may have no check rows yet when
-        # --watch returns, so an empty / pending JSON response is "still
-        # observing" rather than the final verdict — _resolve_final_status
-        # drives the resolver until a final verdict (or its retry budget).
-        verdict = _resolve_final_status(pr, repo, exit_code)
+        # pairing note above). Issue #413: a freshly created PR may have
+        # no check rows yet, so an empty / unparseable JSON response is
+        # "still observing" rather than the final verdict.
+        # Issue #695: `_self_poll_watch` already returns a decided verdict
+        # directly when it observed one (no gh exit code involved
+        # anymore); it only returns `None` on an inconclusive
+        # observation (empty list / unparseable probe), in which case
+        # `_resolve_final_status` drives its bounded retry/backoff.
+        # `exit_code=8` is a neutral "Checks pending" placeholder: there
+        # is no longer a real `gh --watch` exit code to consult, so on
+        # total probe exhaustion this degrades to `indeterminate`
+        # (Issue #685 intent) rather than fabricating a passed/failed
+        # guess.
+        if verdict is None:
+            verdict = _resolve_final_status(pr, repo, exit_code=8)
         status = verdict["status"]
         fail_count = verdict["fail_count"]
         pending_count = verdict["pending_count"]
@@ -873,7 +965,7 @@ def _run_ci_watch_phase(
             # the verdict may describe a different commit than the live
             # head, and the new head's checks may still be running. Don't
             # record it — hand control back to main to restart the full
-            # `gh pr checks --watch` for the new head (which blocks until it
+            # self-poll ci-watch for the new head (which blocks until it
             # completes), rather than tagging a stale head or
             # short-circuiting on the JSON resolver's budget.
             sys.stderr.write(
@@ -893,26 +985,25 @@ def _run_ci_watch_phase(
     # transient-empty race no longer reports `1s`.
     duration = int(round(time.monotonic() - started))
 
-    # Codex review (round 1, Major): once the resolver picks the final
-    # verdict, the script's exit code must reflect that verdict, not
-    # whatever gh returned from the initial `--watch` invocation. With
-    # the retry loop, gh can exit ``8`` ("Checks pending") on the first
-    # observation and then a later JSON probe surfaces the actual
-    # ``passed`` state — returning ``8`` to the caller would falsely
-    # signal "incomplete" to shell-script consumers checking `$?`. The
-    # mapping below mirrors :func:`_classify` (gh's documented codes:
-    # 0=passed, 2=canceled, 8=incomplete) and adds 1 for failed. Issue
-    # #685: `indeterminate` (verdict undetermined) maps to 8 as well —
-    # like `incomplete` it is not a clean pass/fail for `$?` callers.
-    # The later merge-watch block can still override ``0`` → ``9`` when
-    # the post-CI loop itself fails.
+    # Codex review (round 1, Major): the script's exit code must reflect
+    # the resolved verdict. Issue #695: there is no longer a raw gh
+    # process exit code to consult at all (the self-poll loop only ever
+    # calls `gh pr checks --json`), so the mapping below is the sole
+    # source of truth. It mirrors :func:`_classify` (gh's documented
+    # codes: 0=passed, 2=canceled, 8=incomplete) and adds 1 for failed.
+    # Issue #685: `indeterminate` (verdict undetermined) maps to 8 as
+    # well — like `incomplete` it is not a clean pass/fail for `$?`
+    # callers. `status` is always one of the five keys below, so the
+    # ``.get`` default is unreachable in practice. The later merge-watch
+    # block can still override ``0`` → ``9`` when the post-CI loop itself
+    # fails.
     exit_code = {
         "passed": 0,
         "failed": 1,
         "canceled": 2,
         "incomplete": 8,
         "indeterminate": 8,
-    }.get(status, exit_code)
+    }.get(status, 8)
 
     # Issue #685: additive payload enrichment. Per-bucket counts ride
     # along whenever the verdict came from a parseable probe; an

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -635,7 +635,17 @@ def _self_poll_watch(pr: int, repo: str, interval: int) -> "dict | None":
       here, unbounded, at ``interval`` cadence — mirroring the
       indefinite block ``gh --watch`` performed while checks were
       pending, so a CI run that legitimately takes many minutes is
-      never prematurely declared ``incomplete``.
+      never prematurely declared ``incomplete``. Codex review (Issue
+      #695 round 2, P2): this holds even when a check has ALREADY
+      failed while a sibling check is still pending —
+      :func:`_summarize_checks` reports ``status="failed"`` the moment
+      any bucket is in :data:`_FAILED_BUCKETS`, regardless of
+      ``pending_count``, so the termination gate below checks
+      ``pending_count == 0`` directly rather than ``status !=
+      "incomplete"``. Otherwise a fast-failing check would make this
+      function return before ``gh pr checks --watch``'s own
+      wait-for-everything contract would have, missing whatever the
+      still-running sibling check goes on to report.
     * An empty list (no check rows visible yet) or an unparseable probe
       (:func:`_fetch_checks` returns ``None`` — a gh/network hiccup) is
       inconclusive rather than "still running": this function returns
@@ -647,10 +657,12 @@ def _self_poll_watch(pr: int, repo: str, interval: int) -> "dict | None":
     Returns a verdict dict shaped like :func:`_resolve_final_status`'s
     return value (``status`` / ``fail_count`` / ``pending_count`` /
     ``total_checks`` / ``probe_attempts``) once a decided verdict is
-    observed, or ``None`` to signal "inconclusive, hand off". May raise
-    ``KeyboardInterrupt`` (propagated from ``time.sleep`` or the
-    ``gh`` subprocess on SIGINT) — the caller treats that as
-    cancellation, matching the previous ``gh --watch`` Ctrl-C behavior.
+    observed (every check's bucket is outside
+    :data:`_PENDING_BUCKETS`), or ``None`` to signal "inconclusive,
+    hand off". May raise ``KeyboardInterrupt`` (propagated from
+    ``time.sleep`` or the ``gh`` subprocess on SIGINT) — the caller
+    treats that as cancellation, matching the previous ``gh --watch``
+    Ctrl-C behavior.
     """
     probe_attempts = 0
     while True:
@@ -658,7 +670,11 @@ def _self_poll_watch(pr: int, repo: str, interval: int) -> "dict | None":
         probe_attempts += 1
         if checks:
             status, fail_count, pending_count, total = _summarize_checks(checks)
-            if status != "incomplete":
+            if pending_count == 0:
+                # Every check has left the "not yet decided" bucket set
+                # (pass / skipping / fail / cancel only) -- fully
+                # decided, whether that nets out to `passed` or
+                # `failed`.
                 return {
                     "status": status,
                     "fail_count": fail_count,
@@ -666,8 +682,9 @@ def _self_poll_watch(pr: int, repo: str, interval: int) -> "dict | None":
                     "total_checks": total,
                     "probe_attempts": probe_attempts,
                 }
-            # Non-empty but still pending (or an unrecognized bucket):
-            # genuinely still running. Fall through to the unbounded
+            # At least one check is still pending (or an unrecognized
+            # bucket) -- genuinely still running, even if another check
+            # already failed. Fall through to the unbounded
             # interval-cadence poll below.
         else:
             # checks is None (unparseable probe) or [] (no check rows
@@ -924,25 +941,30 @@ def _run_ci_watch_phase(
         # empty check list / an unparseable probe — the Issue #413
         # freshly-created-PR race), handing off to
         # `_resolve_final_status`'s bounded retry/backoff. That resolver
-        # applies the SAME bounded budget to any `incomplete` verdict it
-        # sees, including a REAL pending check that appears mid-budget
-        # (Codex review, Issue #695 round 1 P1): without the loop below,
-        # a PR whose checks start out invisible and then take longer
-        # than the budget to finish would be wrongly declared
-        # `incomplete` instead of watched to completion. So: only accept
-        # the resolver's `incomplete` verdict as final when it reflects
-        # the empty-race itself (`total_checks` is 0 / unknown); once
-        # real, still-pending check rows are observed
-        # (`total_checks > 0`), hand control back to the unbounded
-        # self-poll loop instead of giving up.
+        # applies the SAME bounded budget to any non-empty verdict it
+        # sees while a check is still pending -- including one where
+        # another check has already failed, since `_summarize_checks`
+        # reports `status="failed"` the moment any bucket is in
+        # `_FAILED_BUCKETS`, regardless of `pending_count` (Codex
+        # review, Issue #695 round 1 P1 / round 2 P2): without the loop
+        # below, a PR whose checks start out invisible and then take
+        # longer than the budget to finish -- or where one check fails
+        # fast while a sibling is still running -- would be wrongly
+        # finalized instead of watched to completion. So: only accept
+        # the resolver's verdict as final when `pending_count` is 0 (or
+        # unknown, i.e. the exit-code fallback with no parseable
+        # response at all); whenever real, still-pending check rows are
+        # observed, hand control back to the unbounded self-poll loop
+        # instead of giving up.
         while True:
             verdict = _self_poll_watch(pr, repo, interval)
             if verdict is not None:
                 break
             verdict = _resolve_final_status(pr, repo, exit_code=8)
-            if verdict["status"] == "incomplete" and verdict["total_checks"]:
+            if verdict["pending_count"]:
                 # Real, still-pending checks exist -- not an empty-race
-                # artifact. Resume unbounded polling for them.
+                # artifact, and not fully decided even if a sibling
+                # check already failed. Resume unbounded polling.
                 continue
             break
     except KeyboardInterrupt:

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -130,6 +130,21 @@ MERGE_RESULT_HEAD_UNCONFIRMED = "merged_head_unconfirmed"
 RETRY_BUDGET_SEC = 60
 RETRY_INTERVAL_SEC = 5
 
+# Issue #695 (Codex review round 3, P2): the self-poll loop's own
+# handoff to `_resolve_final_status` (`_run_ci_watch_phase`, on an empty
+# / unparseable first observation) uses a WIDER budget than
+# `RETRY_BUDGET_SEC`. Pre-#695, `gh pr checks --watch` itself blocked
+# until check rows were visible before the JSON-probe race ever mattered
+# — that race was a narrow post-watch API-propagation lag, genuinely
+# bounded to a few seconds. With `--watch` removed, the very FIRST
+# observation for every freshly opened PR can be empty simply because no
+# CI system has registered a check yet (not a lag, an honest "hasn't
+# started"), and some external CI integrations can take longer than
+# `RETRY_BUDGET_SEC` to publish their first check row. Widening this
+# specific handoff's budget gives such integrations room without
+# resorting to unbounded polling on data that has never once appeared.
+CI_WATCH_EMPTY_RACE_BUDGET_SEC = 300
+
 # Issue #685: back off between JSON-probe retries so a persistently
 # flaky `gh pr checks --json` doesn't hammer the API. The sleep starts
 # at RETRY_INTERVAL_SEC and multiplies by RETRY_BACKOFF_FACTOR after
@@ -960,7 +975,16 @@ def _run_ci_watch_phase(
             verdict = _self_poll_watch(pr, repo, interval)
             if verdict is not None:
                 break
-            verdict = _resolve_final_status(pr, repo, exit_code=8)
+            # Issue #695 round 3 (Codex review, P2): use the wider
+            # CI_WATCH_EMPTY_RACE_BUDGET_SEC here rather than the
+            # RETRY_BUDGET_SEC default -- see that constant's docstring
+            # for why the self-poll handoff needs more room than the
+            # narrow post-watch race `_resolve_final_status` was
+            # originally built for.
+            verdict = _resolve_final_status(
+                pr, repo, exit_code=8,
+                budget_sec=CI_WATCH_EMPTY_RACE_BUDGET_SEC,
+            )
             if verdict["pending_count"]:
                 # Real, still-pending checks exist -- not an empty-race
                 # artifact, and not fully decided even if a sibling

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -464,6 +464,47 @@ class JournalEmitTests(unittest.TestCase):
             self.assertEqual(rec["status"], "passed")
             self.assertEqual(_count_ci_events(journal), 1)
 
+    def test_empty_then_failed_with_pending_sibling_waits_for_sibling(self) -> None:
+        """Codex review (Issue #695 round 2, P2), exercised through the
+        `_resolve_final_status` handoff composition: the resolver's own
+        probe can observe a check that already failed while a sibling
+        is still pending. `_summarize_checks` reports `status="failed"`
+        immediately in that shape, but CI is not actually done -- the
+        composition loop in `_run_ci_watch_phase` must key off
+        `pending_count` (not `status`) to decide whether to resume
+        self-poll, so the pending sibling is watched to completion
+        rather than an early `failed` verdict being recorded while it
+        is still running.
+        """
+        fake_run = _make_stateful_fake_run(
+            watch_exit=8,
+            checks_sequence=[
+                [],  # self-poll's first fetch: empty-race -> hand off
+                [{"name": "unit", "state": "COMPLETED", "bucket": "fail"},
+                 {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"}],
+                [{"name": "unit", "state": "COMPLETED", "bucket": "fail"},
+                 {"name": "deploy", "state": "COMPLETED", "bucket": "pass"}],
+            ],
+        )
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 0.5, 9999.0, 9999.5]):
+                rc = pr_watch.main([
+                    "--pr", "205", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(rc, 1)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "failed")
+            self.assertEqual(rec["fail_count"], 1)
+            self.assertEqual(rec["pending_count"], 0)
+            self.assertEqual(_count_ci_events(journal), 1)
+
     def test_transient_empty_then_passes_emits_one_final_event(self) -> None:
         """Issue #413 regression-prevention fixture.
 
@@ -1125,6 +1166,31 @@ class SelfPollWatchTests(unittest.TestCase):
              mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
             verdict = pr_watch._self_poll_watch(1, "octo/repo", 15)
         self.assertEqual(verdict["status"], "passed")
+        self.assertEqual(verdict["probe_attempts"], 3)
+        self.assertEqual(sleep_mock.call_args_list, [mock.call(15), mock.call(15)])
+
+    def test_failed_check_with_sibling_still_pending_keeps_polling(self) -> None:
+        """Codex review (Issue #695 round 2, P2): a check that has
+        already failed must NOT short-circuit the loop while a sibling
+        check is still pending -- `_summarize_checks` reports
+        `status="failed"` the moment any bucket is a failure, regardless
+        of `pending_count`, so the termination gate must key off
+        `pending_count == 0` rather than `status != "incomplete"`.
+        `gh pr checks --watch` itself waits for every check to leave
+        pending before returning, even after one has already gone red.
+        """
+        sequence = [
+            [{"bucket": "fail"}, {"bucket": "pending"}],
+            [{"bucket": "fail"}, {"bucket": "pending"}],
+            [{"bucket": "fail"}, {"bucket": "pass"}],
+        ]
+        with mock.patch.object(pr_watch, "_fetch_checks",
+                               side_effect=sequence), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            verdict = pr_watch._self_poll_watch(1, "octo/repo", 15)
+        self.assertEqual(verdict["status"], "failed")
+        self.assertEqual(verdict["fail_count"], 1)
+        self.assertEqual(verdict["pending_count"], 0)
         self.assertEqual(verdict["probe_attempts"], 3)
         self.assertEqual(sleep_mock.call_args_list, [mock.call(15), mock.call(15)])
 

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -417,6 +417,53 @@ class JournalEmitTests(unittest.TestCase):
             self.assertEqual(rec["status"], "passed")
             self.assertEqual(_count_ci_events(journal), 1)
 
+    def test_empty_then_real_pending_outlasting_budget_still_resolves(self) -> None:
+        """Codex review (Issue #695 round 1, P1): the empty-list handoff
+        from `_self_poll_watch` to `_resolve_final_status` must NOT
+        inherit the resolver's 60s budget for a REAL pending check that
+        shows up afterward.
+
+        Repro: the first probe is `[]` (no check rows yet -- the
+        Issue #413 race), so self-poll hands off to the bounded
+        resolver. The resolver's own probe then sees a genuine
+        `pending` check, but the retry budget is exhausted before it
+        decides (simulated here by jumping `time.monotonic()` straight
+        past the deadline). Without the fix, this would be recorded as
+        a final `incomplete` even though CI was still legitimately
+        running. With the fix, `_run_ci_watch_phase` recognizes the
+        resolver's `incomplete` verdict carries a non-zero
+        `total_checks` (a real check row, not an empty-race artifact)
+        and hands control back to the unbounded self-poll loop, which
+        keeps polling until the check actually decides.
+        """
+        fake_run = _make_stateful_fake_run(
+            watch_exit=8,
+            checks_sequence=[
+                [],  # self-poll's first fetch: empty-race -> hand off
+                [{"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"}],
+                [{"name": "deploy", "state": "COMPLETED", "bucket": "pass"}],
+            ],
+        )
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   # started, resolver set_deadline,
+                                   # resolver deadline-check (jumps past
+                                   # budget -> exhausted), duration.
+                                   side_effect=[0.0, 0.5, 9999.0, 9999.5]):
+                rc = pr_watch.main([
+                    "--pr", "205", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(rc, 0)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(_count_ci_events(journal), 1)
+
     def test_transient_empty_then_passes_emits_one_final_event(self) -> None:
         """Issue #413 regression-prevention fixture.
 

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -1103,6 +1103,44 @@ class Issue685Tests(unittest.TestCase):
         self.assertEqual(verdict["status"], "incomplete")
         self.assertEqual(sleeps, [5, 10, 20, 30])
 
+    def test_ci_watch_phase_widens_budget_for_empty_race_handoff(self) -> None:
+        """Codex review (Issue #695 round 3, P2): the self-poll handoff
+        into `_resolve_final_status` (on an empty/unparseable first
+        observation) must use the wider
+        `CI_WATCH_EMPTY_RACE_BUDGET_SEC`, not the narrow
+        `RETRY_BUDGET_SEC` the post-`--watch` race was originally
+        built for -- otherwise a CI system that takes longer than
+        `RETRY_BUDGET_SEC` (but well under
+        `CI_WATCH_EMPTY_RACE_BUDGET_SEC`) to publish its first check
+        row would be wrongly finalized as `incomplete` before it ever
+        got a chance to run."""
+        captured_kwargs: list = []
+        real_resolve = pr_watch._resolve_final_status
+
+        def spy(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            return real_resolve(*args, **kwargs)
+
+        with mock.patch.object(pr_watch, "_fetch_head_oid", return_value=None), \
+             mock.patch.object(pr_watch, "_self_poll_watch", return_value=None), \
+             mock.patch.object(pr_watch, "_resolve_final_status", side_effect=spy), \
+             mock.patch.object(pr_watch, "_fetch_checks", return_value=[]), \
+             mock.patch.object(pr_watch, "_record_ci_completed"), \
+             mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+             mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+             mock.patch.object(pr_watch.time, "monotonic",
+                               side_effect=[0.0, 0.5, 999999.0, 999999.5]):
+            pr_watch._run_ci_watch_phase(
+                pr=1, repo="octo/repo", interval=5, db_path=Path("/dev/null"),
+            )
+        self.assertEqual(len(captured_kwargs), 1)
+        self.assertEqual(
+            captured_kwargs[0].get("budget_sec"),
+            pr_watch.CI_WATCH_EMPTY_RACE_BUDGET_SEC,
+        )
+        self.assertGreater(pr_watch.CI_WATCH_EMPTY_RACE_BUDGET_SEC,
+                           pr_watch.RETRY_BUDGET_SEC)
+
 
 class SelfPollWatchTests(unittest.TestCase):
     """Issue #695: unit coverage for `_self_poll_watch`, the self-poll

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -343,25 +343,61 @@ class JournalEmitTests(unittest.TestCase):
             rec = _read_ci_event(journal)
             self.assertEqual(rec["status"], "passed")
 
-    def test_pending_check_after_retry_exhaustion_is_incomplete(self) -> None:
-        """Issue #413: a still-running check now drives the retry
-        loop; only after the retry budget is exhausted do we record
-        a final ``incomplete`` event.
-
-        Pre-#413, this test asserted ``status=incomplete`` on the
-        first ``pending`` observation. That path is exactly the
-        race the fix addresses — a pending bucket must be retried,
-        not journaled immediately. We keep the bucket→status
-        coverage by exercising the exhaustion path here (the
-        per-bucket mapping itself is unit-tested in
-        :class:`ClassifyFromChecksTests`).
+    def test_pass_plus_skipping_mix_emits_ci_completed(self) -> None:
+        """Issue #695 end-to-end repro: kura PR #38 had 4 passed + 2
+        skipping + 0 pending checks. `gh pr checks --watch` never
+        treats `skipping` as terminal, so it never returned and
+        `ci_completed` was never journaled -- the secretary's
+        auto-merge gate never fired and a human had to merge manually.
+        `main()` must record a `passed` `ci_completed` event for this
+        shape without hanging.
         """
-        # Always-pending stub: every fetch returns the same payload.
-        fake_run = _make_fake_run(
-            watch_exit=8,  # gh exits 8 ("Checks pending") with this payload
-            checks_json=[
-                {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
-                {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"},
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=0,
+                checks_json=(
+                    [{"name": f"pass-{i}", "state": "COMPLETED", "bucket": "pass"}
+                     for i in range(4)]
+                    + [{"name": f"skip-{i}", "state": "COMPLETED", "bucket": "skipping"}
+                       for i in range(2)]
+                ),
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(rec["fail_count"], 0)
+            self.assertEqual(rec["pending_count"], 0)
+            self.assertEqual(rec["total_checks"], 6)
+
+    def test_pending_then_passes_via_self_poll(self) -> None:
+        """Issue #695: a still-running (``pending`` bucket) check must
+        keep the self-poll loop going, unbounded, at ``--interval``
+        cadence -- mirroring the indefinite block ``gh pr checks
+        --watch`` used to perform while CI was genuinely still running.
+        Once the check transitions to a decided bucket, the self-poll
+        loop returns that verdict directly (no bounded-retry timeout
+        applies to a genuinely-running check).
+
+        Pre-#695, `gh pr checks --watch` handled this blocking itself,
+        and a stray ``pending`` observation reaching the JSON-probe
+        resolver after `--watch` returned was retried only within a
+        60s budget before giving up as ``incomplete`` (see
+        ``test_retry_budget_exhausted_records_incomplete_once`` for
+        that still-valid empty-list race). With `--watch` removed, a
+        genuinely pending check must never be prematurely declared
+        ``incomplete`` -- self-poll keeps polling until it is actually
+        decided, however long that takes.
+        """
+        fake_run = _make_stateful_fake_run(
+            watch_exit=8,
+            checks_sequence=[
+                [{"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                 {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"}],
+                [{"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                 {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"}],
+                [{"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                 {"name": "deploy", "state": "COMPLETED", "bucket": "pass"}],
             ],
         )
         with TempDir() as tmp:
@@ -372,12 +408,14 @@ class JournalEmitTests(unittest.TestCase):
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
                  mock.patch.object(pr_watch.time, "sleep", return_value=None), \
                  mock.patch.object(pr_watch.time, "monotonic",
-                                   side_effect=[100.0, 100.5, 9999.0, 9999.5]):
-                pr_watch.main([
+                                   side_effect=[100.0, 142.0]):
+                rc = pr_watch.main([
                     "--pr", "205", "--repo", "octo/repo", "--interval", "5",
                 ])
+            self.assertEqual(rc, 0)
             rec = _read_ci_event(journal)
-            self.assertEqual(rec["status"], "incomplete")
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(_count_ci_events(journal), 1)
 
     def test_transient_empty_then_passes_emits_one_final_event(self) -> None:
         """Issue #413 regression-prevention fixture.
@@ -395,10 +433,16 @@ class JournalEmitTests(unittest.TestCase):
         fake_run = _make_stateful_fake_run(
             watch_exit=0,
             checks_sequence=[
-                [],  # transient empty (first fetch after watch returns)
+                [],  # transient empty (self-poll hands off on this one)
                 [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}],
             ],
         )
+        # Issue #695: self-poll's own first fetch consumes the `[]` entry
+        # and hands off immediately (no monotonic call); the resolver's
+        # first fetch then sees the `pass` entry and returns immediately
+        # too (also no monotonic call) — so only `started` / `duration`
+        # are consumed here, unlike the pre-#695 4-value sequence that
+        # accounted for the resolver's own retry-budget bookkeeping.
         with TempDir() as tmp:
             journal = tmp / ".state" / "state.db"
             with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
@@ -407,7 +451,7 @@ class JournalEmitTests(unittest.TestCase):
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
                  mock.patch.object(pr_watch.time, "sleep", return_value=None), \
                  mock.patch.object(pr_watch.time, "monotonic",
-                                   side_effect=[100.0, 100.5, 101.0, 142.0]):
+                                   side_effect=[100.0, 142.0]):
                 rc = pr_watch.main([
                     "--pr", "413", "--repo", "octo/repo", "--interval", "5",
                 ])
@@ -535,26 +579,40 @@ class JournalEmitTests(unittest.TestCase):
             rec = _read_ci_event(journal)
             self.assertEqual(rec["status"], "failed")
 
-    def test_gh_exit_2_is_canceled(self) -> None:
-        """gh exit 2 = cancellation. Must NOT be overwritten by JSON probe.
+    def test_keyboard_interrupt_during_self_poll_is_canceled(self) -> None:
+        """SIGINT (Python ``KeyboardInterrupt``) during the self-poll loop
+        must be recorded as ``canceled``, not re-classified by whatever
+        the JSON probe would otherwise say.
 
-        Regression: an earlier draft only honored Python-side
-        KeyboardInterrupt, so a Ctrl-C delivered to gh itself (exit 2)
-        would have been re-classified as passed/failed/incomplete by
-        the JSON probe. The journal must reflect cancellation so the
-        secretary can distinguish "user aborted" from "CI verdict".
+        Issue #695: since the self-poll loop replaced the blocking
+        ``gh pr checks --watch`` subprocess, there is no longer a gh
+        process exit code that can itself signal cancellation (the old
+        "gh exit 2" regression fixture no longer applies) -- the only
+        cancellation source is a KeyboardInterrupt raised inside Python
+        (e.g. from ``time.sleep`` on Ctrl-C), which
+        :func:`_run_ci_watch_phase` must still convert to a ``canceled``
+        verdict without ever consulting ``_fetch_checks`` again after
+        the interrupt.
         """
         with TempDir() as tmp:
             journal = tmp / ".state" / "state.db"
-            self._run(
-                journal,
-                gh_exit=2,
-                checks_json=[{"name": "ci", "state": "COMPLETED", "bucket": "pass"}],
-            )
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch, "_pr_exists", return_value=True), \
+                 mock.patch.object(pr_watch, "_fetch_head_oid", return_value=None), \
+                 mock.patch.object(pr_watch, "_self_poll_watch",
+                                   side_effect=KeyboardInterrupt), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[100.0, 101.0]):
+                rc = pr_watch.main([
+                    "--pr", "42", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(rc, 2)
             rec = _read_ci_event(journal)
             self.assertEqual(rec["status"], "canceled")
 
-    def test_json_probe_failure_falls_back_to_exit_code(self) -> None:
+    def test_json_probe_failure_falls_back_to_indeterminate(self) -> None:
         """If every `gh pr checks --json` probe fails (binary missing /
         malformed stdout), the resolver retries within its budget and
         only after exhaustion does it fall back to the exit-code
@@ -564,6 +622,13 @@ class JournalEmitTests(unittest.TestCase):
         short-circuit the retry budget and bypass the resolver
         entirely; the fix unifies the retry path so probe failures
         and ``incomplete`` observations are both retryable.
+
+        Issue #695: pre-fix, this fixture's ``watch_exit=0`` fed a real
+        `gh pr checks --watch` exit code into the fallback classifier,
+        so total probe failure degraded to an (arguably too-optimistic)
+        ``passed``. With `--watch` removed there is no gh exit code to
+        consult at all -- the fallback is always ``indeterminate``
+        (verdict undetermined), never a guessed ``passed``.
         """
         # Always-FileNotFoundError stub: `_fetch_checks` returns None
         # for every call.
@@ -589,8 +654,7 @@ class JournalEmitTests(unittest.TestCase):
                     "--pr", "205", "--repo", "octo/repo", "--interval", "5",
                 ])
             rec = _read_ci_event(journal)
-            # exit 0 → passed via _classify fallback (post-exhaustion).
-            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(rec["status"], "indeterminate")
 
     def test_transient_probe_failure_then_passes(self) -> None:
         """Codex round-2 Major regression test: a single transient
@@ -908,25 +972,32 @@ class Issue685Tests(unittest.TestCase):
         self.assertNotIn("retry_recommended", rec)
 
     def test_incomplete_is_distinct_from_indeterminate(self) -> None:
-        """A parseable-but-pending verdict stays `incomplete` (with
+        """A parseable-but-empty verdict stays `incomplete` (with
         counts, no retry schedule) — the fetch-failure `indeterminate`
-        is a different word. This is the core 3-value split."""
+        is a different word. This is the core 3-value split.
+
+        Issue #695: a *non-empty* persistently-pending checks list is
+        no longer reachable as a final `incomplete` verdict — the
+        self-poll loop now polls it unbounded until it decides (see
+        ``test_pending_then_passes_via_self_poll``), matching
+        `gh --watch`'s own indefinite block while CI is genuinely
+        running. The empty-list race (no check rows visible at all)
+        is the remaining path that legitimately exhausts the retry
+        budget into `incomplete`.
+        """
         fake_run = _make_fake_run(
             watch_exit=8,
-            checks_json=[
-                {"name": "lint", "bucket": "pass"},
-                {"name": "deploy", "bucket": "pending"},
-            ],
+            checks_json=[],
         )
-        # Always-pending: retry budget exhausts, then record incomplete.
+        # Always-empty: retry budget exhausts, then record incomplete.
         rc, rec = self._run(
             ["--pr", "685", "--repo", "octo/repo", "--interval", "5"],
             fake_run,
             monotonic=[0.0, 0.5, 9999.0, 9999.5],
         )
         self.assertEqual(rec["status"], "incomplete")
-        self.assertEqual(rec["pending_count"], 1)
-        self.assertEqual(rec["total_checks"], 2)
+        self.assertEqual(rec["pending_count"], 0)
+        self.assertEqual(rec["total_checks"], 0)
         # `incomplete` (checks read, still pending) is NOT the
         # fetch-failure path, so it carries no retry schedule.
         self.assertNotIn("retry_recommended", rec)
@@ -943,6 +1014,90 @@ class Issue685Tests(unittest.TestCase):
             verdict = pr_watch._resolve_final_status(1, "octo/repo", 8)
         self.assertEqual(verdict["status"], "incomplete")
         self.assertEqual(sleeps, [5, 10, 20, 30])
+
+
+class SelfPollWatchTests(unittest.TestCase):
+    """Issue #695: unit coverage for `_self_poll_watch`, the self-poll
+    loop that replaced the blocking `gh pr checks --watch` subprocess.
+
+    Root-cause repro (kura PR #38): a PR with 4 passed + 2 skipping + 0
+    pending checks never made `gh pr checks --watch` return, because gh
+    does not treat `skipping` as terminal even though our own
+    classifier does -- so `CI_COMPLETED` was never recorded and the
+    secretary's auto-merge gate never fired.
+    """
+
+    def test_all_pass_resolves_immediately(self) -> None:
+        checks = [{"bucket": "pass"}, {"bucket": "pass"}]
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=checks), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            verdict = pr_watch._self_poll_watch(1, "octo/repo", 30)
+        self.assertEqual(verdict["status"], "passed")
+        self.assertEqual(verdict["total_checks"], 2)
+        self.assertEqual(verdict["probe_attempts"], 1)
+        sleep_mock.assert_not_called()
+
+    def test_fail_resolves_immediately(self) -> None:
+        checks = [{"bucket": "pass"}, {"bucket": "fail"}]
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=checks), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            verdict = pr_watch._self_poll_watch(1, "octo/repo", 30)
+        self.assertEqual(verdict["status"], "failed")
+        self.assertEqual(verdict["fail_count"], 1)
+        sleep_mock.assert_not_called()
+
+    def test_pass_plus_skipping_mix_resolves_immediately(self) -> None:
+        """The literal Issue #695 repro fixture: 4 pass + 2 skipping, 0
+        pending. `gh --watch` never returned for this shape; the
+        self-poll loop must resolve on the very first observation
+        (no sleep / extra poll needed) since every bucket is already
+        decided."""
+        checks = (
+            [{"bucket": "pass"}] * 4 + [{"bucket": "skipping"}] * 2
+        )
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=checks), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            verdict = pr_watch._self_poll_watch(1, "octo/repo", 30)
+        self.assertEqual(verdict["status"], "passed")
+        self.assertEqual(verdict["fail_count"], 0)
+        self.assertEqual(verdict["pending_count"], 0)
+        self.assertEqual(verdict["total_checks"], 6)
+        self.assertEqual(verdict["probe_attempts"], 1)
+        sleep_mock.assert_not_called()
+
+    def test_pending_then_passed_polls_at_interval(self) -> None:
+        """A genuinely pending check keeps the loop going, sleeping
+        `interval` seconds between polls, until it decides."""
+        sequence = [
+            [{"bucket": "pending"}],
+            [{"bucket": "pending"}],
+            [{"bucket": "pass"}],
+        ]
+        with mock.patch.object(pr_watch, "_fetch_checks",
+                               side_effect=sequence), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            verdict = pr_watch._self_poll_watch(1, "octo/repo", 15)
+        self.assertEqual(verdict["status"], "passed")
+        self.assertEqual(verdict["probe_attempts"], 3)
+        self.assertEqual(sleep_mock.call_args_list, [mock.call(15), mock.call(15)])
+
+    def test_empty_list_hands_off_without_sleeping_in_loop(self) -> None:
+        """An empty check list (no rows visible yet) is inconclusive,
+        not "still running" -- returns None immediately so the caller's
+        bounded `_resolve_final_status` retry/backoff handles it,
+        rather than polling unbounded here."""
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=[]), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            verdict = pr_watch._self_poll_watch(1, "octo/repo", 30)
+        self.assertIsNone(verdict)
+        sleep_mock.assert_not_called()
+
+    def test_unparseable_probe_hands_off_without_sleeping_in_loop(self) -> None:
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=None), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            verdict = pr_watch._self_poll_watch(1, "octo/repo", 30)
+        self.assertIsNone(verdict)
+        sleep_mock.assert_not_called()
 
 
 class PowerShellInterpreterProbeTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `tools/pr_watch.py` の CI watch phase を `gh pr checks --watch` から自前ポーリング (`_self_poll_watch`) に置換
- `gh` が `skipping` バケットを terminal 扱いしないため pass 4 + skipping 2 (pending 0) の PR で watch が抜けず `CI_COMPLETED` が記録されない Issue #695 を根治
- 既存の `_classify_from_checks` / bucket 分類 (`_PASSED_BUCKETS = {"pass","skipping"}` 等) はそのまま活用
- Codex 4 round で Blocker/Major ゼロまで in-loop 修正 (empty-race handoff budget / fail+pending 共存 / handoff budget 拡張)

## Test plan
- [x] `tools/test_pr_watch.py` 68 passed / 3 skipped (pwsh 環境依存 skip、既存仕様)
- [x] 新テスト `test_pass_plus_skipping_mix_emits_ci_completed` で Issue #695 再現ケース (4 pass + 2 skipping) が main() 経由で hang せず `ci_completed` 記録
- [x] pending→pass 遷移 / fail+pending 共存 / empty→real pending outlasting budget / empty-race handoff budget の各シナリオを新規テストで cover
- [x] Codex round4 verdict「No actionable correctness issues found」
- [ ] 実 PR で 4 pass + skipping 混在パターンを踏んで watch が正しく exit することを CI 監視で確認 (この PR 自身は該当パターンではないため、後続 PR で経過観察)

Closes #695