### PR TITLE
fix(hooks): block-org-structure — out-of-org worker の既存 tracked ファイル編集への誤発火を解消

### DIFF
--- a/.hooks/block-org-structure.sh
+++ b/.hooks/block-org-structure.sh
@@ -35,10 +35,12 @@ normalize_slashes() {
 
 # Helper: WORKER_DIR の git repo に既に track されているファイルかを判定する（Issue #736）。
 # git 不在 / repo 外 / untracked はすべて非 0（＝従来どおりブロック側に倒れる fail-closed）。
+# :(literal) で pathspec の glob 解釈を無効化する（例: 未 tracked の「registry/*」という
+# パスが tracked ファイルへ glob マッチして誤許可されるのを防ぐ）。
 is_tracked_in_worker_repo() {
   local file="$1"
   command -v git &>/dev/null || return 1
-  git -C "$WORKER_DIR" ls-files --error-unmatch -- "$file" &>/dev/null
+  git -C "$WORKER_DIR" ls-files --error-unmatch -- ":(literal)$file" &>/dev/null
 }
 
 # Helper: ドライブレター表記を統一（Git Bash /c/ → C:/ 変換 + 大文字統一）

--- a/.hooks/block-org-structure.sh
+++ b/.hooks/block-org-structure.sh
@@ -33,6 +33,14 @@ normalize_slashes() {
   echo "$1" | tr '\\' '/'
 }
 
+# Helper: WORKER_DIR の git repo に既に track されているファイルかを判定する（Issue #736）。
+# git 不在 / repo 外 / untracked はすべて非 0（＝従来どおりブロック側に倒れる fail-closed）。
+is_tracked_in_worker_repo() {
+  local file="$1"
+  command -v git &>/dev/null || return 1
+  git -C "$WORKER_DIR" ls-files --error-unmatch -- "$file" &>/dev/null
+}
+
 # Helper: ドライブレター表記を統一（Git Bash /c/ → C:/ 変換 + 大文字統一）
 normalize_drive_letter() {
   local p="$1"
@@ -121,6 +129,16 @@ if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" ]]; then
     if [[ "$CANONICAL_FILE" == "$CLAUDE_DIR/"* || "$CANONICAL_FILE" == "$CLAUDE_DIR" ]]; then
       exit 0
     fi
+  fi
+
+  # 例外 (Issue #736): out-of-org worker の対象リポジトリが registry/ や .dispatcher/ 等を
+  # 正当に含む場合（例: EN ミラー repo の registry/projects.md）、既存 tracked ファイルの
+  # 編集は「worker dir への org 構造の新規作成」ではないため許可する。判定は WORKER_DIR の
+  # git index 照合（git ls-files）。untracked / repo 外 / git 不在は従来どおりブロック側に
+  # 落ちる。in-org worker（WORKER_DIR が claude-org 内）には適用しない — claude-org 本体の
+  # tracked な組織構造ファイル編集をこの緩和で許してしまわないため。
+  if [[ "$WORKER_IN_ORG" == "0" ]] && is_tracked_in_worker_repo "$CANONICAL_FILE"; then
+    exit 0
   fi
 
   # 全深度ブロック: パスコンポーネントに含まれるかチェック

--- a/tests/test-block-org-structure.sh
+++ b/tests/test-block-org-structure.sh
@@ -419,6 +419,13 @@ json='{"tool_name":"Write","tool_input":{"file_path":"'"$TRACKED_WORKER_DIR"'/.s
 ec=$(run_hook_tracked "$json" "$stderr")
 assert_exit 2 "$ec" "Write(tracked): NEW file under .state/ is still blocked"
 
+# 45b. out-of-org Write to untracked path with pathspec metachars (block — :(literal)
+#      keeps "registry/*" from glob-matching tracked files under registry/)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$TRACKED_WORKER_DIR"'/registry/*"}}'
+ec=$(run_hook_tracked "$json" "$stderr")
+assert_exit 2 "$ec" "Write(tracked): untracked glob-metachar path registry/* is blocked"
+
 # 46. in-org Write to tracked registry/projects.md (block — relaxation is out-of-org only)
 #     WORKER_DIR=$REPO_ROOT is inside CLAUDE_ORG_PATH and registry/projects.md is
 #     tracked in this repo, so this asserts the in-org guard is NOT weakened.

--- a/tests/test-block-org-structure.sh
+++ b/tests/test-block-org-structure.sh
@@ -35,7 +35,11 @@ OOO_WORKER_DIR="$(portable_realpath "$CLAUDE_ORG_PATH/../target-repo-test")"
 
 PASS=0; FAIL=0; TEST_NUM=0
 TMPFILES=()
-cleanup() { rm -f "${TMPFILES[@]}"; }
+TMPDIRS=()
+cleanup() {
+  rm -f "${TMPFILES[@]}"
+  [[ ${#TMPDIRS[@]} -gt 0 ]] && rm -rf "${TMPDIRS[@]}"
+}
 trap cleanup EXIT
 
 assert_exit() {
@@ -352,6 +356,76 @@ stderr=$(mktemp); TMPFILES+=("$stderr")
 json='{"tool_name":"Bash","tool_input":{"command":"cp foo ${CLAUDE_ORG_PATH}/.claude/skills/x/SKILL.md"}}'
 ec=$(run_hook_ooo "$json" "$stderr")
 assert_exit 2 "$ec" "Bash(out-of-org): variable \${CLAUDE_ORG_PATH}/.claude/ is blocked"
+
+# ========== Tracked-file Edit Tests (Issue #736: new-creation vs existing-tracked-edit) ==========
+# Models the EN mirror repo case: an out-of-org target repository that itself
+# legitimately tracks org-structure paths (registry/projects.md, .dispatcher/ etc.).
+# Editing an EXISTING tracked file must be allowed (it is not "worker dir への
+# org 構造の新規作成"), while NEW file creation in those dirs stays blocked.
+# The relaxation is out-of-org only: in-org workers keep the original blocking.
+
+TRACKED_WORKER_DIR="$(mktemp -d)"
+TMPDIRS+=("$TRACKED_WORKER_DIR")
+TRACKED_WORKER_DIR="$(portable_realpath "$TRACKED_WORKER_DIR")"
+git -C "$TRACKED_WORKER_DIR" init -q
+mkdir -p "$TRACKED_WORKER_DIR/registry" "$TRACKED_WORKER_DIR/.dispatcher"
+echo "# projects" > "$TRACKED_WORKER_DIR/registry/projects.md"
+echo "# task" > "$TRACKED_WORKER_DIR/.dispatcher/task.md"
+git -C "$TRACKED_WORKER_DIR" add registry/projects.md .dispatcher/task.md
+# Existing but UNTRACKED file: must stay blocked (git ls-files check, not mere existence)
+echo "# untracked" > "$TRACKED_WORKER_DIR/registry/untracked.md"
+
+run_hook_tracked() {
+  local json="$1" stderr_file="$2"
+  local exit_code=0
+  echo "$json" | env WORKER_DIR="$TRACKED_WORKER_DIR" CLAUDE_ORG_PATH="$CLAUDE_ORG_PATH" bash "$HOOK" 2>"$stderr_file" || exit_code=$?
+  echo "$exit_code"
+}
+
+# 40. out-of-org Write to EXISTING tracked registry/projects.md (allow)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$TRACKED_WORKER_DIR"'/registry/projects.md"}}'
+ec=$(run_hook_tracked "$json" "$stderr")
+assert_exit 0 "$ec" "Write(tracked): existing tracked registry/projects.md is allowed"
+
+# 41. out-of-org Edit to EXISTING tracked registry/projects.md (allow)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Edit","tool_input":{"file_path":"'"$TRACKED_WORKER_DIR"'/registry/projects.md"}}'
+ec=$(run_hook_tracked "$json" "$stderr")
+assert_exit 0 "$ec" "Edit(tracked): existing tracked registry/projects.md is allowed"
+
+# 42. out-of-org Write to NEW file under registry/ (block — new creation)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$TRACKED_WORKER_DIR"'/registry/new-file.md"}}'
+ec=$(run_hook_tracked "$json" "$stderr")
+assert_exit 2 "$ec" "Write(tracked): NEW file under registry/ is still blocked"
+assert_stderr_contains "組織構造ディレクトリ" "$stderr" "Write(tracked): new registry/ file stderr mentions 組織構造ディレクトリ"
+
+# 43. out-of-org Write to EXISTING but UNTRACKED registry file (block — not in git index)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$TRACKED_WORKER_DIR"'/registry/untracked.md"}}'
+ec=$(run_hook_tracked "$json" "$stderr")
+assert_exit 2 "$ec" "Write(tracked): existing but untracked registry file is blocked"
+
+# 44. out-of-org Write to EXISTING tracked .dispatcher/task.md (allow — ALWAYS_BLOCKED dirs too)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$TRACKED_WORKER_DIR"'/.dispatcher/task.md"}}'
+ec=$(run_hook_tracked "$json" "$stderr")
+assert_exit 0 "$ec" "Write(tracked): existing tracked .dispatcher/task.md is allowed"
+
+# 45. out-of-org Write to NEW file under .state/ (block — new creation)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$TRACKED_WORKER_DIR"'/.state/state.json"}}'
+ec=$(run_hook_tracked "$json" "$stderr")
+assert_exit 2 "$ec" "Write(tracked): NEW file under .state/ is still blocked"
+
+# 46. in-org Write to tracked registry/projects.md (block — relaxation is out-of-org only)
+#     WORKER_DIR=$REPO_ROOT is inside CLAUDE_ORG_PATH and registry/projects.md is
+#     tracked in this repo, so this asserts the in-org guard is NOT weakened.
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$WORKER_DIR"'/registry/projects.md"}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Write(in-org): tracked registry/projects.md is still blocked"
 
 # --- Summary ---
 echo "# $PASS passed, $FAIL failed out of $TEST_NUM tests"


### PR DESCRIPTION
Closes #736

EN ミラー作業で registry/projects.md(既存 tracked ファイル)の正当な編集がブロックされた誤発火 (2026-07-18) の修正。

## 変更点
- `.hooks/block-org-structure.sh`: Write/Edit 経路に「既存 tracked ファイル編集は許可」の例外を追加。WORKER_DIR の git index 照合(`git ls-files --error-unmatch`、`:(literal)` pathspec で glob 無効化)で新規作成と区別。untracked / repo 外 / git 不在は従来どおりブロック(fail-closed)。
- 緩和は out-of-org worker のみ。in-org worker は tracked でも従来どおりブロック(本体の組織構造保護は不変)。Bash 半(grep ベース)も不変更。
- `tests/test-block-org-structure.sh`: テスト 9 件追加(tracked 許可 / 新規ブロック / untracked ブロック / メタ文字 / in-org 非緩和)。

## Test plan
- shell スイート 421/421 green(hook 単体 64/64)
- python: tests/ 766 OK、tools/ 649 OK (12 skip)、check_role_configs OK
- Codex review: round 1 P2 1 件(glob 穴)→ `:(literal)` で修正、round 2 指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)