### PR TITLE
feat(claude): suppress stale-scrollback false positives in legacy spinner-age detection (cross-cycle diff)

### DIFF
--- a/.dispatcher/references/worker-monitoring.md
+++ b/.dispatcher/references/worker-monitoring.md
@@ -141,9 +141,15 @@
    ```bash
    # inspect_pane の structuredContent を JSON 化して渡す。
    # exit 3 = anomaly 検出、exit 0 = clean。detections[] に {kind, reason, row, matched}。
-   echo "$inspect_json" | py -3 ../tools/inspect_anomaly_scan.py --spinner-threshold-min 5
+   # --spinner-state-file は worker ごとに 1 ファイル。旧形式 spinner-age の
+   # 前サイクル差分抑止 (Issue #698) に使う。省略すると従来どおり stateless scan。
+   echo "$inspect_json" | py -3 ../tools/inspect_anomaly_scan.py \
+       --spinner-threshold-min 5 \
+       --spinner-state-file ../.state/dispatcher/spinner-age-seen/worker-{task_id}.json
    ```
    threshold やパターンの単一定義はこの module 側にあり、regression test (`tests/test_inspect_anomaly_scan.py`、観測 case = row 15 の 529 banner + 9m spinner + bottom 10 空) が契約を pin する。手で判定する場合も上記リストと同義。
