### PR TITLE
fix(tests): shell parity テストが失敗を skip に流していた問題を修正

### DIFF
--- a/tools/test_check_curate_threshold.py
+++ b/tools/test_check_curate_threshold.py
@@ -383,21 +383,45 @@ class TestPendingCandidates(_TreeCase):
                     capture_output=True,
                     encoding="utf-8",
                     errors="replace",
-                    check=True,
                     timeout=60,
                 )
-            except (OSError, subprocess.SubprocessError):
+            except OSError:
                 # A shell on PATH that cannot actually launch/exec here
                 # (sandbox Win32 error 5 etc.) — skip that shell, not the
-                # whole test.
+                # whole test. ONLY launch failure may land here: a shell
+                # that did start and then misbehaved (non-zero exit, wrong
+                # count, hang) is the regression this test exists to catch,
+                # so it must fail below. Catching subprocess.SubprocessError
+                # here instead swallowed exactly that — CalledProcessError
+                # is a SubprocessError, so ``check=True`` turned a real
+                # dialect break into ``continue`` and any other shell's
+                # success then made the whole test green (Issue #766).
+                # ``check=True`` is deliberately not used: the returncode is
+                # asserted explicitly below so the failure message can carry
+                # stderr, and TimeoutExpired (a hung zero-arg awk reading
+                # stdin — see _SKILL_AUDIT_PENDING_AWK) propagates as an
+                # error rather than being mistaken for an unusable shell.
                 continue
             ran_any = True
-            self.assertEqual(
-                int(proc.stdout.strip()),
-                5,
-                f"skill-audit count command gave the wrong result under "
-                f"{shell!r} — likely a shell-portability regression",
-            )
+            # subTest per shell: one broken dialect neither aborts the sweep
+            # nor hides the others, and the failure is reported with the
+            # shell that produced it — zsh coverage is the load-bearing part
+            # (see docstring), so it must never be masked by bash passing.
+            with self.subTest(shell=shell):
+                self.assertEqual(
+                    proc.returncode,
+                    0,
+                    f"skill-audit count command exited "
+                    f"{proc.returncode} under {shell!r} — likely a "
+                    f"shell-portability regression (stderr: "
+                    f"{proc.stderr.strip()!r})",
+                )
+                self.assertEqual(
+                    int(proc.stdout.strip()),
+                    5,
+                    f"skill-audit count command gave the wrong result under "
+                    f"{shell!r} — likely a shell-portability regression",
+                )
         if not ran_any:
             self.skipTest("no shell could launch here — parity skipped")
 
@@ -485,7 +509,7 @@ class TestWorkSkillCount(_TreeCase):
         try:
             # bash being on PATH does not guarantee it can run (e.g.
             # sandboxes where process creation fails with Win32 error
-            # 5) — probe by running and skip on any launch/exec error.
+            # 5) — probe by running and skip on a launch/exec error only.
             # encoding/errors explicit so a failed bash launch can't
             # leak a _readerthread UnicodeDecodeError into the test log
             # before the skip fires (Codex round 2 Minor).
@@ -495,12 +519,181 @@ class TestWorkSkillCount(_TreeCase):
                 capture_output=True,
                 encoding="utf-8",
                 errors="replace",
-                check=True,
                 timeout=60,
             )
-        except (OSError, subprocess.SubprocessError) as exc:
-            self.skipTest(f"bash unusable here ({exc!r}) — parity skipped")
+        except OSError as exc:
+            # Launch failure only. A bash that started and then failed
+            # must NOT be skipped: catching subprocess.SubprocessError
+            # here swallowed CalledProcessError from ``check=True``, i.e.
+            # the exact "pipeline broke" signal (Issue #766). The
+            # returncode is asserted explicitly instead.
+            self.skipTest(f"bash could not launch here ({exc!r}) — parity skipped")
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"skill-audit Step 1 pipeline exited {proc.returncode} "
+            f"(stderr: {proc.stderr.strip()!r})",
+        )
         self.assertEqual(cct.count_work_skills(_REPO_ROOT), int(proc.stdout.strip()))
