### PR TITLE
fix(tests): hook テストを tests/ へ移設し収集漏れ検出ガードを追加

### DIFF
--- a/.hooks/fixture-always-block.sh
+++ b/.hooks/fixture-always-block.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Hook fixture (NOT a test suite): always blocks and logs stdin.
+#
+# settings.json の PreToolUse に一時的に差し込んで「hook 配線そのものが発火するか」を
+# 手動確認するための最小 hook。テストランナー (tests/run-all.sh) の収集対象ではないため、
+# test-*.sh ではなく fixture-*.sh を名乗る（tests/run-all.sh の収集漏れ検出ガードが
+# test に見える命名のファイルを未収集として fail させる）。
+
+echo "[$(date)]  fixture-always-block.sh called" >> /tmp/hook-test.log
+cat >> /tmp/hook-test.log
+echo "" >> /tmp/hook-test.log
+
+echo "ブロック: テスト用の常時ブロック" >&2
+exit 2

--- a/.hooks/test-always-block.sh
+++ b/.hooks/test-always-block.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Minimal test hook: always blocks and logs
-
-echo "[$(date)]  test-always-block.sh called" >> /tmp/hook-test.log
-cat >> /tmp/hook-test.log
-echo "" >> /tmp/hook-test.log
-
-echo "ブロック: テスト用の常時ブロック" >&2
-exit 2

--- a/docs/design/core-harness-extraction.md
+++ b/docs/design/core-harness-extraction.md
@@ -173,7 +173,7 @@ inventory §6 の段階分割を、本 design の Lead 決定を反映して確�
   - hook framework wire-up 規約 doc を `core_harness/docs/hook-contract.md` として明文化（exit code / stdin JSON / stderr format）
 - **ja 側変更**:
   - `worker_roles[*].hooks` の `command` 文字列を `bash "{core_harness_path}/hooks/<script>"` に書き換え（generic hook のみ）。org-specific hooks (`block-org-structure.sh`, `block-git-push.sh` 等) は引き続き `{claude_org_path}/.hooks/...` を指す
-  - `.hooks/` には org-specific hooks (`block-workers-delete.sh`, `block-dispatcher-out-of-scope.sh`, `block-org-structure.sh`, `block-git-push.sh`) と test harness 用の `test-always-block.sh` が残る
+  - `.hooks/` には org-specific hooks (`block-workers-delete.sh`, `block-dispatcher-out-of-scope.sh`, `block-org-structure.sh`, `block-git-push.sh`) と test harness 用の hook fixture `fixture-always-block.sh` が残る
 - **依存**: Step B（schema 側で `{core_harness_path}` placeholder が定義済であること）
 - **AC**:
   - 既存の hook test 8 本が ja 側で green（test 自体は §5 に従い ja 残置）

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,22 +37,34 @@ bash tests/run-all.sh
 ```
 tests/
   __init__.py              # パッケージ初期化（空）
-  test_parsers.py          # dashboard/server.py のパーサーテスト
-  test_org_state_converter.py
-  run-all.sh               # shell hook テストランナー
-  test-block-git-push.sh
-  test-block-org-structure.sh
-  test-check-worker-boundary.sh
-  fixtures/
-    org-state-sample.md    # org-state パーサー用サンプル
-    journal-sample.jsonl   # journal パーサー用サンプル
-    projects-sample.md     # projects パーサー用サンプル
-    workers/
-      worker-abc12345.md   # workers パーサー用サンプル
-    curated/
-      .gitkeep             # スキップ対象の確認用
-      sample-topic.md      # knowledge パーサー用サンプル
+  run-all.sh               # shell hook テストランナー（収集の SoT）
+  test_*.py                # Python テスト（unittest discover が収集）
+  test-*.sh                # shell hook テスト（run-all.sh が収集）
+  sandbox/
+    test_*.sh              # sandbox smoke テスト（run-all.sh が収集）
+  fixtures/                # 各テストのサンプルデータ
 ```
