### PR TITLE
fix(installer): check terminal backend (tmux / WezTerm) required by the default broker transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ claude-org-ja は、Claude Code を 1 つの窓口から複数のワーカーへ
 ## すぐ試す
 
 前提ツール（git / claude / gh / jq / Python）が入っていれば、1 行のコマンドでクローンとセットアップができます。
+既定の起動方式（broker）は端末バックエンドとして tmux（Linux / WSL / macOS）または WezTerm（Windows）を使うため、あわせてインストールしておいてください。renga で起動する場合（後述の `ORG_TRANSPORT=renga`）は不要です。
 
 ```bash
 # macOS / Linux

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,6 +7,8 @@
 #   1. Checks for required commands (git, claude, gh, jq) and prints
 #      installation hints when something is missing. renga is optional
 #      (only needed for ORG_TRANSPORT=renga) and is skipped when absent.
+#      WezTerm (the default broker transport's terminal backend on Windows)
+#      is soft-warned when absent.
 #   2. Clones suisya-systems/claude-org-ja (asks before reusing an
 #      existing directory).
 #   3. Runs `renga mcp install` (user-scope) when renga is present, so the
@@ -111,6 +113,12 @@ if (-not (Test-Prerequisite 'claude' 'https://claude.ai/code (Claude Code CLI)')
 $rengaPresent = Test-OptionalCommand 'renga' 'npm install -g @suisya-systems/renga@0.18.0' 'optional; only needed when ORG_TRANSPORT=renga'
 if (-not (Test-Prerequisite 'gh'     'https://cli.github.com/'))                                { $missing = $true }
 if (-not (Test-Prerequisite 'jq'     'https://jqlang.org/download/'))                           { $missing = $true }
+# WezTerm is the terminal backend the code-default broker transport spawns its
+# panes in on Windows (see docs/design/renga-decoupling.md), so it is
+# effectively required for the default `org up` path. It is NOT needed when
+# falling back to the renga transport (ORG_TRANSPORT=renga), so its absence
+# must not abort the install — soft-warn and continue, same as renga above.
+$null = Test-OptionalCommand 'wezterm' 'https://wezterm.org/' 'needed by the default broker transport (terminal backend); only unnecessary when ORG_TRANSPORT=renga'
 Write-Host ''
 
 if ($missing) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,7 +8,8 @@
 #   1. Checks for required commands (git, claude, gh, jq) and prints
 #      installation hints when something is missing. renga is optional
 #      (only needed for ORG_TRANSPORT=renga), as are the node/npm used
-#      only to install it; all are skipped when absent.
+#      only to install it; all are skipped when absent. tmux (the default
+#      broker transport's terminal backend) is soft-warned when absent.
 #   2. Clones suisya-systems/claude-org-ja (asks before reusing an
 #      existing directory).
 #   3. Runs `renga mcp install` (user-scope) when renga is present, so the
@@ -267,6 +268,20 @@ fi
 optional_or_warn renga "npm install -g @suisya-systems/renga@0.18.0" "optional; only needed when ORG_TRANSPORT=renga"
 require_or_warn gh     "https://cli.github.com/" || missing=1
 require_or_warn jq     "apt install jq / brew install jq / https://jqlang.org/download/" || missing=1
+# tmux is the terminal backend the code-default broker transport spawns its
+# panes in (POSIX / WSL; see docs/design/renga-decoupling.md), so it is
+# effectively required for the default `claude-org-runtime org up` path. It
+# is NOT needed when falling back to the renga transport (ORG_TRANSPORT=renga),
+# so its absence must not abort the install — soft-warn and continue, same as
+# renga above. Windows uses WezTerm instead, and the direct Git-Bash-on-
+# Windows flow lands here (not in install.ps1), so probe WezTerm on that
+# branch too — resolve_command's fallback ladder covers `.exe` shims and
+# per-user install prefixes just like it does for renga.
+if [[ "$IS_WINDOWS_BASH" == "1" ]]; then
+  optional_or_warn wezterm "https://wezterm.org/" "needed by the default broker transport (terminal backend); only unnecessary when ORG_TRANSPORT=renga"
+else
+  optional_or_warn tmux "apt install tmux / brew install tmux" "needed by the default broker transport (terminal backend); only unnecessary when ORG_TRANSPORT=renga"
+fi
 # Capture the absolute path so the later `run renga mcp install` can
 # bypass bash's PATH-extension blind spot for `.cmd` shims (Git Bash
 # on Windows tries `.exe` but not `.cmd` / `.bat`, so a PATH-only


### PR DESCRIPTION
## Summary

The one-liner installers (`scripts/install.sh` / `scripts/install.ps1`) checked git / claude / gh / jq / Python but never verified the terminal backend that the code-default broker transport actually depends on (tmux on POSIX/WSL, WezTerm on Windows — see `docs/design/renga-decoupling.md`). On a tmux-less Linux box the installer succeeded silently and the org only failed later at pane-spawn time. README also never listed the prerequisite.

## Changes

- `scripts/install.sh`: add `optional_or_warn tmux` (POSIX/WSL/macOS) and `optional_or_warn wezterm` on the Git-Bash-on-Windows branch, soft-warn only (same treatment as renga), with the reason string clarifying it is needed by the default broker transport and unnecessary only with `ORG_TRANSPORT=renga`.
- `scripts/install.ps1`: add a `Test-OptionalCommand 'wezterm'` probe following the existing check-function conventions (does not set `$missing`).
- `README.md`: document tmux (Linux / WSL / macOS) / WezTerm (Windows) as the terminal backend prerequisite of the default transport, noting it is not needed when launching via renga.

## Verification

- `bash -n scripts/install.sh` OK; `--dry-run` run shows `[ok] tmux`.
- `install.ps1` parse-checked via Windows PowerShell `Parser::ParseFile` (no pwsh available): OK.
- Codex review: 2 rounds, round 1 raised one P2 (Git-Bash-on-Windows path skipped WezTerm) — fixed; round 2 clean.

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)