+
+
+class TestShellParityFailuresAreNotSwallowed(unittest.TestCase):
+    """Issue #766 guard: the two shell-parity tests above must classify a
+    subprocess outcome as *launch failure -> skip* and *anything else ->
+    red*. They previously caught ``subprocess.SubprocessError``, whose
+    subclass ``CalledProcessError`` is what ``check=True`` raises on the
+    non-zero exit those tests exist to detect — so a genuine dialect
+    break was reported as a skip, and in the multi-shell loop as a PASS
+    as soon as any other shell succeeded.
+
+    Both parity tests are green on a healthy machine, which means a
+    regression here is invisible by construction: reverting the fix
+    would not turn the suite red. So the classification is asserted
+    directly — each parity test is executed against a faked
+    ``subprocess.run`` and its unittest result inspected."""
+
+    _PARITY_TESTS = (
+        (TestPendingCandidates, "test_parity_with_skill_audit_count_command"),
+        (
+            TestWorkSkillCount,
+            "test_parity_with_skill_audit_pipeline_on_real_tree",
+        ),
+    )
+
+    @staticmethod
+    def _fake_shell(returncode, stdout="", stderr="", only_shell=None):
+        """Build a ``subprocess.run`` stand-in for a shell that *did*
+        launch and then behaved badly.
+
+        It honours ``check`` exactly as the real ``subprocess.run`` does.
+        That is what makes this guard discriminating rather than
+        decorative: under a handler that passes ``check=True`` the bad
+        outcome arrives as CalledProcessError (the swallowed shape), and
+        under one that inspects the returncode it arrives as a
+        CompletedProcess. A fake that always returned a CompletedProcess
+        would let the old swallowing handler pass by accident.
+
+        ``only_shell`` limits the misbehaviour to one shell; the others
+        answer correctly."""
+
+        def fake_run(cmd, *args, check=False, **kwargs):
+            if only_shell is not None and cmd[0] != only_shell:
+                return subprocess.CompletedProcess(cmd, 0, stdout="5\n", stderr="")
+            if check and returncode != 0:
+                raise subprocess.CalledProcessError(
+                    returncode, cmd, output=stdout, stderr=stderr
+                )
+            return subprocess.CompletedProcess(
+                cmd, returncode, stdout=stdout, stderr=stderr
+            )
+
+        return fake_run
+
+    @staticmethod
+    def _run_parity(case_cls, name, fake_run):
+        """Run one parity test with the shell layer faked; return its
+        ``unittest.TestResult``. ``shutil.which`` is faked too so the
+        outcome does not depend on which shells this machine has."""
+        result = unittest.TestResult()
+        with mock.patch.object(subprocess, "run", fake_run), mock.patch.object(
+            shutil, "which", lambda cmd: f"/usr/bin/{cmd}"
+        ):
+            case_cls(name).run(result)
+        return result
+
+    def _assert_red(self, fake_run, label):
+        """Every parity test must go red — never skip, never pass."""
+        for case_cls, name in self._PARITY_TESTS:
+            with self.subTest(parity_test=name, misbehaviour=label):
+                result = self._run_parity(case_cls, name, fake_run)
+                self.assertEqual(
+                    result.skipped,
+                    [],
+                    f"{name} turned {label} into a skip — the Issue #766 "
+                    f"swallowing is back",
+                )
+                self.assertFalse(
+                    result.wasSuccessful(),
+                    f"{name} passed despite {label} — the parity assertion "
+                    f"is not reaching the shell result",
+                )
+
+    def test_launch_failure_is_still_skipped(self):
+        """The escape hatch stays: a shell that cannot exec here (sandbox
+        Win32 error 5 etc.) must skip, not fail."""
+
+        def fake_run(*args, **kwargs):
+            raise PermissionError(13, "process creation blocked here")
+
+        for case_cls, name in self._PARITY_TESTS:
+            with self.subTest(parity_test=name):
+                result = self._run_parity(case_cls, name, fake_run)
+                self.assertTrue(
+                    result.wasSuccessful(),
+                    f"{name} failed on a pure launch error — the skip "
+                    f"escape hatch for unusable shells was lost",
+                )
+                self.assertEqual(
+                    len(result.skipped),
+                    1,
+                    f"{name} did not skip when no shell could launch",
+                )
+
+    def test_nonzero_exit_fails(self):
+        """awk failing to open its files exits non-zero with empty stdout
+        (its stderr is eaten by the snippet's 2>/dev/null) — the shape a
+        word-splitting regression actually takes."""
+
+        self._assert_red(self._fake_shell(2), "a non-zero exit")
+
+    def test_wrong_count_fails(self):
+        """Ran fine, answered wrong. Unlike the cases above this one is
+        red under any handler — it guards the count assertion itself
+        against being dropped, not the launch/failure classification."""
+
+        self._assert_red(
+            self._fake_shell(0, stdout="-1\n"), "an impossible count"
+        )
+
+    def test_called_process_error_fails(self):
+        """Direct guard on the swallowed exception type: if ``check=True``
+        is ever reintroduced, its CalledProcessError must not be caught by
+        the launch-failure handler."""
+
+        def fake_run(cmd, *args, **kwargs):
+            raise subprocess.CalledProcessError(2, cmd, output="", stderr="")
+
+        self._assert_red(fake_run, "a CalledProcessError")
+
+    def test_timeout_fails(self):
+        """The other SubprocessError subclass the old handler swallowed: a
+        hung shell (zero-arg awk blocking on stdin) is a defect, not an
+        unusable shell."""
+
+        def fake_run(cmd, *args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 60)
+
+        self._assert_red(fake_run, "a timeout")
+
+    def test_one_bad_shell_is_not_masked_by_the_others(self):
+        """Issue #766's headline symptom, loop-specific: zsh breaks while
+        sh and bash succeed. The old handler continued past zsh and the
+        test reported green — which is precisely the regression the
+        docstring calls load-bearing."""
+
+        result = self._run_parity(
+            TestPendingCandidates,
+            "test_parity_with_skill_audit_count_command",
+            self._fake_shell(2, only_shell="zsh"),
+        )
+        self.assertFalse(
+            result.wasSuccessful(),
+            "a broken zsh was masked by sh/bash succeeding — the whole "
+            "point of sweeping every shell is lost",
+        )
+        self.assertEqual(
+            result.skipped, [], "a broken zsh was reported as a skip"
+        )
 
 
 class TestErrorPath(_TreeCase):


