### PR TITLE
fix(hooks): ワーカーディレクトリ削除ガードの renga 例外を構造的判定へ是正

### DIFF
--- a/.hooks/block-workers-delete.sh
+++ b/.hooks/block-workers-delete.sh
@@ -50,7 +50,85 @@ fi
 
 # renga コマンドは除外する
 # ワーカー起動時に --cwd workers/... と -p "...rm..." が共存し偽陽性を起こすため
-if echo "$COMMAND" | grep -qE '(^|[|&;[:space:]])renga[[:space:]]'; then
+#
+# 例外の成立条件は「コマンド列のどこかに renga トークンがある」ではなく
+# 「トップレベルの全セグメントが renga 起動である」こと。
+# 前者だと `echo renga ; rm -rf workers/` のように無害な renga トークンを 1 つ混ぜるだけで
+# ガード全体がスキップされる（回避経路）。
+# セグメント分割は引用符を尊重するため、renga の -p / --command 引数に含まれる
+# `;` や `&&` では分割されず、正当なワーカー起動は従来どおり通過する。
+
+# コマンドをトップレベル（引用符の外）の制御演算子 ; & | 改行 で分割し、1 行 1 セグメントで出力する
+split_top_level_segments() {
+  local cmd="$1"
+  local len=${#cmd}
+  local seg="" quote="" ch i
+  for ((i = 0; i < len; i++)); do
+    ch="${cmd:i:1}"
+    if [[ -n "$quote" ]]; then
+      seg+="$ch"
+      [[ "$ch" == "$quote" ]] && quote=""
+      continue
+    fi
+    case "$ch" in
+      "'"|'"')
+        quote="$ch"
+        seg+="$ch"
+        ;;
+      '\')
+        # エスケープ: 次の 1 文字は区切りとして解釈しない
+        seg+="$ch"
+        if ((i + 1 < len)); then
+          seg+="${cmd:i+1:1}"
+          i=$((i + 1))
+        fi
+        ;;
+      ';'|'&'|'|'|$'\n')
+        printf '%s\n' "$seg"
+        seg=""
+        ;;
+      *)
+        seg+="$ch"
+        ;;
+    esac
+  done
+  printf '%s\n' "$seg"
+}
+
+# セグメントの実行コマンドが renga かを判定する
+# 先頭の環境変数代入（VAR=value）と env / command プレフィックスは読み飛ばす
+segment_is_renga() {
+  local seg="$1" word
+  local words=()
+  read -ra words <<< "$seg"
+  for word in "${words[@]}"; do
+    case "$word" in
+      *=*) continue ;;
+      env|command) continue ;;
+      renga|*/renga) return 0 ;;
+      *) return 1 ;;
+    esac
+  done
+  return 1
+}
+
+RENGA_ONLY=false
+if [[ "$COMMAND" == *renga* ]]; then
+  RENGA_ONLY=true
+  HAS_SEGMENT=false
+  while IFS= read -r SEGMENT; do
+    # 空白のみのセグメント（区切り文字の連続 && / || 等）は無視
+    [[ -z "${SEGMENT//[[:space:]]/}" ]] && continue
+    HAS_SEGMENT=true
+    if ! segment_is_renga "$SEGMENT"; then
+      RENGA_ONLY=false
+      break
+    fi
+  done < <(split_top_level_segments "$COMMAND")
+  [[ "$HAS_SEGMENT" == "true" ]] || RENGA_ONLY=false
+fi
+
+if [[ "$RENGA_ONLY" == "true" ]]; then
   exit 0
 fi
 

--- a/.hooks/block-workers-delete.sh
+++ b/.hooks/block-workers-delete.sh
@@ -112,8 +112,50 @@ segment_is_renga() {
   return 1
 }
 
+# コマンド置換 / プロセス置換が「シェルに評価される形」で含まれるかを判定する
+# $(...) / `...` / <(...) / >(...) は renga が起動される前にシェルが実行するため、
+# renga 例外の内側であっても破壊的コマンドの実行経路になる。
+# シングルクォートの内側は展開されないので不活性として扱う。
+has_active_substitution() {
+  local cmd="$1"
+  local len=${#cmd}
+  local state="none" ch next i
+  for ((i = 0; i < len; i++)); do
+    ch="${cmd:i:1}"
+    next="${cmd:i+1:1}"
+    case "$state" in
+      single)
+        [[ "$ch" == "'" ]] && state="none"
+        continue
+        ;;
+      double)
+        if [[ "$ch" == '\' ]]; then
+          i=$((i + 1))
+          continue
+        fi
+        [[ "$ch" == '"' ]] && state="none"
+        ;;
+      none)
+        case "$ch" in
+          "'") state="single"; continue ;;
+          '"') state="double"; continue ;;
+          '\') i=$((i + 1)); continue ;;
+          '<'|'>')
+            [[ "$next" == "(" ]] && return 0
+            continue
+            ;;
+        esac
+        ;;
+    esac
+    # single 以外（none / double）では $( と ` がシェルに評価される
+    [[ "$ch" == '`' ]] && return 0
+    [[ "$ch" == '$' && "$next" == "(" ]] && return 0
+  done
+  return 1
+}
+
 RENGA_ONLY=false
