### PR TITLE
fix(claude): 中間ハンドオフ報告受信時にも worker_reported を journal する (Closes #699)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -290,11 +290,17 @@ worker → Secretary peer message
 
 → [`.claude/skills/org-escalation/SKILL.md`](../org-escalation/SKILL.md) を発動する。Secretary は一次承認しない。
 
-#### 1. 進捗報告
+#### 1. 進捗報告（完了以外の中間ハンドオフ報告すべて — 進捗・rebase 報告・依頼 等）
+
+本サブセクションは「進捗」という語に限らず、**完了報告 (2a) / 判断仰ぎ・ブロッカー (0) / plan・prep 引き渡し以外の worker→secretary peer message 全種**（進捗共有・rebase 完了報告・確認依頼等の中間ハンドオフ報告）に適用する。plan / prep の引き渡しは専用 kind（`plan_delivered` / `prep_delivered`、[`docs/journal-events.md`](../../../docs/journal-events.md)）で記帳する既存フローのままとし、`worker_reported` に付け替えない（design-flow 消費側は専用 kind を参照している）。
 
 - worker へ ack を返す（[`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md) の「進捗報告 ack」節。Progress Log 追記より前）。**進捗報告は user に上げない・承認待ちもしない**
 - `.state/workers/worker-{task_id}.md` の Progress Log に追記
-- DB の events テーブルにイベント追記 (`bash tools/journal_append.sh ...`)
+- **DB の events テーブルへ `worker_reported` を必ず追記する（省略不可、Issue #699）**:
+  ```bash
+  bash tools/journal_append.sh worker_reported worker=worker-{task_id} task={task_id} summary="<要約>"
+  ```
+  payload key は event catalog（[`docs/journal-events.md`](../../../docs/journal-events.md) の `worker_reported` 行: `worker`, `task`, `summary`）に合わせる。kind は `worker_reported` に統一（`worker_progress` 等の別名を使わない）。dispatcher の PANE_OUTPUT_WITHOUT_PEER_MSG 判定（[`.dispatcher/references/worker-monitoring.md`](../../../.dispatcher/references/worker-monitoring.md) Step 5.2）は events テーブルの `worker_reported` 痕跡を SQL で参照するため、中間ハンドオフ報告の記帳漏れは「peer message は届いているのに events に痕跡が無い」状態を作り、正常稼働中の worker を silent dead-lock と誤検知する false positive の直接原因になる（2026-07-08 kura conveyor で実例）
 
 #### 2a. 完了報告
 

--- a/.claude/skills/org-delegate/SKILL.md.in
+++ b/.claude/skills/org-delegate/SKILL.md.in
@@ -284,11 +284,17 @@ worker → Secretary peer message
 
 → [`.claude/skills/org-escalation/SKILL.md`](../org-escalation/SKILL.md) を発動する。Secretary は一次承認しない。
 
-#### 1. 進捗報告
+#### 1. 進捗報告（完了以外の中間ハンドオフ報告すべて — 進捗・rebase 報告・依頼 等）
+
+本サブセクションは「進捗」という語に限らず、**完了報告 (2a) / 判断仰ぎ・ブロッカー (0) / plan・prep 引き渡し以外の worker→secretary peer message 全種**（進捗共有・rebase 完了報告・確認依頼等の中間ハンドオフ報告）に適用する。plan / prep の引き渡しは専用 kind（`plan_delivered` / `prep_delivered`、[`docs/journal-events.md`](../../../docs/journal-events.md)）で記帳する既存フローのままとし、`worker_reported` に付け替えない（design-flow 消費側は専用 kind を参照している）。
 
 - worker へ ack を返す（[`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md) の「進捗報告 ack」節。Progress Log 追記より前）。**進捗報告は user に上げない・承認待ちもしない**
 - `.state/workers/worker-{task_id}.md` の Progress Log に追記
-- DB の events テーブルにイベント追記 (`bash tools/journal_append.sh ...`)
+- **DB の events テーブルへ `worker_reported` を必ず追記する（省略不可、Issue #699）**:
+  ```bash
+  bash tools/journal_append.sh worker_reported worker=worker-{task_id} task={task_id} summary="<要約>"
+  ```
+  payload key は event catalog（[`docs/journal-events.md`](../../../docs/journal-events.md) の `worker_reported` 行: `worker`, `task`, `summary`）に合わせる。kind は `worker_reported` に統一（`worker_progress` 等の別名を使わない）。dispatcher の PANE_OUTPUT_WITHOUT_PEER_MSG 判定（[`.dispatcher/references/worker-monitoring.md`](../../../.dispatcher/references/worker-monitoring.md) Step 5.2）は events テーブルの `worker_reported` 痕跡を SQL で参照するため、中間ハンドオフ報告の記帳漏れは「peer message は届いているのに events に痕跡が無い」状態を作り、正常稼働中の worker を silent dead-lock と誤検知する false positive の直接原因になる（2026-07-08 kura conveyor で実例）
 
 #### 2a. 完了報告
 

--- a/.claude/skills/org-delegate/references/ack-template.md
+++ b/.claude/skills/org-delegate/references/ack-template.md
@@ -34,6 +34,8 @@ mcp__org-broker__send_message(
 )
 ```
 
+進捗に限らず、rebase 報告・確認依頼など完了 (2a) / 判断仰ぎ (0) / plan・prep 引き渡し（専用 kind `plan_delivered` / `prep_delivered` で記帳する既存フロー）以外の中間ハンドオフ報告はすべてこの ack を使う。ack 後は SKILL.md Step 5 (1) に従い、Progress Log 追記に加えて `worker_reported` の journal 追記（`bash tools/journal_append.sh worker_reported worker=worker-{task_id} task={task_id} summary="<要約>"`）を必ず行う（記帳漏れは dispatcher の PANE_OUTPUT_WITHOUT_PEER_MSG 誤検知の原因、Issue #699）。
+
 ### 完了報告 ack（PR 未作成時）
 
 ```

--- a/.claude/skills/org-delegate/references/ack-template.md.in
+++ b/.claude/skills/org-delegate/references/ack-template.md.in
@@ -28,6 +28,8 @@ Secretary が worker からの peer message を受け取ったときの ack（ac
 )
 ```
 
+進捗に限らず、rebase 報告・確認依頼など完了 (2a) / 判断仰ぎ (0) / plan・prep 引き渡し（専用 kind `plan_delivered` / `prep_delivered` で記帳する既存フロー）以外の中間ハンドオフ報告はすべてこの ack を使う。ack 後は SKILL.md Step 5 (1) に従い、Progress Log 追記に加えて `worker_reported` の journal 追記（`bash tools/journal_append.sh worker_reported worker=worker-{task_id} task={task_id} summary="<要約>"`）を必ず行う（記帳漏れは dispatcher の PANE_OUTPUT_WITHOUT_PEER_MSG 誤検知の原因、Issue #699）。
+
 ### 完了報告 ack（PR 未作成時）
 
 ```


