### PR TITLE
fix(claude): 窓口 hook の相対パスを絶対パス形へ統一し、正規化監査を追加

### DIFF
--- a/.claude/skills/org-setup/SKILL.md
+++ b/.claude/skills/org-setup/SKILL.md
@@ -145,11 +145,14 @@ hook が解決されず、ガードが無言で無効化する）。prune ツー
 1. `--claude-org-path <abs>` 引数
 2. 既存 `settings.local.json` の `env.CLAUDE_ORG_PATH`
 3. 既存 hook command 内の `bash "<abs>/.hooks/..."` の `<abs>`
-4. audit root（`--root`、既定はリポジトリルート）。`<root>/.hooks/` が実在する場合のみ採用する
+4. audit root（`--root`、既定はリポジトリルート）。`<root>/.hooks/` に schema の
+   `required_hook_scripts` が**全て実在する場合のみ**採用する
 
 窓口テンプレートには `env.CLAUDE_ORG_PATH` が無いため、初回実行では 2 も 3 も取れず 4 で解決される。
-`<root>/.hooks/` が無い（org checkout ではない）場合は 4 も発火せず、
-`unresolved placeholders` で中断するので、誤った `--root` の内容が黙って書き込まれることはない。
+4 の条件を満たさない（org checkout ではない）場合は `unresolved placeholders` で中断するので、
+誤った `--root` の内容が黙って書き込まれることはない。`.hooks/` ディレクトリの実在だけを条件に
+すると、たまたま同名ディレクトリを持つ無関係なプロジェクトを org root として受理し、
+存在しないスクリプトを指す hook（＝生成時点で死んでいるガード）を書いてしまうため。
 
 いずれも取れない場合（fresh install など）は `--claude-org-path` を明示する:
 

--- a/.claude/skills/org-setup/SKILL.md
+++ b/.claude/skills/org-setup/SKILL.md
@@ -136,14 +136,20 @@ closed-world 検証から除外する（`_load_override_allow`）。よって ov
 `disallow_allow_regex`（旧 `mcp__claude-peers__*`、現 `renga-peers` 等）は override 側にあっても
 従来通り ERROR となる。安全契約は override で迂回できない。
 
-#### dispatcher の `{claude_org_path}` 解決
+#### `{claude_org_path}` の解決（窓口 / dispatcher / worker）
 
-dispatcher テンプレートには `{claude_org_path}` プレースホルダがある。
-prune ツールは以下の優先順で解決する:
+窓口・dispatcher・worker のテンプレートには `{claude_org_path}` プレースホルダがある
+（hook command を絶対パスで固定するため。相対パスだと cwd が org ルート以外のロールで
+hook が解決されず、ガードが無言で無効化する）。prune ツールは以下の優先順で解決する:
 
 1. `--claude-org-path <abs>` 引数
 2. 既存 `settings.local.json` の `env.CLAUDE_ORG_PATH`
 3. 既存 hook command 内の `bash "<abs>/.hooks/..."` の `<abs>`
+4. audit root（`--root`、既定はリポジトリルート）。`<root>/.hooks/` が実在する場合のみ採用する
+
+窓口テンプレートには `env.CLAUDE_ORG_PATH` が無いため、初回実行では 2 も 3 も取れず 4 で解決される。
+`<root>/.hooks/` が無い（org checkout ではない）場合は 4 も発火せず、
+`unresolved placeholders` で中断するので、誤った `--root` の内容が黙って書き込まれることはない。
 
 いずれも取れない場合（fresh install など）は `--claude-org-path` を明示する:
 

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -204,7 +204,7 @@ python tools/org_setup_prune.py --user-common-sandbox  # → "no changes"
         "hooks": [
           {
             "type": "command",
-            "command": "bash .hooks/block-workers-delete.sh"
+            "command": "bash \"{claude_org_path}/.hooks/block-workers-delete.sh\""
           }
         ]
       }
@@ -212,6 +212,8 @@ python tools/org_setup_prune.py --user-common-sandbox  # → "no changes"
   }
 }
 ```
+
+**注意**: `{claude_org_path}` は settings.local.json 生成時に解決済みの絶対パスに置換すること。Hook command 内のパスはスペース対策のためクォートされている。相対パス（`bash .hooks/...`）で書くと、cwd が org ルート以外のロール（ディスパッチャーの cwd は `.dispatcher/`）では hook が解決されず、ガードが**エラーも出さずに無効化**する。
 
 **mcp__renga-peers__\* の重複**: ユーザー共通 settings.json と重複するが、窓口は run 直後に renga-peers MCP を必ず使うため、窓口スコープでも明示的に列挙して source-of-truth として固定する（user settings の drift でも窓口が動くことを保証）。
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,7 @@ claude-org-runtime org up                                    # broker daemon を
 1. `/org-setup` — ロール別 `settings.local.json`（窓口・ディスパッチャー・キュレーター・ワーカー）と必須 hook を配置。**初回のみ必須**。未実行だと broker（renga フォールバック時は renga-peers）MCP / git / gh で大量の許可プロンプトが出る。
 2. `/org-start` — 組織を起動。ディスパッチャーが派生する（既定 broker では独立した detached ペイン、renga フォールバックでは同一タブ内 split として。走行中のペインを read-only で覗く attach 導線は [`docs/operations/broker-dogfood-runbook.md`](operations/broker-dogfood-runbook.md) §8 を参照）。キュレーターは知見が溜まったときにオンデマンドで一時起動される。
 
-`/org-setup` は **additive-only**（不足分を追加するだけで既存を消さない）。drift を baseline に戻したい場合は [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) のロール別サンプル JSON で `settings.local.json` を手動置換する。
+`/org-setup` は **additive-only**（不足分を追加するだけで既存を消さない）。drift を baseline に戻したい場合は `python tools/org_setup_prune.py --role <role>` を使う（[`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) のロール別サンプル JSON を SoT として書き戻し、`{claude_org_path}` / `{worker_dir}` プレースホルダを絶対パスへ自動解決する）。サンプル JSON を手でコピーする場合は、**プレースホルダを必ず実環境の絶対パスへ解決すること**（未解決のまま貼ると hook のパスが存在せず、ガードがエラーも出さずに無効化する）。
 
 > **⚠️ main pull 後の 1 回必須（Issue #429 Task B / C + Issue #433）**: 共有 `.claude/settings.json` から個人パスエントリを除去したため（denyRead 系: `Read(~/.ssh/*)` / `Read(~/.aws/*)` 等、denyWrite 系: `~/.claude/settings.json`）、初回 / pull 後に **`python tools/org_setup_prune.py --user-common-sandbox` を 1 回実行**してください（単一フラグで denyRead + denyWrite 両系統を補完）。未実行だと個人環境の sandbox 防御が一時的に弱くなります（[README §個人 sandbox の補強](../README.md) と [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) 参照）。なお `~/.config/gh` は gh CLI が窓口業務動線で必須のため候補から除外しており、過去のリビジョンで個人 settings.json に残っていれば次回実行時に自動的に prune されます。
 >
@@ -257,7 +257,8 @@ git diff .claude/skills/org-setup/references/permissions.md
 
 - **schema に未登録の allow が `permissions.md` または実 settings に混入している場合**: 必要なエントリなら schema にまず追記してから permissions.md / settings.local.json に展開する。不要なら該当エントリを削除する。
 - **`permissions.md` のサンプル JSON が schema と乖離している場合**: schema を正と見なし、`permissions.md` 側を schema に合わせて書き直す。