-if [[ "$COMMAND" == *renga* ]]; then
+if [[ "$COMMAND" == *renga* ]] && ! has_active_substitution "$COMMAND"; then
   RENGA_ONLY=true
   HAS_SEGMENT=false
   while IFS= read -r SEGMENT; do
@@ -160,13 +202,15 @@ WORKERS_CANONICAL=$(portable_realpath "$WORKERS_ABS")
 #
 # 既知���限界: シェル変数経由の間接パス（例: x=../workers; rm -rf "$x"）は
 # 文字列マッチでは検知できない。スキルの文言による指示レベルの保護で補完する。
+# コマンド開始位置の直前に来うる文字。制御演算子・空白に加えて、コマンド置換 /
+# プロセス置換 / サブシェルの開始（$( 、`、<( 、( ）も rm の先頭境界として扱う。
 HAS_RECURSIVE=false
 # 短オプション内の -r/-R
-if echo "$COMMAND" | grep -qE '(^|[|&;[:space:]])rm[[:space:]]+-[a-zA-Z]*[rR]|(^|[|&;[:space:]])rm[[:space:]].*[[:space:]]-[a-zA-Z]*[rR]'; then
+if echo "$COMMAND" | grep -qE '(^|[|&;()`$[:space:]])rm[[:space:]]+-[a-zA-Z]*[rR]|(^|[|&;()`$[:space:]])rm[[:space:]].*[[:space:]]-[a-zA-Z]*[rR]'; then
   HAS_RECURSIVE=true
 fi
 # 長オプション --recursive
-if echo "$COMMAND" | grep -qE '(^|[|&;[:space:]])rm[[:space:]].*--recursive'; then
+if echo "$COMMAND" | grep -qE '(^|[|&;()`$[:space:]])rm[[:space:]].*--recursive'; then
   HAS_RECURSIVE=true
 fi
 if [[ "$HAS_RECURSIVE" != "true" ]]; then