+
+### shell テストの置き場所ルール
+
+**shell テストは必ず `tests/` 直下（または `tests/sandbox/`）に置く。** `.hooks/` 配下に
+テストを置くと `tests/run-all.sh` の収集対象から外れ、CI で実行されないまま気付かれない
+（Issue #787 の実体）。
+
+この置き場所のズレは `tests/run-all.sh` の収集漏れ検出ガードが検出する。ガードは git 追跡
+ファイルから「テストに見える命名」（`test-*.sh` / `test_*.sh` / `*-test.sh` / `*_test.sh`）を
+列挙し、ランナーが実際に実行した集合と突き合わせて、未収集があれば fail する。
+
+- テストでないファイル（hook の fixture 等）は、`test` に見えない名前を付けて収集対象から
+  外す。例: `.hooks/fixture-always-block.sh` は hook 配線の手動確認用 fixture であって
+  テストスイートではないため `fixture-` を名乗る。
+- どうしても例外が必要な場合のみ、`run-all.sh` の `COVERAGE_EXEMPT` に repo root 相対パスを
+  理由コメント付きで追加する。ガードごと削除しないこと。
+
+検出を CI の workflow ではなくランナー側に置いているのは、手元実行と CI の判定基準を
+1 つに保つため。
+
+なお shell テストは実行時の cwd に依存しない（スクリプト自身の位置から repo root を導出する）。
 
 ## テスト結果の保存
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -4,12 +4,124 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 total_pass=0
 total_fail=0
 total_errors=0
 
+# ---------------------------------------------------------------------------
+# 収集
+# ---------------------------------------------------------------------------
+# このループが実行対象の SoT。収集パターンを増やしたら、下の収集漏れ検出ガードの
+# TEST_NAME_RE も併せて見直すこと。
+TEST_FILES=()
 for test_file in "$SCRIPT_DIR"/test-*.sh "$SCRIPT_DIR"/sandbox/test_*.sh; do
   [[ -f "$test_file" ]] || continue