-- **`/org-setup` 再実行後も `settings.local.json` に drift が残る場合**: additive-only なので自動では消えない。`.claude/skills/org-setup/references/permissions.md` のロール別サンプル JSON で該当ロールの `settings.local.json` を**丸ごと置換**して baseline に戻す（**last resort**）。worker サンプルの `{worker_dir}` / `{claude_org_path}` プレースホルダは置換時に実環境の絶対パスへ手で解決する必要がある。ローカル独自に追加していた override があれば事前に控えておくこと。
+- **`/org-setup` 再実行後も `settings.local.json` に drift が残る場合**: additive-only なので自動では消えない。`python tools/org_setup_prune.py --role <role>` で該当ロールの `settings.local.json` を baseline へ**丸ごと置換**する（`.bak` が自動生成される。`--dry-run` で先に diff を確認できる）。`.claude/skills/org-setup/references/permissions.md` のサンプル JSON を手でコピーする経路は **last resort** であり、その場合は**窓口・ディスパッチャー・ワーカーいずれのサンプルでも** `{claude_org_path}` / `{worker_dir}` プレースホルダを実環境の絶対パスへ手で解決する必要がある（未解決のまま貼ると hook のパスが存在せず、ガードがエラーも出さずに無効化する）。ローカル独自に追加していた override があれば事前に控えておくこと。
+- **`hook command is not anchored at the org root` / `hook command references a script that does not exist` が出る場合**: hook command が相対パス（`bash .hooks/...`）や裸のファイル名（`bash block-workers-delete.sh`）になっている。cwd が org ルート以外のロール（ディスパッチャーの cwd は `.dispatcher/`）では hook が解決されず、**ガードがエラーも出さずに無効化する**。`permissions.md` 側を `bash "{claude_org_path}/.hooks/<script>"` 形式へ直し、既存端末の `settings.local.json` は `python tools/org_setup_prune.py --role <role>` で再生成する。
 
 ### schema の JSON parse エラー / 読み込み失敗
 

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -589,6 +590,329 @@ class IsGitTrackedFailClosedTests(unittest.TestCase):
             )
 
 