### PR DESCRIPTION
Closes #766

## 背景

`tools/test_check_curate_threshold.py` の shell parity テストが、**awk スニペットが非ゼロ終了しても fail せず skip する**状態だった。`subprocess.CalledProcessError` は `subprocess.SubprocessError` のサブクラスなので、`except (OSError, subprocess.SubprocessError)` が「起動できたが非ゼロ終了」＝まさに検出したい失敗を「そのシェルが使えない環境だった」と同じ扱いで握りつぶしていた。

さらにループ側は失敗シェルを `continue` で読み飛ばすため、**他のシェルが 1 つでも通れば全体が緑**になっていた。docstring は「zsh では unquoted `$var` が word-split されないため zsh 実行が load-bearing」と書いており、守りたい不変条件がそのまま無効化されていた。

## 実行結果: 隠れていた失敗は無かった

修正後もパリティテストは緑。事前に 3 シェル（sh / bash / zsh）を個別実行して全て `rc=0` / `count=5` を確認済み。**実際のシェル方言バグは存在しなかった。**

## 変更内容

1. **skip の条件を `OSError`（起動不能）だけに絞った** — allowlist 化
2. **`check=True` を外して returncode を明示 assert** — 失敗メッセージに stderr を載せられ、`TimeoutExpired`（ゼロ引数 awk が stdin でハングする型）も skip ではなく error として表に出る
3. **ループを `subTest(shell=...)` 化** — 1 シェルの失敗が他を隠さず、どのシェルが壊れたかが報告に残る
4. **恒久ガード `TestShellParityFailuresAreNotSwallowed` を追加**（新規 6 テスト） — 両パリティテストを fake した `subprocess.run` の下で実行し、その unittest 結果を直接 assert する（起動失敗 → skip / それ以外 → 赤）

## 設計判断

**denylist ではなく allowlist を採用。** Issue の提案（`CalledProcessError` を先に捕まえて fail）は「失敗する例外型を列挙する」形で、`TimeoutExpired` が skip 側に残り、将来 stdlib がサブクラスを増やすたびに同じ穴が開く。skip 側を `OSError` だけに絞れば構造的に閉じる。

**ループは即 fail でも失敗収集でもなく `subTest`。** docstring が「zsh 実行が load-bearing（bash だけだと退行を隠す）」と書いており、どのシェルが壊れたかの帰属と全シェル掃引の両立が要件。採用前に pytest 9 / unittest の双方で subTest 失敗が確実に赤くなることを実測（pytest が subtest を握りつぶす版だと本末転倒なため）。

**一時的な失敗注入ではなく恒久ガード。** 両パリティテストは健全な環境では緑なので、退行しても suite は赤くならない（invisible by construction）。分類そのものを assert する形にしないと、次に同じ握りつぶしが入っても誰も気付けない。PR #789 の「収集漏れ検出ガード」と同じ型。

## 握りつぶしが本当に直ったことの検証

ファイルを変更せず、メモリ上で**旧ハンドラを差し戻した版**を exec してガードだけ走らせ、ケース単位で判別性を確認:

- **旧コードを検出**: nonzero exit / `CalledProcessError` / timeout / **one bad shell masked by others**（主症状）の 4 件
- **旧コードでも通る**: launch failure → skip（escape hatch 維持の確認なので設計どおり）/ wrong count（count assertion 自体のガードで分類とは別軸。docstring に明記）

途中で fake を 1 度作り直している。初版は `CompletedProcess` を返すだけで `check=True` を再現しておらず、旧コードでは偶発的な `ValueError` で赤くなるだけで握りつぶし経路を判別できていなかった（主症状ケースが旧コードでも通っていた）。実 `subprocess.run` と同じく `check` を honor する形に直して判別性を確保した。

## 検証

- `python -m unittest tools.test_check_curate_threshold`: 38 tests OK（既存 32 + 新規 6）
- CI 相当 3 経路すべて緑: `unittest discover -s tools` 715 OK / `unittest discover -s tests` 805 OK / `bash tests/run-all.sh` 531 passed・収集漏れ検出 OK
- Codex セルフレビュー: 1 round で収束、Blocker / Major / Minor いずれもゼロ

## スコープ外

EN ミラー（`suisya-systems/claude-org`）の同一ファイル。ja からの機械ミラーのため追従待ち。

🤖 Generated with [Claude Code](https://claude.com/claude-code)