### PR TITLE
fix(claude): _CLAUDE_ORG_REPO_NAMES に 'claude-org' を追加 — EN ミラー clone での self-edit 誤分類を修正

### DIFF
--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -355,6 +355,31 @@ class TestRoleDetection(unittest.TestCase):
         self.assertEqual(layout.role, "claude-org-self-edit")
         self.assertTrue(layout.self_edit)
 
+    def test_claude_org_self_edit_role_for_en_mirror_origin(self):
+        """EN mirror clones carry an ``origin`` named ``claude-org`` (no
+        ``-ja`` suffix), while the self-edit task still runs under the
+        canonical ``claude-org-ja`` slug. Self-edit detection must recognize
+        that origin repo name too, else EN self-edit tasks misclassify as
+        ephemeral Pattern C and need a manual override (observed in the EN
+        v1.0.0 release). Build a fresh sandbox whose git origin is the EN
+        mirror URL."""
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        sb = _Sandbox(Path(td.name))
+        _Sandbox.init_git_with_origin(
+            sb.claude_org_root,
+            "https://github.com/suisya-systems/claude-org.git",
+        )
+        layout = rwl.resolve(
+            task_id="t-en",
+            project_slug="claude-org-ja",
+            mode="edit",
+            claude_org_root=sb.claude_org_root,
+            state_db_path=sb.db_path,
+        )
+        self.assertEqual(layout.role, "claude-org-self-edit")
+        self.assertTrue(layout.self_edit)
+
     def test_audit_mode_forces_doc_audit_even_for_claude_org(self):
         layout = rwl.resolve(
             task_id="t-3",

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -266,7 +266,7 @@ _CLAUDE_ORG_SELF_EDIT_SLUG = "claude-org-ja"
 # ``git@github.com:<user>/claude-org-ja.git``), not at suisya-systems'.
 # Tuple constant so adding additional self-edit repo names is a one-line
 # change.
-_CLAUDE_ORG_REPO_NAMES: tuple[str, ...] = ("claude-org-ja",)
+_CLAUDE_ORG_REPO_NAMES: tuple[str, ...] = ("claude-org-ja", "claude-org")
 
 # Capture <owner>/<repo> from common github URL forms:
 #   https://github.com/owner/repo(.git)


### PR DESCRIPTION
## 概要

EN ミラー (origin 名 `claude-org`) の clone 上で self-edit タスクがエフェメラル Pattern C に誤分類され手動 override が必要だった問題 (EN v1.0.0 リリースで実害確認、suisya-systems/claude-org#489 の tooling 項) の修正。判定定数に `claude-org` を追加し、ja 側 (origin 名 `claude-org-ja`) の既存判定は不変。

この変更は auto-mirror で EN 側 tools/ にも流れる。

Refs suisya-systems/claude-org#489

## Test plan

- tests/test_resolve_worker_layout.py に claude-org origin ケースを追加 (+25行)
- 既存判定の後方互換をテストで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8D1zUapGLsfDiDjn9UHy8