+HOOK_PATH_SCHEMA: dict = {
+    "version": 1,
+    "global": {"forbidden_allow_exact": [], "forbidden_allow_regex": []},
+    "required_hook_scripts": ["block-workers-delete.sh"],
+    "roles": {"secretary": {"docs_section": "窓口", "settings_paths": []}},
+}
+
+
+def _md_with_secretary_hook(command: str) -> str:
+    block = {
+        "permissions": {"allow": []},
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": command}],
+                }
+            ]
+        },
+    }
+    return (
+        "# perms\n\n## 窓口 (`<repo>/.claude/settings.local.json`)\n\n"
+        "```json\n" + json.dumps(block, indent=2) + "\n```\n"
+    )
+
+
+class HookCommandPathTests(unittest.TestCase):
+    """Hook commands must normalize to ``<org root>/.hooks/<script>``.
+
+    Issue #768: ``required_hooks.command_contains`` matches the bare
+    script basename anywhere in the command string, so a relative
+    ``bash .hooks/x.sh`` and the absolute quoted form are the same to
+    it -- but the relative form silently no-ops for any role whose cwd
+    is not the org root. Every ``_flagged`` case below passes
+    ``command_contains``; only this check rejects them.
+    """
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.root = Path(self.td.name)
+        (self.root / ".hooks").mkdir()
+        (self.root / ".hooks" / "block-workers-delete.sh").write_text(
+            "#!/usr/bin/env bash\n", encoding="utf-8"
+        )
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def _run(self, command, schema=None):
+        md = self.root / "permissions.md"
+        md.write_text(_md_with_secretary_hook(command), encoding="utf-8")
+        return crc.check_hook_command_paths(
+            schema or HOOK_PATH_SCHEMA, md, self.root
+        )
+
+    def _assert_flagged(self, command, needle="not anchored at the org root"):
+        findings = self._run(command)
+        self.assertEqual(len(findings), 1, [f.format() for f in findings])
+        self.assertEqual(findings[0].severity, "ERROR")
+        self.assertIn(needle, findings[0].message)
+
+    def _assert_clean(self, command):
+        findings = self._run(command)
+        self.assertEqual(findings, [], [f.format() for f in findings])
+
+    def test_relative_hooks_dir_is_flagged(self):
+        # The literal Issue #768 shape.
+        self._assert_flagged("bash .hooks/block-workers-delete.sh")
+
+    def test_bare_filename_is_flagged(self):
+        # Cheapest reintroduction of #768, and the case a ``.hooks/``-keyed
+        # trigger would skip entirely.
+        self._assert_flagged("bash block-workers-delete.sh")
+
+    def test_dot_slash_filename_is_flagged(self):
+        self._assert_flagged("bash ./block-workers-delete.sh")
+
+    def test_other_directory_is_flagged(self):
+        self._assert_flagged("bash scripts/block-workers-delete.sh")
+
+    def test_quoted_bare_filename_is_flagged(self):
+        self._assert_flagged('bash "block-workers-delete.sh"')
+
+    def test_cd_then_bare_filename_is_flagged(self):
+        self._assert_flagged(
+            'cd "{claude_org_path}" && bash block-workers-delete.sh'
+        )
+
+    def test_anchored_command_with_unanchored_fallback_is_flagged(self):
+        self._assert_flagged(
+            'bash "{claude_org_path}/.hooks/block-workers-delete.sh"'
+            " || bash block-workers-delete.sh"
+        )
+
+    def test_missing_separator_is_flagged(self):
+        self._assert_flagged('bash "{claude_org_path}block-workers-delete.sh"')
+
+    def test_foreign_absolute_root_is_flagged(self):
+        # A leading-slash ``command_contains`` fragment would pass this.
+        self._assert_flagged(
+            'bash "/some/other/root/.hooks/block-workers-delete.sh"'
+        )
+
+    def test_parent_traversal_is_flagged(self):
+        self._assert_flagged(
+            'bash "{claude_org_path}/.hooks/../../etc/block-workers-delete.sh"'
+        )
+
+    def test_missing_script_is_flagged(self):
+        self._assert_flagged(
+            'bash "{claude_org_path}/.hooks/block-does-not-exist.sh"',
+            needle="does not exist",
+        )
+
+    def test_placeholder_absolute_form_passes(self):
+        self._assert_clean(
+            'bash "{claude_org_path}/.hooks/block-workers-delete.sh"'
+        )
+
+    def test_windows_backslash_form_passes(self):
+        self._assert_clean(
+            'bash "{claude_org_path}\\.hooks\\block-workers-delete.sh"'
+        )
+
+    def test_command_without_hook_reference_is_ignored(self):
+        self._assert_clean("echo hello")
+
+    def test_operator_custom_hook_is_ignored(self):
+        # Not a required hook script and not under .hooks/: operator-owned.
+        self._assert_clean('bash "{claude_org_path}/mytools/my-own-lint.sh"')
+
+    def test_worker_roles_template_is_checked(self):
+        schema = dict(HOOK_PATH_SCHEMA)
+        schema["worker_roles"] = {
+            "$comment": "string entries must be skipped, not crashed on",
+            "default": {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "bash .hooks/block-workers-delete.sh",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            },
+        }
+        findings = self._run(
+            'bash "{claude_org_path}/.hooks/block-workers-delete.sh"', schema
+        )
+        self.assertEqual(len(findings), 1, [f.format() for f in findings])
+        self.assertIn("worker_roles.default", findings[0].source)
+
+    def test_non_org_source_root_returns_no_findings(self):
+        # Guard against a false-positive storm: pointing the check at a
+        # directory that ships no .hooks/ must not flag every template.
+        with tempfile.TemporaryDirectory() as bare:
+            md = self.root / "permissions.md"
+            md.write_text(
+                _md_with_secretary_hook("bash .hooks/block-workers-delete.sh"),
+                encoding="utf-8",
+            )
+            findings = crc.check_hook_command_paths(
+                HOOK_PATH_SCHEMA, md, Path(bare)
+            )
+        self.assertEqual(findings, [])
+
+
+class OnDiskHookPathTests(unittest.TestCase):
+    """Root-anchoring check for *generated* settings files.
+
+    Opt-in: only the ``--include-local`` / ``--role`` paths run it, so
+    the CI invocation stays byte-identical. Real ``settings.local.json``
+    files are gitignored, so this is the only mechanical way to confirm
+    an installed terminal was actually migrated.
+    """
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.root = Path(self.td.name)
+        (self.root / ".hooks").mkdir()
+        (self.root / ".hooks" / "block-workers-delete.sh").write_text(
+            "#!/usr/bin/env bash\n", encoding="utf-8"
+        )
+        self.settings = self.root / ".claude" / "settings.local.json"
+        self.settings.parent.mkdir()
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def _config(self, command):
+        return {
+            "permissions": {"allow": []},
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": command}],
+                    }
+                ]
+            },
+        }
+
+    def _run(self, command):
+        return crc.check_on_disk_hook_paths(
+            HOOK_PATH_SCHEMA,
+            self.settings,
+            "secretary",
+            self._config(command),
+            self.root,
+        )
+
+    def test_relative_command_on_disk_is_flagged(self):
+        findings = self._run("bash .hooks/block-workers-delete.sh")
+        self.assertEqual(len(findings), 1, [f.format() for f in findings])
+        self.assertIn("not anchored at the org root", findings[0].message)
+
+    def test_resolved_absolute_command_passes(self):
+        cmd = (
+            'bash "' + self.root.resolve().as_posix()
+            + '/.hooks/block-workers-delete.sh"'
+        )
+        self.assertEqual(self._run(cmd), [])
+
+    def test_claude_project_dir_variable_passes(self):
+        # Claude Code expands this itself; tracked .claude/settings.json
+        # legitimately uses it.
+        self.assertEqual(
+            self._run(
+                'bash "${CLAUDE_PROJECT_DIR}/.hooks/block-workers-delete.sh"'
+            ),
+            [],
+        )
+
+    def test_unresolved_prune_placeholder_on_disk_is_flagged(self):
+        # The "pasted the permissions.md sample without resolving it" case:
+        # the literal placeholder is not a real path, so the guard is dead.
+        findings = self._run(
+            'bash "{claude_org_path}/.hooks/block-workers-delete.sh"'
+        )
+        self.assertEqual(len(findings), 1, [f.format() for f in findings])
+        self.assertIn("not anchored at the org root", findings[0].message)
+
+    def test_skipped_when_root_ships_no_hooks_dir(self):
+        with tempfile.TemporaryDirectory() as bare:
+            findings = crc.check_on_disk_hook_paths(
+                HOOK_PATH_SCHEMA,
+                self.settings,
+                "secretary",
+                self._config("bash .hooks/block-workers-delete.sh"),
+                Path(bare),
+            )
+        self.assertEqual(findings, [])
+
+    def _check_on_disk(self, include_untracked):
+        schema = {
+            **HOOK_PATH_SCHEMA,
+            "roles": {
+                "secretary": {
+                    "docs_section": "窓口",
+                    "settings_paths": [".claude/settings.local.json"],
+                }
+            },
+        }
+        self.settings.write_text(
+            json.dumps(self._config("bash .hooks/block-workers-delete.sh")),
+            encoding="utf-8",
+        )
+        return crc.check_on_disk(
+            schema,
+            self.root,
+            include_untracked=include_untracked,
+            role_override="secretary",
+        )
+
+    def test_opt_in_path_reports_the_finding(self):
+        messages = [f.message for f in self._check_on_disk(True)]
+        self.assertTrue(
+            any("not anchored at the org root" in m for m in messages),
+            messages,
+        )
+
+    def test_default_path_does_not_report_the_finding(self):
+        # CI does not pass --include-local / --role, so its result must be
+        # unchanged by this feature.
+        messages = [f.message for f in self._check_on_disk(False)]
+        self.assertFalse(
+            any("not anchored at the org root" in m for m in messages),
+            messages,
+        )
+
+
+class NonOrgAuditRootTests(unittest.TestCase):
+    """``--root`` pointing outside an org checkout must stay non-fatal.
+
+    ``check_hook_command_paths`` validates the SoT templates, which ship
+    next to ``.hooks/``, so ``run()`` anchors it at ``REPO_ROOT`` rather
+    than the audit root. Without that, every template command would be
+    reported as a missing script whenever ``--root`` is elsewhere.
+    """
+
+    def test_docs_only_run_with_foreign_root_is_clean(self):
+        with tempfile.TemporaryDirectory() as bare:
+            findings = crc.run(
+                schema_path=crc.DEFAULT_SCHEMA,
+                permissions_md=crc.DEFAULT_PERMISSIONS_MD,
+                root=Path(bare),
+                include_on_disk=False,
+            )
+        self.assertEqual(
+            findings, [], msg="\n".join(f.format() for f in findings)
+        )
+
+    def test_main_docs_only_with_foreign_root_exits_zero(self):
+        with tempfile.TemporaryDirectory() as bare:
+            rc = crc.main(["--docs-only", "--root", bare])
+        self.assertEqual(rc, 0)
+
+
 class RealRepoSmokeTests(unittest.TestCase):
     """Sanity check: the real schema + real permissions.md must pass.
 
@@ -602,6 +926,18 @@ class RealRepoSmokeTests(unittest.TestCase):
             permissions_md=crc.DEFAULT_PERMISSIONS_MD,
             root=crc.REPO_ROOT,
             include_on_disk=True,
+        )
+        self.assertEqual(
+            findings, [], msg="\n".join(f.format() for f in findings)
+        )
+
+    def test_real_repo_hook_commands_are_root_anchored(self):
+        # Named regression lock for Issue #768: a reintroduced relative hook
+        # command fails here with a legible test name, not only inside the
+        # aggregate projection smoke above.
+        schema = crc.load_schema(crc.DEFAULT_SCHEMA)
+        findings = crc.check_hook_command_paths(
+            schema, crc.DEFAULT_PERMISSIONS_MD, crc.REPO_ROOT
         )
         self.assertEqual(
             findings, [], msg="\n".join(f.format() for f in findings)

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -721,6 +721,44 @@ class HookCommandPathTests(unittest.TestCase):
         # Not a required hook script and not under .hooks/: operator-owned.
         self._assert_clean('bash "{claude_org_path}/mytools/my-own-lint.sh"')
 
+    def test_suffix_glued_to_quoted_path_is_flagged(self):
+        # The shell joins the quote to what abuts it, so this really runs
+        # ...block-workers-delete.sh.bak, which does not exist -> guard dead.
+        # Validating the quoted segment alone would call this anchored.
+        self._assert_flagged(
+            'bash "{claude_org_path}/.hooks/block-workers-delete.sh".bak',
+            needle="does not exist",
+        )
+
+    def test_prefix_glued_to_quoted_path_is_flagged(self):
+        self._assert_flagged(
+            'bash /wrong"{claude_org_path}/.hooks/block-workers-delete.sh"'
+        )
+
+    def test_symlinked_root_is_accepted(self):
+        # A checkout reached through a symlink is lexically different but
+        # identifies the same script; it must not be reported.
+        link = Path(self.td.name).parent / (self.root.name + "-link")
+        try:
+            link.symlink_to(self.root, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks unavailable")
+        try:
+            md = self.root / "permissions.md"
+            md.write_text(
+                _md_with_secretary_hook(
+                    'bash "' + link.as_posix()
+                    + '/.hooks/block-workers-delete.sh"'
+                ),
+                encoding="utf-8",
+            )
+            findings = crc.check_hook_command_paths(
+                HOOK_PATH_SCHEMA, md, self.root
+            )
+        finally:
+            link.unlink()
+        self.assertEqual(findings, [], [f.format() for f in findings])
+
     def test_worker_roles_template_is_checked(self):
         schema = dict(HOOK_PATH_SCHEMA)
         schema["worker_roles"] = {
@@ -836,6 +874,34 @@ class OnDiskHookPathTests(unittest.TestCase):
         )
         self.assertEqual(len(findings), 1, [f.format() for f in findings])
         self.assertIn("not anchored at the org root", findings[0].message)
+
+    def test_declared_org_path_anchors_a_worktree_worker(self):
+        # A worker in a worktree has root=<worktree> but its hooks correctly
+        # point at the central checkout named by env.CLAUDE_ORG_PATH.
+        # Anchoring on root would flag every valid hook.
+        worktree = self.root / ".worktrees" / "task"
+        (worktree / ".claude").mkdir(parents=True)
+        config = self._config(
+            'bash "' + self.root.resolve().as_posix()
+            + '/.hooks/block-workers-delete.sh"'
+        )
+        config["env"] = {"CLAUDE_ORG_PATH": self.root.resolve().as_posix()}
+        findings = crc.check_on_disk_hook_paths(
+            HOOK_PATH_SCHEMA,
+            worktree / ".claude" / "settings.local.json",
+            "worker",
+            config,
+            worktree,
+        )
+        self.assertEqual(findings, [], [f.format() for f in findings])
+
+    def test_declared_org_path_still_flags_a_relative_command(self):
+        config = self._config("bash .hooks/block-workers-delete.sh")
+        config["env"] = {"CLAUDE_ORG_PATH": self.root.resolve().as_posix()}
+        findings = crc.check_on_disk_hook_paths(
+            HOOK_PATH_SCHEMA, self.settings, "worker", config, self.root
+        )
+        self.assertEqual(len(findings), 1, [f.format() for f in findings])
 
     def test_skipped_when_root_ships_no_hooks_dir(self):
         with tempfile.TemporaryDirectory() as bare:

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -903,6 +903,56 @@ class OnDiskHookPathTests(unittest.TestCase):
         )
         self.assertEqual(len(findings), 1, [f.format() for f in findings])
 
+    def test_project_dir_variable_resolves_to_the_project_not_the_org_root(self):
+        # ${CLAUDE_PROJECT_DIR} expands to the directory holding the settings
+        # file. When that differs from the org root, a script that exists only
+        # centrally makes this command dead and it must be reported.
+        worktree = self.root / ".worktrees" / "task"
+        (worktree / ".claude").mkdir(parents=True)
+        config = self._config(
+            'bash "${CLAUDE_PROJECT_DIR}/.hooks/block-workers-delete.sh"'
+        )
+        config["env"] = {"CLAUDE_ORG_PATH": self.root.resolve().as_posix()}
+        findings = crc.check_on_disk_hook_paths(
+            HOOK_PATH_SCHEMA,
+            worktree / ".claude" / "settings.local.json",
+            "worker",
+            config,
+            worktree,
+        )
+        self.assertEqual(len(findings), 1, [f.format() for f in findings])
+
+    def test_project_dir_variable_passes_when_script_is_present(self):
+        worktree = self.root / ".worktrees" / "task"
+        (worktree / ".claude").mkdir(parents=True)
+        (worktree / ".hooks").mkdir()
+        (worktree / ".hooks" / "block-workers-delete.sh").write_text(
+            "#!/usr/bin/env bash\n", encoding="utf-8"
+        )
+        config = self._config(
+            'bash "${CLAUDE_PROJECT_DIR}/.hooks/block-workers-delete.sh"'
+        )
+        config["env"] = {"CLAUDE_ORG_PATH": self.root.resolve().as_posix()}
+        findings = crc.check_on_disk_hook_paths(
+            HOOK_PATH_SCHEMA,
+            worktree / ".claude" / "settings.local.json",
+            "worker",
+            config,
+            worktree,
+        )
+        self.assertEqual(findings, [], [f.format() for f in findings])
+
+    def test_stale_declared_org_path_is_reported(self):
+        # A moved / deleted checkout leaves every absolute hook command dead;
+        # silently skipping would hide a broken installation.
+        config = self._config("bash /gone/.hooks/block-workers-delete.sh")
+        config["env"] = {"CLAUDE_ORG_PATH": str(self.root / "gone")}
+        findings = crc.check_on_disk_hook_paths(
+            HOOK_PATH_SCHEMA, self.settings, "worker", config, self.root
+        )
+        self.assertEqual(len(findings), 1, [f.format() for f in findings])
+        self.assertIn("no .hooks/", findings[0].message)
+
     def test_skipped_when_root_ships_no_hooks_dir(self):
         with tempfile.TemporaryDirectory() as bare:
             findings = crc.check_on_disk_hook_paths(

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -231,43 +231,74 @@ def check_docs(schema: dict, permissions_md: Path) -> list:
 
 
 _HOOKS_DIR_MARKER = ".hooks/"
+_SHELL_WORD_BREAKS = frozenset(" \t\r\n;|&<>()")
+_WINDOWS_ABS_RE = re.compile(r"^[A-Za-z]:/")
+
+
+def _shell_words(command: str) -> list:
+    """Split ``command`` into shell words, honouring quote concatenation.
+
+    Quoted segments must NOT be validated on their own: the shell joins
+    a quote to whatever abuts it, so ``bash "<root>/.hooks/x.sh".bak``
+    is the single word ``<root>/.hooks/x.sh.bak`` and actually executes
+    a file that does not exist -- leaving the guard dead, which is the
+    very failure mode Issue #768 is about. Treating the quoted part
+    alone would report that command as correctly anchored.
+    """
+    words: list = []
+    current: list = []
+    started = False
+    quote = None
+    for ch in command:
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            else:
+                current.append(ch)
+            continue
+        if ch in ('"', "'"):
+            quote = ch
+            started = True
+            continue
+        if ch in _SHELL_WORD_BREAKS:
+            if started:
+                words.append("".join(current))
+                current = []
+                started = False
+            continue
+        current.append(ch)
+        started = True
+    if started:
+        words.append("".join(current))
+    return words
+
+
+def _is_absolute_posixish(path: str) -> bool:
+    """True for ``/unix/abs`` and ``C:/windows/abs`` alike."""
+    return path.startswith("/") or bool(_WINDOWS_ABS_RE.match(path))
 
 
 def _hook_script_refs(command: str, required_scripts: frozenset) -> list:
-    """Path-like tokens in ``command`` that should resolve to a hook script.
-
-    Double-quoted segments are taken whole (hook commands quote the path
-    so it survives spaces in the org root); the unquoted remainder is
-    split on whitespace.
+    """Shell words in ``command`` that should resolve to a hook script.
 
     The selection test deliberately does NOT key off the ``.hooks/``
     literal alone. Issue #768 is a *cwd-dependent hook command* defect,
     and the cheapest way to reintroduce it is to drop the directory from
     the path entirely (``bash block-workers-delete.sh``). A ``.hooks/``
-    -only trigger would skip exactly those commands, so a token also
+    -only trigger would skip exactly those commands, so a word also
     qualifies when it names -- or ends with -- one of the schema's
-    ``required_hook_scripts``. Tokens that match none of the three tests
+    ``required_hook_scripts``. Words matching none of the three tests
     are operator-owned commands and are left alone.
     """