+  TEST_FILES+=("$test_file")
+done
+
+# ---------------------------------------------------------------------------
+# 収集漏れ検出ガード (Issue #787)
+# ---------------------------------------------------------------------------
+# 「テストに見える命名のシェルファイル」を git 追跡ファイル（index 込み）から列挙し、
+# 上の収集ループが実際に拾った集合と突き合わせる。差分があれば error として fail する。
+#
+# Issue #787 の実体は個別テストのバグではなく「テストが .hooks/ に置かれていて CI から
+# 静かに漏れていた」という置き場所のズレだった。該当ファイルを救うだけでは同型が再発する
+# ため、ズレそのものを検出する。既知本数の固定チェックではなく未収集ファイルの検出に
+# しているのは、テストを 1 本足すたびに数字を更新する保守コストを避けるため。
+#
+# 検出は CI ではなくこのランナーに置く。手元実行と CI の判定基準を 1 つに保つため
+# （workflow 側に書くと SoT が二重化する）。
+#
+# 意図的に収集対象外にするファイルは COVERAGE_EXEMPT に理由付きで足すこと。
+# ガードごと消すのではなく、例外を 1 行ずつ明示的に増やす方向で運用する。
+
+TEST_NAME_RE='(^|/)(test[-_][^/]*|[^/]*[-_]test)\.sh$'
+
+# repo root 相対パスを 1 行 1 件で記載する。空が正常。
+COVERAGE_EXEMPT=()
+
+coverage_status="ok"
+
+_coverage_contains() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+check_test_collection_coverage() {
+  local rel item
+  local -a candidates=() collected_rel=() uncollected=() stale_exempt=()
+
+  if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    coverage_status="skipped"
+    echo ""
+    echo "WARN: git リポジトリとして読めないため収集漏れ検出をスキップしました"
+    echo "      （テスト収集のカバレッジは未検証です）"
+    return 0
+  fi
+
+  # git ls-files のパスも collected_rel も REPO_ROOT 相対で揃える
+  # （このランナーは tests/ 直下にあり REPO_ROOT = git top-level が前提）
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    candidates+=("$rel")
+  done < <(git -C "$REPO_ROOT" ls-files --full-name | grep -E "$TEST_NAME_RE" || true)
+
+  for item in ${TEST_FILES[@]+"${TEST_FILES[@]}"}; do
+    collected_rel+=("${item#"$REPO_ROOT"/}")
+  done
+
+  for rel in ${candidates[@]+"${candidates[@]}"}; do
+    _coverage_contains "$rel" ${collected_rel[@]+"${collected_rel[@]}"} && continue
+    _coverage_contains "$rel" ${COVERAGE_EXEMPT[@]+"${COVERAGE_EXEMPT[@]}"} && continue
+    uncollected+=("$rel")
+  done
+
+  # 除外指定の腐敗検出: 収集済み / 候補ですらないエントリが残っていたら知らせる
+  for rel in ${COVERAGE_EXEMPT[@]+"${COVERAGE_EXEMPT[@]}"}; do
+    if _coverage_contains "$rel" ${collected_rel[@]+"${collected_rel[@]}"}; then
+      stale_exempt+=("$rel (収集されているので除外指定は不要)")
+    elif ! _coverage_contains "$rel" ${candidates[@]+"${candidates[@]}"}; then
+      stale_exempt+=("$rel (テスト候補として存在しない)")
+    fi
+  done
+
+  if [[ ${#uncollected[@]} -gt 0 || ${#stale_exempt[@]} -gt 0 ]]; then
+    coverage_status="failed"
+    echo ""
+    echo "ERROR: テスト収集漏れ検出ガードが失敗しました (Issue #787)"
+    if [[ ${#uncollected[@]} -gt 0 ]]; then
+      echo "  テストに見えるが tests/run-all.sh が実行していないファイル:"
+      for rel in "${uncollected[@]}"; do
+        echo "    - $rel"
+      done
+      echo "  対処: tests/ 配下へ移設して収集対象に入れるか、テストでないなら"
+      echo "        test に見えない名前へ変更するか、COVERAGE_EXEMPT に理由付きで追加する。"
+    fi
+    if [[ ${#stale_exempt[@]} -gt 0 ]]; then
+      echo "  COVERAGE_EXEMPT の陳腐化したエントリ:"
+      for rel in "${stale_exempt[@]}"; do
+        echo "    - $rel"
+      done
+      echo "  対処: 不要になったエントリを削除する。"
+    fi
+    ((total_errors++))
+  fi
+}
+
+echo "収集したテスト: ${#TEST_FILES[@]} 本"
+check_test_collection_coverage
+
+# ---------------------------------------------------------------------------
+# 実行
+# ---------------------------------------------------------------------------
+for test_file in ${TEST_FILES[@]+"${TEST_FILES[@]}"}; do
   echo ""
   echo "=== $(basename "$test_file") ==="
   output=$(bash "$test_file" 2>&1)
@@ -45,6 +157,11 @@ total_tests=$((total_pass + total_fail))
 echo ""
 echo "==============================="
 echo "Total: $total_tests tests, $total_pass passed, $total_fail failed, $total_errors errors"
+case "$coverage_status" in
+  ok)      echo "収集漏れ検出: OK (${#TEST_FILES[@]} 本を収集)" ;;
+  failed)  echo "収集漏れ検出: FAILED (上の ERROR を参照)" ;;
+  skipped) echo "収集漏れ検出: SKIPPED (git 不可のため未検証)" ;;
+esac
 echo "==============================="
 
 [[ $total_fail -eq 0 && $total_errors -eq 0 ]]

--- a/tests/test-block-dangerous-git.sh
+++ b/tests/test-block-dangerous-git.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # block-dangerous-git.sh のテスト（Issue #470）
-# 実行: bash .hooks/test-block-dangerous-git.sh
+# 実行: bash tests/test-block-dangerous-git.sh
 #
 # 主な確認観点:
 #   - 素の git push --force / -f / バンドル短オプション → deny
@@ -14,7 +14,9 @@
 
 set -euo pipefail
 
-HOOK=".hooks/block-dangerous-git.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/.hooks/block-dangerous-git.sh"
 PASS=0
 FAIL=0
 
@@ -302,5 +304,5 @@ run_test "git status && git push --force-with-lease origin main (後続セグメ
   "$(mk_bash_json "git status && git push --force-with-lease origin main")" 2
 
 echo ""
-echo "=== Results: $PASS passed, $FAIL failed ==="
+echo "# $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-block-workers-delete.sh
+++ b/tests/test-block-workers-delete.sh
@@ -1,16 +1,36 @@
 #!/usr/bin/env bash
 # block-workers-delete.sh のテスト
-# 実行: bash .hooks/test-block-workers-delete.sh
+# 実行: bash tests/test-block-workers-delete.sh
 
 set -euo pipefail
 
-HOOK=".hooks/block-workers-delete.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/.hooks/block-workers-delete.sh"
 PASS=0
 FAIL=0
+
+# Portable realpath -m (matches hook fallback: GNU realpath → python3 → python)
+portable_realpath() {
+  local target="$1"
+  if result=$(command realpath -m "$target" 2>/dev/null); then
+    echo "$result"
+  elif result=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$target" 2>/dev/null); then
+    echo "$result"
+  elif result=$(python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$target" 2>/dev/null); then
+    echo "$result"
+  else
+    echo "FATAL: realpath -m も python も利用できません" >&2
+    exit 1
+  fi
+}
+
 # hook と同じ流儀で workers パスを解決する（registry/org-config.md の workers_dir は
-# ORG_ROOT 起点の相対パスとして定義されているため、CLAUDE_ORG_PATH があれば優先する）
-TEST_ORG_ROOT="${CLAUDE_ORG_PATH:-$(pwd)}"
-WORKERS_DIR=$(realpath -m "$TEST_ORG_ROOT/../workers")
+# ORG_ROOT 起点の相対パスとして定義されている）。既定は REPO_ROOT で、hook 側にも
+# 同じ値を CLAUDE_ORG_PATH として明示的に渡すことで、ランナーの cwd に依存せず
+# テストと hook の workers パス解決を一致させる。
+TEST_ORG_ROOT="${CLAUDE_ORG_PATH:-$REPO_ROOT}"
+WORKERS_DIR=$(portable_realpath "$TEST_ORG_ROOT/../workers")
 
 run_test() {
   local description="$1"
@@ -18,7 +38,7 @@ run_test() {
   local expected_exit="$3"  # 0=許可, 2=ブロック
 
   actual_exit=0
-  echo "$input_json" | bash "$HOOK" >/dev/null 2>&1 || actual_exit=$?
+  echo "$input_json" | CLAUDE_ORG_PATH="$TEST_ORG_ROOT" bash "$HOOK" >/dev/null 2>&1 || actual_exit=$?
 
   if [[ "$actual_exit" -eq "$expected_exit" ]]; then
     echo "  PASS: $description"
@@ -224,10 +244,11 @@ echo ""
 # CLAUDE_ORG_PATH 起点で config / workers パスを解決していることを担保する。
 echo "[cwd 非依存性 (CLAUDE_ORG_PATH 起点解決)]"
 
-HOOK_ABS="$(realpath "$HOOK")"
+# HOOK は REPO_ROOT 起点で組み立て済みなので既に絶対パス。
 # .dispatcher 配下を擬似 cwd として使う。ORG_ROOT は TEST_ORG_ROOT に揃える
 # （WORKERS_DIR と整合した workers パス解決を hook 側で起こすため）
-ALT_CWD="$(pwd)/.dispatcher"
+HOOK_ABS="$HOOK"
+ALT_CWD="$REPO_ROOT/.dispatcher"
 
 if [[ ! -d "$ALT_CWD" ]]; then
   echo "  SKIP: .dispatcher ディレクトリが無いため cwd 非依存テストを省略"
@@ -268,5 +289,5 @@ else
 fi
 
 echo ""
-echo "=== Results: $PASS passed, $FAIL failed ==="
+echo "# $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
Closes #787
Refs #777 #786

## 背景

`.hooks/` 配下に置かれた shell テストが CI で一度も実行されていなかった。CI は `bash tests/run-all.sh` を呼び、runner の収集対象は `tests/test-*.sh` のグロブなので、`.hooks/` 配下は拾われない。**置き場所の違いだけによる漏れ。**

漏れていたテストのうち 2 本が破壊的操作の抑止 hook のもの（ワーカーディレクトリ削除抑止 / 危険な git 操作抑止）。#777 では、テスト 25 件が green のまま例外条件の穴が生きていた。

## 変更内容

### 1. CI で一度も走っていなかったテスト 110 本を CI 対象化

`.hooks/` の shell テスト 2 本を `tests/` へ移設。runner 合計 **421 → 531 tests, 531 passed, 0 failed**（workers-delete 41 本 + dangerous-git 69 本が新規に CI 対象）。

### 2.【本タスクの主眼】収集漏れ検出ガードを `tests/run-all.sh` に実装

git 追跡ファイルから「テストに見える命名」(`test-*.sh` / `test_*.sh` / `*-test.sh` / `*_test.sh`) を列挙し、runner が実際に実行した集合と突き合わせ、未収集があれば fail する。**置き場所を間違えたテストが今後 CI から静かに漏れることがなくなる。**

- **検出は workflow ではなく runner 側**: `.github/workflows/` に書くと手元実行と CI で判定基準が二重化するため
- **固定本数チェックではなく未収集ファイル検出**: テストを 1 本足すたびに数字を更新する保守コストを避ける
- **`COVERAGE_EXEMPT`（例外リスト）は陳腐化も検出する**: 例外の逃げ道が無いと将来ガードごと削除されるため 1 行ずつ理由付きで足す方向へ誘導しつつ、「収集済み / 存在しない」エントリを stale として fail させ、逃げ道が形骸化しないようにした。現在の中身は空

### 3. 移設した 2 本の cwd 依存を除去

HOOK パスを実行時 cwd 相対からスクリプト位置起点へ是正。workers パス解決も `REPO_ROOT` 既定 + hook へ `CLAUDE_ORG_PATH` 明示渡しに変更。GNU 依存の `realpath -m` は portable 版へ置換。サマリー行も runner が解釈できる形式へ統一。

### 4. `.hooks/test-always-block.sh` → `fixture-always-block.sh` へ改名

これは「stdin をログして `exit 2` するだけの最小 hook」で、settings.json に一時的に差して *hook 配線そのものが発火するか* を手で確かめる道具。守るべき production 挙動を持たないため、テスト化しても回帰価値がゼロ。実際の欠陥は中身ではなく **命名がテスト収集規約と衝突していたこと** なので `fixture-` 名にした。`.hooks/` に残したのは、これが hook であり hook 置き場がそこだから。

参照箇所を全数確認し生きた配線は 0 件（`docs/design/core-harness-extraction.md` の記述 1 行のみで本 PR で更新済み）。

## 動作確認

- クリーン実行: 531 passed / 0 failed / 0 errors、exit 0、`収集漏れ検出: OK (12 本を収集)`
- **意図的な検出漏れを作って fail することを確認**:
  - `.hooks/test-stray-example.sh` を作って index 追加 → ガードが該当ファイル名を挙げて fail、exit 1
  - 同ファイルを `COVERAGE_EXEMPT` に追加 → exit 0（例外が効く）
  - ファイルだけ消して例外エントリを残置 → 陳腐化検出が fail、exit 1
  - 検証用の足場は全て撤去済み
- cwd 非依存性: `.dispatcher` / `docs` / `/` の 3 箇所から実行し、いずれも 41 / 69 で同一結果
- `python tools/check_role_configs.py --include-worker-settings .` → OK
- 触った 2 doc は `tools/audit_link_paths.py` で新規指摘なし
- Codex セルフレビュー: 1 round で Blocker / Major ともに 0 件

## 既知の限界（意図的に残した穴）

**git が使えない環境では WARN + `収集漏れ検出: SKIPPED` 表示に留め fail させない。** runner の契約は「shell テストを走らせること」であり、CI には必ず git があるためゲートとしては実効。

Python テスト側の収集漏れは対象外（`unittest discover` の担当領域）。現時点で `tests/` `tools/` 以外に `test_*.py` は 0 件であることは確認済み。

## スコープ外

`tests/test-block-dangerous-git.sh` と `tests/test-block-pretooluse-hooks.sh` のカバレッジ重複統合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)