### PR DESCRIPTION
## 概要

secretary の worker peer-message 受信処理のうち、完了報告以外の中間ハンドオフ報告 (進捗・rebase 報告・依頼) 受信時にも `worker_reported` イベントを events テーブルへ必ず記帳する手順を skill prose に焼き込む。dispatcher の PANE_OUTPUT_WITHOUT_PEER_MSG 判定は events テーブルを参照するため、記帳漏れが false positive の原因だった (2026-07-08 kura conveyor 実例)。

## 変更点

- `.claude/skills/org-delegate/SKILL.md(.in)`: Step 5「1. 進捗報告」を「完了以外の中間ハンドオフ報告すべて」に拡張し、`journal_append.sh worker_reported ... summary=` を省略不可の手順として明記。plan/prep 引き渡しは専用 kind (`plan_delivered`/`prep_delivered`) の既存フローのまま carve out (Codex round 1 指摘反映)
- `.claude/skills/org-delegate/references/ack-template.md(.in)`: 進捗報告 ack 節に記帳必須の整合追記

## kind の統一判断

`worker_reported` に統一。根拠: dispatcher 判定 SQL の kind 集合 / journal-events.md catalog / delegation-lifecycle-contract T3 がすべて `worker_reported` を参照。`worker_progress` はテストフィクスチャのみで運用未使用。payload key は catalog 準拠の `summary=`。

## 検証

- gen_skill_prose --check rc=0 (drift なし) / audit_link_paths baseline 同数 (新規違反ゼロ) / unittest 62 OK
- Codex レビュー 2 round で収束 (round 2 クリーン、Blocker/Major ゼロ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)