### PR TITLE
feat(claude): mirror Docker build allow set into worker role schema + bump runtime pin to 0.1.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.36,<0.2",
+    "claude-org-runtime>=0.1.37,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,16 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.37 for the narrow Docker build allow set in the worker
+# role templates: role_configs_schema.json appends Bash(docker build:*) /
+# Bash(docker buildx build:*) / Bash(docker images:*) /
+# Bash(docker image inspect:*) to worker_roles.default and
+# worker_roles.claude-org-self-edit permissions.allow, so Docker-project
+# workers no longer trip APPROVAL_BLOCKED on repeated docker builds
+# (runtime PR #148; ja #723 mirrors the same four entries into
+# tools/org_extension_schema.json in this paired commit). Schema-only change —
+# no DEFAULT_NOTIFY / classifier-vocabulary / attention change. The earlier
+# 0.1.36 floor (below) is subsumed.
 # Floor bumped to 0.1.36 for three broker/herdr delivery fixes: broker observer
 # lease so a background-hosted duplicate sidecar no longer claims-then-drops
 # messages, exposing per-agent receive_mode via list_peers (runtime #132);
@@ -98,7 +108,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.36,<0.2
+claude-org-runtime>=0.1.37,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -610,7 +610,11 @@
           "Bash(git stash:*)",
           "Bash(git fetch:*)",
           "Bash(git merge:*)",
-          "Bash(sleep:*)"
+          "Bash(sleep:*)",
+          "Bash(docker build:*)",
+          "Bash(docker buildx build:*)",
+          "Bash(docker images:*)",
+          "Bash(docker image inspect:*)"
         ],
         "deny": [
           "Bash(git push *)",
@@ -776,7 +780,11 @@
           "Bash(git stash:*)",
           "Bash(git fetch:*)",
           "Bash(git merge:*)",
-          "Bash(sleep:*)"
+          "Bash(sleep:*)",
+          "Bash(docker build:*)",
+          "Bash(docker buildx build:*)",
+          "Bash(docker images:*)",
+          "Bash(docker image inspect:*)"
         ],
         "deny": [
           "Bash(git push *)",


### PR DESCRIPTION
## Summary
- Mirrors the 4 narrow Docker build allow entries shipped in claude-org-runtime 0.1.37 (runtime PR suisya-systems/claude-org-runtime#148) into `tools/org_extension_schema.json` for both `worker_roles.default` and `worker_roles.claude-org-self-edit` — inserted byte-identical to the bundled schema (md5-verified). doc-audit role and the frozen `references/permissions.md` renga anchor are untouched
- Bumps the runtime pin floor to `>=0.1.37,<0.2` in `pyproject.toml` and `requirements.txt` (with the conventional floor-bump history note)
- Live venv already upgraded to 0.1.37; `uv.lock` is untracked in this repo (precedent: 0.1.36 bump d07e3d8) — the live lock was minimally refreshed for claude-org-runtime only

Closes #723

## Verification
- `tools/check_runtime_schema_drift.py`: OK rc=0 (plus `--semantic`: 14 fixtures OK)
- `claude-org-runtime settings generate` smoke over 3 role/pattern combos: all 4 docker entries present in generated worker settings
- Local CI-equivalent run: tests/ 723 OK, tools/ 649 OK, drift OK, check_role_configs OK; one pre-existing shell-hook test failure reproduces identically on unmodified main (environment-dependent, unrelated)
- Codex review round 1: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)