### PR TITLE
fix(claude): apply が新規URLプロジェクトの基底cloneを配置 + brief配置の一般則化

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -228,16 +228,37 @@ class TestIssue484AliasRemoteRow(unittest.TestCase):
         self.assertEqual(plan.layout.pattern, "A")
         self.assertIsNone(plan.layout.pattern_variant)
         self.assertFalse(plan.layout.self_edit)
+        # Issue #709: a URL-only registered project with no local clone yet
+        # now routes into the canonical ``<clone>/.worktrees/<task>/`` layout
+        # and carries a pending base clone that apply will ``git clone``
+        # first — instead of the old legacy-direct ``workers/<slug>/`` path
+        # that left the worker in a non-git dir (the #709 bug). The clone
+        # target is the canonical ``workers/<slug>/`` location.
+        clone_target = (self.sb.workers / "claude-org-en").resolve()
         self.assertEqual(
             Path(plan.layout.worker_dir),
-            (self.sb.workers / "claude-org-en").resolve(),
+            (clone_target / ".worktrees" / "en-translation-sync-v2").resolve(),
         )
+        self.assertIsNotNone(plan.base_repo)
+        self.assertEqual(Path(plan.base_repo).resolve(), clone_target)
+        self.assertIsNotNone(plan.pending_clone)
+        self.assertEqual(
+            plan.pending_clone.url,
+            "https://github.com/suisya-systems/claude-org",
+        )
+        self.assertEqual(Path(plan.pending_clone.target).resolve(), clone_target)
+        # Pattern A worktree carve-out: sandbox pattern flips to B, base-clone
+        # is surfaced for the runtime (Issue #489 parity).
+        self.assertEqual(plan.settings_args["pattern"], "B")
+        self.assertEqual(plan.settings_args["base-clone"], str(clone_target))
         # The DELEGATE body advertises a clone source (Pattern A label).
         self.assertIn("clone or reuse:", plan.delegate_body)
         self.assertIn(
             "https://github.com/suisya-systems/claude-org", plan.delegate_body
         )
-        # bug 1: non-self-edit brief, no in-place-edit directive.
+        # bug 1: non-self-edit brief, no in-place-edit directive. Brief name
+        # stays CLAUDE.md at plan time (the clone isn't present to inspect);
+        # apply re-evaluates against the real checkout (Issue #712).
         self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
         brief = gwb.render(plan.config)
         self.assertNotIn("直接編集すること", brief)
@@ -2646,6 +2667,523 @@ class TestIssue489AtomicApplyRollback(unittest.TestCase):
         )
         match = [r for r in self.sb.list_runs() if r["task_id"] == "happy-task"]
         self.assertEqual(match[0]["status"], "queued")
