### PR TITLE
fix(claude): pr-watch 306s indeterminate — fall back to statusCheckRollup on gh < 2.50

### DIFF
--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -38,6 +38,18 @@ Behavior:
   :func:`_classify_from_checks` already treats as decided. gh's
   documented ``bucket`` values are ``{pass, fail, pending, skipping,
   cancel}``.
+* Issue #739: ``gh pr checks --json`` requires gh >= 2.50.0. On an
+  older gh (Ubuntu 24.04 archive ships 2.45.0) the flag is unknown, so
+  every probe returned empty stdout and each ci-watch round burned the
+  full empty-race resolver budget (13 probes, ~306s) before landing on
+  ``indeterminate`` — even though CI was green (reproduced on all 8
+  PRs of 2026-07-18/19 + ja#743; #719's startup evaluation didn't help
+  because at spawn time the rollup was still pending, routing the
+  whole watch onto the broken probe). :func:`_fetch_checks` now
+  detects the unknown-flag failure, caches the incapability, and
+  serves all probes from ``gh pr view --json statusCheckRollup``
+  (supported on old gh) normalized through the #719 rollup→bucket
+  mapping, so classification is identical to the native probe.
 * Once the self-poll loop observes a decided verdict, or bails out on
   an inconclusive observation (an empty check list / an unparseable
   probe — the Issue #413 freshly-created-PR race), the result is
@@ -528,6 +540,50 @@ def _classify_from_checks(checks: "list[dict]") -> str:
     return _summarize_checks(checks)[0]
 
 
+# Issue #739: capability cache for `gh pr checks --json`. The `--json`
+# flag was only added in gh 2.50.0; on an older gh (e.g. the Ubuntu
+# 24.04 archive still ships 2.45.0) every probe exits non-zero with
+# "unknown flag: --json" on stderr and an EMPTY stdout — an unparseable
+# probe, every time. Pre-#739 that made every ci-watch round burn the
+# full CI_WATCH_EMPTY_RACE_BUDGET_SEC resolver budget (13 probes,
+# ~306s) and land on `indeterminate` even though CI was green — the
+# startup rollup evaluation (#719) didn't help because at spawn time
+# (right after PR creation) the rollup is still pending, so the whole
+# watch rode on the broken probe. Once the unknown-flag failure is
+# seen, we cache ``False`` here and route every subsequent probe
+# through `gh pr view --json statusCheckRollup` (supported on old gh —
+# the same normalized read #719 already uses) instead of re-spawning a
+# subprocess that can never succeed. ``None`` = not yet determined.
+_CHECKS_JSON_SUPPORTED: "bool | None" = None
+
+
+def _fetch_checks_via_rollup(pr: int, repo: str) -> "list[dict] | None":
+    """Checks-shaped probe over ``statusCheckRollup`` (Issue #739).
+
+    Fallback used when the installed gh predates ``pr checks --json``
+    (< 2.50.0). Reads the same aggregate rollup as the startup
+    evaluation (:func:`_fetch_status_rollup`) and normalizes each node
+    to a ``gh pr checks``-style ``bucket`` dict
+    (:func:`_rollup_entry_bucket`), so every downstream consumer
+    (:func:`_self_poll_watch` / :func:`_resolve_final_status` /
+    :func:`_summarize_checks`) classifies identically to the native
+    probe. Returns ``None`` on a fetch/parse failure and ``[]`` when
+    the rollup is empty (no checks visible yet) — preserving the
+    caller-visible tri-state (verdict list / empty / unreadable).
+    """
+    rollup = _fetch_status_rollup(pr, repo)
+    if rollup is None:
+        return None
+    return [
+        {
+            "bucket": _rollup_entry_bucket(entry),
+            "state": entry.get("state") or entry.get("status"),
+            "name": entry.get("name") or entry.get("context"),
+        }
+        for entry in rollup
+    ]
+
+
 def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
     """Return parsed `gh pr checks <pr> --json` results, or ``None`` on error.
 
@@ -544,7 +600,23 @@ def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
     output is unparseable or the binary is missing entirely — that's
     the only condition under which downgrading to the exit-code
     classifier is appropriate.
+
+    Issue #739: when the probe fails because the installed gh does not
+    know the ``--json`` flag at all (added in gh 2.50.0; "unknown flag"
+    on stderr + empty stdout), that is a *permanent* capability gap,
+    not a transient outage — retrying can never succeed. We log it
+    once, cache the incapability in :data:`_CHECKS_JSON_SUPPORTED`,
+    and serve this and every later probe from the rollup fallback
+    (:func:`_fetch_checks_via_rollup`). Any other unparseable probe
+    (network blip, malformed stdout) keeps the existing ``None`` →
+    bounded-retry semantics unchanged, now with a diagnostic line
+    naming gh's exit code and stderr so a future probe failure is
+    attributable from the pane log instead of surfacing only as a
+    306s ``indeterminate`` (the way this bug class hid).
     """
+    global _CHECKS_JSON_SUPPORTED
+    if _CHECKS_JSON_SUPPORTED is False:
+        return _fetch_checks_via_rollup(pr, repo)
     try:
         result = subprocess.run(
             [
@@ -562,6 +634,21 @@ def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
     try:
         data = json.loads(result.stdout or "")
     except json.JSONDecodeError:
+        stderr = result.stderr if isinstance(result.stderr, str) else ""
+        if result.returncode != 0 and "unknown flag" in stderr:
+            _CHECKS_JSON_SUPPORTED = False
+            sys.stderr.write(
+                "tools/pr_watch.py: warning: this gh does not support "
+                "`gh pr checks --json` (added in gh 2.50.0); falling back "
+                "to `gh pr view --json statusCheckRollup` for all CI "
+                "probes. Consider upgrading gh.\n"
+            )
+            return _fetch_checks_via_rollup(pr, repo)
+        sys.stderr.write(
+            "tools/pr_watch.py: warning: unparseable `gh pr checks "
+            f"--json` probe (exit {result.returncode}"
+            f"{', stderr: ' + stderr.strip().splitlines()[0] if stderr.strip() else ''})\n"
+        )
         return None
     if not isinstance(data, list):
         return None

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -2783,5 +2783,214 @@ class StartupStateEvalTests(unittest.TestCase):
             self.assertNotIn("total_checks", rec)
 
 
+class ChecksJsonFallbackTests(unittest.TestCase):
+    """Issue #739: gh < 2.50.0 has no `gh pr checks --json` flag.
+
+    Real-world shape (gh 2.45.0, Ubuntu 24.04 archive): the probe exits
+    1 with "unknown flag: --json" on stderr and EMPTY stdout — an
+    unparseable probe on every attempt. Pre-#739 that made every
+    ci-watch round burn the full CI_WATCH_EMPTY_RACE_BUDGET_SEC
+    resolver budget (13 probes, ~306s) and record `indeterminate` with
+    `retry_recommended`, even though CI was green (reproduced on all 8
+    PRs of 2026-07-18/19 + ja#743, each with a single green check
+    named 'test'). #719's startup evaluation didn't cover it because
+    at spawn time — right after PR creation — the rollup is still
+    pending, so the whole watch rode on the broken probe.
+
+    The fix: `_fetch_checks` detects the unknown-flag failure, caches
+    the incapability, and serves this and all later probes from
+    `gh pr view --json statusCheckRollup` (supported on old gh),
+    normalized through the #719 rollup→bucket mapping.
+    """
+
+    # Verbatim gh 2.45.0 behavior for `gh pr checks ... --json ...`.
+    _UNKNOWN_FLAG_STDERR = (
+        "unknown flag: --json\n"
+        "\n"
+        "Usage:  gh pr checks [<number> | <url> | <branch>] [flags]\n"
+    )
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def _fake_run(
+        self,
+        *,
+        rollup_sequence: "list | None",
+        checks_calls: "list | None" = None,
+    ):
+        """`subprocess.run` stub for an old-gh environment.
+
+        * `gh pr checks ... --json ...` → exit 1, empty stdout,
+          "unknown flag: --json" on stderr (recorded in `checks_calls`).
+        * `gh pr view --json statusCheckRollup` → next entry of
+          `rollup_sequence` (last entry reused); an entry of ``None``
+          simulates an unreadable rollup (empty stdout, exit 1).
+        * `gh pr view --json number` / `headRefOid` → benign defaults.
+        """
+        idx = {"i": 0}
+
+        def fake_run(cmd, *args, **kwargs):
+            if "checks" in cmd and "--json" in cmd:
+                if checks_calls is not None:
+                    checks_calls.append(list(cmd))
+                return mock.Mock(
+                    returncode=1,
+                    stdout="",
+                    stderr=self._UNKNOWN_FLAG_STDERR,
+                )
+            if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
+                jval = cmd[cmd.index("--json") + 1]
+                if jval in ("number", "headRefOid"):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if jval == "statusCheckRollup":
+                    seq = rollup_sequence or [None]
+                    i = idx["i"]
+                    entry = seq[i] if i < len(seq) else seq[-1]
+                    if i < len(seq) - 1:
+                        idx["i"] = i + 1
+                    if entry is None:
+                        return mock.Mock(returncode=1, stdout="", stderr="")
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps({"statusCheckRollup": entry}),
+                        stderr="",
+                    )
+            return mock.Mock(returncode=0)
+
+        return fake_run
+
+    # -- unit level: _fetch_checks ------------------------------------
+
+    def test_unknown_json_flag_falls_back_to_rollup(self) -> None:
+        """The unknown-flag probe is answered from the rollup, in the
+        same bucket vocabulary the native probe would have used."""
+        rollup = [{"__typename": "CheckRun", "name": "test",
+                   "status": "COMPLETED", "conclusion": "SUCCESS"}]
+        fake_run = self._fake_run(rollup_sequence=[rollup])
+        with mock.patch.object(pr_watch, "_CHECKS_JSON_SUPPORTED", None), \
+             mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+            checks = pr_watch._fetch_checks(739, "octo/repo")
+            self.assertEqual(
+                checks,
+                [{"bucket": "pass", "state": "COMPLETED", "name": "test"}],
+            )
+            self.assertIs(pr_watch._CHECKS_JSON_SUPPORTED, False)
+
+    def test_fallback_is_cached_after_first_unknown_flag(self) -> None:
+        """After the first unknown-flag failure the broken subprocess is
+        never spawned again — later probes go straight to the rollup."""
+        rollup = [{"__typename": "CheckRun", "name": "test",
+                   "status": "COMPLETED", "conclusion": "SUCCESS"}]
+        checks_calls: list = []
+        fake_run = self._fake_run(
+            rollup_sequence=[rollup], checks_calls=checks_calls,
+        )
+        with mock.patch.object(pr_watch, "_CHECKS_JSON_SUPPORTED", None), \
+             mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+            pr_watch._fetch_checks(739, "octo/repo")
+            pr_watch._fetch_checks(739, "octo/repo")
+            pr_watch._fetch_checks(739, "octo/repo")
+        self.assertEqual(len(checks_calls), 1)
+
+    def test_unknown_flag_with_unreadable_rollup_is_none(self) -> None:
+        """Fallback active but the rollup is ALSO unreadable → ``None``
+        (the continued-fetch-failure → `indeterminate` path is kept for
+        genuine outages)."""
+        fake_run = self._fake_run(rollup_sequence=[None])
+        with mock.patch.object(pr_watch, "_CHECKS_JSON_SUPPORTED", None), \
+             mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+            self.assertIsNone(pr_watch._fetch_checks(739, "octo/repo"))
+
+    def test_transient_unparseable_probe_does_not_flip_cache(self) -> None:
+        """An unparseable probe WITHOUT the unknown-flag signature (a
+        network blip / malformed stdout) keeps the existing transient
+        semantics: ``None`` now, native probe retried next time."""
+        def fake_run(cmd, *args, **kwargs):
+            if "checks" in cmd and "--json" in cmd:
+                return mock.Mock(returncode=1, stdout="", stderr="HTTP 502")
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+
+        with mock.patch.object(pr_watch, "_CHECKS_JSON_SUPPORTED", None), \
+             mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+            self.assertIsNone(pr_watch._fetch_checks(739, "octo/repo"))
+            self.assertIsNone(pr_watch._CHECKS_JSON_SUPPORTED)
+
+    # -- end to end: the pinned 306s reproduction, now green ----------
+
+    def test_old_gh_green_ci_resolves_passed_not_indeterminate(self) -> None:
+        """The exact field failure, pinned: single check 'test', CI goes
+        green, gh has no `pr checks --json`. Pre-#739 this recorded
+        `indeterminate` after burning the full 300s resolver budget
+        (duration_sec=306 / probe_attempts=13 / retry_recommended on
+        all observed PRs). It must now resolve `passed` via the rollup
+        fallback, with exactly ONE doomed native-probe spawn."""
+        pending = [{"__typename": "CheckRun", "name": "test",
+                    "status": "IN_PROGRESS", "conclusion": None}]
+        green = [{"__typename": "CheckRun", "name": "test",
+                  "status": "COMPLETED", "conclusion": "SUCCESS"}]
+        checks_calls: list = []
+        sleeps: list = []
+        # Startup eval sees pending (watcher spawns right after PR
+        # creation — the reason #719 alone could not cover this bug),
+        # one fallback poll still pending, then green.
+        fake_run = self._fake_run(
+            rollup_sequence=[pending, pending, green],
+            checks_calls=checks_calls,
+        )
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "_CHECKS_JSON_SUPPORTED", None), \
+                 mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", sleeps.append), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 40.0]):
+                rc = pr_watch.main([
+                    "--pr", "739", "--repo", "octo/repo", "--interval", "30",
+                ])
+            self.assertEqual(rc, 0)
+            self.assertEqual(_count_ci_events(journal), 1)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(rec["total_checks"], 1)
+            self.assertEqual(rec["fail_count"], 0)
+            self.assertEqual(rec["pending_count"], 0)
+            self.assertNotIn("retry_recommended", rec)
+            # One unknown-flag spawn, then cached: never retried.
+            self.assertEqual(len(checks_calls), 1)
+            # Still-pending fallback observation polls at --interval
+            # cadence (the self-poll loop, not the bounded resolver).
+            self.assertEqual(sleeps, [30])
+
+    def test_old_gh_red_ci_resolves_failed(self) -> None:
+        """Same environment, red CI: the fallback must report an honest
+        `failed`, not `indeterminate`."""
+        pending = [{"__typename": "CheckRun", "name": "test",
+                    "status": "IN_PROGRESS", "conclusion": None}]
+        red = [{"__typename": "CheckRun", "name": "test",
+                "status": "COMPLETED", "conclusion": "FAILURE"}]
+        fake_run = self._fake_run(rollup_sequence=[pending, red])
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "_CHECKS_JSON_SUPPORTED", None), \
+                 mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 35.0]):
+                rc = pr_watch.main([
+                    "--pr", "739", "--repo", "octo/repo", "--interval", "30",
+                ])
+            self.assertEqual(rc, 1)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "failed")
+            self.assertEqual(rec["fail_count"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Root-cause fix for the pr-watch 306s `indeterminate` verdict (Issue #739, graph-migration B1). The watcher returned `indeterminate` on every PR of the 2026-07-18/19 EN mirror belt (all 8 PRs) and again on ja PR #743, even though CI was green in every case.

## Root cause

The 3 leading hypotheses were all wrong; the actual cause is a 4th:

`gh pr checks --json` is a flag **added in gh 2.50.0**, but this host runs the Ubuntu 24.04 archive build **gh 2.45.0**. Every probe hit `unknown flag: --json` (exit 1, empty stdout) and fell through to the unparseable/empty-race resolver, exhausting the 300s budget over 13 probes (the backoff series lands probe #13 at t≈305s — an exact match to the observed 306s / 13 attempts). This started when #695 replaced `--watch` (which works on 2.45) with `--json` self-polling. #720's startup rollup evaluation didn't catch it because the watcher spawns right after PR creation while CI is still pending.

## Changes (`tools/pr_watch.py`, `tools/test_pr_watch.py`)

1. `_fetch_checks` gains unknown-flag detection: on detection it caches the capability gap at module level and serves all subsequent probes from `gh pr view --json statusCheckRollup` (works on gh 2.45) via the new `_fetch_checks_via_rollup`, reusing #719's rollup→bucket normalization. Classification vocabulary is identical to the native probe.
2. Non-unknown-flag unparseable probes keep the existing transient handling (bounded retry → indeterminate) and gain diagnostic logging (gh exit code + stderr) so future probe failures are identifiable from the pane log.
3. 6 regression tests (`ChecksJsonFallbackTests`) pin the gh 2.45 real response shape as a mock and assert the "single check 'test', CI green ⇒ 306s indeterminate" field failure now resolves to `passed`. Fallback caching, indeterminate-retained-on-rollup-unreadable, and transient-probe cache non-pollution are also covered.

## Design decisions

- Fallback is gated on the **unknown-flag signature only**, not on any unparseable probe, so the existing transient semantics (bounded retry → indeterminate) are preserved for genuine transient failures. Only a deterministic capability gap is treated specially. (Alternative: parsing `gh --version` — rejected as too output-format-dependent.)
- No constant changes (probe interval / budget unchanged).

## Verification (full)

- `tools/test_pr_watch.py`: 87 passed / tools/ 655 passed (12 pre-existing skips) / tests/ 770 passed / drift fixture OK
- Live E2E: ran pr_watch against merged PR #743 with an isolated STATE_DB_PATH → `passed` / 1s / head=c66fd19 (was 306s indeterminate before the fix). The fallback probe alone fetched green in 0.5s on the real gh.
- Codex review (`codex exec review --base main`, gpt-5.5): round 1 clean, no Blocker/Major ("no discrete correctness issues").

## Note

Upgrading the host's gh to 2.50+ auto-restores the native probe (cache is per-process); the fix is correct either way. The acceptance-criteria "live 1-PR dogfood" is out of worker scope (done Lead-side post-merge).

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
