### PR TITLE
fix(claude): pr_watch 起動直後に PR の絶対状態を一括評価 — 起動前完了 CI の indeterminate 落ちを解消

### DIFF
--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -13,6 +13,17 @@ Behavior:
 
 * Resolves the repo via ``gh repo view --json nameWithOwner`` when
   ``--repo`` is omitted.
+* Issue #719: BEFORE the transition-observing watch loop, evaluates the
+  PR's absolute CI state once via ``gh pr view --json statusCheckRollup``
+  (:func:`_evaluate_startup_state`). When CI already finished before the
+  watcher spawned — every check terminal — it records ``ci_completed``
+  (passed/failed) immediately and proceeds to merge-watch, instead of
+  waiting for a running→completed transition that already happened. Such
+  already-decided PRs previously degraded to a ~306s ``indeterminate``
+  via the empty-race resolver handoff (5x reproduced 2026-07-16). A
+  non-terminal / empty / unreadable startup rollup falls through to the
+  existing self-poll path below (additive, not a replacement), and
+  ``indeterminate`` stays reserved for a *continued* fetch failure.
 * Issue #695: watches CI via a **self-poll loop** over
   ``gh pr checks <PR> --json bucket,state,name`` (:func:`_fetch_checks`
   / :func:`_self_poll_watch`) at ``--interval`` cadence, instead of
@@ -557,6 +568,161 @@ def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
     return [c for c in data if isinstance(c, dict)]
 
 