+
+   **旧形式 spinner-age の false positive 抑止 (Issue #698)**: Claude Code は完了ターンの所要時間サマリ (`✻ Cooked for 31m 40s` 等) を live な旧形式 spinner と**同一の shape** で描画する。これが idle worker のスクロールバックに残ると、毎サイクル「5 分以上回る stuck spinner」として再マッチし false positive alert を繰り返していた。単一フレームでは凍結サマリと本物の stuck spinner を内容・位置だけで区別できないため、helper は「live spinner の `for Xm Ys` counter は毎サイクル進むが、凍結サマリは byte 一致で不変」という不変条件で差分を取る。`--spinner-state-file` を worker ごとに渡すと、前サイクルと同一の旧形式 spinner 行は凍結サマリとみなして検知を抑止する。初回観測は必ず発火 (差分対象が無い) し、完全凍結した live pane は hash ベースの STALL 経路 (`tools/inspect_pane_state.py`) が拾うので signal は失われない。state file 欠落 / 破損時は「前サイクル無し」扱いで再発火する安全側フォールバック (本物の stuck spinner を state file の不備で黙殺しない)。
 
    #### (e) 実行シーケンス (journal + de-dup + notify)
    以下の順番で厳密に実行する:

--- a/.dispatcher/references/worker-monitoring.md.in
+++ b/.dispatcher/references/worker-monitoring.md.in
@@ -137,9 +137,15 @@
    ```bash
    # inspect_pane の structuredContent を JSON 化して渡す。
    # exit 3 = anomaly 検出、exit 0 = clean。detections[] に {kind, reason, row, matched}。
-   echo "$inspect_json" | py -3 ../tools/inspect_anomaly_scan.py --spinner-threshold-min 5
+   # --spinner-state-file は worker ごとに 1 ファイル。旧形式 spinner-age の
+   # 前サイクル差分抑止 (Issue #698) に使う。省略すると従来どおり stateless scan。
+   echo "$inspect_json" | py -3 ../tools/inspect_anomaly_scan.py \
+       --spinner-threshold-min 5 \
+       --spinner-state-file ../.state/dispatcher/spinner-age-seen/worker-{task_id}.json
    ```
    threshold やパターンの単一定義はこの module 側にあり、regression test (`tests/test_inspect_anomaly_scan.py`、観測 case = row 15 の 529 banner + 9m spinner + bottom 10 空) が契約を pin する。手で判定する場合も上記リストと同義。
+
+   **旧形式 spinner-age の false positive 抑止 (Issue #698)**: Claude Code は完了ターンの所要時間サマリ (`✻ Cooked for 31m 40s` 等) を live な旧形式 spinner と**同一の shape** で描画する。これが idle worker のスクロールバックに残ると、毎サイクル「5 分以上回る stuck spinner」として再マッチし false positive alert を繰り返していた。単一フレームでは凍結サマリと本物の stuck spinner を内容・位置だけで区別できないため、helper は「live spinner の `for Xm Ys` counter は毎サイクル進むが、凍結サマリは byte 一致で不変」という不変条件で差分を取る。`--spinner-state-file` を worker ごとに渡すと、前サイクルと同一の旧形式 spinner 行は凍結サマリとみなして検知を抑止する。初回観測は必ず発火 (差分対象が無い) し、完全凍結した live pane は hash ベースの STALL 経路 (`tools/inspect_pane_state.py`) が拾うので signal は失われない。state file 欠落 / 破損時は「前サイクル無し」扱いで再発火する安全側フォールバック (本物の stuck spinner を state file の不備で黙殺しない)。
 
    #### (e) 実行シーケンス (journal + de-dup + notify)
    以下の順番で厳密に実行する:

--- a/tests/test_inspect_anomaly_scan.py
+++ b/tests/test_inspect_anomaly_scan.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -196,6 +197,108 @@ class SpinnerAgeTests(unittest.TestCase):
         self.assertEqual(ias.scan_lines(["working for 9m on the task"]), [])
 
 
+class SpinnerCrossCycleDiffTests(unittest.TestCase):
+    """Issue #698: suppress a frozen scrollback summary re-matched each cycle.
+
+    A completed turn renders ``✻ Cooked for 31m 40s`` in the same shape as a
+    live old-form spinner; parked in an idle worker's scrollback it tripped a
+    recurring false-positive ERROR every dispatcher cycle. The diff keys on the
+    invariant that separates them: a live spinner's counter advances, a frozen
+    summary is byte-identical.
+    """
+
+    NOTE = "✻ Cooked for 31m 40s"
+
+    def test_first_observation_still_fires(self) -> None:
+        # No prior state (None) — pre-#698 behaviour, the aged spinner fires.
+        dets = ias.scan_lines([self.NOTE])
+        self.assertEqual([d.reason for d in dets], ["spinner_age:31m"])
+        # An explicitly empty prev set is also "not seen last cycle" → fires.
+        dets = ias.scan_lines([self.NOTE], prev_spinner_keys=set())
+        self.assertEqual([d.reason for d in dets], ["spinner_age:31m"])
+
+    def test_recurring_identical_note_suppressed(self) -> None:
+        prev = ias.spinner_age_keys([self.NOTE])
+        dets = ias.scan_lines([self.NOTE], prev_spinner_keys=prev)
+        self.assertEqual(dets, [])
+
+    def test_rotated_glyph_same_note_still_suppressed(self) -> None:
+        # The glyph rotates frame-to-frame; a frozen summary must stay
+        # suppressed regardless of which glyph it is drawn with.
+        prev = ias.spinner_age_keys(["✻ Cooked for 31m 40s"])
+        dets = ias.scan_lines(["✺ Cooked for 31m 40s"], prev_spinner_keys=prev)
+        self.assertEqual(dets, [])
+
+    def test_live_spinner_counter_advance_still_fires(self) -> None:
+        # Same verb, advanced counter → different key → real live spinner fires.
+        prev = ias.spinner_age_keys(["✻ Cogitating for 9m 12s"])
+        dets = ias.scan_lines(
+            ["✻ Cogitating for 9m 45s"], prev_spinner_keys=prev
+        )
+        self.assertEqual([d.reason for d in dets], ["spinner_age:9m"])
+
+    def test_prev_keys_do_not_suppress_other_error_classes(self) -> None:
+        # The diff only gates spinner_age; substring / status / regex ERRORs
+        # are never suppressed by prior spinner state.
+        prev = {"Cooked for 31m 40s"}
+        for line, expect in (
+            ("API Error: 529 Overloaded", "substring:API Error"),
+            ("Overloaded (529), retrying…", "status_code:529"),
+            ("Error: boom", "regex:^Error: "),
+        ):
+            with self.subTest(line=line):
+                dets = ias.scan_lines([line], prev_spinner_keys=prev)
+                self.assertIn(expect, {d.reason for d in dets})
+
+    def test_scrollback_note_suppressed_but_live_spinner_kept(self) -> None:
+        # A pane carrying BOTH a frozen scrollback note and a genuinely live
+        # spinner: the note (seen last cycle) is suppressed, the live spinner
+        # (advanced counter) fires. Exercises the #698 target scenario.
+        prev = {
+            ias.spinner_identity_key("✻ Cooked for 31m 40s"),
+            ias.spinner_identity_key("✻ Sautéed for 9m 0s"),
+        }
+        pane = [
+            {"row": 12, "text": "✻ Cooked for 31m 40s"},   # frozen scrollback
+            {"row": 30, "text": "✻ Sautéed for 9m 20s"},   # live: counter moved
+        ]
+        dets = ias.scan_lines(pane, prev_spinner_keys=prev)
+        self.assertEqual(
+            [(d.row, d.reason) for d in dets], [(30, "spinner_age:9m")]
+        )
+
+    def test_below_threshold_never_tracked_or_fired(self) -> None:
+        # A 2m spinner is below threshold: no detection, and not tracked as a
+        # key (so it cannot suppress a later above-threshold match).
+        self.assertEqual(ias.spinner_age_keys(["✻ Cogitating for 2m 30s"]), [])
+        self.assertEqual(
+            ias.scan_lines(
+                ["✻ Cogitating for 2m 30s"], prev_spinner_keys=set()
+            ),
+            [],
+        )
+
+
+class SpinnerIdentityKeyTests(unittest.TestCase):
+    def test_glyph_and_indent_normalized(self) -> None:
+        self.assertEqual(
+            ias.spinner_identity_key("   ✻  Cooked for 31m 40s  "),
+            "Cooked for 31m 40s",
+        )
+
+    def test_different_glyphs_same_key(self) -> None:
+        self.assertEqual(
+            ias.spinner_identity_key("✻ Cooked for 31m 40s"),
+            ias.spinner_identity_key("✺ Cooked for 31m 40s"),
+        )
+
+    def test_advancing_counter_changes_key(self) -> None:
+        self.assertNotEqual(
+            ias.spinner_identity_key("✻ Cooked for 31m 40s"),
+            ias.spinner_identity_key("✻ Cooked for 31m 43s"),
+        )
+
+
 class NormalizationTests(unittest.TestCase):
     def test_accepts_bare_strings(self) -> None:
         dets = ias.scan_lines(["API Error: 529"])
@@ -232,6 +335,53 @@ class CliTests(unittest.TestCase):
         payload = {"lines": ["✻ Working for 3m 0s"]}
         proc = self._run(payload, "--spinner-threshold-min", "2")
         self.assertEqual(proc.returncode, 3)
+
+    def test_cli_spinner_state_file_round_trip(self) -> None:
+        # Issue #698 end-to-end: first cycle fires and persists the key; a
+        # second cycle over the *same* frozen pane reads it back and suppresses.
+        payload = {"lines": ["✻ Cooked for 31m 40s"]}
+        with tempfile.TemporaryDirectory() as td:
+            state = str(Path(td) / "sub" / "worker-x.json")  # parent auto-made
+
+            first = self._run(payload, "--spinner-state-file", state)
+            self.assertEqual(first.returncode, 3)
+            self.assertIn(
+                "spinner_age:31m",
+                {d["reason"] for d in json.loads(first.stdout)["detections"]},
+            )
+            written = json.loads(Path(state).read_text(encoding="utf-8"))
+            self.assertEqual(written["spinner_keys"], ["Cooked for 31m 40s"])
+
+            second = self._run(payload, "--spinner-state-file", state)
+            self.assertEqual(second.returncode, 0)
+            self.assertEqual(json.loads(second.stdout)["detections"], [])
+
+    def test_cli_spinner_state_file_live_counter_keeps_firing(self) -> None:
+        # A live spinner advances its counter each cycle, so it fires every
+        # time even with a state file threaded through.
+        with tempfile.TemporaryDirectory() as td:
+            state = str(Path(td) / "worker-y.json")
+            c1 = self._run(
+                {"lines": ["✻ Cogitating for 9m 12s"]},
+                "--spinner-state-file",
+                state,
+            )
+            self.assertEqual(c1.returncode, 3)
+            c2 = self._run(
+                {"lines": ["✻ Cogitating for 9m 45s"]},
+                "--spinner-state-file",
+                state,
+            )
+            self.assertEqual(c2.returncode, 3)
+
+    def test_cli_missing_state_file_treated_as_first_cycle(self) -> None:
+        # A non-existent state path is "nothing seen last cycle": fire + create.
+        payload = {"lines": ["✻ Cooked for 31m 40s"]}
+        with tempfile.TemporaryDirectory() as td:
+            state = str(Path(td) / "absent.json")
+            proc = self._run(payload, "--spinner-state-file", state)
+            self.assertEqual(proc.returncode, 3)
+            self.assertTrue(Path(state).exists())
 
 
 if __name__ == "__main__":

--- a/tools/inspect_anomaly_scan.py
+++ b/tools/inspect_anomaly_scan.py
@@ -27,6 +27,22 @@ Scope: this module covers the ERROR-class detections (substring + anchored
 regex + spinner age). APPROVAL_BLOCKED detection stays in the prose §4(b)
 because it is target-line + cursor-position sensitive and not part of
 Issue #492.
+
+**Spinner false-positive suppression (Issue #698)**: Claude Code renders a
+completed turn's summary in the *same* ``{glyph} {verb} for {Xm Ys}`` shape
+as a live old-form spinner (e.g. ``✻ Cooked for 31m 40s``). Such a summary
+lingers in the scrollback of an idle worker, so every dispatcher cycle
+re-matched it as a "5-minute stuck spinner" and emitted a recurring
+false-positive ERROR alert. A single pane frame cannot tell a frozen
+summary from a genuinely stuck spinner by content or position alone, so this
+module keys on the invariant that actually separates them: a **live** spinner's
+``for Xm Ys`` counter advances every cycle, while a frozen scrollback summary
+is byte-identical. When the caller threads the previous cycle's spinner
+identity keys back in (CLI ``--spinner-state-file``), an unchanged old-form
+spinner is suppressed. The first observation of any spinner still fires (no
+prior state to diff against), and a fully-frozen *live* pane is still caught
+by the hash-based STALL path (``tools/inspect_pane_state.py``), so no real
+signal is lost. Without prior state the scan behaves exactly as before.
 """
 
 from __future__ import annotations
@@ -36,7 +52,8 @@ import json
 import re
 import sys
 from dataclasses import asdict, dataclass
-from typing import Iterable, Optional, Sequence, Union
+from pathlib import Path
+from typing import Collection, Iterable, Optional, Sequence, Union
 
 # Default spinner-age threshold in minutes. A Claude Code spinner that has
 # been counting for this many minutes or more is treated as a stuck run.
@@ -91,6 +108,26 @@ SPINNER_AGE_PATTERN = (
 )
 _SPINNER_AGE_RE = re.compile(SPINNER_AGE_PATTERN)
 
+# Leading spinner glyphs + surrounding whitespace, stripped to form a stable
+# cross-cycle identity for an old-form spinner line (Issue #698). The glyph
+# rotates frame-to-frame even on a frozen summary line, and the indent can
+# shift, so both are normalized away; what remains (``verb for Xm Ys``) is
+# constant for a frozen scrollback summary and changes for a live spinner
+# whose counter advances.
+_SPINNER_GLYPH_PREFIX_RE = re.compile(
+    r"^\s*[✻✺✶✷✸✹✦✧✱✲✳·∙▪●○◍◌◐◑◒◓*]+\s*"
+)
+
+
+def spinner_identity_key(text: str) -> str:
+    """Glyph/indent-normalized identity for an old-form spinner line.
+
+    Used by the cross-cycle diff suppression (Issue #698): a frozen scrollback
+    summary (``✻ Cooked for 31m 40s``) maps to a constant key across cycles,
+    while a live spinner's key changes as its ``for Xm Ys`` counter advances.
+    """
+    return _SPINNER_GLYPH_PREFIX_RE.sub("", text).rstrip()
+
 
 @dataclass(frozen=True)
 class Detection:
@@ -133,12 +170,23 @@ def scan_lines(
     lines: Iterable[Union[str, dict]],
     *,
     spinner_threshold_min: int = SPINNER_AGE_THRESHOLD_MIN,
+    prev_spinner_keys: Optional[Collection[str]] = None,
 ) -> list[Detection]:
     """Scan **all** visible pane lines for ERROR-class anomalies.
 
     Returns a list of :class:`Detection`, one per matching line/trigger.
     An empty list means the pane looks clean. The scan deliberately covers
     every row (Issue #492 gap 1) rather than only the bottom N.
+
+    ``prev_spinner_keys`` (Issue #698): identity keys
+    (:func:`spinner_identity_key`) of the old-form spinner lines that reached
+    the threshold on the *previous* cycle for this same worker. An aged
+    spinner whose key is in this set is a frozen scrollback summary (its
+    ``for Xm Ys`` counter did not advance) and its ``spinner_age`` detection
+    is suppressed. ``None`` (the default) means "no prior state" — every aged
+    spinner fires, so callers that do not thread state keep the pre-#698
+    behaviour exactly. Only ``spinner_age`` detections are affected; substring
+    / status-code / anchored-regex ERROR detections are never suppressed.
     """
     detections: list[Detection] = []
     for row, text in _normalize(lines):
@@ -191,6 +239,14 @@ def scan_lines(
         if m:
             minutes = int(m.group(1))
             if minutes >= spinner_threshold_min:
+                # Cross-cycle diff (Issue #698): an identical old-form spinner
+                # line already seen last cycle is a frozen scrollback summary,
+                # not a live spinner (whose counter would have advanced), so
+                # skip the recurring false positive. The first observation
+                # (prev_spinner_keys None/absent) still fires.
+                key = spinner_identity_key(text)
+                if prev_spinner_keys is not None and key in prev_spinner_keys:
+                    continue
                 detections.append(
                     Detection(
                         kind="error",
@@ -201,6 +257,29 @@ def scan_lines(
                 )
 
     return detections
+
+
+def spinner_age_keys(
+    lines: Iterable[Union[str, dict]],
+    *,
+    spinner_threshold_min: int = SPINNER_AGE_THRESHOLD_MIN,
+) -> list[str]:
+    """Identity keys of every threshold-reaching old-form spinner line.
+
+    This is the set the caller persists after a cycle so the next cycle can
+    diff against it (Issue #698). Keys are collected for **all** aged spinner
+    lines regardless of whether their detection was suppressed, so a summary
+    that fired once (first observation) is remembered and suppressed next
+    cycle.
+    """
+    keys: list[str] = []
+    for _, text in _normalize(lines):
+        if not text:
+            continue
+        m = _SPINNER_AGE_RE.match(text)
+        if m and int(m.group(1)) >= spinner_threshold_min:
+            keys.append(spinner_identity_key(text))
+    return keys
 
 
 def _load_lines(payload: dict) -> Sequence[Union[str, dict]]:
@@ -221,6 +300,47 @@ def _load_lines(payload: dict) -> Sequence[Union[str, dict]]:
         "input JSON must be a list of lines or contain a 'lines' / "
         "'structuredContent.lines' array"
     )
+
+
+def _read_spinner_state(path: Optional[str]) -> Optional[list[str]]:
+    """Load the previous cycle's aged-spinner keys from ``path``.
+
+    Returns ``None`` when no state file was requested (so :func:`scan_lines`
+    keeps its stateless pre-#698 behaviour), or an empty list when the file is
+    absent / unreadable / malformed (treat as "nothing seen last cycle" — the
+    first cycle after a corrupt or missing file re-fires, which is the safe
+    side: a real stuck spinner is never silently masked by a bad state file).
+    """
+    if path is None:
+        return None
+    p = Path(path)
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    keys = data.get("spinner_keys") if isinstance(data, dict) else data
+    if not isinstance(keys, list):
+        return []
+    return [str(k) for k in keys]
+
+
+def _write_spinner_state(path: str, keys: Sequence[str]) -> None:
+    """Persist this cycle's aged-spinner keys to ``path`` (best effort).
+
+    Creates the parent directory if needed. A write failure is swallowed: the
+    next cycle then reads no prior state and re-fires, which is the safe side.
+    """
+    p = Path(path)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            json.dumps({"spinner_keys": list(keys)}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -245,12 +365,35 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             f"many minutes is an ERROR-equivalent (default: {SPINNER_AGE_THRESHOLD_MIN})."
         ),
     )
+    parser.add_argument(
+        "--spinner-state-file",
+        default=None,
+        help=(
+            "Per-worker JSON file holding the previous cycle's aged-spinner "
+            "identity keys (Issue #698). When given, an old-form spinner whose "
+            "line is unchanged from last cycle is a frozen scrollback summary "
+            "and its detection is suppressed; the file is then rewritten with "
+            "this cycle's keys. Omit for a stateless scan (pre-#698 behaviour)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     payload = json.load(args.input)
+    lines = list(_load_lines(payload))
+
+    prev_keys = _read_spinner_state(args.spinner_state_file)
     detections = scan_lines(
-        _load_lines(payload), spinner_threshold_min=args.spinner_threshold_min
+        lines,
+        spinner_threshold_min=args.spinner_threshold_min,
+        prev_spinner_keys=prev_keys,
     )
+    if args.spinner_state_file is not None:
+        _write_spinner_state(
+            args.spinner_state_file,
+            spinner_age_keys(
+                lines, spinner_threshold_min=args.spinner_threshold_min
+            ),
+        )
     json.dump(
         {"detections": [asdict(d) for d in detections]},
         sys.stdout,


### PR DESCRIPTION
## Summary
- `tools/inspect_anomaly_scan.py`: legacy spinner-age detection no longer flags static duration annotations left in scrollback ("Cooked for 31m 40s" etc.) as live stuck spinners. Adopts Issue #698 option 2 (cross-cycle diff): a live spinner's counter advances every cycle, while a frozen summary line stays byte-identical — position-independent and robust
- Option 1 (tail-proximity) deliberately rejected: real stuck-spinner fixture #492 sits far from the tail while the #698 false positives sit near it, so position cannot separate them without suppressing genuine stalls
- Fail-safe design: first observation always fires; missing/corrupt state file degrades to "no previous cycle" (re-fires); fully frozen panes are still caught by the hash-based STALL path
- `--spinner-state-file` CLI option (one state file per worker) for the dispatcher loop; `scan_lines()` keeps byte-identical behavior when the new argument is omitted
- Generated `worker-monitoring.md` updated via its `.md.in` source (regen-verified)

Closes #698

## Verification
- 37 unit/CLI tests pass (incl. #492 regression pin and live-counter-always-fires cases); related test_inspect_pane_state 36 pass
- `gen_skill_prose --check` exit 0 for both transports (no generation drift)
- Codex review: round 1 P2 (template not updated) fixed; round 2 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)