### PR TITLE
feat(claude): guard new-project worker dirs with a delivery .gitignore for org-internal artifacts

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -150,6 +150,13 @@ class TestBuildDelegatePlan(unittest.TestCase):
         self.assertIn("窓口ペイン名: `secretary`", body)
         # Brief path uses CLAUDE.md (not self_edit)
         self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+        # Issue #725: preview/plan must disclose the delivery-guard .gitignore
+        # that apply writes for a Pattern A new-project (base_repo None).
+        self.assertIsNone(plan.base_repo)
+        self.assertIn(
+            Path(plan.layout.worker_dir) / ".gitignore",
+            plan.artifacts_to_create,
+        )
 
     def test_pattern_b_when_concurrent_active_run(self):
         self.sb.add_active_run(
@@ -337,6 +344,140 @@ class TestApplyDelegatePlan(unittest.TestCase):
         # Only the queued reservation; no in_use/review (= Active Work Items)
         # rows were created by apply.
         self.assertEqual(statuses, {"queued"})
+
+    # ---- Issue #725: Pattern A new-project delivery guard ----
+
+    def test_apply_pattern_a_writes_delivery_gitignore(self):
+        """Issue #725: a Pattern A new-project (base_repo None, worker
+        ``git init``s the delivery dir) gets a worker_dir/.gitignore that
+        ignores the org-internal artifacts."""
+        plan, result = self._apply()
+        self.assertIsNone(plan.base_repo)  # precondition: new-project path
+        worker_dir = Path(plan.layout.worker_dir)
+        gitignore = worker_dir / ".gitignore"
+        self.assertEqual(result.gitignore_path, gitignore)
+        self.assertTrue(gitignore.exists())
+        lines = {ln.strip() for ln in gitignore.read_text(encoding="utf-8").splitlines()}
+        # Anchored to root so a subdir with the same basename stays tracked.
+        self.assertIn(f"/{plan.brief_out_path.name}", lines)
+        self.assertIn("/send_plan.json", lines)
+        self.assertIn("/.claude/settings.local.json", lines)
+        self.assertIn(gdp._GITIGNORE_MANAGED_HEADER, lines)
+
+    def test_apply_pattern_a_gitignore_prevents_leak(self):
+        """The end-to-end regression for the #725 incident: after the worker
+        ``git init``s and ``git add -A``s the delivery tree, the brief /
+        send_plan / settings must NOT be staged, while a genuine project file
+        is."""
+        plan, result = self._apply()
+        worker_dir = Path(plan.layout.worker_dir)
+        # Simulate the worker's first-commit sequence on the delivered project.
+        settings = worker_dir / ".claude" / "settings.local.json"
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        settings.write_text("{}\n", encoding="utf-8")
+        real_file = worker_dir / "app.py"
+        real_file.write_text("print('hello')\n", encoding="utf-8")
+        env = {**__import__("os").environ,
+               "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"}
+        subprocess.run(["git", "-C", str(worker_dir), "init", "-q"],
+                       check=True, env=env)
+        subprocess.run(["git", "-C", str(worker_dir), "add", "-A"],
+                       check=True, env=env)
+        staged = subprocess.check_output(
+            ["git", "-C", str(worker_dir), "diff", "--cached", "--name-only"],
+            env=env,
+        ).decode("utf-8").split()
+        self.assertNotIn(plan.brief_out_path.name, staged)
+        self.assertNotIn("send_plan.json", staged)
+        self.assertNotIn(".claude/settings.local.json", staged)
+        # The real deliverable is unaffected; .gitignore itself is fine to ship.
+        self.assertIn("app.py", staged)
+        self.assertIn(".gitignore", staged)
+
+    def test_ensure_gitignore_idempotent_and_appends(self):
+        """Re-running the guard never duplicates lines, preserves a
+        pre-existing .gitignore, and only adds the header once."""
+        plan, _ = self._apply()
+        worker_dir = Path(plan.layout.worker_dir)
+        gitignore = worker_dir / ".gitignore"
+        send_plan = worker_dir / "send_plan.json"
+        # Second call is a no-op (everything already present).
+        self.assertIsNone(
+            gdp._ensure_worker_dir_gitignore(plan, send_plan_path=send_plan)
+        )
+        # Rewrite with unrelated pre-existing content, then re-run: the guard
+        # appends its block under one header without clobbering the original.
+        gitignore.write_text("node_modules/\n", encoding="utf-8")
+        out = gdp._ensure_worker_dir_gitignore(plan, send_plan_path=send_plan)
+        self.assertEqual(out, gitignore)
+        text = gitignore.read_text(encoding="utf-8")
+        self.assertIn("node_modules/", text)
+        self.assertIn("/send_plan.json", text)
+        self.assertEqual(text.count(gdp._GITIGNORE_MANAGED_HEADER), 1)
+        # And now idempotent again.
+        self.assertIsNone(
+            gdp._ensure_worker_dir_gitignore(plan, send_plan_path=send_plan)
+        )
+
+    def test_apply_gitignore_follows_custom_send_plan_out(self):
+        """Issue #725 (Codex P2): ``--send-plan-out`` relocating the manifest
+        inside worker_dir must still be ignored — the guard anchors on the
+        actual output path, not the default basename."""
+        plan = gdp.build_delegate_plan(
+            task_id="apply-test",
+            project_slug="clock-app",
+            description="implement something",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        worker_dir = Path(plan.layout.worker_dir)
+        custom_send_plan = worker_dir / "meta" / "delegate.json"
+        result = gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+            send_plan_out=custom_send_plan,
+        )
+        self.assertEqual(result.send_plan_path, custom_send_plan)
+        lines = {
+            ln.strip()
+            for ln in (worker_dir / ".gitignore").read_text(encoding="utf-8").splitlines()
+        }
+        self.assertIn("/meta/delegate.json", lines)
+
+    def test_apply_gitignore_omits_send_plan_when_written_outside_worker_dir(self):
+        """Issue #725 (Codex P2 follow-up): a send_plan written OUTSIDE the
+        delivery tree must not add any send_plan ignore line — otherwise a
+        legitimate project-authored root ``send_plan.json`` would be silently
+        excluded from the worker's first commit."""
+        plan = gdp.build_delegate_plan(
+            task_id="apply-test",
+            project_slug="clock-app",
+            description="implement something",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        worker_dir = Path(plan.layout.worker_dir)
+        outside_send_plan = self.sb.root / "external_send_plan.json"
+        result = gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+            send_plan_out=outside_send_plan,
+        )
+        self.assertEqual(result.send_plan_path, outside_send_plan)
+        lines = {
+            ln.strip()
+            for ln in (worker_dir / ".gitignore").read_text(encoding="utf-8").splitlines()
+        }
+        self.assertNotIn("/send_plan.json", lines)
+        self.assertFalse(any("send_plan" in ln for ln in lines))
+        # Brief + settings guards are unaffected.
+        self.assertIn(f"/{plan.brief_out_path.name}", lines)
+        self.assertIn("/.claude/settings.local.json", lines)
 
 
 # ---------------------------------------------------------------------------
@@ -981,7 +1122,7 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         self.assertEqual(
             Path(plan.base_repo).resolve(), self.sb.claude_org_root.resolve()
         )
-        gdp.apply_delegate_plan(
+        result = gdp.apply_delegate_plan(
             plan,
             state_db_path=self.sb.db_path,
             claude_org_root=self.sb.claude_org_root,
@@ -996,6 +1137,10 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         # Brief landed inside the worktree
         brief = worker_dir / "CLAUDE.local.md"
         self.assertTrue(brief.exists())
+        # Issue #725: worktree layouts inherit the base repo's .gitignore, so
+        # the delivery guard is out of scope and writes nothing here.
+        self.assertIsNone(result.gitignore_path)
+        self.assertFalse((worker_dir / ".gitignore").exists())
 
     def test_apply_idempotent_when_worktree_already_registered(self):
         plan = self._build_self_edit_b(task_id="idem-task")

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -722,6 +722,13 @@ def build_delegate_plan(
         brief_out_path,
         Path(layout.worker_dir) / ".claude" / "settings.local.json",
     ]
+    # Issue #725: Pattern A with no base clone (the new-project the worker
+    # ``git init``s) also gets a worker_dir/.gitignore written at apply time
+    # to keep the org-internal artifacts out of the deliverable. Surface it in
+    # the plan's artifact list so ``preview`` discloses the same side effect
+    # apply performs (same predicate as ``_ensure_worker_dir_gitignore``).
+    if layout.pattern == "A" and base_repo is None:
+        artifacts.append(Path(layout.worker_dir) / ".gitignore")
 
     # Phase 1 PR4: surface base_clone into settings_args for Pattern B so the
     # runtime can substitute `{base_clone}` in
@@ -798,6 +805,11 @@ class ApplyResult:
     settings_skipped_reason: Optional[str]
     send_plan_path: Path
     db_reservation: dict[str, Any]
+    # Issue #725: worker_dir/.gitignore path when apply wrote/updated it to
+    # keep org-internal delivery artifacts out of a Pattern A new-project's
+    # git history. ``None`` for every other pattern (they inherit a base
+    # repo's .gitignore) and when the managed lines were already present.
+    gitignore_path: Optional[Path] = None
 
 
 def _reserve_in_db(
@@ -1207,6 +1219,119 @@ def _write_brief(plan: DelegatePlan) -> Path:
     return out
 
 
+# Marks the block apply appends to a Pattern A new-project's ``.gitignore``
+# (Issue #725). The header lets a human / re-run recognise the org-managed
+# lines and keeps the append idempotent (we never duplicate the header).
+_GITIGNORE_MANAGED_HEADER = (
+    "# --- claude-org delegation artifacts (Issue #725) — not part of the "
+    "deliverable ---"
+)
+
+
+def _worker_dir_anchored(worker_dir: Path, target: Path) -> Optional[str]:
+    """Return ``target`` as a root-anchored .gitignore pattern relative to
+    ``worker_dir`` (e.g. ``/send_plan.json`` or ``/sub/send_plan.json``), or
+    ``None`` when ``target`` resolves outside ``worker_dir``.
+
+    ``None`` means "do not add an ignore line": a manifest written outside the
+    delivery tree cannot leak into it, and adding a placeholder like
+    ``/send_plan.json`` would instead wrongly exclude a legitimate root-level
+    ``send_plan.json`` the delivered project itself creates. POSIX-normalized
+    so the pattern stays valid on Windows-authored paths too.
+    """
+    try:
+        rel = target.resolve().relative_to(worker_dir.resolve())
+    except (ValueError, OSError):
+        return None
+    return "/" + rel.as_posix()
+
+
+def _managed_gitignore_lines(plan: DelegatePlan, *, send_plan_path: Path) -> list[str]:
+    """The org-internal artifact paths apply keeps out of a Pattern A
+    new-project's git history (Issue #725).
+
+    Anchored to the worker_dir root with a leading ``/`` so only the
+    top-level brief / send_plan / settings are ignored — a subdirectory the
+    delivered project legitimately creates with the same basename (e.g. a
+    real ``docs/CLAUDE.md``) is left tracked. The brief basename is taken
+    from ``plan.brief_out_path`` so the rule follows whichever name the
+    resolver chose (``CLAUDE.md`` or ``CLAUDE.local.md``). The send_plan line
+    follows the *actual* output path (``--send-plan-out`` may relocate it
+    inside worker_dir), and is omitted entirely when the manifest is written
+    outside worker_dir (it can't leak there, and a placeholder would wrongly
+    ignore a project-authored ``send_plan.json``).
+    """
+    worker_dir = Path(plan.layout.worker_dir)
+    lines = [f"/{plan.brief_out_path.name}"]
+    send_plan_line = _worker_dir_anchored(worker_dir, send_plan_path)
+    if send_plan_line is not None:
+        lines.append(send_plan_line)
+    lines.append("/.claude/settings.local.json")
+    return lines
+
+
+def _ensure_worker_dir_gitignore(
+    plan: DelegatePlan, *, send_plan_path: Path
+) -> Optional[Path]:
+    """Create/append ``worker_dir/.gitignore`` so the org-internal delivery
+    artifacts never enter a Pattern A new-project's git history (Issue #725).
+
+    Design decision — approach (a) ``.gitignore`` over approach (b) "rename
+    the brief to ``CLAUDE.local.md``" (both floated in Issue #725):
+
+    - (a) is the structural root fix. It covers all three leaking artifacts
+      (brief, ``send_plan.json``, ``.claude/settings.local.json``) in one
+      place and is independent of the brief filename.
+    - (b) alone does NOT stop the leak: ``CLAUDE.local.md`` is only untracked
+      when a ``.gitignore`` lists it, and a brand-new ``git init``-ed
+      delivery dir has no such ``.gitignore``. So (b) would still commit the
+      brief (plus send_plan / settings), i.e. it needs (a) anyway. Its only
+      extra benefit — freeing the ``CLAUDE.md`` *name* for the delivered
+      project — is not worth the added blast radius (it would change the
+      Pattern A brief filename, delegate body, and existing apply tests). We
+      therefore keep the current ``CLAUDE.md`` placement for backward compat
+      and ignore whatever basename the brief actually has. If a delivered
+      project later wants its own tracked root ``CLAUDE.md``, a human removes
+      the one anchored line under the marked header.
+
+    Scope — Pattern A with no base clone only (``base_repo is None``): the
+    "new project the worker will ``git init``" case, where worker_dir is a
+    fresh non-git directory with no inherited .gitignore. Pattern B and the
+    Issue #489 Pattern-A-with-worktree layout both carry ``base_repo`` and
+    inherit the base repo's ``.gitignore`` (out of scope per Issue #725).
+    Pattern C edits an existing registered repo, whose tracked ``.gitignore``
+    must not be polluted.
+
+    Idempotent: managed lines already present are not re-added, the header is
+    never duplicated, and a pre-existing ``.gitignore`` is appended to (not
+    overwritten). Returns the ``.gitignore`` path when written/updated, else
+    ``None`` (out of scope, or every managed line already present).
+    """
+    if plan.layout.pattern != "A" or plan.base_repo is not None:
+        return None
+    worker_dir = Path(plan.layout.worker_dir)
+    gitignore = worker_dir / ".gitignore"
+    wanted = _managed_gitignore_lines(plan, send_plan_path=send_plan_path)
+    existing_text = ""
+    existing_lines: set[str] = set()
+    if gitignore.exists():
+        existing_text = gitignore.read_text(encoding="utf-8")
+        existing_lines = {ln.strip() for ln in existing_text.splitlines()}
+    missing = [ln for ln in wanted if ln not in existing_lines]
+    if not missing:
+        return None
+    header_present = _GITIGNORE_MANAGED_HEADER in existing_lines
+    block = missing if header_present else [_GITIGNORE_MANAGED_HEADER, *missing]
+    worker_dir.mkdir(parents=True, exist_ok=True)
+    if existing_text:
+        sep = "" if existing_text.endswith("\n") else "\n"
+        new_text = existing_text + sep + "\n".join(block) + "\n"
+    else:
+        new_text = "\n".join(block) + "\n"
+    gitignore.write_text(new_text, encoding="utf-8")
+    return gitignore
+
+
 def _build_settings_generate_cmd(
     settings_args: dict[str, Any],
     *,
@@ -1415,6 +1540,18 @@ def apply_delegate_plan(
     # failure so the next dispatch sees Pattern A as free.
     try:
         brief_path = _write_brief(plan)
+        # Resolve the send_plan output path up-front so the delivery guard can
+        # ignore the manifest's *actual* location (``--send-plan-out`` may
+        # relocate it inside worker_dir), not just the default basename.
+        if send_plan_out is None:
+            send_plan_out = brief_path.with_name("send_plan.json")
+        # Issue #725: keep the org-internal delivery artifacts out of a
+        # Pattern A new-project's git history via a worker_dir/.gitignore.
+        # No-op (returns None) for every pattern that inherits a base repo's
+        # .gitignore. Anchors on the final brief basename + send_plan path.
+        gitignore_path = _ensure_worker_dir_gitignore(
+            plan, send_plan_path=send_plan_out
+        )
         settings_path: Optional[Path] = None
         skipped_reason: Optional[str] = None
         if skip_settings:
@@ -1423,8 +1560,6 @@ def apply_delegate_plan(
             settings_path, skipped_reason = _run_settings_generate(
                 plan, runtime_cmd=runtime_cmd
             )
-        if send_plan_out is None:
-            send_plan_out = brief_path.with_name("send_plan.json")
         send_plan_path = _write_send_plan(plan, out_path=send_plan_out)
     except BaseException:
         _abandon_queued_run(state_db_path, plan.task_id)
@@ -1436,6 +1571,7 @@ def apply_delegate_plan(
         settings_skipped_reason=skipped_reason,
         send_plan_path=send_plan_path,
         db_reservation=db_reservation,
+        gitignore_path=gitignore_path,
     )
 
 
@@ -1794,6 +1930,8 @@ def _cmd_apply(args: argparse.Namespace) -> int:
     elif result.settings_skipped_reason:
         print(f"settings: SKIPPED ({result.settings_skipped_reason})")
     print(f"send_plan: {result.send_plan_path}")
+    if result.gitignore_path is not None:
+        print(f"gitignore: {result.gitignore_path} (Issue #725 delivery guard)")
     print(_next_step_hint())
     return 0
 


### PR DESCRIPTION
## Summary
- `gen_delegate_payload.py` apply now writes/appends a `.gitignore` in the worker_dir (root-anchored `/CLAUDE.md`, `/send_plan.json`, `/.claude/settings.local.json`) — but only for Pattern A with no base repo (fresh `git init` delivery targets), so org-internal artifacts can no longer land in the delivered tree via the worker's initial `git add -A`
- Scope deliberately narrow: Pattern B / Pattern-A-worktree inherit the base repo's .gitignore; Pattern C must not touch an existing repo's tracked .gitignore
- Issue #725's alternative (renaming the brief to CLAUDE.local.md) rejected as a standalone fix — in a fresh git init dir CLAUDE.local.md is tracked too, so the .gitignore is needed either way (rationale in docstring)
- `--send-plan-out` relocations are followed: ignored when inside worker_dir, never added when outside (avoids masking a project's own send_plan.json)
- `preview` now discloses the .gitignore in `artifacts_to_create` (preview/apply contract consistency)

Closes #725

## Verification
- All 98 tests green (existing Pattern A/B apply + golden tests unbroken); new regression tests: generation, end-to-end "git add -A leaks nothing", idempotent append, custom send-plan-out inside/outside, preview disclosure
- Codex review: 3 P2s resolved across rounds 1-3; round 4 clean
- CLI --help smoke OK (no cp932-incompatible characters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)