+def _rollup_entry_bucket(entry: dict) -> str:
+    """Map one ``gh pr view --json statusCheckRollup`` node to a
+    ``gh pr checks``-style bucket (Issue #719).
+
+    ``statusCheckRollup`` returns two node shapes:
+
+    * ``CheckRun`` (GitHub Actions / app check) — keyed on ``status`` (the
+      lifecycle: ``QUEUED`` / ``IN_PROGRESS`` / ``COMPLETED`` / ``PENDING``
+      / ``WAITING`` / ``REQUESTED``) plus ``conclusion`` (the result once
+      ``COMPLETED``: ``SUCCESS`` / ``FAILURE`` / ``SKIPPED`` / ``NEUTRAL``
+      / ``CANCELLED`` / ``TIMED_OUT`` / ``ACTION_REQUIRED`` /
+      ``STARTUP_FAILURE`` / ``STALE``).
+    * ``StatusContext`` (legacy commit status) — keyed on ``state``
+      (``SUCCESS`` / ``FAILURE`` / ``ERROR`` / ``PENDING`` / ``EXPECTED``).
+
+    Both are normalized into the same ``pass`` / ``skipping`` / ``fail`` /
+    ``pending`` vocabulary :func:`_summarize_checks` already classifies, so
+    the startup evaluation reuses that tested aggregation verbatim. Any
+    node we cannot read conclusively degrades to ``pending`` (conservative:
+    never fabricate a ``pass``, fall through to the polling path instead).
+    """
+    # StatusContext: a single `state` field.
+    state = (entry.get("state") or "").upper()
+    if state:
+        if state == "SUCCESS":
+            return "pass"
+        if state in ("FAILURE", "ERROR"):
+            return "fail"
+        # PENDING / EXPECTED / anything unrecognized → not yet decided.
+        return "pending"
+    # CheckRun: `status` (lifecycle) + `conclusion` (result once COMPLETED).
+    status = (entry.get("status") or "").upper()
+    if status and status != "COMPLETED":
+        # QUEUED / IN_PROGRESS / PENDING / WAITING / REQUESTED → running.
+        return "pending"
+    conclusion = (entry.get("conclusion") or "").upper()
+    if conclusion == "SUCCESS":
+        return "pass"
+    if conclusion in ("SKIPPED", "NEUTRAL"):
+        return "skipping"
+    if conclusion in ("FAILURE", "CANCELLED", "TIMED_OUT",
+                      "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"):
+        return "fail"
+    # COMPLETED with an empty / unknown conclusion, or a node we cannot
+    # read at all → conservatively "not yet decided".
+    return "pending"
+
+
+def _summarize_rollup(rollup: "list[dict]") -> "tuple[str, int, int, int]":
+    """Aggregate a ``statusCheckRollup`` list into
+    ``(status, fail_count, pending_count, total)`` (Issue #719).
+
+    Delegates to :func:`_summarize_checks` after normalizing each rollup
+    node to a synthetic ``bucket`` (see :func:`_rollup_entry_bucket`), so
+    the startup evaluation and the ``gh pr checks`` polling path classify
+    identically.
+    """
+    return _summarize_checks(
+        [{"bucket": _rollup_entry_bucket(e)}
+         for e in rollup if isinstance(e, dict)]
+    )
+
+
+def _fetch_status_rollup(pr: int, repo: str) -> "list[dict] | None":
+    """Return the PR's aggregate ``statusCheckRollup``, or ``None`` (Issue #719).
+
+    Reads the PR's *absolute* CI state in one shot via
+    ``gh pr view <pr> --json statusCheckRollup`` — the aggregate of every
+    check run + commit status attached to the head commit. This is the
+    whole-state snapshot the startup evaluation consults, distinct from the
+    incremental ``gh pr checks`` probe the self-poll loop uses: on a PR
+    whose CI finished *before* the watcher spawned, ``gh pr checks`` can
+    momentarily report "no checks reported" (an empty / unparseable probe)
+    while the rollup already carries the decided verdict, which is exactly
+    the race that degraded such PRs to a ~306s ``indeterminate``.
+
+    Best-effort: any gh / parse failure (binary missing, non-zero exit
+    with no JSON, unparseable stdout, unexpected shape) degrades to
+    ``None`` so the caller falls through to the existing polling path
+    rather than aborting.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr), "--repo", repo,
+             "--json", "statusCheckRollup"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
+            check=False,
+        )
+    except OSError:
+        return None
+    try:
+        # ``ValueError`` covers json.JSONDecodeError; ``TypeError`` covers a
+        # non-string stdout (e.g. a Mock in tests that don't stub this call).
+        data = json.loads(result.stdout or "")
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    rollup = data.get("statusCheckRollup")
+    if not isinstance(rollup, list):
+        return None
+    return [e for e in rollup if isinstance(e, dict)]
+
+
+def _evaluate_startup_state(pr: int, repo: str) -> "dict | None":
+    """One-shot absolute-state evaluation run before the watch loop (Issue #719).
+
+    The self-poll loop is transition-oriented: it watches CI move from
+    running to completed. When the watcher spawns *after* CI already
+    finished there is no such transition left to observe, and an empty /
+    unparseable first ``gh pr checks`` probe used to hand off to the
+    bounded empty-race resolver — which, when the probe never became
+    parseable, degraded to a ~306s ``indeterminate`` even though the
+    verdict was already decided (5x reproduced 2026-07-16:
+    en#504/505/506, ja#718, en#509).
+
+    This reads the PR's aggregate status check rollup once and, when every
+    check has ALREADY reached a terminal state, returns a decided verdict
+    (same shape as :func:`_resolve_final_status`) so the caller records
+    ``ci_completed`` (passed/failed) immediately and proceeds to
+    merge-watch. It returns ``None`` — "no terminal verdict at startup,
+    use the existing polling path" — when the rollup is unreadable (a fetch
+    failure), empty (no checks visible yet), or still has at least one
+    pending check. That keeps the change strictly additive: a non-terminal
+    or unobservable startup state behaves exactly as before, and
+    ``indeterminate`` stays reserved for a *continued* fetch failure
+    (distinguished from this completed-observation short-circuit).
+    """
+    rollup = _fetch_status_rollup(pr, repo)
+    if not rollup:
+        # None (fetch failure) or [] (no checks visible yet): not a
+        # terminal observation. Defer to the self-poll + resolver path,
+        # which owns the freshly-created-PR empty-race and the continued
+        # fetch-failure → indeterminate classification.
+        return None
+    status, fail_count, pending_count, total = _summarize_rollup(rollup)
+    if pending_count:
+        # At least one check still running: let the self-poll loop observe
+        # the transition to completion (existing behavior, unchanged).
+        return None
+    # Every check is already decided (pass / skipping / fail / cancel) →
+    # record the verdict now instead of waiting for a transition that
+    # already happened. `status` here is only ever `passed` or `failed`
+    # (an empty rollup / any pending check returned None above).
+    return {
+        "status": status,
+        "fail_count": fail_count,
+        "pending_count": pending_count,
+        "total_checks": total,
+        "probe_attempts": 1,
+    }
+
+
 def _resolve_final_status(
     pr: int,
     repo: str,
@@ -1052,6 +1218,18 @@ def _run_ci_watch_phase(
     canceled = False
     verdict: "dict | None" = None
     try:
+        # Issue #719: startup absolute-state evaluation. BEFORE entering
+        # the transition-observing self-poll loop, read the PR's aggregate
+        # status check rollup once. If CI already finished before the
+        # watcher spawned (every check terminal), record that verdict
+        # immediately instead of waiting for a running→completed
+        # transition that already happened — which otherwise degraded such
+        # PRs to a ~306s `indeterminate` via the empty-race resolver
+        # handoff. A non-terminal / empty / unreadable startup state
+        # returns None and falls through to the existing self-poll +
+        # resolver path below, unchanged (additive, not a replacement).
+        verdict = _evaluate_startup_state(pr, repo)
+        #
         # Issue #695: self-poll replaces the blocking `gh pr checks
         # --watch` subprocess. Raises KeyboardInterrupt on SIGINT, same
         # as the previous blocking subprocess.run(cmd) did.
@@ -1076,7 +1254,10 @@ def _run_ci_watch_phase(
         # response at all); whenever real, still-pending check rows are
         # observed, hand control back to the unbounded self-poll loop
         # instead of giving up.
-        while True:
+        #
+        # Issue #719: skipped entirely when the startup evaluation above
+        # already produced a terminal verdict (CI was done before spawn).
+        while verdict is None:
             verdict = _self_poll_watch(pr, repo, interval)
             if verdict is not None:
                 break
@@ -1094,6 +1275,7 @@ def _run_ci_watch_phase(
                 # Real, still-pending checks exist -- not an empty-race
                 # artifact, and not fully decided even if a sibling
                 # check already failed. Resume unbounded polling.
+                verdict = None
                 continue
             break
     except KeyboardInterrupt:

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -1122,6 +1122,7 @@ class Issue685Tests(unittest.TestCase):
             return real_resolve(*args, **kwargs)
 
         with mock.patch.object(pr_watch, "_fetch_head_oid", return_value=None), \
+             mock.patch.object(pr_watch, "_evaluate_startup_state", return_value=None), \
              mock.patch.object(pr_watch, "_self_poll_watch", return_value=None), \
              mock.patch.object(pr_watch, "_resolve_final_status", side_effect=spy), \
              mock.patch.object(pr_watch, "_fetch_checks", return_value=[]), \
@@ -1456,6 +1457,19 @@ class MergeWatchTests(unittest.TestCase):
                     and "--json" in cmd
                     and cmd[cmd.index("--json") + 1] == "headRefOid"):
                 return mock.Mock(returncode=0, stdout="{}", stderr="")
+            # Issue #719 startup probe: `gh pr view <pr> --json
+            # statusCheckRollup`. Return an empty rollup so
+            # `_evaluate_startup_state` defers to the self-poll path
+            # WITHOUT consuming a view_sequence entry (these fixtures drive
+            # the CI verdict through `gh pr checks`, not the rollup).
+            if (cmd[:3] == ["gh", "pr", "view"]
+                    and "--json" in cmd
+                    and cmd[cmd.index("--json") + 1] == "statusCheckRollup"):
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps({"statusCheckRollup": []}),
+                    stderr="",
+                )
             # Merge-watch probe: `gh pr view <pr> --json number,url,...`
             if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
                 idx = view_idx["i"]
@@ -2049,6 +2063,17 @@ class HeadPollLoopbackTests(unittest.TestCase):
                             stdout=json.dumps({"headRefOid": oid}),
                             stderr="",
                         )
+                    if jval == "statusCheckRollup":
+                        # Issue #719 startup probe: empty rollup so
+                        # `_evaluate_startup_state` defers to the self-poll
+                        # path WITHOUT consuming an mw_seq entry (this
+                        # fixture drives the verdict + head loopback through
+                        # `gh pr checks` + headRefOid, not the rollup).
+                        return mock.Mock(
+                            returncode=0,
+                            stdout=json.dumps({"statusCheckRollup": []}),
+                            stderr="",
+                        )
                     # merge-watch poll (long --json field list).
                     i = mw_calls["i"]
                     payload = mw_seq[i] if i < len(mw_seq) else mw_seq[-1]
@@ -2546,6 +2571,216 @@ class WatchAbortedTests(unittest.TestCase):
             self.assertEqual(len(rows), 1)
             self.assertEqual(rows[0]["pr"], 5)
             self.assertIn("RuntimeError", rows[0]["error"])
+
+
+class StartupStateEvalTests(unittest.TestCase):
+    """Issue #719: the startup absolute-state evaluation.
+
+    When the watcher spawns *after* CI already finished, there is no
+    running→completed transition left to observe. Before entering the
+    self-poll loop, `_evaluate_startup_state` reads the PR's aggregate
+    `gh pr view --json statusCheckRollup` once; if every check is already
+    terminal it records `ci_completed` (passed/failed) immediately instead
+    of degrading to a ~306s `indeterminate` via the empty-race resolver
+    handoff (5x reproduced 2026-07-16: en#504/505/506, ja#718, en#509).
+
+    Four systems: startup already-passed / already-failed /
+    running→completed / continued fetch-failure.
+    """
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    @staticmethod
+    def _fake_run(
+        *,
+        rollup_stdout: "str | None",
+        rollup_returncode: int = 0,
+        checks_sequence: "list | None" = None,
+        checks_raises: "Exception | None" = None,
+        checks_calls: "list | None" = None,
+    ):
+        """Build a `subprocess.run` stub for the startup-eval tests.
+
+        * `gh pr view --json number` → PR exists.
+        * `gh pr view --json headRefOid` → `{}` (head detection off).
+        * `gh pr view --json statusCheckRollup` → `rollup_stdout`
+          (``None`` simulates an unparseable / no-checks probe).
+        * `gh pr checks --json ...` → next entry of `checks_sequence`
+          (last entry reused), or raises `checks_raises`. Each such call
+          is appended to `checks_calls` so a test can assert whether the
+          polling path ran at all.
+        """
+        idx = {"i": 0}
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
+                jval = cmd[cmd.index("--json") + 1]
+                if jval == "number":
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if jval == "headRefOid":
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if jval == "statusCheckRollup":
+                    return mock.Mock(
+                        returncode=rollup_returncode,
+                        stdout="" if rollup_stdout is None else rollup_stdout,
+                        stderr="",
+                    )
+            if "checks" in cmd and "--json" in cmd:
+                if checks_calls is not None:
+                    checks_calls.append(list(cmd))
+                if checks_raises is not None:
+                    raise checks_raises
+                seq = checks_sequence or [[]]
+                i = idx["i"]
+                payload = seq[i] if i < len(seq) else seq[-1]
+                if i < len(seq) - 1:
+                    idx["i"] = i + 1
+                return mock.Mock(
+                    returncode=_gh_exit_for_payload(payload),
+                    stdout=json.dumps(payload),
+                    stderr="",
+                )
+            return mock.Mock(returncode=0)
+
+        return fake_run
+
+    def test_startup_already_passed_records_immediately(self) -> None:
+        """A rollup that is entirely terminal + green at spawn records
+        `passed` immediately, WITHOUT ever polling `gh pr checks` (proving
+        the transition-observation path was short-circuited)."""
+        rollup = {"statusCheckRollup": [
+            {"__typename": "CheckRun", "name": "build",
+             "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"__typename": "CheckRun", "name": "lint",
+             "status": "COMPLETED", "conclusion": "SKIPPED"},
+            {"__typename": "StatusContext", "context": "ci/legacy",
+             "state": "SUCCESS"},
+        ]}
+        checks_calls: list = []
+        fake_run = self._fake_run(
+            rollup_stdout=json.dumps(rollup), checks_calls=checks_calls,
+        )
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 3.0]):
+                rc = pr_watch.main(["--pr", "719", "--repo", "octo/repo"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(_count_ci_events(journal), 1)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(rec["fail_count"], 0)
+            self.assertEqual(rec["pending_count"], 0)
+            self.assertEqual(rec["total_checks"], 3)
+            self.assertEqual(rec["duration_sec"], 3)
+            # The whole point of #719: no transition polling was needed.
+            self.assertEqual(checks_calls, [])
+
+    def test_startup_already_failed_records_immediately(self) -> None:
+        """A rollup with a terminal failure at spawn records `failed`
+        immediately (exit 1), again without polling `gh pr checks`."""
+        rollup = {"statusCheckRollup": [
+            {"__typename": "CheckRun", "name": "build",
+             "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"__typename": "CheckRun", "name": "test",
+             "status": "COMPLETED", "conclusion": "FAILURE"},
+        ]}
+        checks_calls: list = []
+        fake_run = self._fake_run(
+            rollup_stdout=json.dumps(rollup), checks_calls=checks_calls,
+        )
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 2.0]):
+                rc = pr_watch.main(["--pr", "719", "--repo", "octo/repo"])
+            self.assertEqual(rc, 1)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "failed")
+            self.assertEqual(rec["fail_count"], 1)
+            self.assertEqual(rec["total_checks"], 2)
+            self.assertEqual(checks_calls, [])
+
+    def test_startup_running_then_completed_uses_polling(self) -> None:
+        """A rollup that still has a pending check at spawn is NON-terminal:
+        `_evaluate_startup_state` returns None and the existing self-poll
+        path observes the running→completed transition via `gh pr checks`
+        and records `passed`."""
+        rollup = {"statusCheckRollup": [
+            {"__typename": "CheckRun", "name": "build",
+             "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"__typename": "CheckRun", "name": "deploy",
+             "status": "IN_PROGRESS", "conclusion": None},
+        ]}
+        checks_calls: list = []
+        fake_run = self._fake_run(
+            rollup_stdout=json.dumps(rollup),
+            checks_sequence=[
+                [{"name": "build", "state": "COMPLETED", "bucket": "pass"},
+                 {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"}],
+                [{"name": "build", "state": "COMPLETED", "bucket": "pass"},
+                 {"name": "deploy", "state": "COMPLETED", "bucket": "pass"}],
+            ],
+            checks_calls=checks_calls,
+        )
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 4.0]):
+                rc = pr_watch.main([
+                    "--pr", "719", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(rc, 0)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(_count_ci_events(journal), 1)
+            # Non-terminal startup → the polling path DID run.
+            self.assertGreaterEqual(len(checks_calls), 1)
+
+    def test_continued_fetch_failure_is_indeterminate(self) -> None:
+        """When the startup rollup is unreadable AND every `gh pr checks`
+        probe also fails, the verdict is `indeterminate` (continued fetch
+        failure) — distinct from a completed observation. This is the ONLY
+        route to `indeterminate` after #719."""
+        checks_calls: list = []
+        fake_run = self._fake_run(
+            # Rollup probe returns empty stdout → unparseable → None.
+            rollup_stdout=None, rollup_returncode=1,
+            checks_raises=FileNotFoundError("gh transient outage"),
+            checks_calls=checks_calls,
+        )
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 0.5, 9999.0, 9999.5]):
+                rc = pr_watch.main([
+                    "--pr", "719", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(rc, 8)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "indeterminate")
+            self.assertTrue(rec["retry_recommended"])
+            # No per-bucket counts on the fetch-failure path (nothing read).
+            self.assertNotIn("total_checks", rec)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

watcher 起動前に CI が完了している PR を監視すると、`gh pr checks` が起動直後に「no checks reported」で空応答を返し得るため、遷移を観測できないまま ~306s 後に indeterminate [retry recommended] へ落ちていた (2026-07-16 に5件連続再現: en#504/505/506, ja#718, en#509)。ユーザー診断「起動直後に全体の状況を確認する仕様にすべき」に基づく修正。

- **`_evaluate_startup_state()` 新設**: watch loop 突入前に `gh pr view --json statusCheckRollup` で絶対状態を1回評価。全 check terminal なら**即座に** ci_completed (passed/failed) を記録・peer 通知して merge-watch へ
- 非 terminal / 空 / 取得失敗のときのみ既存 self-poll 経路へ (追加であって置換ではない — 遷移検知・merge-watch・通知の形は不変)
- indeterminate は「取得失敗の継続」のみに限定 (完了済み観測と区別)
- 取得元に rollup を採用した理由: 起動直後の `gh pr checks` 空応答が実因のため、checks 一本では直せない。rollup は CheckRun/StatusContext を正規化して既存 `_summarize_checks` を再利用

Closes #719

## Test plan

- 新規 StartupStateEvalTests 4系統: already-passed / already-failed / running→completed / 取得失敗継続
- tools 649 OK / tests 723 OK / pr_watch 単体 81 OK
- Codex review (gpt-5.5, --base main): Blocker/Major ゼロ (round1)
- --help 実端末スモーク (cp932) OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8D1zUapGLsfDiDjn9UHy8