+
+
+# ---------------------------------------------------------------------------
+# Issue #709: apply materializes the base clone for URL-only new projects
+# ---------------------------------------------------------------------------
+
+
+class TestIssue709BaseCloneMaterialization(unittest.TestCase):
+    """Issue #709: a registry row with a remote URL and no local clone yet
+    used to dispatch Pattern A *legacy-direct* — the brief landed in a non-git
+    ``workers/<slug>/`` dir and the worker was blocked on the first git op.
+    apply must now ``git clone`` the base into the canonical
+    ``workers/<slug>/`` and cut ``<clone>/.worktrees/<task>/`` off it. The
+    hermetic ``URL`` is a local *bare* repo (no network)."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        # with_claude_org_origin=False so the sandbox git-init doesn't race
+        # our per-test seeds (matches the other worktree-creation classes).
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
+        import os
+        self._git_env = os.environ.copy()
+        self._git_env.update(
+            {
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _git(self, repo: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args], check=True, capture_output=True,
+            env=self._git_env,
+        )
+
+    def _make_bare_remote(
+        self, name: str, *, claude_md: str | None = None
+    ) -> Path:
+        """Build a bare repo (stands in for the registered remote URL) with
+        one commit on ``main``; optionally seed a tracked ``CLAUDE.md``."""
+        src = Path(self._td.name) / f"{name}-src"
+        src.mkdir()
+        self._git(src, "init", "-q", "-b", "main")
+        (src / "README.md").write_text("hi\n", encoding="utf-8")
+        if claude_md is not None:
+            (src / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
+        self._git(src, "add", "-A")
+        self._git(src, "commit", "-q", "-m", "init")
+        bare = Path(self._td.name) / f"{name}.git"
+        subprocess.run(
+            ["git", "clone", "-q", "--bare", str(src), str(bare)],
+            check=True, capture_output=True, env=self._git_env,
+        )
+        return bare
+
+    def _set_url_registry(self, slug: str, url: str) -> None:
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| {slug} | {slug} | {url} | Remote proj | dev |\n",
+            encoding="utf-8",
+        )
+
+    def _build(self, *, task_id: str, slug: str = "newproj"):
+        return gdp.build_delegate_plan(
+            task_id=task_id,
+            project_slug=slug,
+            description="first dispatch",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+
+    def test_plan_records_pending_clone_and_canonical_worktree_layout(self):
+        bare = self._make_bare_remote("newproj")
+        self._set_url_registry("newproj", str(bare))
+        plan = self._build(task_id="np-plan")
+        # Legacy-direct is gone: worker_dir is the canonical worktree layout.
+        clone_target = (self.sb.workers / "newproj").resolve()
+        self.assertEqual(plan.layout.pattern, "A")
+        self.assertEqual(
+            Path(plan.layout.worker_dir),
+            (clone_target / ".worktrees" / "np-plan").resolve(),
+        )
+        self.assertIsNotNone(plan.base_repo)
+        self.assertEqual(Path(plan.base_repo).resolve(), clone_target)
+        # Pending clone points at the registered URL + canonical target.
+        self.assertIsNotNone(plan.pending_clone)
+        self.assertEqual(plan.pending_clone.url, str(bare))
+        self.assertEqual(
+            Path(plan.pending_clone.target).resolve(), clone_target
+        )
+        # Sandbox pattern flips to B (worktree carve-outs) like Issue #489.
+        self.assertEqual(plan.settings_args["pattern"], "B")
+        self.assertEqual(
+            plan.settings_args["base-clone"], str(clone_target)
+        )
+        # The render config's worker dir tracks the rewritten worktree path
+        # (not the pre-rewrite base-clone root), so the brief tells the worker
+        # to work in the worktree, and the rendered brief agrees.
+        self.assertEqual(
+            Path(plan.config["worker"]["dir"]),
+            (clone_target / ".worktrees" / "np-plan").resolve(),
+        )
+        brief = gwb.render(plan.config)
+        self.assertIn(
+            str((clone_target / ".worktrees" / "np-plan").resolve()), brief
+        )
+        self.assertNotIn(f"作業ディレクトリ: `{clone_target}`", brief)
+
+    def test_plan_is_pure_no_clone_placed(self):
+        bare = self._make_bare_remote("newproj")
+        self._set_url_registry("newproj", str(bare))
+        self._build(task_id="np-pure")
+        # build_delegate_plan must not clone — the target stays absent.
+        self.assertFalse((self.sb.workers / "newproj").exists())
+
+    def test_apply_clones_base_and_creates_worktree(self):
+        bare = self._make_bare_remote("newproj")
+        self._set_url_registry("newproj", str(bare))
+        plan = self._build(task_id="np-apply")
+        result = gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        clone_target = self.sb.workers / "newproj"
+        # The base clone was materialized as a real git repo.
+        self.assertTrue((clone_target / ".git").exists())
+        # The worktree is a real checkout (has a .git file) registered
+        # against the clone.
+        worker_dir = Path(plan.layout.worker_dir)
+        self.assertTrue(worker_dir.exists())
+        self.assertTrue((worker_dir / ".git").exists())
+        out = subprocess.check_output(
+            ["git", "-C", str(clone_target),
+             "worktree", "list", "--porcelain"],
+        ).decode("utf-8", errors="replace")
+        registered = {
+            Path(line[len("worktree "):].strip()).resolve()
+            for line in out.splitlines() if line.startswith("worktree ")
+        }
+        self.assertIn(worker_dir.resolve(), registered)
+        # Brief landed inside the worktree; the run is queued Pattern A.
+        self.assertTrue(result.brief_path.exists())
+        self.assertEqual(result.brief_path.parent.resolve(), worker_dir.resolve())
+        row = [r for r in self.sb.list_runs() if r["task_id"] == "np-apply"][0]
+        self.assertEqual(row["status"], "queued")
+        self.assertEqual(row["pattern"], "A")
+
+    def test_apply_is_idempotent_on_reapply(self):
+        bare = self._make_bare_remote("newproj")
+        self._set_url_registry("newproj", str(bare))
+        plan = self._build(task_id="np-idem")
+        gdp.apply_delegate_plan(
+            plan, state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root, skip_settings=True,
+        )
+        # Second apply must not re-clone or duplicate the worktree.
+        gdp.apply_delegate_plan(
+            plan, state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root, skip_settings=True,
+        )
+        clone_target = self.sb.workers / "newproj"
+        out = subprocess.check_output(
+            ["git", "-C", str(clone_target),
+             "worktree", "list", "--porcelain"],
+        ).decode("utf-8", errors="replace")
+        worktrees = [
+            line for line in out.splitlines() if line.startswith("worktree ")
+        ]
+        # main clone + the one task worktree = 2 entries, no duplicate.
+        self.assertEqual(len(worktrees), 2)
+
+    def test_apply_clone_failure_is_blocking_and_leaks_no_db_row(self):
+        # A bogus (non-existent) local repo path is a clone URL that git
+        # cannot resolve — hermetic, no network.
+        bogus = str(Path(self._td.name) / "does-not-exist.git")
+        self._set_url_registry("newproj", bogus)
+        plan = self._build(task_id="np-fail")
+        self.assertIsNotNone(plan.pending_clone)
+        with self.assertRaises(gdp.BaseCloneApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan, state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root, skip_settings=True,
+            )
+        self.assertIn("git clone", str(cm.exception))
+        # BaseCloneApplyError is a WorktreeApplyError subclass (callers that
+        # catch the base type keep working).
+        self.assertIsInstance(cm.exception, gdp.WorktreeApplyError)
+        # No queued row leaked (clone failed before the DB reservation).
+        self.assertFalse(
+            any(r["task_id"] == "np-fail" for r in self.sb.list_runs())
+        )
+
+    def test_apply_rejects_unrelated_repo_appearing_at_target(self):
+        # Race guard (Issue #370): a plan is built while the target is absent
+        # (pending clone), then an UNRELATED github-origin repo appears at
+        # workers/<slug>/ before apply. The idempotent-reuse path must revalidate
+        # the origin against the registered URL and refuse, not dispatch against
+        # the wrong repo. Registered URL is github so the origin gate is strict;
+        # apply never reaches a network clone because the target is a git repo.
+        self._set_url_registry(
+            "newproj", "https://github.com/suisya-systems/newproj.git"
+        )
+        plan = self._build(task_id="np-race")
+        self.assertIsNotNone(plan.pending_clone)
+        # An unrelated repo lands at the canonical target after planning.
+        target = self.sb.workers / "newproj"
+        target.mkdir(parents=True)
+        self._git(target, "init", "-q", "-b", "main")
+        self._git(target, "remote", "add", "origin",
+                  "https://github.com/some-other-org/unrelated.git")
+        with self.assertRaises(gdp.BaseCloneApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan, state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root, skip_settings=True,
+            )
+        self.assertIn("does not match", str(cm.exception))
+        self.assertFalse(
+            any(r["task_id"] == "np-race" for r in self.sb.list_runs())
+        )
+
+    def test_placeholder_dash_path_stays_legacy_direct_no_pending_clone(self):
+        # ``-`` is a placeholder, not a URL — must NOT trigger auto-clone
+        # (existing legacy-direct behavior preserved).
+        self._set_url_registry("newproj", "-")
+        plan = self._build(task_id="np-dash")
+        self.assertEqual(plan.layout.pattern, "A")
+        self.assertIsNone(plan.pending_clone)
+        self.assertIsNone(plan.base_repo)
+        self.assertEqual(
+            Path(plan.layout.worker_dir),
+            (self.sb.workers / "newproj").resolve(),
+        )
+
+    def test_url_registry_with_residue_stays_blocking_no_pending_clone(self):
+        # Residue in workers/<slug>/ must keep the Issue #489 BLOCKING path
+        # (auto-clone only fires into an empty/absent target).
+        bare = self._make_bare_remote("newproj")
+        self._set_url_registry("newproj", str(bare))
+        slug_dir = self.sb.workers / "newproj"
+        slug_dir.mkdir()
+        (slug_dir / "CLAUDE.md").write_text("old brief", encoding="utf-8")
+        (slug_dir / "send_plan.json").write_text("{}", encoding="utf-8")
+        plan = self._build(task_id="np-residue")
+        self.assertIsNone(plan.pending_clone)
+        self.assertIsNone(plan.base_repo)
+        self.assertTrue(plan.blocking_warnings)
+        self.assertTrue(
+            any("Pattern-A residue" in w for w in plan.blocking_warnings)
+        )
+
+    def test_unknown_slug_stays_ephemeral_c_no_pending_clone(self):
+        # No registry row at all → Pattern C ephemeral, never a pending clone.
+        plan = self._build(task_id="np-unknown", slug="totally-unregistered")
+        self.assertEqual(plan.layout.pattern, "C")
+        self.assertIsNone(plan.pending_clone)
+
+
+# ---------------------------------------------------------------------------
+# Issue #712: brief placement generalized to "repo tracks CLAUDE.md"
+# ---------------------------------------------------------------------------
+
+
+class TestIssue712BriefPlacement(unittest.TestCase):
+    """Issue #712: the worker brief must go to ``CLAUDE.local.md`` whenever the
+    repo the worker lands in already tracks a ``CLAUDE.md`` — not only for
+    self-edit — so the generated brief never clobbers the project's own
+    checked-in CLAUDE.md. The brief *template* stays normal (decoupled from
+    the placement)."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
+        import os
+        self._git_env = os.environ.copy()
+        self._git_env.update(
+            {
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _git(self, repo: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args], check=True, capture_output=True,
+            env=self._git_env,
+        )
+
+    # --- helper unit tests -------------------------------------------------
+
+    def test_repo_tracks_claude_md_helper(self):
+        repo = Path(self._td.name) / "r"
+        repo.mkdir()
+        self._git(repo, "init", "-q", "-b", "main")
+        # No CLAUDE.md yet.
+        self.assertFalse(gdp._repo_tracks_claude_md(repo))
+        (repo / "CLAUDE.md").write_text("proj\n", encoding="utf-8")
+        # Untracked file does not count.
+        self.assertFalse(gdp._repo_tracks_claude_md(repo))
+        self._git(repo, "add", "CLAUDE.md")
+        self._git(repo, "commit", "-q", "-m", "add claude")
+        self.assertTrue(gdp._repo_tracks_claude_md(repo))
+        # Non-git dir and absent dir → False (fail-safe).
+        plain = Path(self._td.name) / "plain"
+        plain.mkdir()
+        self.assertFalse(gdp._repo_tracks_claude_md(plain))
+        self.assertFalse(gdp._repo_tracks_claude_md(Path(self._td.name) / "nope"))
+
+    def test_resolve_brief_filename_rule(self):
+        repo = Path(self._td.name) / "r2"
+        repo.mkdir()
+        self._git(repo, "init", "-q", "-b", "main")
+        (repo / "CLAUDE.md").write_text("proj\n", encoding="utf-8")
+        self._git(repo, "add", "CLAUDE.md")
+        self._git(repo, "commit", "-q", "-m", "c")
+        # self_edit short-circuit → local regardless of repo contents.
+        self.assertEqual(
+            gdp._resolve_brief_filename(self_edit=True, repo_dir=Path("/nope")),
+            "CLAUDE.local.md",
+        )
+        # Non-self-edit but repo tracks CLAUDE.md → local (the #712 rule).
+        self.assertEqual(
+            gdp._resolve_brief_filename(self_edit=False, repo_dir=repo),
+            "CLAUDE.local.md",
+        )
+        # Non-self-edit, no tracked CLAUDE.md → plain.
+        empty = Path(self._td.name) / "empty"
+        empty.mkdir()
+        self._git(empty, "init", "-q", "-b", "main")
+        self.assertEqual(
+            gdp._resolve_brief_filename(self_edit=False, repo_dir=empty),
+            "CLAUDE.md",
+        )
+
+    # --- integration: existing local clone that tracks CLAUDE.md -----------
+
+    def test_pattern_b_local_repo_tracking_claude_md_uses_local_md(self):
+        # A registered LOCAL project repo that tracks CLAUDE.md, forced to
+        # Pattern B via an active run → base_repo is that repo → brief is
+        # placed at CLAUDE.local.md, but the brief *body* stays the normal
+        # (non-self-edit) template.
+        project_repo = Path(self._td.name) / "clock-repo"
+        project_repo.mkdir()
+        self._git(project_repo, "init", "-q", "-b", "main")
+        (project_repo / "CLAUDE.md").write_text(
+            "# project agent file\n", encoding="utf-8"
+        )
+        self._git(project_repo, "add", "CLAUDE.md")
+        self._git(project_repo, "commit", "-q", "-m", "seed")
+        self._git(project_repo, "update-ref",
+                  "refs/remotes/origin/HEAD", "refs/heads/main")
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| 時計 | clock-app | {project_repo} | Clock | - |\n",
+            encoding="utf-8",
+        )
+        self.sb.add_active_run(
+            task_id="prev-clock",
+            project_slug="clock-app",
+            worker_dir=str(self.sb.workers / "clock-app"),
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="clock-712",
+            project_slug="clock-app",
+            description="add feature",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertEqual(Path(plan.base_repo).resolve(), project_repo.resolve())
+        # #712: brief placed at CLAUDE.local.md because the base tracks CLAUDE.md.
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.local.md")
+        # Decoupled from the template: config self_edit stays False, so the
+        # rendered body is the normal brief (no in-place-edit directive).
+        self.assertFalse(plan.config["worker"]["self_edit"])
+        brief = gwb.render(plan.config)
+        self.assertNotIn("直接編集すること", brief)
+        # DELEGATE body advertises the CLAUDE.local.md path.
+        self.assertIn("CLAUDE.local.md", plan.delegate_body)
+
+    def test_pattern_b_local_repo_without_claude_md_uses_plain_md(self):
+        project_repo = Path(self._td.name) / "clock-repo2"
+        project_repo.mkdir()
+        self._git(project_repo, "init", "-q", "-b", "main")
+        (project_repo / "README.md").write_text("hi\n", encoding="utf-8")
+        self._git(project_repo, "add", "README.md")
+        self._git(project_repo, "commit", "-q", "-m", "seed")
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| 時計 | clock-app | {project_repo} | Clock | - |\n",
+            encoding="utf-8",
+        )
+        self.sb.add_active_run(
+            task_id="prev-clock2",
+            project_slug="clock-app",
+            worker_dir=str(self.sb.workers / "clock-app"),
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="clock-712b",
+            project_slug="clock-app",
+            description="add feature",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+
+    # --- interaction: #709 pending clone whose source tracks CLAUDE.md -----
+
+    def _make_bare_remote(self, name: str, *, claude_md: str | None) -> Path:
+        src = Path(self._td.name) / f"{name}-src"
+        src.mkdir()
+        self._git(src, "init", "-q", "-b", "main")
+        (src / "README.md").write_text("hi\n", encoding="utf-8")
+        if claude_md is not None:
+            (src / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
+        self._git(src, "add", "-A")
+        self._git(src, "commit", "-q", "-m", "init")
+        bare = Path(self._td.name) / f"{name}.git"
+        subprocess.run(
+            ["git", "clone", "-q", "--bare", str(src), str(bare)],
+            check=True, capture_output=True, env=self._git_env,
+        )
+        return bare
+
+    def _set_url_registry(self, slug: str, url: str) -> None:
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| {slug} | {slug} | {url} | Remote proj | dev |\n",
+            encoding="utf-8",
+        )
+
+    def test_pending_clone_brief_flips_to_local_when_source_tracks_claude_md(self):
+        bare = self._make_bare_remote(
+            "trackedproj", claude_md="# UPSTREAM PROJECT CLAUDE\n"
+        )
+        self._set_url_registry("trackedproj", str(bare))
+        plan = gdp.build_delegate_plan(
+            task_id="tracked-apply",
+            project_slug="trackedproj",
+            description="first dispatch",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        # At plan time the clone is absent → CLAUDE.md is the best guess.
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+        result = gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        worker_dir = Path(plan.layout.worker_dir)
+        # apply re-evaluated post-clone → brief moved to CLAUDE.local.md.
+        self.assertEqual(result.brief_path.name, "CLAUDE.local.md")
+        self.assertTrue((worker_dir / "CLAUDE.local.md").exists())
+        # The project's own tracked CLAUDE.md is intact (NOT clobbered).
+        tracked = worker_dir / "CLAUDE.md"
+        self.assertTrue(tracked.exists())
+        self.assertEqual(
+            tracked.read_text(encoding="utf-8"), "# UPSTREAM PROJECT CLAUDE\n"
+        )
+        # send_plan.json points the worker at the corrected file.
+        send_plan = json.loads(
+            result.send_plan_path.read_text(encoding="utf-8")
+        )
+        self.assertIn("CLAUDE.local.md", send_plan["message"])
+        self.assertNotIn("CLAUDE.md・設定配置済み", send_plan["message"])
+
+    def test_pending_clone_brief_stays_md_when_source_has_no_claude_md(self):
+        bare = self._make_bare_remote("plainproj", claude_md=None)
+        self._set_url_registry("plainproj", str(bare))
+        plan = gdp.build_delegate_plan(
+            task_id="plain-apply",
+            project_slug="plainproj",
+            description="first dispatch",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        result = gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        # No tracked CLAUDE.md in the source → brief stays CLAUDE.md.
+        self.assertEqual(result.brief_path.name, "CLAUDE.md")
+        self.assertTrue(
+            (Path(plan.layout.worker_dir) / "CLAUDE.md").exists()
+        )
 
 
 if __name__ == "__main__":

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -45,7 +45,7 @@ import re
 import shutil
 import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Optional
 
@@ -78,6 +78,19 @@ class WorktreeApplyError(RuntimeError):
     """
 
 
+class BaseCloneApplyError(WorktreeApplyError):
+    """Raised by ``apply`` when the Issue #709 base clone cannot be
+    materialized (``git clone`` failed — network / auth / bad URL — or the
+    target directory turned out to be non-empty and non-git).
+
+    Subclasses :class:`WorktreeApplyError` so existing ``except
+    WorktreeApplyError`` callers still catch it, while tests can assert the
+    more specific type. Like the worktree-creation errors, it fires BEFORE
+    any DB reservation, so it never leaks a ``queued`` run row; the message
+    is the BLOCKING stop-and-instruct-the-human surface the task calls for.
+    """
+
+
 class BlockingPreviewWarningError(RuntimeError):
     """Raised by ``apply`` when the plan carries one or more
     ``blocking_warnings`` (Issue #489 surface). Distinct from
@@ -100,6 +113,26 @@ _PATTERN_A_RESIDUE_FILENAMES: tuple[str, ...] = (
     "send_plan.json",
     ".claude",
 )
+
+
+@dataclass(frozen=True)
+class PendingClone:
+    """A base clone that ``apply`` must materialize before cutting the
+    worktree (Issue #709).
+
+    The planner sets this when a project is registered with a *remote URL*
+    (not a local path) and no local clone exists yet at the canonical
+    ``workers_dir/<slug>/`` location. ``build_delegate_plan`` stays pure —
+    it only records the intent — and ``apply`` runs ``git clone <url>
+    <target>`` (then ``git worktree add`` off the fresh clone). Without
+    this, a first dispatch onto a URL-only project left the worker in a
+    non-git ``workers_dir/<slug>/`` directory that had only the brief
+    files, so every git operation failed with a permission / not-a-repo
+    error (the 2026-07-16 real-world block this fix removes).
+    """
+
+    url: str
+    target: str
 
 
 @dataclass(frozen=True)
@@ -135,6 +168,16 @@ class DelegatePlan:
     # ``apply`` raises :class:`BlockingPreviewWarningError` rather than
     # touching the DB / filesystem.
     blocking_warnings: list[str] = field(default_factory=list)
+    # Issue #709: base clone ``apply`` must ``git clone`` before cutting the
+    # worktree (URL-only registered project, no local clone yet). None for
+    # every existing layout (clone already present, ``-`` placeholder,
+    # ephemeral C, self-edit). See :class:`PendingClone`.
+    pending_clone: Optional[PendingClone] = None
+    # Registry ``project.path`` for this slug (URL or local path), carried so
+    # ``apply`` can re-render the DELEGATE body if the post-clone brief
+    # placement flips to CLAUDE.local.md (Issue #712 interaction). None when
+    # the project has no registry row.
+    project_path: Optional[str] = None
 
     def to_summary_dict(self) -> dict[str, Any]:
         return {
@@ -154,6 +197,11 @@ class DelegatePlan:
             "base_repo": str(self.base_repo) if self.base_repo else None,
             "warnings": list(self.warnings),
             "blocking_warnings": list(self.blocking_warnings),
+            "pending_clone": (
+                {"url": self.pending_clone.url, "target": self.pending_clone.target}
+                if self.pending_clone is not None
+                else None
+            ),
         }
 
 
@@ -202,8 +250,89 @@ def _summarize_description(description: str, limit: int = 120) -> str:
     return one_line[: limit - 1].rstrip() + "…"
 
 
-def _brief_filename(self_edit: bool) -> str:
-    return "CLAUDE.local.md" if self_edit else "CLAUDE.md"
+def _repo_tracks_claude_md(repo_dir: Path) -> bool:
+    """True iff ``CLAUDE.md`` is a git-tracked file in ``repo_dir``.
+
+    Issue #712 general rule: when the repo a worker will land in already
+    tracks a ``CLAUDE.md`` (the project's own checked-in brief/agent file),
+    the generated worker brief MUST go to ``CLAUDE.local.md`` so it never
+    clobbers that tracked file — exactly the breakage that forced *this*
+    task's own brief onto ``CLAUDE.local.md`` after a manual recovery.
+
+    Fail-safe: returns ``False`` when ``repo_dir`` is absent, is not a git
+    repo, or git is unavailable, so non-git / ephemeral dirs fall through to
+    the plain ``CLAUDE.md`` name. This is a read-only probe (same class as
+    the resolver's ``git check-ignore`` Step 0.7 probe), so the planner
+    stays side-effect free.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_dir), "ls-files", "--error-unmatch",
+             "--", "CLAUDE.md"],
+            capture_output=True,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return proc.returncode == 0
+
+
+def _resolve_brief_filename(*, self_edit: bool, repo_dir: Path) -> str:
+    """Decide the worker brief filename (Issue #712 generalization).
+
+    Two independent signals push the brief to ``CLAUDE.local.md``:
+
+    - ``self_edit`` (the ``config["worker"]["self_edit"]`` flag, which also
+      covers the Pattern C ``gitignored_repo_root`` sub-mode) — the historical
+      trigger; and
+    - ``repo_dir`` already git-tracks a ``CLAUDE.md`` — the new general rule:
+      any project whose repo ships its own CLAUDE.md, not just self-edit.
+
+    The two are decoupled from the brief *template* selection (still driven
+    by ``self_edit`` inside :func:`tools.gen_worker_brief.render`): a normal
+    project that merely happens to track a CLAUDE.md gets the *normal* brief
+    body, only written under the ``.local.md`` name.
+    """
+    if self_edit or _repo_tracks_claude_md(repo_dir):
+        return "CLAUDE.local.md"
+    return "CLAUDE.md"
+
+
+def _is_clone_url(path: Optional[str]) -> bool:
+    """True iff a registry ``project.path`` is a remote/clonable URL rather
+    than a local git repo or a ``-`` placeholder (Issue #709).
+
+    A local *working* git repo (``is_local_git_repo`` True) is handled by the
+    existing local-path base derivation and is not a clone URL. ``-`` / empty
+    are placeholders that stay on the legacy direct layout (no URL to clone).
+    Everything else — https / ssh / scp-style / ``file://`` / a local *bare*
+    repo used as an origin (the hermetic-test stand-in for a real remote) —
+    is treated as clonable; ``git clone`` itself validates it at apply time.
+    """
+    if not path or path.strip() in ("", "-"):
+        return False
+    return not rwl.is_local_git_repo(path)
+
+
+def _dir_is_empty_or_absent(path: Path) -> bool:
+    """True iff ``path`` does not exist or is an empty directory.
+
+    The Issue #709 safety gate: apply only auto-clones a base into
+    ``workers_dir/<slug>/`` when nothing is there yet. A directory holding
+    any entry (Pattern-A residue, loose notes, a partial clone) is left to
+    the existing residue-BLOCKING / legacy-direct handling so auto-clone
+    never clobbers pre-existing content.
+    """
+    if not path.exists():
+        return True
+    if not path.is_dir():
+        return False
+    try:
+        next(iter(path.iterdir()))
+    except StopIteration:
+        return True
+    except OSError:
+        return False
+    return False
 
 
 def _has_pattern_a_residue(workers_slug_dir: Path) -> bool:
@@ -413,8 +542,6 @@ def build_delegate_plan(
     )
 
     self_edit = bool(config["worker"]["self_edit"])
-    brief_filename = _brief_filename(self_edit)
-    brief_out_path = Path(layout.worker_dir) / brief_filename
 
     # Issue #370: the claude-org mirror's registry-display alias
     # ``claude-org-en`` (the 通称 column) and the canonical project slug
@@ -444,21 +571,6 @@ def build_delegate_plan(
         match = rwl.find_project(rows, project_slug)
         if match is not None:
             project_path = match.path
-
-    delegate_body = _format_delegate_body(
-        layout=layout,
-        task_id=task_id,
-        description=description,
-        project_path=project_path,
-        permission_mode=permission_mode,
-        verification_depth=verification_depth,
-        brief_filename=brief_filename,
-    )
-
-    artifacts = [
-        brief_out_path,
-        Path(layout.worker_dir) / ".claude" / "settings.local.json",
-    ]
 
     # Pattern B: figure out which repo `git worktree add` should be run from.
     # live_repo_worktree → Secretary's live claude-org repo;
@@ -530,6 +642,87 @@ def build_delegate_plan(
                 project_slug, project_path, Path(workers_dir_for_norm)
             )
 
+    # Issue #709: URL-only registered project, first dispatch, no local clone.
+    # The resolver landed on the legacy Pattern A direct path
+    # (``workers_dir/<slug>/``) because no clone was found — but the registry
+    # carries a *remote URL*, so the fix is to materialize the canonical base
+    # clone at apply time and route the worker into
+    # ``<clone>/.worktrees/<task>/`` (the Issue #489 unified layout), instead
+    # of dropping the brief into a non-git directory the worker can't commit
+    # from. We only *plan* the clone here (pure); ``apply`` runs ``git clone``.
+    #
+    # Gates (each preserves an existing behavior):
+    #   - ``base_repo is None``  → an already-detected clone (canonical /
+    #     legacy ``_repo_clone`` / registered local path) is reused unchanged.
+    #   - ``pattern == "A"``     → Pattern B without a base still fails loudly
+    #     in ``_ensure_worktree`` (that surface is intentional); a brand-new
+    #     project has no active run so it always resolves to Pattern A anyway.
+    #   - ``_is_clone_url``      → ``-`` / empty placeholders and local-path
+    #     rows stay on the legacy direct layout (no URL to clone).
+    #   - worker_dir == target AND empty/absent → residue in
+    #     ``workers_dir/<slug>/`` keeps the existing Issue #489 residue-BLOCKING
+    #     / legacy handling; auto-clone never clobbers pre-existing content.
+    pending_clone: Optional[PendingClone] = None
+    if (
+        layout.pattern == "A"
+        and base_repo is None
+        and _is_clone_url(project_path)
+    ):
+        clone_target = (Path(workers_dir_for_norm) / project_slug).resolve()
+        try:
+            wd_resolved = Path(layout.worker_dir).resolve()
+        except OSError:
+            wd_resolved = Path(layout.worker_dir)
+        if wd_resolved == clone_target and _dir_is_empty_or_absent(clone_target):
+            new_worker_dir = (clone_target / ".worktrees" / task_id).resolve()
+            new_settings = dict(layout.settings_args)
+            new_settings["worker-dir"] = str(new_worker_dir)
+            new_settings["out"] = str(
+                new_worker_dir / ".claude" / "settings.local.json"
+            )
+            layout = replace(
+                layout,
+                worker_dir=str(new_worker_dir),
+                settings_args=new_settings,
+            )
+            # Keep the render config in lock-step: the brief template renders
+            # ``${worker_dir}`` from ``config["worker"]["dir"]`` (built above
+            # off the pre-rewrite layout). Without this the generated brief
+            # would tell the worker to work in the old non-git base-clone root
+            # instead of the worktree we route them into (Codex review).
+            config["worker"]["dir"] = str(new_worker_dir)
+            base_repo = clone_target
+            pending_clone = PendingClone(
+                url=project_path, target=str(clone_target)  # type: ignore[arg-type]
+            )
+
+    # Issue #712: brief placement is a general rule now — CLAUDE.local.md when
+    # self_edit OR the repo the worker lands in already tracks a CLAUDE.md.
+    # Check the base clone for worktree layouts (the worktree inherits the
+    # clone's tracked files) and the worker_dir itself otherwise. For a
+    # pending clone the base isn't cloned yet, so this returns CLAUDE.md now
+    # and ``apply`` re-evaluates against the freshly checked-out worktree.
+    brief_repo_dir = base_repo if base_repo is not None else Path(layout.worker_dir)
+    brief_filename = _resolve_brief_filename(
+        self_edit=self_edit, repo_dir=brief_repo_dir
+    )
+    brief_out_path = Path(layout.worker_dir) / brief_filename
+
+    delegate_body = _format_delegate_body(
+        layout=layout,
+        task_id=task_id,
+        description=description,
+        project_path=project_path,
+        permission_mode=permission_mode,
+        verification_depth=verification_depth,
+        brief_filename=brief_filename,
+    )
+
+    artifacts = [
+        brief_out_path,
+        Path(layout.worker_dir) / ".claude" / "settings.local.json",
+    ]
+
     # Phase 1 PR4: surface base_clone into settings_args for Pattern B so the
     # runtime can substitute `{base_clone}` in
     # `worker_roles.<role>.sandbox_by_pattern.B.filesystem`. resolve_worker_layout
@@ -587,6 +780,8 @@ def build_delegate_plan(
         base_repo=base_repo,
         warnings=warnings,
         blocking_warnings=blocking_warnings,
+        pending_clone=pending_clone,
+        project_path=project_path,
     )
 
 
@@ -796,6 +991,107 @@ def _is_registered_worktree(base_repo: Path, worker_dir: Path) -> bool:
             if p == target:
                 return True
     return False
+
+
+def _ensure_base_clone(plan: DelegatePlan) -> None:
+    """Materialize the Issue #709 pending base clone before the worktree.
+
+    No-op unless ``plan.pending_clone`` is set (URL-only registered project,
+    first dispatch, no local clone yet). Runs ``git clone <url> <target>`` so
+    the subsequent :func:`_ensure_worktree` has a real local base to
+    ``git worktree add`` from — instead of dropping the brief into a non-git
+    ``workers_dir/<slug>/`` directory the worker cannot commit from.
+
+    Idempotent: if ``target`` is already a git repo (a partial-retry re-run),
+    returns quietly. Fails closed (:class:`BaseCloneApplyError`) when the
+    clone cannot complete or the target is non-empty and non-git — the
+    BLOCKING stop-and-instruct surface. Runs BEFORE any DB reservation, so an
+    abort leaks no ``queued`` run row.
+    """
+    pc = plan.pending_clone
+    if pc is None:
+        return
+    target = Path(pc.target)
+    if rwl.is_local_git_repo(str(target)):
+        # Idempotent re-run — but only when the repo already sitting at the
+        # target is genuinely the intended clone. Validate its origin against
+        # the registered URL exactly like the mainline discovery path
+        # (``find_workers_dir_clone`` → ``_origin_matches_registered``), so a
+        # different repo that appeared at ``workers/<slug>/`` between plan and
+        # apply cannot silently redirect dispatch at the wrong project
+        # (Issue #370 precedent for "別 repo への誤派遣").
+        if rwl._origin_matches_registered(target, pc.url):
+            return
+        raise BaseCloneApplyError(
+            f"pending base clone target {target} is already a git repo, but "
+            f"its origin does not match the registered clone URL {pc.url!r} "
+            f"for project {plan.project_slug!r}. Refusing to dispatch against "
+            f"a possibly-unrelated repo (Issue #370). Secretary must reconcile "
+            f"the directory (remove it to re-clone, or fix its origin) and "
+            f"retry apply."
+        )
+    if target.exists() and any(target.iterdir()):
+        raise BaseCloneApplyError(
+            f"pending base clone target {target} exists with content but is "
+            f"not a git repo; refusing to `git clone` into it. Secretary must "
+            f"clean the directory (or clone {pc.url} there manually) and retry."
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        ["git", "clone", pc.url, str(target)], capture_output=True
+    )
+    if proc.returncode != 0:
+        stderr = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise BaseCloneApplyError(
+            f"`git clone {pc.url}` into {target} failed (rc={proc.returncode}): "
+            f"{stderr}. The registry registers {plan.project_slug!r} with a "
+            f"remote URL but no local clone exists yet, so apply attempted the "
+            f"canonical base clone and could not complete it (network / auth / "
+            f"bad URL?). Fix connectivity or clone the base manually at "
+            f"{target} and retry apply."
+        )
+
+
+def _finalize_pending_clone_brief(plan: DelegatePlan) -> DelegatePlan:
+    """Re-evaluate brief placement after a pending clone materialized.
+
+    At plan time the Issue #709 clone did not exist, so
+    :func:`build_delegate_plan` defaulted the brief name to ``CLAUDE.md``. Now
+    that the worktree is checked out we can apply the Issue #712 general rule
+    against real contents: if the freshly cloned repo tracks a ``CLAUDE.md``,
+    move the brief to ``CLAUDE.local.md`` (and re-render the DELEGATE body so
+    ``send_plan.json`` points the worker at the right file) rather than
+    clobbering the project's own tracked CLAUDE.md.
+
+    No-op for non-pending plans, for plans that already chose
+    ``CLAUDE.local.md`` (self-edit), or when the clone tracks no CLAUDE.md.
+    """
+    if plan.pending_clone is None:
+        return plan
+    if plan.brief_out_path.name != "CLAUDE.md":
+        return plan
+    worker_dir = Path(plan.layout.worker_dir)
+    if not _repo_tracks_claude_md(worker_dir):
+        return plan
+    new_brief = worker_dir / "CLAUDE.local.md"
+    new_body = _format_delegate_body(
+        layout=plan.layout,
+        task_id=plan.task_id,
+        description=plan.description,
+        project_path=plan.project_path,
+        permission_mode=plan.permission_mode,
+        verification_depth=plan.verification_depth,
+        brief_filename="CLAUDE.local.md",
+    )
+    return replace(
+        plan,
+        brief_out_path=new_brief,
+        delegate_body=new_body,
+        artifacts_to_create=[
+            new_brief,
+            worker_dir / ".claude" / "settings.local.json",
+        ],
+    )
 
 
 def _ensure_worktree(plan: DelegatePlan) -> None:
@@ -1090,12 +1386,23 @@ def apply_delegate_plan(
             "apply refused: preview emitted blocking warnings:\n  - "
             + "\n  - ".join(plan.blocking_warnings)
         )
+    # Issue #709: materialize the base clone FIRST for a URL-only registered
+    # project's first dispatch (no local clone yet). Runs before the worktree
+    # add and before any DB write, so a clone failure leaks no queued row.
+    # No-op unless the plan carries a pending clone.
+    _ensure_base_clone(plan)
     # Issue #309: create the worktree FIRST. If this fails (dirty dir,
     # git error, etc.) we must not leak a `runs.status='queued'` row,
     # because resolve_worker_layout treats `queued` as an active run and
     # would silently steer the next delegation onto another Pattern B
-    # branch (Codex Major 2026-05-06). No-op for Pattern A / C.
+    # branch (Codex Major 2026-05-06). No-op for Pattern A / C without a
+    # base clone; fires for the Issue #709 pending-clone worktree too.
     _ensure_worktree(plan)
+    # Issue #712 interaction: with the clone now checked out, re-evaluate the
+    # brief placement against real contents (a pending clone couldn't be
+    # inspected at plan time). May flip brief_out_path / delegate_body to
+    # CLAUDE.local.md; a no-op for every non-pending plan.
+    plan = _finalize_pending_clone_brief(plan)
     db_reservation = _reserve_in_db(
         plan, state_db_path=state_db_path, claude_org_root=claude_org_root
     )


### PR DESCRIPTION
## 概要

conveyor 実運用 (2026-07-16) で顕在化した払い出し機構の2バグを修正する。

**#709 — 基底 clone 自動配置**: registry Path が URL の新規プロジェクト初回 apply で、基底 clone を `workers/<slug>/` に配置してから canonical worktree を切る (plan が PendingClone を計画 → apply が実体化 → 再評価の3段構成; resolver の純粋性は維持)。従来は非 git dir に brief だけ置いてワーカーが即ブロッカー化していた。clone 失敗 / origin 不一致 (#370 の別 repo 誤派遣対策、mainline discovery と同一 trust gate) は DB 予約前に BLOCKING 停止。

**#712 — brief 配置の一般則化**: 「worker が入る repo に tracked CLAUDE.md があれば brief は常に CLAUDE.local.md へ」を独立ルール化 (self-edit 判定の拡張ではない)。ja 本家の Pattern A worktree で毎回 tracked CLAUDE.md (Secretary 指示文書) をブリーフが上書き破壊していた恒常バグの根治。pending clone の場合は checkout 後に再評価して切替え。

既存挙動 (残渣 BLOCKING / legacy direct / エフェメラル C / 既存 reuse / URL-only Pattern B) は全て不変。

Closes #709
Closes #712

## Test plan

- 新規テスト群 TestIssue709BaseCloneMaterialization / TestIssue712BriefPlacement (hermetic: ローカル bare repo を URL 代用)
- tests/ 722 + tools/ 643 全 green
- Codex review 3 rounds: R1 worker_dir 不同期 (Major) 修正 → R2 reuse の origin 未検証 (Major) 修正 → R3 コード指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8D1zUapGLsfDiDjn9UHy8