### PR TITLE
docs(claude): org-delegate に並列同一ファイル委譲の brief 文言テンプレを追記

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -118,6 +118,19 @@ allowed-tools:
 
 背景: cp で destination の修正を機械的に巻き戻す事故が過去に発生（destination 側の credential 露出対策 Blocker fix を revert 寸前まで進んだ）。ワーカーへの brief で「初手 cp 禁止 / 取り込み戦略を明示」を要求する。
 
+### 並列委譲で同一ファイルを編集するケースの brief 事前文言
+
+複数 worker を並列派遣し、それらが**同一ファイル（特に同一領域）を編集する**ことが brief 組み立て時点で分かっている場合、`gen_delegate_payload.py` の `--impl-guidance` に次の趣旨の文言をあらかじめ入れる:
+
+> 並走タスク {parallel_task_id} が同じファイル {path} を編集中。窓口が merge 順序の続報を送るので、その続報を受けてから base upstream（通常 `origin/main`）へ rebase して完了報告すること
+
+運用上の注意 2 点:
+
+- **窓口の続報は merge 順序の決定だけでは送らない**。先行 PR が merge され base upstream に反映されたことを確認してから後続 worker に送る（順序決定直後に送ると、先行変更を含まない upstream へ rebase してしまい conflict 防止が成立しない）
+- **rebase 先と適用範囲の読み替え**は [`.claude/skills/org-delegate/references/worker-claude-template.md`](references/worker-claude-template.md) の「完了報告前の rebase」規定に従う（`full` 限定・PR ベースが `origin/main` 以外なら実際の base upstream に読み替え）
+
+事後の追指示（peer message での追送）でも救えるが（2026-07-22 の ja#747 / ja#748 並列編集の実例）、brief 段階で入れておけば窓口→worker の 1 往復が減り、integration point conflict を事前に防げる。完了報告前に base upstream へ rebase してから報告する既存運用と組み合わせると、窓口の残作業は merge 順序の決定と続報通知だけに縮退する。
+
 ## Step 0: プロジェクト名前解決（窓口が実行）
 
 ユーザーの依頼からプロジェクトを特定する:

--- a/.claude/skills/org-delegate/SKILL.md.in
+++ b/.claude/skills/org-delegate/SKILL.md.in
@@ -112,6 +112,19 @@ allowed-tools:
 
 背景: cp で destination の修正を機械的に巻き戻す事故が過去に発生（destination 側の credential 露出対策 Blocker fix を revert 寸前まで進んだ）。ワーカーへの brief で「初手 cp 禁止 / 取り込み戦略を明示」を要求する。
 
+### 並列委譲で同一ファイルを編集するケースの brief 事前文言
+
+複数 worker を並列派遣し、それらが**同一ファイル（特に同一領域）を編集する**ことが brief 組み立て時点で分かっている場合、`gen_delegate_payload.py` の `--impl-guidance` に次の趣旨の文言をあらかじめ入れる:
+
+> 並走タスク {parallel_task_id} が同じファイル {path} を編集中。窓口が merge 順序の続報を送るので、その続報を受けてから base upstream（通常 `origin/main`）へ rebase して完了報告すること
+
+運用上の注意 2 点:
+
+- **窓口の続報は merge 順序の決定だけでは送らない**。先行 PR が merge され base upstream に反映されたことを確認してから後続 worker に送る（順序決定直後に送ると、先行変更を含まない upstream へ rebase してしまい conflict 防止が成立しない）
+- **rebase 先と適用範囲の読み替え**は [`.claude/skills/org-delegate/references/worker-claude-template.md`](references/worker-claude-template.md) の「完了報告前の rebase」規定に従う（`full` 限定・PR ベースが `origin/main` 以外なら実際の base upstream に読み替え）
+
+事後の追指示（peer message での追送）でも救えるが（2026-07-22 の ja#747 / ja#748 並列編集の実例）、brief 段階で入れておけば窓口→worker の 1 往復が減り、integration point conflict を事前に防げる。完了報告前に base upstream へ rebase してから報告する既存運用と組み合わせると、窓口の残作業は merge 順序の決定と続報通知だけに縮退する。
+
 ## Step 0: プロジェクト名前解決（窓口が実行）
 
 ユーザーの依頼からプロジェクトを特定する:


### PR DESCRIPTION
## Summary

キュレーター提案（ユーザー承認済み）の実装。並列 worker が同一ファイルを編集する委譲パターンで、brief 段階から merge 順序調整を織り込む文言テンプレを org-delegate に追記する。

- `.claude/skills/org-delegate/SKILL.md.in` の「委譲前チェックリスト」配下に「並列委譲で同一ファイルを編集するケースの brief 事前文言」サブセクションを新設（生成物 SKILL.md は `tools/gen_skill_prose.py` で再生成）
- 内容: 並列派遣で同一ファイル編集が brief 組み立て時点で分かっている場合、`gen_delegate_payload.py --impl-guidance` に「並走タスク {parallel_task_id} が同ファイルを編集中。窓口が merge 順序を通知するので、先行 PR の merge・base upstream への反映を確認した続報を受けてから rebase して完了報告すること」の趣旨を事前記載する
- 根拠: 2026-07-22 の ja#747/#748 並列編集の実例（事後追指示で手戻りゼロに救えたが、brief 事前記載なら 1 往復少ない）。完了報告前 rebase 運用と組み合わせると、窓口の作業は merge 順序決定だけに縮退する

## Codex レビュー反映

- 続報の送信タイミングを「先行 PR merge・base upstream 反映確認後」に明確化（早すぎる続報で未反映 upstream に rebase する穴を塞ぐ）
- rebase 指示を worker-claude-template.md の規定（full 限定・base upstream 読み替え）への参照付きに修正
- 修正後ラウンドで Blocker/Major ゼロ確認

## Verification

- `gen_skill_prose.py --check` clean（CI drift check と同一コマンド）
- `tools.test_gen_skill_prose` 62 tests OK / `audit_link_paths.py` 新規指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