-    refs: list = []
-    remainder: list = []
-    pos = 0
-    for m in re.finditer(r'"([^"]*)"', command):
-        remainder.append(command[pos:m.start()])
-        refs.append(m.group(1))
-        pos = m.end()
-    remainder.append(command[pos:])
-    for token in " ".join(remainder).split():
-        refs.append(token.strip("'"))
     selected: list = []
-    for ref in refs:
-        slashed = ref.replace("\\", "/")
+    for word in _shell_words(command):
+        slashed = word.replace("\\", "/")
         if (
             _HOOKS_DIR_MARKER in slashed
             or posixpath.basename(slashed) in required_scripts
             or any(slashed.endswith(s) for s in required_scripts)
         ):
-            selected.append(ref)
+            selected.append(word)
     return selected
 
 
@@ -311,6 +342,17 @@ def _check_template_hook_paths(
             normalized = posixpath.normpath(resolved.replace("\\", "/"))
             script = posixpath.basename(normalized)
             expected = posixpath.normpath(root_posix + "/" + ".hooks" + "/" + script)
+            if normalized != expected and _is_absolute_posixish(normalized):
+                # A checkout reached through a symlink yields a valid but
+                # lexically different path; compare canonical targets before
+                # rejecting. Only for already-absolute paths -- resolving a
+                # relative one would silently anchor it at the CWD, which is
+                # precisely the defect being audited.
+                try:
+                    if Path(normalized).resolve() == Path(expected).resolve():
+                        normalized = expected
+                except OSError:
+                    pass
             if normalized != expected:
                 findings.append(
                     Finding(
@@ -436,8 +478,20 @@ def check_on_disk_hook_paths(
     -- real ``settings.local.json`` files are gitignored, so CI never
     sees whether an installed terminal still carries the relative form
     that Issue #768 shipped.
+
+    The anchor is the org root the file itself declares in
+    ``env.CLAUDE_ORG_PATH``, falling back to ``root``. A worker running
+    inside a worktree has ``root`` set to that worktree while its hooks
+    correctly point at the central checkout, so anchoring on ``root``
+    there would report every valid hook as unanchored.
     """
-    resolved_root = Path(root).resolve()
+    env = (config or {}).get("env") or {}
+    declared = env.get("CLAUDE_ORG_PATH") if isinstance(env, dict) else None
+    anchor = declared if isinstance(declared, str) and declared else root
+    try:
+        resolved_root = Path(anchor).resolve()
+    except OSError:
+        return []
     if not (resolved_root / ".hooks").is_dir():
         return []
     return _check_template_hook_paths(

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import posixpath
 import re
 import subprocess
 import sys
@@ -153,6 +154,8 @@ __all__ = [
     "extract_role_blocks",
     "check_worker_settings",
     "check_docs",
+    "check_hook_command_paths",
+    "check_on_disk_hook_paths",
     "check_on_disk",
     "run",
     "main",
@@ -225,6 +228,226 @@ def check_docs(schema: dict, permissions_md: Path) -> list:
             )
         )
     return findings
+
+
+_HOOKS_DIR_MARKER = ".hooks/"
+
+
+def _hook_script_refs(command: str, required_scripts: frozenset) -> list:
+    """Path-like tokens in ``command`` that should resolve to a hook script.
+
+    Double-quoted segments are taken whole (hook commands quote the path
+    so it survives spaces in the org root); the unquoted remainder is
+    split on whitespace.
+
+    The selection test deliberately does NOT key off the ``.hooks/``
+    literal alone. Issue #768 is a *cwd-dependent hook command* defect,
+    and the cheapest way to reintroduce it is to drop the directory from
+    the path entirely (``bash block-workers-delete.sh``). A ``.hooks/``
+    -only trigger would skip exactly those commands, so a token also
+    qualifies when it names -- or ends with -- one of the schema's
+    ``required_hook_scripts``. Tokens that match none of the three tests
+    are operator-owned commands and are left alone.
+    """
+    refs: list = []
+    remainder: list = []
+    pos = 0
+    for m in re.finditer(r'"([^"]*)"', command):
+        remainder.append(command[pos:m.start()])
+        refs.append(m.group(1))
+        pos = m.end()
+    remainder.append(command[pos:])
+    for token in " ".join(remainder).split():
+        refs.append(token.strip("'"))
+    selected: list = []
+    for ref in refs:
+        slashed = ref.replace("\\", "/")
+        if (
+            _HOOKS_DIR_MARKER in slashed
+            or posixpath.basename(slashed) in required_scripts
+            or any(slashed.endswith(s) for s in required_scripts)
+        ):
+            selected.append(ref)
+    return selected
+
+
+def _iter_hook_commands(config: dict):
+    hooks = (config or {}).get("hooks") or {}
+    if not isinstance(hooks, dict):
+        return
+    for event, entries in hooks.items():
+        for entry in entries or []:
+            if not isinstance(entry, dict):
+                continue
+            for sub in entry.get("hooks") or []:
+                if isinstance(sub, dict) and isinstance(sub.get("command"), str):
+                    yield event, sub["command"]
+
+
+def _check_template_hook_paths(
+    source: str,
+    role: str,
+    config: dict,
+    source_root: Path,
+    required_scripts: frozenset,
+    placeholders: tuple = ("{claude_org_path}",),
+) -> list:
+    """Report hook commands in ``config`` that are not root-anchored.
+
+    ``placeholders`` names the tokens substituted with the org root
+    before normalization. Templates resolve ``{claude_org_path}``; a
+    *generated* settings file must not still contain it, so the on-disk
+    caller passes a different set and the surviving literal is reported
+    (that is the "pasted the sample without resolving it" case).
+    """
+    findings: list = []
+    resolved_root = Path(source_root).resolve()
+    root_posix = resolved_root.as_posix()
+    for event, command in _iter_hook_commands(config):
+        for ref in _hook_script_refs(command, required_scripts):
+            resolved = ref
+            for token in placeholders:
+                resolved = resolved.replace(token, root_posix)
+            normalized = posixpath.normpath(resolved.replace("\\", "/"))
+            script = posixpath.basename(normalized)
+            expected = posixpath.normpath(root_posix + "/" + ".hooks" + "/" + script)
+            if normalized != expected:
+                findings.append(
+                    Finding(
+                        source,
+                        role,
+                        "ERROR",
+                        (
+                            f"{event} hook command is not anchored at the org "
+                            f"root: {ref!r} normalizes to {normalized!r}, "
+                            f"expected {expected!r}. A relative or otherwise "
+                            "unanchored hook path silently no-ops for any role "
+                            "whose cwd is not the org root; use: "
+                            'bash "{claude_org_path}/.hooks/<script>"'
+                        ),
+                    )
+                )
+                continue
+            if not (resolved_root / ".hooks" / script).is_file():
+                findings.append(
+                    Finding(
+                        source,
+                        role,
+                        "ERROR",
+                        (
+                            f"{event} hook command references a script that "
+                            f"does not exist: {expected!r}"
+                        ),
+                    )
+                )
+    return findings
+
+
+def check_hook_command_paths(
+    schema: dict,
+    permissions_md: Path,
+    source_root: Path = REPO_ROOT,
+    *,
+    schema_path: Path = DEFAULT_SCHEMA,
+) -> list:
+    """Every org-role hook command must resolve to ``<root>/.hooks/<script>``.
+
+    ``required_hooks.command_contains`` only asserts that the script
+    *basename* appears somewhere in the command string, so the relative
+    ``bash .hooks/x.sh`` and the absolute ``bash "<root>/.hooks/x.sh"``
+    are indistinguishable to it -- yet the relative form is a silent
+    no-op for every role whose cwd is not the org root (the dispatcher
+    runs in ``.dispatcher/``). That is how Issue #768 passed CI.
+
+    This check normalizes rather than matching substrings: placeholders
+    are substituted with the org root, ``\\`` is folded to ``/`` for
+    Windows-form commands, the result is ``normpath``-ed and compared
+    for *equality* against the root-anchored path, and the script must
+    exist on disk. Equality rejects the four cases a path-fragment
+    substring test would still pass: a foreign absolute root, a ``..``
+    escape, a nonexistent script, and a bare relative filename.
+
+    ``source_root`` is the checkout that ships ``.hooks/`` -- NOT the
+    audit ``--root``. The sources validated here are the SoT *templates*
+    (permissions.md role blocks and the schema's ``worker_roles``), which
+    always travel next to the hook scripts they name, so anchoring them
+    at an unrelated audit root would emit one spurious finding per
+    template command. Returns ``[]`` when ``source_root`` has no
+    ``.hooks/`` directory, mirroring the prune tool's guard.
+    """
+    resolved_root = Path(source_root).resolve()
+    if not (resolved_root / ".hooks").is_dir():
+        return []
+    required_scripts = frozenset(schema.get("required_hook_scripts") or ())
+    findings: list = []
+    if Path(permissions_md).is_file():
+        text = Path(permissions_md).read_text(encoding="utf-8")
+        blocks = extract_role_blocks(text, schema["roles"])
+        for role_name, role_schema in schema["roles"].items():
+            if not role_schema.get("docs_section"):
+                continue
+            config = blocks.get(role_name)
+            if not isinstance(config, dict) or "__parse_error__" in config:
+                # check_docs already reports missing / unparsable blocks.
+                continue
+            findings.extend(
+                _check_template_hook_paths(
+                    f"permissions.md[{role_schema['docs_section']}]",
+                    role_name,
+                    config,
+                    resolved_root,
+                    required_scripts,
+                )
+            )
+    schema_name = Path(schema_path).name
+    for wr_name, template in (schema.get("worker_roles") or {}).items():
+        if not isinstance(template, dict):
+            continue  # ``$comment*`` string entries
+        findings.extend(
+            _check_template_hook_paths(
+                f"{schema_name}[worker_roles.{wr_name}]",
+                wr_name,
+                template,
+                resolved_root,
+                required_scripts,
+            )
+        )
+    return findings
+
+
+# ``${CLAUDE_PROJECT_DIR}`` is expanded by Claude Code itself, so a
+# generated settings file may legitimately carry it; ``{claude_org_path}``
+# is a prune-time placeholder and must already be resolved on disk.
+_ON_DISK_PLACEHOLDERS = ("${CLAUDE_PROJECT_DIR}",)
+
+
+def check_on_disk_hook_paths(
+    schema: dict,
+    settings_path: Path,
+    role: str,
+    config: dict,
+    root: Path,
+) -> list:
+    """Root-anchoring check for one *generated* settings file.
+
+    Opt-in counterpart to ``check_hook_command_paths``: wired only into
+    the ``--include-local`` / ``--role`` paths, which already read
+    on-disk files. Without it a merged fix is unverifiable in the field
+    -- real ``settings.local.json`` files are gitignored, so CI never
+    sees whether an installed terminal still carries the relative form
+    that Issue #768 shipped.
+    """
+    resolved_root = Path(root).resolve()
+    if not (resolved_root / ".hooks").is_dir():
+        return []
+    return _check_template_hook_paths(
+        str(settings_path),
+        role,
+        config,
+        resolved_root,
+        frozenset(schema.get("required_hook_scripts") or ()),
+        placeholders=_ON_DISK_PLACEHOLDERS,
+    )
 
 
 class _GitTrackedError(Exception):
@@ -372,6 +595,12 @@ def check_on_disk(
                     extra_allowed=_load_override_allow(path),
                 )
             )
+            if include_untracked:
+                findings.extend(
+                    check_on_disk_hook_paths(
+                        schema, path, role_override, config, Path(root)
+                    )
+                )
         if not checked_any:
             findings.append(
                 Finding(
@@ -432,6 +661,12 @@ def check_on_disk(
                     extra_allowed=_load_override_allow(path),
                 )
             )
+            if include_untracked:
+                findings.extend(
+                    check_on_disk_hook_paths(
+                        schema, path, role_name, config, Path(root)
+                    )
+                )
     return findings
 
 
@@ -448,6 +683,13 @@ def run(
     findings: list = []
     findings.extend(validate_schema_integrity(schema))
     findings.extend(check_docs(schema, permissions_md))
+    # Anchored at REPO_ROOT (the checkout shipping .hooks/), not ``root``:
+    # this validates the SoT templates, which are not root-dependent.
+    findings.extend(
+        check_hook_command_paths(
+            schema, permissions_md, REPO_ROOT, schema_path=schema_path
+        )
+    )
     if include_on_disk:
         findings.extend(
             check_on_disk(

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -315,45 +315,63 @@ def _iter_hook_commands(config: dict):
                     yield event, sub["command"]
 
 
-def _check_template_hook_paths(
+def _anchored_at(normalized: str, script: str, anchor: Path) -> bool:
+    """True iff ``normalized`` is ``<anchor>/.hooks/<script>``."""
+    expected = posixpath.normpath(
+        anchor.as_posix() + "/" + ".hooks" + "/" + script
+    )
+    if normalized == expected:
+        return True
+    if not _is_absolute_posixish(normalized):
+        # Resolving a relative path would silently anchor it at the CWD --
+        # precisely the defect being audited. Never accept one.
+        return False
+    # A checkout reached through a symlink is lexically different but names
+    # the same script; compare canonical targets before rejecting.
+    try:
+        return Path(normalized).resolve() == Path(expected).resolve()
+    except OSError:
+        return False
+
+
+def _check_hook_paths(
     source: str,
     role: str,
     config: dict,
-    source_root: Path,
+    anchors: tuple,
     required_scripts: frozenset,
-    placeholders: tuple = ("{claude_org_path}",),
+    placeholders: dict,
 ) -> list:
     """Report hook commands in ``config`` that are not root-anchored.
 
-    ``placeholders`` names the tokens substituted with the org root
-    before normalization. Templates resolve ``{claude_org_path}``; a
-    *generated* settings file must not still contain it, so the on-disk
-    caller passes a different set and the surviving literal is reported
-    (that is the "pasted the sample without resolving it" case).
+    ``anchors`` are the roots under whose ``.hooks/`` a command may
+    legitimately live; a command is accepted when it resolves under any
+    of them AND the script exists there. ``placeholders`` maps each
+    substitutable token to the root it expands to -- they differ, so
+    they cannot share one value: ``{claude_org_path}`` is a prune-time
+    placeholder resolved to the org root, while ``${CLAUDE_PROJECT_DIR}``
+    is expanded by Claude Code to the *project* directory holding the
+    settings file. A generated settings file must not still contain
+    ``{claude_org_path}``, so the on-disk caller omits it and the
+    surviving literal is reported (the "pasted the sample without
+    resolving it" case).
     """
     findings: list = []
-    resolved_root = Path(source_root).resolve()
-    root_posix = resolved_root.as_posix()
     for event, command in _iter_hook_commands(config):
         for ref in _hook_script_refs(command, required_scripts):
             resolved = ref
-            for token in placeholders:
-                resolved = resolved.replace(token, root_posix)
+            for token, value in placeholders.items():
+                resolved = resolved.replace(token, value)
             normalized = posixpath.normpath(resolved.replace("\\", "/"))
             script = posixpath.basename(normalized)
-            expected = posixpath.normpath(root_posix + "/" + ".hooks" + "/" + script)
-            if normalized != expected and _is_absolute_posixish(normalized):
-                # A checkout reached through a symlink yields a valid but
-                # lexically different path; compare canonical targets before
-                # rejecting. Only for already-absolute paths -- resolving a
-                # relative one would silently anchor it at the CWD, which is
-                # precisely the defect being audited.
-                try:
-                    if Path(normalized).resolve() == Path(expected).resolve():
-                        normalized = expected
-                except OSError:
-                    pass
-            if normalized != expected:
+            matched = next(
+                (a for a in anchors if _anchored_at(normalized, script, a)),
+                None,
+            )
+            if matched is None:
+                expected = posixpath.normpath(
+                    anchors[0].as_posix() + "/" + ".hooks" + "/" + script
+                )
                 findings.append(
                     Finding(
                         source,
@@ -370,7 +388,7 @@ def _check_template_hook_paths(
                     )
                 )
                 continue
-            if not (resolved_root / ".hooks" / script).is_file():
+            if not (matched / ".hooks" / script).is_file():
                 findings.append(
                     Finding(
                         source,
@@ -378,7 +396,10 @@ def _check_template_hook_paths(
                         "ERROR",
                         (
                             f"{event} hook command references a script that "
-                            f"does not exist: {expected!r}"
+                            "does not exist: "
+                            + posixpath.normpath(
+                                matched.as_posix() + "/.hooks/" + script
+                            )
                         ),
                     )
                 )
@@ -433,12 +454,13 @@ def check_hook_command_paths(
                 # check_docs already reports missing / unparsable blocks.
                 continue
             findings.extend(
-                _check_template_hook_paths(
+                _check_hook_paths(
                     f"permissions.md[{role_schema['docs_section']}]",
                     role_name,
                     config,
-                    resolved_root,
+                    (resolved_root,),
                     required_scripts,
+                    {"{claude_org_path}": resolved_root.as_posix()},
                 )
             )
     schema_name = Path(schema_path).name
@@ -446,21 +468,19 @@ def check_hook_command_paths(
         if not isinstance(template, dict):
             continue  # ``$comment*`` string entries
         findings.extend(
-            _check_template_hook_paths(
+            _check_hook_paths(
                 f"{schema_name}[worker_roles.{wr_name}]",
                 wr_name,
                 template,
-                resolved_root,
+                (resolved_root,),
                 required_scripts,
+                {"{claude_org_path}": resolved_root.as_posix()},
             )
         )
     return findings
 
 
-# ``${CLAUDE_PROJECT_DIR}`` is expanded by Claude Code itself, so a
-# generated settings file may legitimately carry it; ``{claude_org_path}``
-# is a prune-time placeholder and must already be resolved on disk.
-_ON_DISK_PLACEHOLDERS = ("${CLAUDE_PROJECT_DIR}",)
+_CLAUDE_PROJECT_DIR = "${CLAUDE_PROJECT_DIR}"
 
 
 def check_on_disk_hook_paths(
@@ -479,28 +499,54 @@ def check_on_disk_hook_paths(
     sees whether an installed terminal still carries the relative form
     that Issue #768 shipped.
 
-    The anchor is the org root the file itself declares in
-    ``env.CLAUDE_ORG_PATH``, falling back to ``root``. A worker running
-    inside a worktree has ``root`` set to that worktree while its hooks
-    correctly point at the central checkout, so anchoring on ``root``
-    there would report every valid hook as unanchored.
+    Two roots are legitimate here and they are NOT interchangeable: the
+    org root the file declares in ``env.CLAUDE_ORG_PATH`` (falling back
+    to ``root``), and the project directory holding the settings file,
+    which is what Claude Code expands ``${CLAUDE_PROJECT_DIR}`` to. A
+    worker in a worktree has ``root`` set to that worktree while its
+    hooks correctly point at the central checkout, so collapsing the two
+    would either flag every valid hook or accept a dead
+    ``${CLAUDE_PROJECT_DIR}`` path that only exists centrally.
     """
     env = (config or {}).get("env") or {}
     declared = env.get("CLAUDE_ORG_PATH") if isinstance(env, dict) else None
-    anchor = declared if isinstance(declared, str) and declared else root
+    declared = declared if isinstance(declared, str) and declared else None
     try:
-        resolved_root = Path(anchor).resolve()
+        org_root = Path(declared).resolve() if declared else Path(root).resolve()
+        project_dir = Path(settings_path).resolve().parent.parent
     except OSError:
         return []
-    if not (resolved_root / ".hooks").is_dir():
+    if not (org_root / ".hooks").is_dir():
+        if declared is not None:
+            # An explicitly declared root with no .hooks/ is a broken
+            # installation (e.g. the checkout was moved or deleted): every
+            # absolute hook command in this file is dead. Only the silent
+            # ``root`` fallback may be skipped.
+            return [
+                Finding(
+                    str(settings_path),
+                    role,
+                    "ERROR",
+                    (
+                        "env.CLAUDE_ORG_PATH points at "
+                        f"{org_root.as_posix()!r}, which has no .hooks/ "
+                        "directory; every hook command anchored there is "
+                        "dead. Repoint it at the org checkout and "
+                        "regenerate via tools/org_setup_prune.py."
+                    ),
+                )
+            ]
         return []
-    return _check_template_hook_paths(
+    anchors = (org_root,)
+    if project_dir != org_root and (project_dir / ".hooks").is_dir():
+        anchors = (org_root, project_dir)
+    return _check_hook_paths(
         str(settings_path),
         role,
         config,
-        resolved_root,
+        anchors,
         frozenset(schema.get("required_hook_scripts") or ()),
-        placeholders=_ON_DISK_PLACEHOLDERS,
+        {_CLAUDE_PROJECT_DIR: project_dir.as_posix()},
     )
 
 

--- a/tools/org_setup_prune.py
+++ b/tools/org_setup_prune.py
@@ -214,7 +214,7 @@ def detect_claude_org_path(current: dict | None) -> str | None:
     return None
 
 
-def _root_as_claude_org_path(root: Path) -> str | None:
+def _root_as_claude_org_path(root: Path, schema: dict) -> str | None:
     """Last-resort ``{claude_org_path}`` source: the audit root itself.
 
     Only consulted when neither ``--claude-org-path`` nor the existing
@@ -224,16 +224,23 @@ def _root_as_claude_org_path(root: Path) -> str | None:
     hook command, so ``detect_claude_org_path`` has nothing to infer
     from and prune would abort on an unresolved placeholder.
 
-    Guarded on ``<root>/.hooks`` being a real directory so a ``--root``
-    that is not an org checkout still hits the unresolved-placeholder
-    abort in ``build_target`` rather than silently generating hook
-    commands anchored at a directory that holds no hook scripts.
+    Accepted only when every ``required_hook_scripts`` entry really
+    exists under ``<root>/.hooks/``. A bare ``.hooks/`` directory test
+    would accept an unrelated project that happens to have one and then
+    write hook commands pointing at scripts that do not exist -- a
+    generated guard that is dead on arrival. Failing the test leaves the
+    unresolved-placeholder abort in ``build_target`` reachable, which is
+    the documented fail-safe for a mistaken ``--root``.
     """
     try:
         resolved = root.resolve()
     except OSError:
         return None
-    if not (resolved / ".hooks").is_dir():
+    hooks_dir = resolved / ".hooks"
+    if not hooks_dir.is_dir():
+        return None
+    required = schema.get("required_hook_scripts") or ()
+    if not all((hooks_dir / name).is_file() for name in required):
         return None
     return resolved.as_posix()
 
@@ -1025,7 +1032,7 @@ def process_role(
     cop = (
         claude_org_path_arg
         or detect_claude_org_path(current)
-        or _root_as_claude_org_path(root)
+        or _root_as_claude_org_path(root, schema)
     )
     role_schema = schema["roles"].get(role, {})
     try:

--- a/tools/org_setup_prune.py
+++ b/tools/org_setup_prune.py
@@ -214,6 +214,30 @@ def detect_claude_org_path(current: dict | None) -> str | None:
     return None
 
 
+def _root_as_claude_org_path(root: Path) -> str | None:
+    """Last-resort ``{claude_org_path}`` source: the audit root itself.
+
+    Only consulted when neither ``--claude-org-path`` nor the existing
+    settings file yields a value. The secretary template carries no
+    ``env.CLAUDE_ORG_PATH``, and on the first run after the template
+    gained the placeholder the on-disk file still holds the old relative
+    hook command, so ``detect_claude_org_path`` has nothing to infer
+    from and prune would abort on an unresolved placeholder.
+
+    Guarded on ``<root>/.hooks`` being a real directory so a ``--root``
+    that is not an org checkout still hits the unresolved-placeholder
+    abort in ``build_target`` rather than silently generating hook
+    commands anchored at a directory that holds no hook scripts.
+    """
+    try:
+        resolved = root.resolve()
+    except OSError:
+        return None
+    if not (resolved / ".hooks").is_dir():
+        return None
+    return resolved.as_posix()
+
+
 # ---------- merge ----------
 
 def deep_merge(base: dict, overlay: dict) -> dict:
@@ -998,7 +1022,11 @@ def process_role(
             print(f"[org_setup_prune] role={role}: override file has invalid shape: {ov_path} ({shape_err}); aborting.", file=sys.stderr)
             return 2
 
-    cop = claude_org_path_arg or detect_claude_org_path(current)
+    cop = (
+        claude_org_path_arg
+        or detect_claude_org_path(current)
+        or _root_as_claude_org_path(root)
+    )
     role_schema = schema["roles"].get(role, {})
     try:
         target = build_target(

--- a/tools/test_org_setup_prune.py
+++ b/tools/test_org_setup_prune.py
@@ -34,7 +34,7 @@ SAMPLE_PERMISSIONS_MD = """# perms
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "hooks": [{"type": "command", "command": "bash .hooks/block-workers-delete.sh"}]
+        "hooks": [{"type": "command", "command": "bash \\"{claude_org_path}/.hooks/block-workers-delete.sh\\""}]
       }
     ]
   }
@@ -142,6 +142,9 @@ class EndToEndTests(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         self.root = Path(self.td.name)
         (self.root / ".claude").mkdir()
+        # The {claude_org_path} root fallback only fires when the root looks
+        # like an org checkout, i.e. carries a .hooks/ directory.
+        (self.root / ".hooks").mkdir()
         # Stale current settings with drift entries.
         self.cur_path = self.root / ".claude" / "settings.local.json"
         self.cur_path.write_text(json.dumps({
@@ -228,15 +231,85 @@ class EndToEndTests(unittest.TestCase):
         self.assertIn("C:/from-existing/.hooks/block-no-verify.sh", cmd)
 
     def test_dispatcher_aborts_when_placeholder_unresolvable(self) -> None:
-        # Fresh dispatcher dir with no existing settings.
+        # Fresh dispatcher dir with no existing settings, and a root that is
+        # not an org checkout (no .hooks/), so the root fallback stays out of
+        # the way and the unresolved-placeholder abort is still reachable.
+        bare = self.root / "bare"
+        bare.mkdir()
         rc = p.main([
             "--role", "dispatcher",
-            "--root", str(self.root),
+            "--root", str(bare),
             "--schema", str(self._schema_file()),
             "--permissions-md", str(self._md_file()),
         ])
         # Should exit non-zero (SystemExit string -> exit code 1 from argparse).
         self.assertNotEqual(rc, 0)
+
+    # ---- Issue #768: {claude_org_path} resolution precedence -------------
+    # The secretary template carries the placeholder but no env.CLAUDE_ORG_PATH,
+    # so on a first run there is nothing to detect it from. These pin the full
+    # chain: explicit arg > detected from existing settings > audit root.
+
+    def _prune_secretary(self, *extra: str) -> int:
+        return p.main([
+            "--role", "secretary",
+            "--root", str(self.root),
+            "--schema", str(self._schema_file()),
+            "--permissions-md", str(self._md_file()),
+            "--no-backup",
+            *extra,
+        ])
+
+    def _written_hook_command(self) -> str:
+        cfg = json.loads(self.cur_path.read_text(encoding="utf-8"))
+        return cfg["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+
+    def test_secretary_placeholder_falls_back_to_root(self) -> None:
+        self.assertEqual(self._prune_secretary(), 0)
+        expected = (
+            'bash "' + self.root.resolve().as_posix()
+            + '/.hooks/block-workers-delete.sh"'
+        )
+        self.assertEqual(self._written_hook_command(), expected)
+
+    def test_explicit_arg_beats_root_fallback(self) -> None:
+        self.assertEqual(
+            self._prune_secretary("--claude-org-path", "C:/explicit"), 0
+        )
+        cmd = self._written_hook_command()
+        self.assertIn("C:/explicit/.hooks/block-workers-delete.sh", cmd)
+        self.assertNotIn(self.root.resolve().as_posix(), cmd)
+
+    def test_detected_env_beats_root_fallback(self) -> None:
+        self.cur_path.write_text(json.dumps({
+            "env": {"CLAUDE_ORG_PATH": "C:/from-existing"},
+            "permissions": {"allow": []},
+        }), encoding="utf-8")
+        self.assertEqual(self._prune_secretary(), 0)
+        cmd = self._written_hook_command()
+        self.assertIn("C:/from-existing/.hooks/block-workers-delete.sh", cmd)
+        self.assertNotIn(self.root.resolve().as_posix(), cmd)
+
+    def test_secretary_aborts_when_root_is_not_an_org_checkout(self) -> None:
+        bare = self.root / "bare2"
+        (bare / ".claude").mkdir(parents=True)
+        rc = p.main([
+            "--role", "secretary",
+            "--root", str(bare),
+            "--schema", str(self._schema_file()),
+            "--permissions-md", str(self._md_file()),
+            "--no-backup",
+        ])
+        self.assertNotEqual(rc, 0)
+
+    def test_second_prune_run_is_content_stable(self) -> None:
+        # Run 1 writes the absolute form; run 2 must re-detect that exact value
+        # (detect_claude_org_path reads the quoted hook command) and produce a
+        # byte-identical file, so the fallback cannot drift the anchor.
+        self.assertEqual(self._prune_secretary(), 0)
+        first = self.cur_path.read_text(encoding="utf-8")
+        self.assertEqual(self._prune_secretary(), 0)
+        self.assertEqual(self.cur_path.read_text(encoding="utf-8"), first)
 
 
 class SafetyGateTests(unittest.TestCase):

--- a/tools/test_org_setup_prune.py
+++ b/tools/test_org_setup_prune.py
@@ -69,6 +69,10 @@ SAMPLE_PERMISSIONS_MD = """# perms
 SAMPLE_SCHEMA = {
     "version": 1,
     "global": {"forbidden_allow_exact": [], "forbidden_allow_regex": []},
+    "required_hook_scripts": [
+        "block-workers-delete.sh",
+        "block-no-verify.sh",
+    ],
     "roles": {
         "user_common": {"docs_section": "ユーザー共通", "settings_paths": []},
         "secretary": {"docs_section": "窓口", "settings_paths": [".claude/settings.local.json"]},
@@ -143,8 +147,13 @@ class EndToEndTests(unittest.TestCase):
         self.root = Path(self.td.name)
         (self.root / ".claude").mkdir()
         # The {claude_org_path} root fallback only fires when the root looks
-        # like an org checkout, i.e. carries a .hooks/ directory.
+        # like an org checkout: a .hooks/ directory holding every
+        # required_hook_scripts entry.
         (self.root / ".hooks").mkdir()
+        for name in SAMPLE_SCHEMA["required_hook_scripts"]:
+            (self.root / ".hooks" / name).write_text(
+                "#!/usr/bin/env bash\n", encoding="utf-8"
+            )
         # Stale current settings with drift entries.
         self.cur_path = self.root / ".claude" / "settings.local.json"
         self.cur_path.write_text(json.dumps({
@@ -296,6 +305,25 @@ class EndToEndTests(unittest.TestCase):
         rc = p.main([
             "--role", "secretary",
             "--root", str(bare),
+            "--schema", str(self._schema_file()),
+            "--permissions-md", str(self._md_file()),
+            "--no-backup",
+        ])
+        self.assertNotEqual(rc, 0)
+
+    def test_root_with_hooks_dir_but_no_org_scripts_is_rejected(self) -> None:
+        # An unrelated project that happens to carry a .hooks/ directory must
+        # not be accepted as the org root: the generated hook commands would
+        # point at scripts that do not exist, i.e. a guard dead on arrival.
+        foreign = self.root / "foreign"
+        (foreign / ".claude").mkdir(parents=True)
+        (foreign / ".hooks").mkdir()
+        (foreign / ".hooks" / "unrelated-lint.sh").write_text(
+            "#!/usr/bin/env bash\n", encoding="utf-8"
+        )
+        rc = p.main([
+            "--role", "secretary",
+            "--root", str(foreign),
             "--schema", str(self._schema_file()),
             "--permissions-md", str(self._md_file()),
             "--no-backup",


### PR DESCRIPTION
## 背景

Issue #768。`.claude/skills/org-setup/references/permissions.md` の窓口セクションだけが
`bash .hooks/block-workers-delete.sh`（相対パス）で、他ロールは全て
`bash "{claude_org_path}/.hooks/<script>.sh"`（quoted 絶対パス展開形）だった。

相対形は cwd が ja ルート以外のロール（ディスパッチャーの cwd は `.dispatcher/`）のセッションで
解決に失敗する。Claude Code はリポジトリルートの `.claude/settings.local.json`（= 窓口の設定）も
読み込むため、そこに書かれた相対パスが `.dispatcher/.hooks/...` として解決され、
PreToolUse hook が non-blocking エラーで素通りする。結果としてワーカーディレクトリの
削除ガードが黙って無効になる。

## 変更内容

### 1. 欠陥そのものの修正

`permissions.md:207` の窓口 hook command を他ロールと同じ `{claude_org_path}` 展開形へ統一。
fence 直後に不変条件の注記を追加。

### 2. 監査の粒度是正（新チェック `check_hook_command_paths`）

既存の `required_hooks.command_contains` は script の basename 部分一致で、相対形と絶対形を
区別できない（本 Issue が CI を素通りした理由）。新チェックは部分一致をやめ、
placeholder 展開 → 区切り文字の畳み込み → normpath → **等価比較** + スクリプト実在確認を行う。

**発火条件は schema の `required_hook_scripts`（basename 集合）駆動**。初版設計は発火条件が
「コマンドに `.hooks/` を含むか」の部分一致だったため、欠陥を最も安く再導入する形
`bash block-workers-delete.sh`（`.hooks/` を含まない）を丸ごと取りこぼしていた。
ultracode の敵対レビューが 6 変種の素通りを実コードで実証したため改訂している。
現在 11 種の回避形を検出し、正当な 4 形で誤検知ゼロ。

### 3. prune の placeholder 解決に root フォールバック

窓口テンプレは `env.CLAUDE_ORG_PATH` を持たないため、1 だけ入れると
`org_setup_prune.py --role secretary` が `unresolved placeholders` で失敗する。
優先順は **明示引数 > 既存 settings からの検出 > audit root**。root は
「`.hooks/` に `required_hook_scripts` が全て実在する」ことを受理条件にしており、
無関係なプロジェクトを org root と誤認しない。

### 4. on-disk 監査（人間承認済みの判断）

実 `settings.local.json` は gitignore 対象で CI 監査外のため、これが無いと
移行が効いたかを機械的に確認する手段がゼロだった。既に on-disk を読んでいる
`--include-local` / `--role` 経路にのみ追加し、CI 経路（`--include-worker-settings .`）の
挙動が不変であることを実測確認済み。

## スキーマを変更していない理由

`org_extension_schema.json` への `command_regex` 追加は次の三重で不可であり、実コードで裏を取った:

1. 同梱 JSON Schema の `additionalProperties: false` が未知キーを拒否する
2. runtime validator は未知キーを無視するため、`command_contains` を外すと既定 `""` で false-green 化する
3. `check_runtime_schema_drift.py` が runtime 0.1.38 の同梱スキーマに byte lock を掛けており CI で ACTIVE

`check_runtime_schema_drift` が OK であることが、スキーマ未変更の証明になっている。

## 検証

- tests/ 805 OK / tools/ 709 OK (skipped=2) / shell 421 passed
- `check_role_configs.py --include-worker-settings .` rc 0
- `check_runtime_schema_drift.py` OK
- `--help` の実端末スモーク OK
- 相対形へ戻した写しに対し `--docs-only` が rc 1 で当該行のみ検出することを確認
- Codex セルフレビュー（`-m gpt-5.6-sol`、前景、3 round）: round 1 で P1×1 + P2×2、
  round 2 で P1×2 + P2×1、**round 3 は指摘なし**。Blocker / Major ゼロで収束

## 既存端末への影響（マージだけでは直らない）

実 `settings.local.json` は gitignore 対象のため、本 PR は既存端末の設定を直さない。
マージ後に ja root の複製スクリプトで以下を実行する必要がある:

```
python tools/org_setup_prune.py --role secretary --dry-run
python tools/org_setup_prune.py --role secretary
python tools/check_role_configs.py --include-local
```

dry-run 差分は 1 行のみ。`.dispatcher/` と `.curator/` は既に正しく操作不要。

## スコープ外（別途対応）

hook 本体 `.hooks/block-workers-delete.sh` の fail-open 経路を棚卸しした結果、
コマンドに特定の語を含めるとガード全体がスキップされる経路と、`CLAUDE_ORG_PATH` 不在時の
cwd フォールバックが残っている。本 PR では触らず、別 Issue として起票する。

Closes #768
