### PR TITLE
docs(claude): work-discovery の allowed-tools 説明を「機械的担保」から実態に訂正

### DIFF
--- a/.claude/skills/work-discovery/SKILL.md
+++ b/.claude/skills/work-discovery/SKILL.md
@@ -42,8 +42,13 @@ open Issue を triage し、依存解決済みの候補を「N 件 + 推奨 1 �
 - **INV-1 propose-only**: 本スキルの出力は「候補リスト + 提示」のみ。生成後に**停止する**。
   spawn / delegate / ブランチ作成 / commit / PR / Issue・PR への書き込みを**一切しない**。
   （allowed-tools が repo 解決（`tools/work_discovery_repos.py`）と scan（`tools/work_discovery_scan.py`）の
-  read-only コマンドだけに絞られているのは、この不変条件の機械的担保でもある。resolver も scan と同じく
-  read-only で、`git remote get-url` と任意の `gh repo view` 読み取りのみを行い、書き込み・spawn・git 変更をしない。）
+  read-only コマンドだけに絞られているのは、この不変条件の**宣言的な意図表明**であって機械的強制ではない。
+  `allowed-tools` は列挙したツールを起動ターンに限って事前承認するフィールドで、列挙外のツールを禁じない
+  （列挙外は通常の permission 設定に従い確認プロンプトが出るだけ）。絞り込みの実利は正路の明示と
+  プロンプト削減であり、正路を外れたときに確認という摩擦が立つこと。不変条件を機械的に強制したい場合は
+  `PreToolUse` フック（例: [`.hooks/block-foreground-subagent.sh`](../../../.hooks/block-foreground-subagent.sh)）を
+  別途置く。resolver も scan と同じく read-only で、`git remote get-url` と任意の `gh repo view` 読み取りのみを
+  行い、書き込み・spawn・git 変更をしない。）
 - **INV-2 着手判断は人間ゲート必須**: 候補の選択は人間のみ。選ばれた候補は
   **既存の [`/org-delegate`](../org-delegate/SKILL.md) の Step 0 から**通常委譲フローに入る。
   本スキルが org-delegate を自分で呼ぶことは禁止。推奨（rank 1）の自動着手も禁止。


### PR DESCRIPTION
## 背景

Issue #773。`.claude/skills/work-discovery/SKILL.md` が、skill frontmatter の `allowed-tools` の絞り込みを
**「この不変条件の機械的担保でもある」**と説明していたが、これは Claude Code の実際の仕様と異なる。

公式仕様（code.claude.com/docs/en/skills）では `allowed-tools` は **skill を invoke したターンに限って
列挙ツールを事前承認する**フィールドであり、**利用可能なツールを制限しない**。列挙外のツールも呼び出し可能で、
通常の permission 設定に従う（＝確認プロンプトが出るだけ）。窓口は契約上 per-tool prompt で動く役割
（`docs/contracts/role-contract.md:57`）なので、未登録コマンドで確認が出ることは設計どおりの挙動である。

この誤記は実害を出している: Issue #771 の調査でこの記述を真に受けた結果、「triage 中は窓口がファイルを
1 つも開けない」「org-delegate が自身の手順に必要なツールを禁じている」という誤った結論に至り、
7 ファイルの改訂提案まで進んだ。独立検証で全面的に否定され、実際に必要だったのは 2 ファイルだった。

## 変更内容

1 ファイル、prose のみ。

- 「機械的担保」→「**宣言的な意図表明**であって機械的強制ではない」に訂正
- 実際の semantics（起動ターン限定の事前承認 / 列挙外は禁止されずプロンプトが出るだけ）を明記
- 絞り込みの実利を正しく述べ直す（正路の明示とプロンプト削減、正路を外れたときに確認という摩擦が立つこと）
- **本当に機械強制したい場合の手段**として `PreToolUse` フック（既存の `.hooks/block-foreground-subagent.sh`）
  を 1 行で示す。否定だけして代替を示さないと「では何が保証するのか」の穴が残るため

## 点検して変更しなかった箇所

隣接する 2 箇所を個別に評価し、いずれも訂正不要と判断した:

- `.claude/skills/org-attach/SKILL.md:232` — 「何を allowed-tools に含めないか」を述べているだけで、
  omission が呼び出しを prevent するとは主張していない。記述として正確
- `.claude/skills/org-conveyor/SKILL.md:82` — むしろ**正しい記述**。union 列挙で
  「非アクティブ transport のツールまで認可され per-transport auth モデルを迂回する」＝
  「列挙すると事前承認される」という実 semantics そのものを述べている

repo 全体を `機械的担保` / `機械的に担保` / `機械強制` で grep した結果、誤記は本 PR が直す 1 箇所のみだった。

## スコープ外

`allowed-tools` frontmatter 自体は一切変更していない（本 PR は prose の正確性のみが対象）。
Issue #773 に併記した org-delegate の事前承認登録漏れ（`Bash(git cat-file:*)` 等が未登録で、
`references/delegate-flow-details.md` §1.5 が要求する操作のたびに余計な確認が出る）は follow-up として保留。

## 検証

Codex レビュー（`--base origin/main`）: Blocker / Major ゼロ、指摘ゼロ。
`tools/audit_link_paths.py` で新規リンクの表記規約適合も確認済み。

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