--- a/.hooks/block-workers-delete.sh
+++ b/.hooks/block-workers-delete.sh
@@ -66,6 +66,12 @@ split_top_level_segments() {
   for ((i = 0; i < len; i++)); do
     ch="${cmd:i:1}"
     if [[ -n "$quote" ]]; then
+      # ダブルクォート内の \" は閉じ引用符ではない（シングルクォート内の \ はただの文字）
+      if [[ "$quote" == '"' && "$ch" == '\' ]] && ((i + 1 < len)); then
+        seg+="$ch${cmd:i+1:1}"
+        i=$((i + 1))
+        continue
+      fi
       seg+="$ch"
       [[ "$ch" == "$quote" ]] && quote=""
       continue

--- a/.hooks/block-workers-delete.sh
+++ b/.hooks/block-workers-delete.sh
@@ -62,7 +62,7 @@ fi
 split_top_level_segments() {
   local cmd="$1"
   local len=${#cmd}
-  local seg="" quote="" ch i
+  local seg="" quote="" ch prev i
   for ((i = 0; i < len; i++)); do
     ch="${cmd:i:1}"
     if [[ -n "$quote" ]]; then
@@ -83,7 +83,18 @@ split_top_level_segments() {
           i=$((i + 1))
         fi
         ;;
-      ';'|'&'|'|'|$'\n')
+      '&')
+        # リダイレクトの & （2>&1 / &>file 等）は区切りではない
+        prev=""
+        ((i > 0)) && prev="${cmd:i-1:1}"
+        if [[ "$prev" == ">" || "$prev" == "<" || "${cmd:i+1:1}" == ">" ]]; then
+          seg+="$ch"
+        else
+          printf '%s\n' "$seg"
+          seg=""
+        fi
+        ;;
+      ';'|'|'|$'\n')
         printf '%s\n' "$seg"
         seg=""
         ;;

--- a/.hooks/test-block-workers-delete.sh
+++ b/.hooks/test-block-workers-delete.sh
@@ -97,6 +97,29 @@ run_test "rm --force --recursive (長オプション複数)" \
 
 echo ""
 
+# --- renga 例外の回避経路 (Issue #777) ---
+# 「コマンド列のどこかに renga トークンがある」だけで例外が成立していた頃の回避を固定する。
+# 例外はトップレベルの全セグメントが renga 起動である場合にのみ成立する。
+echo "[renga 例外の回避防止]"
+
+run_test "echo renga ; rm -rf workers (無害な renga トークン混入)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo renga ; rm -rf ${WORKERS_DIR}\"}}" \
+  2
+
+run_test "renga 起動に破壊的コマンドを後続連結 (renga ... && rm -rf workers)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"renga new-tab --cwd ${WORKERS_DIR}/dummy-test && rm -rf ${WORKERS_DIR}/dummy-test\"}}" \
+  2
+
+run_test "renga 起動をパイプ後段に置いた rm -rf workers" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"renga list | grep -q x ; rm -rf ${WORKERS_DIR}/WI-016\"}}" \
+  2
+
+run_test "コメントに renga を書いた rm -rf workers" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm -rf ${WORKERS_DIR}/WI-016 # renga cleanup\"}}" \
+  2
+
+echo ""
+
 # --- 許可されるべきケース ---
 echo "[許可対象]"
 
@@ -122,6 +145,20 @@ run_test "rm -rf /tmp/workers/cache (P2: 無関係パスの偽陽性防止)" \
 
 run_test "renga new-tab で workers パスを含むコマンド (偽陽性防止)" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"renga new-tab --command \\\"cd ${WORKERS_DIR}/dummy-test && claude -p 'rm -rf test'\\\"\"}}" \
+  0
+
+# 正当なワーカー起動: 先頭が renga で、引用符の内側に workers パスと rm が同居する形。
+# 引用符内の ; / && では分割しないため、1 セグメント = renga 起動として例外が成立する。
+run_test "renga 起動 (--cwd workers/... + -p 内に rm、引用符内に区切り文字)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p 'cd ${WORKERS_DIR}/dummy-test && rm -rf build; make'\"}}" \
+  0
+
+run_test "renga 起動を renga コマンドのみで連結 (全セグメント renga)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"renga list && renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p 'rm -rf tmp'\"}}" \
+  0
+
+run_test "環境変数プレフィックス付き renga 起動 (VAR=value renga ...)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ORG_TRANSPORT=broker renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p 'rm -rf tmp'\"}}" \
   0
 
 run_test "ls workers ディレクトリ (削除ではない)" \

--- a/.hooks/test-block-workers-delete.sh
+++ b/.hooks/test-block-workers-delete.sh
@@ -118,6 +118,23 @@ run_test "コメントに renga を書いた rm -rf workers" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm -rf ${WORKERS_DIR}/WI-016 # renga cleanup\"}}" \
   2
 
+# コマンド置換 / プロセス置換は renga 起動前にシェルが実行するため、renga 例外の内側でも
+# 破壊的コマンドの実行経路になる。展開が起きる形では例外を成立させない。
+SUBST_CMD="renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p \"\$(rm -rf ${WORKERS_DIR}/dummy-test)\""
+run_test "renga 起動の引数内 \$( ) コマンド置換" \
+  "$(jq -n --arg cmd "$SUBST_CMD" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')" \
+  2
+
+BACKTICK_CMD="renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p \"\`rm -rf ${WORKERS_DIR}/dummy-test\`\""
+run_test "renga 起動の引数内バッククォート置換" \
+  "$(jq -n --arg cmd "$BACKTICK_CMD" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')" \
+  2
+
+PROCSUB_CMD="renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p x <(rm -rf ${WORKERS_DIR}/dummy-test)"
+run_test "renga 起動の <( ) プロセス置換" \
+  "$(jq -n --arg cmd "$PROCSUB_CMD" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')" \
+  2
+
 echo ""
 
 # --- 許可されるべきケース ---
@@ -159,6 +176,12 @@ run_test "renga 起動を renga コマンドのみで連結 (全セグメント 
 
 run_test "環境変数プレフィックス付き renga 起動 (VAR=value renga ...)" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ORG_TRANSPORT=broker renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p 'rm -rf tmp'\"}}" \
+  0
+
+# シングルクォート内の $( ) はシェルに展開されないため不活性 = 例外は成立する
+SQ_SUBST_CMD="renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p 'echo \$(rm -rf ${WORKERS_DIR}/dummy-test)'"
+run_test "renga 起動のシングルクォート内 \$( ) (不活性なので許可)" \
+  "$(jq -n --arg cmd "$SQ_SUBST_CMD" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')" \
   0
 
 run_test "ls workers ディレクトリ (削除ではない)" \

--- a/.hooks/test-block-workers-delete.sh
+++ b/.hooks/test-block-workers-delete.sh
@@ -193,6 +193,12 @@ run_test "renga 起動 + &> リダイレクト (& を区切りにしない)" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p 'rm -rf tmp' &> /dev/null\"}}" \
   0
 
+# ダブルクォート内のエスケープ済み引用符 \" で引用符状態を誤って閉じない
+ESCQ_CMD="renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p \"echo \\\"x\\\" && rm -rf build\""
+run_test "renga 起動の -p 内にエスケープ済み引用符 + && (偽陽性防止)" \
+  "$(jq -n --arg cmd "$ESCQ_CMD" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')" \
+  0
+
 run_test "ls workers ディレクトリ (削除ではない)" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls ${WORKERS_DIR}/\"}}" \
   0

--- a/.hooks/test-block-workers-delete.sh
+++ b/.hooks/test-block-workers-delete.sh
@@ -184,6 +184,15 @@ run_test "renga 起動のシングルクォート内 \$( ) (不活性なので�
   "$(jq -n --arg cmd "$SQ_SUBST_CMD" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')" \
   0
 
+# リダイレクトの & は区切りではない (2>&1 で余計なセグメントを作らない)
+run_test "renga 起動 + 2>&1 リダイレクト (& を区切りにしない)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p 'rm -rf tmp' > /dev/null 2>&1\"}}" \
+  0
+
+run_test "renga 起動 + &> リダイレクト (& を区切りにしない)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"renga new-tab --cwd ${WORKERS_DIR}/dummy-test -p 'rm -rf tmp' &> /dev/null\"}}" \
+  0
+
 run_test "ls workers ディレクトリ (削除ではない)" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls ${WORKERS_DIR}/\"}}" \
   0


### PR DESCRIPTION
Closes #777

## 背景

`.hooks/block-workers-delete.sh` の renga 例外は「コマンド列のどこかに `renga ` トークンがある」で成立していたため、任意のコマンドに混ぜるだけでガード全体がスキップされた。

窓口が修正前のフックを ja ルート cwd で実測した結果:

| コマンド | 修正前 | 修正後 |
|---|---|---|
| `rm -rf ../workers/` | exit 2 (ブロック) | exit 2 |
| `echo renga ; rm -rf ../workers/` | **exit 0 (通過)** | exit 2 |
| `renga x && rm -rf ../workers/` | **exit 0 (通過)** | exit 2 |

exit 0 は許可を意味するため、この 2 経路は実際に削除が実行される。

## 変更内容

1. **renga 例外の成立条件を「トップレベルの全セグメントが renga 起動である」に変更**。1 つでも非 renga セグメントがあれば例外は成立せず通常判定に落ちる。
2. **セグメント分割は引用符を尊重する自前スキャナで行う**。renga の `-p` / `--command` 引数内の `;` / `&&`、エスケープ済み引用符では分割しないため、`--cwd workers/...` と `-p` 内 `rm` が共存する正当なワーカー起動は従来どおり通過する。
3. **`$(...)` / バッククォート / `<(...)` を含むコマンドは例外を成立させない**。これらは renga 起動前にシェルが実行するため、例外の内側が削除の実行経路になっていた。シングルクォート内は展開されないので不活性扱い。
4. **再帰削除検知の先頭境界に `$(` / バッククォート / `(` を追加**。従来は直前が制御演算子か空白のときしか一致せず `$(rm -rf ...)` を取りこぼしていた。

## 設計判断

- **複合コマンド**: 先頭が renga でも後続に非 renga セグメントがあれば例外を成立させない。renga 起動は単体コマンドとして発行されるため、連結された破壊的操作まで保護する理由がない。
- **リダイレクトの `&`** (`2>&1` / `&>`) は区切りにしない（偽陽性防止）。
- セグメント単位の素朴な AND 判定は、既存の for ループ回避テスト（パスと rm が別セグメント）が退行するため不採用。全体判定は維持し、例外の成立条件だけを絞った。

## テストの補強

修正前のテストは 25 件あり削除の書き方は網羅されていたが、**例外に関するテストは「正当な起動が誤ってブロックされないこと」の 1 件のみ**で、例外を悪用して通り抜けられないことを見るテストは存在しなかった。この非対称が、25 件 green のまま穴が生きていた原因。

- 回避 7 ケース追加（トークン混入 / 後続連結 / パイプ後段 / コメント / `$( )` / バッククォート / `<( )`）
- 許可 6 ケース追加（引用符内区切り / renga のみ連結 / `VAR=` プレフィックス / `2>&1` / `&>` / エスケープ引用符）
- 計 41 passed / 0 failed、`tests/run-all.sh` 421 passed / 0 failed
- Codex セルフレビュー 3 round で P1 x1 / P2 x2 を修正、4 round 目クリーン

## 既知の残課題（本 PR スコープ外）

`tests/run-all.sh` は `tests/test-*.sh` のみを拾い `.hooks/test-*.sh` を実行しないため、**このフックテストは CI で走らない**（本変更以前からの既存ギャップ）。他の `.hooks` テストも巻き込むため別 Issue で扱う。

同ファイル 61 行の `ORG_ROOT` cwd フォールバックは #778 の対象として未変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)