### PR TITLE
feat(claude): per-project default base branch in registry + --base-ref override

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -214,6 +214,7 @@ python tools/gen_delegate_payload.py apply \
 
 - `--mode edit|audit` (default `edit`): claude-org 上の **読み取り専用** 監査タスクは `--mode audit` を明示する
 - `--branch <name>`: planned_branch を上書き。default は `feat/<task-id>` (description に "fix"/"bug"/"修正" を含むと `fix/<task-id>`)
+- `--base-ref <branch>`: worktree の**起点ブランチ**を単発で上書き (Issue #808)。既定は [`registry/projects.md`](../../../registry/projects.md) の `base_branch` 列、それも空欄なら `origin/HEAD`。**優先順位は `--base-ref` > `base_branch` 列 > `origin/HEAD`**。プロジェクトの常態（例 `develop` に feature を溜める）は列に書き、本フラグは hotfix を `main` から切る等の**逸脱時のみ**使う。値はブランチ名（`origin/develop` 表記も可）。`origin` に存在しないブランチを指定した `apply` は既定ブランチへ黙って落ちず fail loud で止まる。解決結果は `preview --json` の `summary.base_branch` / `summary.base_ref` と DELEGATE 本文の「ベース:」行に出る。この値は後続の `gh pr create --base` の既定でもある（[`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md) 2b-i）ので、起点とマージ先は常に一致する
 - `--commit-prefix "<prefix>"`: 省略時は project_slug の頭部から推論 (例: `claude-org-ja` → `feat(claude):`)
 - `--closes-issue N` / `--refs-issues N1 N2`: 「Closes #N」「Refs #N1 #N2」を brief に埋め込む
 - `--impl-target <path>` / `--impl-guidance "<text>"` / `--knowledge <path>`: optional な `[implementation]` / `[references]` セクション

--- a/.claude/skills/org-delegate/SKILL.md.in
+++ b/.claude/skills/org-delegate/SKILL.md.in
@@ -208,6 +208,7 @@ python tools/gen_delegate_payload.py apply \
 
 - `--mode edit|audit` (default `edit`): claude-org 上の **読み取り専用** 監査タスクは `--mode audit` を明示する
 - `--branch <name>`: planned_branch を上書き。default は `feat/<task-id>` (description に "fix"/"bug"/"修正" を含むと `fix/<task-id>`)
+- `--base-ref <branch>`: worktree の**起点ブランチ**を単発で上書き (Issue #808)。既定は [`registry/projects.md`](../../../registry/projects.md) の `base_branch` 列、それも空欄なら `origin/HEAD`。**優先順位は `--base-ref` > `base_branch` 列 > `origin/HEAD`**。プロジェクトの常態（例 `develop` に feature を溜める）は列に書き、本フラグは hotfix を `main` から切る等の**逸脱時のみ**使う。値はブランチ名（`origin/develop` 表記も可）。`origin` に存在しないブランチを指定した `apply` は既定ブランチへ黙って落ちず fail loud で止まる。解決結果は `preview --json` の `summary.base_branch` / `summary.base_ref` と DELEGATE 本文の「ベース:」行に出る。この値は後続の `gh pr create --base` の既定でもある（[`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md) 2b-i）ので、起点とマージ先は常に一致する
 - `--commit-prefix "<prefix>"`: 省略時は project_slug の頭部から推論 (例: `claude-org-ja` → `feat(claude):`)
 - `--closes-issue N` / `--refs-issues N1 N2`: 「Closes #N」「Refs #N1 #N2」を brief に埋め込む
 - `--impl-target <path>` / `--impl-guidance "<text>"` / `--knowledge <path>`: optional な `[implementation]` / `[references]` セクション

--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -53,6 +53,7 @@ allowed-tools:
 ユーザーが「OK」「確認した」「問題ない」「進めて」等の **明示的承認** を出した直後に発動する:
 
 - 必要に応じて窓口がプッシュ・PR 作成を行う（ワーカーには `git push` / PR 作成権限がない）。PR 本文の言語規約は `feedback_pr_issue_english`（PR / Issue は英語）に従う
+- **`gh pr create --base` は派遣時の起点ブランチと同じ設定を読む（Issue #808）**: プロジェクトの既定マージ先は [`registry/projects.md`](../../../registry/projects.md) の `base_branch` 列が SoT。値がある行（例 `develop`）は `gh pr create --base <base_branch>` を既定とし、**空欄 / `-` の行は従来どおり `--base` を付けない**（repo の既定ブランチ宛）。worktree を切った起点と PR のマージ先が食い違うと、develop が先行している分の差分が PR に混入するため、両者は必ず同じ値を使う。当該タスクの実効値は派遣時の DELEGATE 本文の「ベース:」行、または `send_plan.json` の `summary.base_branch` / `summary.base_ref` で確認できる（`--base-ref` で単発上書きされた hotfix もそこに出る）。値の解決順は `--base-ref` > `base_branch` 列 > `origin/HEAD`
 - **PR 番号が確定したら直ちに `tools/set_run_pr_open.py` で `runs.pr_url` / `runs.branch` を back-fill する** (Issue #323):
   ```bash
   python tools/set_run_pr_open.py --task-id <task_id> --pr <PR>

--- a/.claude/skills/org-pull-request/SKILL.md.in
+++ b/.claude/skills/org-pull-request/SKILL.md.in
@@ -51,6 +51,7 @@ allowed-tools:
 ユーザーが「OK」「確認した」「問題ない」「進めて」等の **明示的承認** を出した直後に発動する:
 
 - 必要に応じて窓口がプッシュ・PR 作成を行う（ワーカーには `git push` / PR 作成権限がない）。PR 本文の言語規約は `feedback_pr_issue_english`（PR / Issue は英語）に従う
+- **`gh pr create --base` は派遣時の起点ブランチと同じ設定を読む（Issue #808）**: プロジェクトの既定マージ先は [`registry/projects.md`](../../../registry/projects.md) の `base_branch` 列が SoT。値がある行（例 `develop`）は `gh pr create --base <base_branch>` を既定とし、**空欄 / `-` の行は従来どおり `--base` を付けない**（repo の既定ブランチ宛）。worktree を切った起点と PR のマージ先が食い違うと、develop が先行している分の差分が PR に混入するため、両者は必ず同じ値を使う。当該タスクの実効値は派遣時の DELEGATE 本文の「ベース:」行、または `send_plan.json` の `summary.base_branch` / `summary.base_ref` で確認できる（`--base-ref` で単発上書きされた hotfix もそこに出る）。値の解決順は `--base-ref` > `base_branch` 列 > `origin/HEAD`
 - **PR 番号が確定したら直ちに `tools/set_run_pr_open.py` で `runs.pr_url` / `runs.branch` を back-fill する** (Issue #323):
   ```bash
   python tools/set_run_pr_open.py --task-id <task_id> --pr <PR>

--- a/docs/overview-technical.md
+++ b/docs/overview-technical.md
@@ -203,6 +203,7 @@ Curator (org-curate) → knowledge/curated/ に整理・統合
 
 - ユーザーが作業を依頼すると、`registry/projects.md` に自動登録される
 - 手動で `registry/projects.md` を編集してもよい
+- `main` に直接マージしない運用（feature を `develop` に溜める等）のプロジェクトは、`base_branch` 列に既定の起点 / マージ先ブランチを書く（Issue #808）。派遣時の worktree は `origin/<base_branch>` から切られ、同じ値が `gh pr create --base` の既定になる。**空欄の行は従来どおり `origin/HEAD`** なので既存行の編集は不要。単発の逸脱は `gen_delegate_payload.py --base-ref <branch>` で上書きする（優先順位は `--base-ref` > `base_branch` 列 > `origin/HEAD`）。列の意味と失敗時の挙動は [`registry/projects.md`](../registry/projects.md) 冒頭を参照
 
 ### ダッシュボードのカスタマイズ
 

--- a/registry/projects.md
+++ b/registry/projects.md
@@ -21,10 +21,18 @@ claude-org-ja 自身（self-edit）は本レジストリに載せない。`tools
 - 「パス」が GitHub URL でない行（ローカルパス / `-`）は owner/repo を導けず構造的に scan 対象外（`skipped` + signal）。明示 opt-out しておくとその skip signal も出ない。
 - claude-org-ja 自身（home repo）はこの表に載らない契約は不変。home を scan 対象に含めるかは `registry/org-config.md` の `triage_home`（既定 off）で決める。
 
-| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | triage |
-|---|---|---|---|---|---|
-| 時計アプリ | clock-app | - | Webブラウザで動くデジタル時計 | デザイン変更、機能追加 | no |
-| renga | renga | https://github.com/suisya-systems/renga | Rust 製の Claude Code 用ターミナルマルチプレクサ（TUI） | 機能追加、バグ修正、Issue 対応 | |
-| サンドボックス検証 | sandbox-probe | - | Issue #376 / #377 用の sandbox profile / hook / settings 配備の実測検証エリア。candidate profile を handcraft して probe を回し allow/deny matrix を作る | Pre-Phase 0 spike、probe 反復、profile validation | no |
-| ランタイム | claude-org-runtime | https://github.com/suisya-systems/claude-org-runtime | Layer 2 = org-runtime: claude-org-ja から抽出された Python runtime (dispatcher / state schema / reference role prompts)。ja は pin で参照する | role_configs_schema.json 同期、release 駆動、dispatcher / settings.generator のメンテ | |
-| token-tracking | token-tracking | https://github.com/aainc/token-tracking | Claude Code OTel ローカル監視スタック (otel-collector + Prometheus + Grafana)。個人 (Pro/Max) ローカル構成 + Team plan スケール拡張ガイド付き | dashboard 改修、collector / Grafana 設定更新、export スクリプト機能追加、Team 化作業 | no |
+「base_branch」列（Issue #808）はそのプロジェクトの**既定の起点ブランチ兼 PR マージ先**を宣言する。`main` に直接マージせず `develop` に feature を溜める二系統運用のリポジトリのための設定:
+
+- **空欄 / `-` = 未設定**。従来どおり `origin/HEAD`（リモートが知る既定ブランチ）から worktree を切り、PR も repo の既定ブランチ宛になる。**本列の追加前から在る行は 1 文字も編集せずそのまま有効**。
+- 値を書いた行は、派遣時に `origin/<base_branch>` から worktree を切り（[`tools/gen_delegate_payload.py`](../tools/gen_delegate_payload.py) の `_resolve_base_ref`）、`gh pr create --base <base_branch>` が PR フローの既定になる（[`.claude/skills/org-pull-request/SKILL.md`](../.claude/skills/org-pull-request/SKILL.md) 2a）。
+- 値はブランチ名（`develop`）。git が表示する形の `origin/develop` と書いても同じものとして扱う（前後空白は trim）。
+- 単発の逸脱（hotfix を `main` から切る等）は本列を書き換えず `gen_delegate_payload.py --base-ref main` で上書きする。**優先順位は `--base-ref` > 本列 > `origin/HEAD`**。
+- 設定したブランチが `origin` に存在しない場合、派遣は apply 時に fail loud で停止する（既定ブランチへ黙って落ちない。Issue #480 の stale-base ガードと同じ立場）。
+
+| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | triage | base_branch |
+|---|---|---|---|---|---|---|
+| 時計アプリ | clock-app | - | Webブラウザで動くデジタル時計 | デザイン変更、機能追加 | no | |
+| renga | renga | https://github.com/suisya-systems/renga | Rust 製の Claude Code 用ターミナルマルチプレクサ（TUI） | 機能追加、バグ修正、Issue 対応 | | |
+| サンドボックス検証 | sandbox-probe | - | Issue #376 / #377 用の sandbox profile / hook / settings 配備の実測検証エリア。candidate profile を handcraft して probe を回し allow/deny matrix を作る | Pre-Phase 0 spike、probe 反復、profile validation | no | |
+| ランタイム | claude-org-runtime | https://github.com/suisya-systems/claude-org-runtime | Layer 2 = org-runtime: claude-org-ja から抽出された Python runtime (dispatcher / state schema / reference role prompts)。ja は pin で参照する | role_configs_schema.json 同期、release 駆動、dispatcher / settings.generator のメンテ | | |
+| token-tracking | token-tracking | https://github.com/aainc/token-tracking | Claude Code OTel ローカル監視スタック (otel-collector + Prometheus + Grafana)。個人 (Pro/Max) ローカル構成 + Team plan スケール拡張ガイド付き | dashboard 改修、collector / Grafana 設定更新、export スクリプト機能追加、Team 化作業 | no | |

--- a/tests/fixtures/transport_seam/worker_brief_normal_full.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_normal_full.golden.md
@@ -44,7 +44,7 @@
 追加ゲート: commit 完了後・完了報告前に **`codex` CLI が available なら** `codex exec review`（review surface）で差分セルフレビューを実行する（`codex exec` 直打ちの長文プロンプト形は廃止。review surface は中小 diff で約 2 倍速・安全側 Blocker/Major のパリティは同等）。未導入環境では skip して通常の完了報告に進む。
 
 ```bash
-# --base はブランチのベース（通常 origin/main）。ローカル main は古いと別タスク差分を巻き込むため remote-tracking の origin/main を使う。参照前に git fetch origin を 1 回（fetch 不能でも review は継続）。前景実行して出力（Blocker/Major 相当）を読んでから次へ進む。
+# --base はこのブランチのベース upstream（origin/main）。ローカルの追跡なしブランチは古いと別タスク差分を巻き込むため remote-tracking ref を使う。参照前に git fetch origin を 1 回（fetch 不能でも review は継続）。前景実行して出力（Blocker/Major 相当）を読んでから次へ進む。
 codex exec review --base origin/main -m gpt-5.6-sol -c model_reasoning_effort=medium < /dev/null
 ```
 

--- a/tests/fixtures/transport_seam/worker_brief_self_edit_full.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_self_edit_full.golden.md
@@ -34,7 +34,7 @@
 ## Codex セルフレビュー
 検証深度 full。`codex` available なら commit 後、`codex exec review`（review surface）で差分セルフレビュー（直打ち長文プロンプト形は廃止。中小 diff で約 2 倍速・安全側パリティ同等）:
 ```bash
-# --base はブランチのベース（通常 origin/main）。ローカル main は古いと別タスク差分を巻き込むため remote-tracking の origin/main を使う。参照前に git fetch origin を 1 回（fetch 不能でも review は継続）。前景実行して出力を読んでから次へ進む。
+# --base はこのブランチのベース upstream（origin/main）。ローカルの追跡なしブランチは古いと別タスク差分を巻き込むため remote-tracking ref を使う。参照前に git fetch origin を 1 回（fetch 不能でも review は継続）。前景実行して出力を読んでから次へ進む。
 codex exec review --base origin/main -m gpt-5.6-sol -c model_reasoning_effort=medium < /dev/null
 ```
 - **前景実行する**（背景化 `&` はゲート素通り事故を招く）。Blocker/Major 修正、**round 既定上限 3**（brief の実装ガイダンスで別値指定があればそちら優先）

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -3331,5 +3331,311 @@ class TestIssue712BriefPlacement(unittest.TestCase):
         )
 
 
+class TestNormalizeBaseBranch(unittest.TestCase):
+    """Issue #808: one normalizer for both inputs (--base-ref and the registry
+    ``base_branch`` column) so they cannot disagree on what a value means."""
+
+    def test_bare_branch_name_passes_through(self):
+        self.assertEqual(gdp.normalize_base_branch("develop"), "develop")
+
+    def test_origin_prefix_is_stripped(self):
+        # An operator writing the ref the way git prints it must land on the
+        # same branch as the bare name.
+        self.assertEqual(gdp.normalize_base_branch("origin/develop"), "develop")
+
+    def test_surrounding_whitespace_is_trimmed(self):
+        # Markdown table cells arrive padded.
+        self.assertEqual(gdp.normalize_base_branch("  develop  "), "develop")
+        self.assertEqual(gdp.normalize_base_branch(" origin/ develop "), "develop")
+
+    def test_unset_forms_map_to_none(self):
+        # None == "not configured" == keep the historical origin/HEAD path.
+        for value in (None, "", "   ", "-", " - ", "origin/"):
+            with self.subTest(value=value):
+                self.assertIsNone(gdp.normalize_base_branch(value))
+
+    def test_slashed_branch_name_survives(self):
+        # Only a leading ``origin/`` is special; a real hierarchical branch
+        # name must not be mangled.
+        self.assertEqual(
+            gdp.normalize_base_branch("release/2026-Q3"), "release/2026-Q3"
+        )
+        self.assertEqual(
+            gdp.normalize_base_branch("origin/release/2026-Q3"), "release/2026-Q3"
+        )
+
+
+class TestBaseBranchResolution(unittest.TestCase):
+    """Issue #808: per-project default base branch + --base-ref override.
+
+    Covers the precedence chain (CLI > registry > origin/HEAD), the worktree
+    actually being cut from the configured branch, and the fail-loud refusal
+    when the configured branch does not exist on origin.
+    """
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except FileNotFoundError:
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        # This class drives its own git init (needs a controlled main/develop
+        # divergence), so it opts out of the sandbox-level init.
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
+        import os
+        self._git_env = os.environ.copy()
+        self._git_env.update(
+            {
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+        base = self.sb.claude_org_root
+        self._git("init", "-q", "-b", "main")
+        self._git("commit", "--allow-empty", "-m", "main-1", "-q")
+        self.main_sha = self._rev_parse("main")
+        self._git("update-ref", "refs/remotes/origin/main", self.main_sha)
+        self._git("symbolic-ref", "refs/remotes/origin/HEAD",
+                  "refs/remotes/origin/main")
+        # A develop branch that is genuinely AHEAD of main, so a test can tell
+        # "cut from develop" apart from "cut from origin/HEAD" by SHA alone.
+        self._git("commit", "--allow-empty", "-m", "develop-1", "-q")
+        self.develop_sha = self._rev_parse("HEAD")
+        self._git("update-ref", "refs/remotes/origin/develop", self.develop_sha)
+        # Leave the checkout back on main so HEAD is not itself develop.
+        self._git("reset", "--hard", "-q", self.main_sha)
+        self.assertNotEqual(self.main_sha, self.develop_sha)
+        self.base = base
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    # -- helpers ----------------------------------------------------------
+    def _git(self, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(self.sb.claude_org_root), *args],
+            check=True, env=self._git_env, capture_output=True,
+        )
+
+    def _rev_parse(self, ref: str) -> str:
+        return subprocess.check_output(
+            ["git", "-C", str(self.sb.claude_org_root), "rev-parse", ref],
+        ).decode().strip()
+
+    def _write_registry(self, base_branch: str) -> None:
+        """Rewrite the sandbox registry with the Issue #808 column."""
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 "
+            "| base_branch |\n"
+            "|---|---|---|---|---|---|\n"
+            f"| claude-org-ja | claude-org-ja | {self.sb.claude_org_root} "
+            f"| Self | スキル改善 | {base_branch} |\n",
+            encoding="utf-8",
+        )
+
+    def _plan(self, *, task_id: str = "bb-task", base_ref_override=None):
+        return gdp.build_delegate_plan(
+            task_id=task_id,
+            project_slug="claude-org-ja",
+            description="base branch dispatch",
+            base_ref_override=base_ref_override,
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={
+                "pattern": "B",
+                "pattern_variant": "live_repo_worktree",
+                "role": "claude-org-self-edit",
+                "self_edit": True,
+            },
+        )
+
+    def _apply(self, plan):
+        return gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+
+    # -- precedence -------------------------------------------------------
+    def test_registry_base_branch_is_used_when_no_cli_override(self):
+        self._write_registry("develop")
+        plan = self._plan()
+        self.assertEqual(plan.base_branch, "develop")
+        self.assertEqual(plan.base_branch_source, "registry")
+        self.assertEqual(plan.to_summary_dict()["base_ref"], "origin/develop")
+
+    def test_cli_base_ref_beats_registry(self):
+        # The hotfix escape hatch: registry says develop, this dispatch cuts
+        # from main.
+        self._write_registry("develop")
+        plan = self._plan(base_ref_override="main")
+        self.assertEqual(plan.base_branch, "main")
+        self.assertEqual(plan.base_branch_source, "cli")
+
+    def test_cli_base_ref_used_when_registry_column_absent(self):
+        # The sandbox default registry has no base_branch column at all.
+        plan = self._plan(base_ref_override="develop")
+        self.assertEqual(plan.base_branch, "develop")
+        self.assertEqual(plan.base_branch_source, "cli")
+
+    def test_unset_registry_column_falls_back_to_origin_head(self):
+        for cell in ("", "-"):
+            with self.subTest(cell=cell):
+                self._write_registry(cell)
+                plan = self._plan()
+                self.assertIsNone(plan.base_branch)
+                self.assertEqual(plan.base_branch_source, "origin_head")
+                self.assertEqual(
+                    plan.to_summary_dict()["base_ref"], "origin/HEAD"
+                )
+
+    def test_no_registry_column_falls_back_to_origin_head(self):
+        # Backwards compatibility: the pre-#808 registry shape.
+        plan = self._plan()
+        self.assertIsNone(plan.base_branch)
+        self.assertEqual(plan.base_branch_source, "origin_head")
+
+    def test_origin_prefixed_registry_value_is_normalized(self):
+        self._write_registry("origin/develop")
+        self.assertEqual(self._plan().base_branch, "develop")
+
+    # -- DELEGATE body ----------------------------------------------------
+    def test_delegate_body_announces_the_configured_base(self):
+        self._write_registry("develop")
+        body = self._plan().delegate_body
+        self.assertIn("ベース: origin/develop", body)
+        self.assertIn("registry base_branch", body)
+
+    def test_delegate_body_names_the_cli_flag_as_source(self):
+        self._write_registry("develop")
+        body = self._plan(base_ref_override="main").delegate_body
+        self.assertIn("ベース: origin/main", body)
+        self.assertIn("--base-ref", body)
+
+    def test_delegate_body_unchanged_when_unconfigured(self):
+        # Every pre-#808 project must keep its byte-identical body.
+        body = self._plan().delegate_body
+        self.assertNotIn("ベース:", body)
+
+    # -- apply: the worktree is actually cut from the configured branch ----
+    def test_apply_cuts_worktree_from_configured_base_branch(self):
+        self._write_registry("develop")
+        plan = self._plan(task_id="cut-develop")
+        self._apply(plan)
+        worker_dir = Path(plan.layout.worker_dir)
+        head = subprocess.check_output(
+            ["git", "-C", str(worker_dir), "rev-parse", "HEAD"],
+        ).decode().strip()
+        self.assertEqual(head, self.develop_sha)
+        # ...and specifically NOT the origin/HEAD default the pre-#808 code
+        # would have used.
+        self.assertNotEqual(head, self.main_sha)
+
+    def test_apply_cuts_from_origin_head_when_unconfigured(self):
+        plan = self._plan(task_id="cut-default")
+        self._apply(plan)
+        head = subprocess.check_output(
+            ["git", "-C", str(plan.layout.worker_dir), "rev-parse", "HEAD"],
+        ).decode().strip()
+        self.assertEqual(head, self.main_sha)
+
+    def test_apply_honours_cli_override_at_the_git_level(self):
+        self._write_registry("develop")
+        plan = self._plan(task_id="cut-hotfix", base_ref_override="main")
+        self._apply(plan)
+        head = subprocess.check_output(
+            ["git", "-C", str(plan.layout.worker_dir), "rev-parse", "HEAD"],
+        ).decode().strip()
+        self.assertEqual(head, self.main_sha)
+
+    # -- apply: fail loud on a missing branch ------------------------------
+    def test_apply_fails_loud_when_registry_branch_missing_on_origin(self):
+        self._write_registry("develp")  # typo, never pushed
+        plan = self._plan(task_id="missing-registry")
+        with self.assertRaises(gdp.BaseBranchApplyError) as cm:
+            self._apply(plan)
+        msg = str(cm.exception)
+        self.assertIn("develp", msg)
+        # The message must name the input the operator has to fix.
+        self.assertIn("base_branch", msg)
+        self.assertIn("claude-org-ja", msg)
+        # It must NOT have degraded to the default branch.
+        self.assertFalse(Path(plan.layout.worker_dir).exists())
+
+    def test_apply_fails_loud_when_cli_branch_missing_on_origin(self):
+        plan = self._plan(task_id="missing-cli", base_ref_override="nope")
+        with self.assertRaises(gdp.BaseBranchApplyError) as cm:
+            self._apply(plan)
+        self.assertIn("--base-ref", str(cm.exception))
+
+    def test_missing_base_branch_is_a_worktree_apply_error_subclass(self):
+        # Existing `except WorktreeApplyError` callers must keep catching it.
+        self.assertTrue(
+            issubclass(gdp.BaseBranchApplyError, gdp.WorktreeApplyError)
+        )
+
+    def test_missing_base_branch_leaks_no_queued_run_row(self):
+        # Same invariant as the other pre-reservation aborts: a leaked
+        # `queued` row makes the next dispatch see the pattern as occupied.
+        self._write_registry("does-not-exist")
+        plan = self._plan(task_id="no-leak")
+        with self.assertRaises(gdp.BaseBranchApplyError):
+            self._apply(plan)
+        self.assertEqual(
+            [r for r in self.sb.list_runs() if r["task_id"] == "no-leak"], []
+        )
+
+
+class TestBaseRefCliFlag(unittest.TestCase):
+    """Issue #808: the --base-ref flag is wired through both subcommands and
+    the --from-toml input form."""
+
+    def test_flag_parses_on_preview_and_apply(self):
+        parser = gdp._build_parser()
+        for cmd in ("preview", "apply"):
+            with self.subTest(cmd=cmd):
+                args = parser.parse_args(
+                    [cmd, "--task-id", "t", "--project-slug", "p",
+                     "--base-ref", "develop"]
+                )
+                self.assertEqual(args.base_ref_override, "develop")
+
+    def test_flag_defaults_to_none(self):
+        args = gdp._build_parser().parse_args(
+            ["preview", "--task-id", "t", "--project-slug", "p"]
+        )
+        self.assertIsNone(args.base_ref_override)
+
+    def test_toml_base_ref_is_read_and_cli_wins(self):
+        with tempfile.TemporaryDirectory() as td:
+            toml_path = Path(td) / "worker_brief.toml"
+            toml_path.write_text(
+                '[task]\nid = "t1"\nbase_ref = "develop"\n'
+                '[project]\nname = "p1"\n',
+                encoding="utf-8",
+            )
+            loaded = gdp._load_task_args_from_toml(toml_path)
+            self.assertEqual(loaded["base_ref_override"], "develop")
+
+            # TOML alone wins when the flag is absent...
+            args = gdp._build_parser().parse_args(
+                ["preview", "--from-toml", str(toml_path)]
+            )
+            self.assertEqual(
+                gdp._gather_plan_kwargs(args)["base_ref_override"], "develop"
+            )
+            # ...and the CLI flag overrides it when both are given.
+            args = gdp._build_parser().parse_args(
+                ["preview", "--from-toml", str(toml_path), "--base-ref", "main"]
+            )
+            self.assertEqual(
+                gdp._gather_plan_kwargs(args)["base_ref_override"], "main"
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -3590,6 +3590,331 @@ class TestBaseBranchResolution(unittest.TestCase):
         )
 
 
+class TestBaseBranchReachesTheBrief(unittest.TestCase):
+    """Issue #808 / Codex Round 1 Major: the effective base must reach the
+    rendered worker brief, or the worker's `codex exec review --base ...`
+    would diff a develop-based task against origin/main and treat every
+    develop-only commit as part of the task's own change."""
+
+    def _render(self, base_ref=None):
+        config = {
+            "task": {
+                "id": "t1",
+                "description": "d",
+                "verification_depth": "full",
+                "branch": "feat/t1",
+                "commit_prefix": "feat:",
+            },
+            "worker": {
+                "dir": "/tmp/w",
+                "pattern": "B",
+                "role": "default",
+                "self_edit": False,
+            },
+            "project": {"name": "p", "description": "pd"},
+            "paths": {"claude_org": "/tmp/org"},
+        }
+        if base_ref is not None:
+            config["task"]["base_ref"] = base_ref
+        return gwb.render(config)
+
+    def test_configured_base_ref_lands_in_the_review_command(self):
+        out = self._render("origin/develop")
+        self.assertIn(
+            "codex exec review --base origin/develop", out
+        )
+        self.assertNotIn("--base origin/main", out)
+
+    def test_default_stays_origin_main(self):
+        # Every pre-#808 brief must render byte-identically.
+        self.assertIn("codex exec review --base origin/main", self._render())
+
+    def test_non_string_base_ref_is_rejected(self):
+        config = {
+            "task": {
+                "id": "t1", "description": "d", "verification_depth": "full",
+                "branch": "b", "commit_prefix": "p:", "base_ref": 5,
+            },
+            "worker": {
+                "dir": "/tmp/w", "pattern": "B", "role": "default",
+                "self_edit": False,
+            },
+            "project": {"name": "p", "description": "pd"},
+            "paths": {"claude_org": "/tmp/org"},
+        }
+        with self.assertRaises(gwb.ConfigError):
+            gwb.validate(config)
+
+    def test_planner_injects_the_effective_base_into_the_config(self):
+        with tempfile.TemporaryDirectory() as td:
+            sb = _Sandbox(Path(td))
+            plan = gdp.build_delegate_plan(
+                task_id="brief-base",
+                project_slug="claude-org-ja",
+                description="d",
+                base_ref_override="develop",
+                claude_org_root=sb.claude_org_root,
+                state_db_path=sb.db_path,
+                layout_overrides={
+                    "pattern": "B",
+                    "pattern_variant": "live_repo_worktree",
+                    "role": "claude-org-self-edit",
+                    "self_edit": True,
+                },
+            )
+            self.assertEqual(plan.config["task"]["base_ref"], "origin/develop")
+            self.assertIn(
+                "codex exec review --base origin/develop", gwb.render(plan.config)
+            )
+
+    def test_planner_leaves_base_ref_unset_when_unconfigured(self):
+        with tempfile.TemporaryDirectory() as td:
+            sb = _Sandbox(Path(td))
+            plan = gdp.build_delegate_plan(
+                task_id="brief-default",
+                project_slug="claude-org-ja",
+                description="d",
+                claude_org_root=sb.claude_org_root,
+                state_db_path=sb.db_path,
+                layout_overrides={
+                    "pattern": "B",
+                    "pattern_variant": "live_repo_worktree",
+                    "role": "claude-org-self-edit",
+                    "self_edit": True,
+                },
+            )
+            self.assertNotIn("base_ref", plan.config["task"])
+
+
+class TestBaseBranchAgainstRealRemote(unittest.TestCase):
+    """Issue #808 / Codex Round 1 Major: the remote-tracking ref is a cache,
+    so existence must be decided against the remote itself.
+
+    Uses a local bare repo as ``origin`` -- the same hermetic stand-in for a
+    real remote the rest of this module uses.
+    """
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except FileNotFoundError:
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        root = Path(self._td.name)
+        import os
+        self._env = os.environ.copy()
+        self._env.update({
+            "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@example.com",
+        })
+        # origin: a bare repo carrying main + develop.
+        self.origin = root / "origin.git"
+        self._run(["git", "init", "-q", "--bare", "-b", "main", str(self.origin)])
+        seed = root / "seed"
+        self._run(["git", "init", "-q", "-b", "main", str(seed)])
+        self._run(["git", "-C", str(seed), "commit", "--allow-empty", "-m", "m1", "-q"])
+        self._run(["git", "-C", str(seed), "checkout", "-q", "-b", "develop"])
+        self._run(["git", "-C", str(seed), "commit", "--allow-empty", "-m", "d1", "-q"])
+        self._run(["git", "-C", str(seed), "remote", "add", "origin", str(self.origin)])
+        self._run(["git", "-C", str(seed), "push", "-q", "origin", "main", "develop"])
+        self.seed = seed
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _run(self, cmd, check=True):
+        return subprocess.run(cmd, check=check, env=self._env, capture_output=True)
+
+    def _clone(self, name: str, *extra: str) -> Path:
+        target = Path(self._td.name) / name
+        self._run(["git", "clone", "-q", *extra, str(self.origin), str(target)])
+        return target
+
+    def test_single_branch_clone_still_resolves_the_configured_branch(self):
+        """False-negative guard: a restricted fetch refspec means plain
+        `git fetch origin` never creates origin/develop, but develop DOES
+        exist on the remote, so the dispatch must not be refused."""
+        clone = self._clone("single", "--single-branch", "--branch", "main")
+        # Precondition: the local remote-tracking ref genuinely is absent.
+        probe = subprocess.run(
+            ["git", "-C", str(clone), "rev-parse", "--verify", "--quiet",
+             "refs/remotes/origin/develop"],
+            capture_output=True,
+        )
+        self.assertNotEqual(probe.returncode, 0, "fixture did not restrict the refspec")
+        self.assertTrue(gdp._materialize_origin_branch(clone, "develop"))
+        # ...and the ref is now materialized, so `git worktree add` can use it.
+        self.assertEqual(
+            subprocess.run(
+                ["git", "-C", str(clone), "rev-parse", "--verify", "--quiet",
+                 "refs/remotes/origin/develop"],
+                capture_output=True,
+            ).returncode,
+            0,
+        )
+
+    def test_stale_remote_tracking_ref_of_a_deleted_branch_is_refused(self):
+        """False-positive guard: `git fetch origin` does not prune, so a
+        branch deleted on the remote leaves a stale local ref behind."""
+        clone = self._clone("stale")
+        self._run(["git", "-C", str(clone), "fetch", "-q", "origin"])
+        # Delete develop on the remote; the clone's stale ref survives.
+        self._run(["git", "-C", str(self.seed), "push", "-q", "origin",
+                   "--delete", "develop"])
+        self._run(["git", "-C", str(clone), "fetch", "-q", "origin"])
+        self.assertEqual(
+            subprocess.run(
+                ["git", "-C", str(clone), "rev-parse", "--verify", "--quiet",
+                 "refs/remotes/origin/develop"],
+                capture_output=True,
+            ).returncode,
+            0,
+            "fixture expected a surviving stale ref",
+        )
+        self.assertFalse(gdp._materialize_origin_branch(clone, "develop"))
+
+    def test_existing_branch_resolves_and_refreshes_to_the_remote_tip(self):
+        clone = self._clone("fresh")
+        # Advance develop on the remote after the clone.
+        self._run(["git", "-C", str(self.seed), "checkout", "-q", "develop"])
+        self._run(["git", "-C", str(self.seed), "commit", "--allow-empty",
+                   "-m", "d2", "-q"])
+        self._run(["git", "-C", str(self.seed), "push", "-q", "origin", "develop"])
+        remote_tip = subprocess.check_output(
+            ["git", "-C", str(self.seed), "rev-parse", "develop"],
+        ).decode().strip()
+        self.assertTrue(gdp._materialize_origin_branch(clone, "develop"))
+        local = subprocess.check_output(
+            ["git", "-C", str(clone), "rev-parse", "refs/remotes/origin/develop"],
+        ).decode().strip()
+        self.assertEqual(local, remote_tip)
+
+    def test_missing_branch_on_the_remote_is_refused(self):
+        clone = self._clone("missing")
+        self.assertFalse(gdp._materialize_origin_branch(clone, "no-such-branch"))
+
+    def test_no_origin_remote_falls_back_to_the_local_ref(self):
+        # Purely-local repos (and this module's other fixtures) synthesize
+        # refs/remotes/origin/* with update-ref and have no real remote.
+        local = Path(self._td.name) / "local"
+        self._run(["git", "init", "-q", "-b", "main", str(local)])
+        self._run(["git", "-C", str(local), "commit", "--allow-empty",
+                   "-m", "c", "-q"])
+        sha = subprocess.check_output(
+            ["git", "-C", str(local), "rev-parse", "main"],
+        ).decode().strip()
+        self._run(["git", "-C", str(local), "update-ref",
+                   "refs/remotes/origin/develop", sha])
+        self.assertTrue(gdp._materialize_origin_branch(local, "develop"))
+        self.assertFalse(gdp._materialize_origin_branch(local, "absent"))
+
+
+class TestReusedWorktreeBaseGuard(unittest.TestCase):
+    """Issue #808 / Codex Round 1 Major: `_ensure_worktree` returns early for
+    an already-registered worktree, so a retry that changes the base would
+    otherwise keep the old branch while advertising the new PR base."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except FileNotFoundError:
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
+        import os
+        self._env = os.environ.copy()
+        self._env.update({
+            "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@example.com",
+        })
+        self._git("init", "-q", "-b", "main")
+        self._git("commit", "--allow-empty", "-m", "m1", "-q")
+        main_sha = self._out("rev-parse", "main")
+        self._git("update-ref", "refs/remotes/origin/main", main_sha)
+        self._git("symbolic-ref", "refs/remotes/origin/HEAD",
+                  "refs/remotes/origin/main")
+        self._git("commit", "--allow-empty", "-m", "d1", "-q")
+        self._git("update-ref", "refs/remotes/origin/develop",
+                  self._out("rev-parse", "HEAD"))
+        self._git("reset", "--hard", "-q", main_sha)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _git(self, *args):
+        subprocess.run(["git", "-C", str(self.sb.claude_org_root), *args],
+                       check=True, env=self._env, capture_output=True)
+
+    def _out(self, *args) -> str:
+        return subprocess.check_output(
+            ["git", "-C", str(self.sb.claude_org_root), *args],
+        ).decode().strip()
+
+    def _plan(self, *, task_id, base_ref_override=None):
+        return gdp.build_delegate_plan(
+            task_id=task_id,
+            project_slug="claude-org-ja",
+            description="d",
+            base_ref_override=base_ref_override,
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={
+                "pattern": "B",
+                "pattern_variant": "live_repo_worktree",
+                "role": "claude-org-self-edit",
+                "self_edit": True,
+            },
+        )
+
+    def _apply(self, plan):
+        return gdp.apply_delegate_plan(
+            plan, state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root, skip_settings=True,
+        )
+
+    def test_creation_records_the_base_it_cut_from(self):
+        plan = self._plan(task_id="rec", base_ref_override="develop")
+        self._apply(plan)
+        self.assertEqual(
+            gdp._recorded_worktree_base(
+                self.sb.claude_org_root, plan.layout.planned_branch
+            ),
+            "origin/develop",
+        )
+
+    def test_reuse_with_the_same_base_is_still_idempotent(self):
+        plan = self._plan(task_id="same", base_ref_override="develop")
+        self._apply(plan)
+        # Second apply of an identical plan must not raise.
+        self._apply(self._plan(task_id="same", base_ref_override="develop"))
+
+    def test_reuse_refuses_when_the_configured_base_changed(self):
+        # First dispatch cuts from develop; the retry says main.
+        self._apply(self._plan(task_id="changed", base_ref_override="develop"))
+        retry = self._plan(task_id="changed", base_ref_override="main")
+        with self.assertRaises(gdp.BaseBranchApplyError) as cm:
+            self._apply(retry)
+        msg = str(cm.exception)
+        self.assertIn("origin/develop", msg)   # what the branch was cut from
+        self.assertIn("origin/main", msg)      # what this dispatch wants
+        self.assertIn("worktree remove", msg)  # the recovery instruction
+
+    def test_reuse_without_a_record_proceeds(self):
+        # Worktrees created before Issue #808 carry no record; the guard must
+        # only ever add a refusal where an authoritative record disagrees.
+        plan = self._plan(task_id="norec", base_ref_override="develop")
+        self._apply(plan)
+        self._git("config", "--unset",
+                  f"branch.{plan.layout.planned_branch}.claudeOrgBase")
+        self._apply(self._plan(task_id="norec", base_ref_override="main"))
+
+    def test_unconfigured_dispatch_does_not_churn_a_recorded_worktree(self):
+        # origin/HEAD is a moving symbolic ref, so a recorded concrete branch
+        # is not evidence of disagreement.
+        self._apply(self._plan(task_id="unconf", base_ref_override="develop"))
+        self._apply(self._plan(task_id="unconf"))
+
+
 class TestBaseRefCliFlag(unittest.TestCase):
     """Issue #808: the --base-ref flag is wired through both subcommands and
     the --from-toml input form."""

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -3629,6 +3630,22 @@ class TestBaseBranchReachesTheBrief(unittest.TestCase):
         # Every pre-#808 brief must render byte-identically.
         self.assertIn("codex exec review --base origin/main", self._render())
 
+    def test_shell_metacharacters_in_the_ref_are_quoted(self):
+        """Codex Round 2 Blocker: git permits `;` / `$( )` in ref names and
+        this value lands in a ```bash fence the worker copy-pastes, so a raw
+        interpolation would be command execution, not a ref."""
+        out = self._render("origin/foo$(id);whoami")
+        self.assertNotIn("--base origin/foo$(id);whoami", out)
+        self.assertIn(
+            "--base " + shlex.quote("origin/foo$(id);whoami"), out
+        )
+        # Round-trips back to the literal ref when the shell parses it.
+        line = next(
+            l for l in out.splitlines() if l.startswith("codex exec review")
+        )
+        argv = shlex.split(line.split("<")[0])
+        self.assertEqual(argv[argv.index("--base") + 1], "origin/foo$(id);whoami")
+
     def test_non_string_base_ref_is_rejected(self):
         config = {
             "task": {
@@ -3899,6 +3916,18 @@ class TestReusedWorktreeBaseGuard(unittest.TestCase):
         self.assertIn("origin/main", msg)      # what this dispatch wants
         self.assertIn("worktree remove", msg)  # the recovery instruction
 
+    def test_reuse_refuses_when_the_configured_branch_vanished_from_origin(self):
+        """Codex Round 2 Major: the reuse path must run the same existence
+        check as creation, or a branch deleted from origin after the first
+        apply is silently advertised as the PR base."""
+        self._apply(self._plan(task_id="vanished", base_ref_override="develop"))
+        # Simulate the branch disappearing from the remote. This fixture has no
+        # real origin, so the local remote-tracking ref IS the authority here.
+        self._git("update-ref", "-d", "refs/remotes/origin/develop")
+        with self.assertRaises(gdp.BaseBranchApplyError) as cm:
+            self._apply(self._plan(task_id="vanished", base_ref_override="develop"))
+        self.assertIn("does not exist on the remote", str(cm.exception))
+
     def test_reuse_without_a_record_proceeds(self):
         # Worktrees created before Issue #808 carry no record; the guard must
         # only ever add a refusal where an authoritative record disagrees.
@@ -3908,11 +3937,25 @@ class TestReusedWorktreeBaseGuard(unittest.TestCase):
                   f"branch.{plan.layout.planned_branch}.claudeOrgBase")
         self._apply(self._plan(task_id="norec", base_ref_override="main"))
 
-    def test_unconfigured_dispatch_does_not_churn_a_recorded_worktree(self):
-        # origin/HEAD is a moving symbolic ref, so a recorded concrete branch
-        # is not evidence of disagreement.
-        self._apply(self._plan(task_id="unconf", base_ref_override="develop"))
-        self._apply(self._plan(task_id="unconf"))
+    def test_reuse_refuses_when_the_override_is_dropped(self):
+        """Codex Round 2 Blocker: dropping the override on a retry is the same
+        mismatch as changing it — origin/HEAD resolves to a concrete branch
+        (main) that disagrees with the recorded develop."""
+        self._apply(self._plan(task_id="dropped", base_ref_override="develop"))
+        with self.assertRaises(gdp.BaseBranchApplyError) as cm:
+            self._apply(self._plan(task_id="dropped"))
+        msg = str(cm.exception)
+        self.assertIn("origin/develop", msg)
+        self.assertIn("origin/main", msg)
+
+    def test_unconfigured_reuse_of_an_unconfigured_worktree_is_idempotent(self):
+        # The genuine no-churn case: recorded base == resolved origin/HEAD.
+        self._apply(self._plan(task_id="plain"))
+        self.assertEqual(
+            gdp._recorded_worktree_base(self.sb.claude_org_root, "feat/plain"),
+            "origin/main",
+        )
+        self._apply(self._plan(task_id="plain"))
 
 
 class TestBaseRefCliFlag(unittest.TestCase):

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -4004,6 +4004,25 @@ class TestBaseRefCliFlag(unittest.TestCase):
                 gdp._gather_plan_kwargs(args)["base_ref_override"], "main"
             )
 
+    def test_non_string_toml_base_ref_is_a_config_error_not_a_traceback(self):
+        """Codex Round 3 Major: `base_ref = 5` used to reach
+        normalize_base_branch and abort with a raw AttributeError."""
+        with tempfile.TemporaryDirectory() as td:
+            toml_path = Path(td) / "worker_brief.toml"
+            toml_path.write_text(
+                '[task]\nid = "t1"\nbase_ref = 5\n[project]\nname = "p1"\n',
+                encoding="utf-8",
+            )
+            with self.assertRaises(SystemExit) as cm:
+                gdp._load_task_args_from_toml(toml_path)
+            self.assertIn("base_ref must be a string", str(cm.exception))
+
+    def test_normalize_rejects_non_strings_with_a_clear_type_error(self):
+        # Guard for direct build_delegate_plan callers, which bypass the CLI.
+        with self.assertRaises(TypeError) as cm:
+            gdp.normalize_base_branch(5)
+        self.assertIn("must be a string", str(cm.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -372,6 +372,95 @@ class TestHeaderNameParsing(unittest.TestCase):
             self.assertIn(p.triage.strip().lower(), recognised)
 
 
+class TestBaseBranchColumn(unittest.TestCase):
+    """Issue #808: optional `base_branch` column declares a project's standard
+    cut point / merge target (e.g. `develop` on a two-track repo). The header
+    is the live ja registry's shape: `triage` then `base_branch`.
+
+    The load-bearing property under test is backwards compatibility: every row
+    written before the column existed must keep parsing, unedited, with
+    ``base_branch == ""`` (= "unset", which the delegation pipeline maps back
+    to the historical ``origin/HEAD`` behaviour).
+    """
+
+    _LIVE_HEADER = (
+        "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | triage "
+        "| base_branch |\n"
+        "|---|---|---|---|---|---|---|\n"
+    )
+
+    def test_base_branch_column_populates_raw_value(self):
+        text = self._LIVE_HEADER + (
+            "| くら | kura | https://github.com/x/kura | K | t |  | develop |\n"
+        )
+        projects = parse_projects_text(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].name, "kura")
+        self.assertEqual(projects[0].base_branch, "develop")
+        # The neighbouring column must not be shifted by the addition.
+        self.assertEqual(projects[0].triage, "")
+
+    def test_raw_value_is_preserved_verbatim(self):
+        # Normalization (trim / `origin/` prefix / `-` placeholder) belongs to
+        # gen_delegate_payload.normalize_base_branch, not to the parser, so a
+        # fork can assert on the literal cell. Only the generic cell-level
+        # strip applies.
+        text = self._LIVE_HEADER + (
+            "| n | slug | / | d | t |  | origin/develop |\n"
+        )
+        self.assertEqual(parse_projects_text(text)[0].base_branch, "origin/develop")
+
+    def test_empty_cell_normalizes_to_empty(self):
+        text = self._LIVE_HEADER + "| n | slug | / | d | t | no |  |\n"
+        projects = parse_projects_text(text)
+        self.assertEqual(projects[0].base_branch, "")
+        self.assertEqual(projects[0].triage, "no")
+
+    def test_row_short_of_the_column_still_parses(self):
+        """The no-edit compatibility contract: a pre-#808 row that simply
+        stops before the new column is valid, not a mismatch."""
+        text = self._LIVE_HEADER + "| n | slug | / | d | t | no |\n"
+        projects = parse_projects_text(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].name, "slug")
+        self.assertEqual(projects[0].triage, "no")
+        self.assertEqual(projects[0].base_branch, "")
+
+    def test_header_without_the_column_leaves_base_branch_empty(self):
+        # A fork registry that hasn't adopted the column at all.
+        text = (
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | triage |\n"
+            "|---|---|---|---|---|---|\n"
+            "| n | slug | / | d | t | no |\n"
+        )
+        self.assertEqual(parse_projects_text(text)[0].base_branch, "")
+
+    def test_column_order_does_not_matter_in_header_mode(self):
+        # Header mode maps by name, so an operator who inserts base_branch
+        # before triage gets the same result.
+        text = (
+            "| 通称 | プロジェクト名 | パス | 説明 | base_branch | triage |\n"
+            "|---|---|---|---|---|---|\n"
+            "| n | slug | / | d | develop | no |\n"
+        )
+        project = parse_projects_text(text)[0]
+        self.assertEqual(project.base_branch, "develop")
+        self.assertEqual(project.triage, "no")
+
+    def test_positional_fallback_never_populates_base_branch(self):
+        # Alias-less header -> positional mode, which owns cells[0..5] only and
+        # must not mistake a 7th cell for base_branch.
+        text = (
+            "| a | b | c | d | e | f | g |\n"
+            "|---|---|---|---|---|---|---|\n"
+            "| n | slug | / | d | t | upstream | develop |\n"
+        )
+        projects = parse_projects_text(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].mirror_of, "upstream")
+        self.assertEqual(projects[0].base_branch, "")
+
+
 class TestIterRows(unittest.TestCase):
 
     def test_classifies_lines(self):

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -1079,6 +1079,39 @@ def _materialize_origin_branch(base_repo: Path, branch: str) -> bool:
     return subprocess.run(local_probe, capture_output=True).returncode == 0
 
 
+def _missing_base_branch_error(
+    base_repo: Path,
+    *,
+    base_branch: str,
+    base_branch_source: str,
+    project_slug: Optional[str],
+) -> "BaseBranchApplyError":
+    """Build the fail-loud error for a configured branch the remote doesn't have.
+
+    Shared by the creation path (:func:`_resolve_base_ref`) and the reuse path
+    (:func:`_assert_reused_worktree_base`) so both give the operator the same
+    diagnosis and recovery, instead of only failing when a worktree happens to
+    be created (Codex Round 2 Major).
+    """
+    ref = f"{_ORIGIN_REF_PREFIX}{base_branch}"
+    source_hint = {
+        "cli": "the --base-ref flag passed to this dispatch",
+        "registry": (
+            "the `base_branch` column of registry/projects.md for project "
+            f"{project_slug!r}"
+        ),
+    }.get(base_branch_source, f"base_branch_source={base_branch_source!r}")
+    return BaseBranchApplyError(
+        f"configured base branch {base_branch!r} does not exist on the "
+        f"remote: {ref} could not be resolved against origin in {base_repo}. "
+        f"It was configured by {source_hint}. Refusing to fall back to "
+        "origin/HEAD, because silently using the default branch is exactly "
+        "the diff pollution a per-project base branch exists to prevent "
+        "(Issue #808). Fix the configured name (typo?), push the branch to "
+        "origin, or drop the setting to use origin/HEAD, then retry apply."
+    )
+
+
 def _resolve_base_ref(
     base_repo: Path,
     *,
@@ -1128,25 +1161,11 @@ def _resolve_base_ref(
         ref = f"{_ORIGIN_REF_PREFIX}{base_branch}"
         if _materialize_origin_branch(base_repo, base_branch):
             return ref
-        origin_head = "origin/HEAD"
-        source_hint = {
-            "cli": "the --base-ref flag passed to this dispatch",
-            "registry": (
-                "the `base_branch` column of "
-                f"registry/projects.md for project "
-                f"{project_slug!r}"
-            ),
-        }.get(base_branch_source, f"base_branch_source={base_branch_source!r}")
-        raise BaseBranchApplyError(
-            f"configured base branch {base_branch!r} does not exist on the "
-            f"remote: {ref} is not a remote-tracking ref in {base_repo} (even "
-            f"after `git fetch origin`). It was configured by {source_hint}. "
-            "Refusing to fall back to origin/HEAD, because silently cutting "
-            "the worktree from the default branch is exactly the diff "
-            "pollution a per-project base branch exists to prevent (Issue "
-            "#808). Fix the configured name (typo?), push the branch to "
-            f"origin, or drop the setting to use {origin_head}, then retry "
-            "apply."
+        raise _missing_base_branch_error(
+            base_repo,
+            base_branch=base_branch,
+            base_branch_source=base_branch_source,
+            project_slug=project_slug,
         )
     proc = subprocess.run(
         ["git", "-C", str(base_repo), "symbolic-ref", "--short",
@@ -1275,23 +1294,42 @@ def _assert_reused_worktree_base(plan: DelegatePlan, branch: str) -> None:
     (``origin/main`` is typically an ancestor of a develop-cut branch, so
     narrowing develop → main would slip through).
 
-    No record (worktree predates Issue #808, or was created by hand) means we
-    cannot verify, so reuse proceeds unchanged — this check only ever adds a
-    refusal where an authoritative record disagrees.
+    No record (worktree predates Issue #808, or was created by hand) means the
+    recorded-vs-configured comparison cannot run, so reuse proceeds — this
+    check only ever adds a refusal where an authoritative record disagrees.
+    The existence check below runs either way, because a configured branch
+    that has since been deleted from origin must fail on the reuse path too
+    (Codex Round 2 Major: otherwise apply only fails loud when it happens to
+    create a worktree, and an unusable PR base is advertised on retries).
     """
+    # Existence first: an advertised PR base that no longer exists on the
+    # remote is broken regardless of what the branch was cut from.
+    if plan.base_branch is not None and not _materialize_origin_branch(
+        plan.base_repo, plan.base_branch
+    ):
+        raise _missing_base_branch_error(
+            plan.base_repo,
+            base_branch=plan.base_branch,
+            base_branch_source=plan.base_branch_source,
+            project_slug=plan.project_slug,
+        )
     recorded = _recorded_worktree_base(plan.base_repo, branch)
     if recorded is None:
         return
-    expected = (
-        f"{_ORIGIN_REF_PREFIX}{plan.base_branch}"
-        if plan.base_branch is not None
-        else None
-    )
+    if plan.base_branch is not None:
+        expected: Optional[str] = f"{_ORIGIN_REF_PREFIX}{plan.base_branch}"
+    else:
+        # Unconfigured dispatch: the cut point would be origin/HEAD, so
+        # resolve it to the concrete branch it points at and compare against
+        # that. Accepting every unconfigured retry (Codex Round 2 Blocker)
+        # would let "first apply cut from develop, retry drops the override"
+        # keep the develop-based branch while the send plan advertises the
+        # repo default — the very mismatch this guard exists for.
+        expected = _resolve_base_ref(plan.base_repo)
     if expected is None or recorded == expected:
-        # ``expected is None`` = this dispatch is unconfigured (origin/HEAD).
-        # origin/HEAD is a moving symbolic ref, so a recorded concrete branch
-        # is not evidence of disagreement; stay silent rather than churn every
-        # pre-existing worktree.
+        # ``expected is None`` = origin/HEAD is unset, so there is nothing
+        # authoritative to compare against. The creation path raises on that
+        # separately; reuse has no cut point to redo, so stay silent.
         return
     raise BaseBranchApplyError(
         f"worker_dir {plan.layout.worker_dir} is an existing worktree whose "

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -681,6 +681,15 @@ def build_delegate_plan(
     if base_branch is None:
         base_branch = registry_base_branch
         base_branch_source = "registry" if base_branch is not None else "origin_head"
+    # Feed the effective ref into the brief so the worker's Codex self-review
+    # (``codex exec review --base ...``) diffs against the branch this task was
+    # actually cut from. Without this the rendered brief keeps saying
+    # ``origin/main``, and a develop-based task would review every develop-only
+    # commit as if it were its own change (Codex Round 1 Major). Left unset
+    # when unconfigured so the template default (``origin/main``) still renders
+    # byte-identically for every pre-#808 dispatch.
+    if base_branch is not None:
+        config["task"]["base_ref"] = f"{_ORIGIN_REF_PREFIX}{base_branch}"
 
     # Pattern B: figure out which repo `git worktree add` should be run from.
     # live_repo_worktree → Secretary's live claude-org repo;
@@ -994,6 +1003,82 @@ def _reserve_in_db(
         conn.close()
 
 
+def _has_origin_remote(base_repo: Path) -> bool:
+    """True iff ``base_repo`` has an ``origin`` remote configured.
+
+    Purely-local repos (and the hermetic test fixtures that synthesize
+    ``refs/remotes/origin/*`` with ``update-ref`` and no real remote) have
+    none; :func:`_fetch_base_origin` already treats that as its quiet path,
+    and :func:`_materialize_origin_branch` mirrors the same rule.
+    """
+    probe = subprocess.run(
+        ["git", "-C", str(base_repo), "remote", "get-url", "origin"],
+        capture_output=True,
+    )
+    return probe.returncode == 0
+
+
+def _materialize_origin_branch(base_repo: Path, branch: str) -> bool:
+    """Ensure ``refs/remotes/origin/<branch>`` exists and matches the remote.
+
+    Returns True when the cut point is usable, False when the branch does not
+    exist on the remote (the caller then raises
+    :class:`BaseBranchApplyError`).
+
+    Why this is not just a local ``rev-parse`` on the remote-tracking ref
+    (Codex Round 1 Major): ``refs/remotes/origin/<branch>`` is a *cache* of
+    the remote, and the plain ``git fetch origin`` run by
+    :func:`_fetch_base_origin` keeps it wrong in two opposite ways —
+
+    - **false negative**: a clone made with a restricted fetch refspec
+      (``git clone --single-branch``) never creates ``origin/develop`` even
+      though ``develop`` exists on the remote, so a local-only probe would
+      refuse a perfectly valid dispatch; and
+    - **false positive**: the fetch does not prune, so a branch deleted on the
+      remote leaves a stale local ``origin/develop`` behind and the worktree
+      would be cut from a branch that no longer exists.
+
+    So the remote itself is the authority (``git ls-remote --heads``), and the
+    ref is then fetched explicitly with an exact refspec — which both defeats
+    a restricted refspec and force-updates a stale ref to the live tip.
+
+    When no ``origin`` remote is configured there is nothing to ask, so we
+    fall back to the local remote-tracking ref (same quiet path as
+    :func:`_fetch_base_origin`).
+    """
+    local_probe = ["git", "-C", str(base_repo), "rev-parse", "--verify",
+                   "--quiet", f"refs/remotes/{_ORIGIN_REF_PREFIX}{branch}"]
+    if not _has_origin_remote(base_repo):
+        return subprocess.run(local_probe, capture_output=True).returncode == 0
+    ls = subprocess.run(
+        ["git", "-C", str(base_repo), "ls-remote", "--exit-code", "--heads",
+         "origin", f"refs/heads/{branch}"],
+        capture_output=True,
+    )
+    if ls.returncode != 0:
+        # rc=2 is ls-remote's "no matching refs"; any other non-zero is a
+        # transport failure. Both mean "we could not prove the branch is
+        # there", and the caller's fail-loud message covers both (it names
+        # the configured input and tells the operator to fix / push it) —
+        # degrading to origin/HEAD is never an option here.
+        return False
+    fetch = subprocess.run(
+        ["git", "-C", str(base_repo), "fetch", "origin",
+         f"+refs/heads/{branch}:refs/remotes/{_ORIGIN_REF_PREFIX}{branch}"],
+        capture_output=True,
+    )
+    if fetch.returncode != 0:
+        stderr = (fetch.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise WorktreeApplyError(
+            f"`git fetch origin {branch}` failed (rc={fetch.returncode}) in "
+            f"{base_repo}: {stderr}. The branch exists on the remote but its "
+            "remote-tracking ref could not be updated, so the worktree would "
+            "be cut from a possibly-stale commit (Issue #480 / #808). Fix the "
+            "network / remote and retry apply."
+        )
+    return subprocess.run(local_probe, capture_output=True).returncode == 0
+
+
 def _resolve_base_ref(
     base_repo: Path,
     *,
@@ -1041,12 +1126,7 @@ def _resolve_base_ref(
     """
     if base_branch is not None:
         ref = f"{_ORIGIN_REF_PREFIX}{base_branch}"
-        probe = subprocess.run(
-            ["git", "-C", str(base_repo), "rev-parse", "--verify", "--quiet",
-             f"refs/remotes/{ref}"],
-            capture_output=True,
-        )
-        if probe.returncode == 0:
+        if _materialize_origin_branch(base_repo, base_branch):
             return ref
         origin_head = "origin/HEAD"
         source_hint = {
@@ -1103,11 +1183,7 @@ def _fetch_base_origin(base_repo: Path) -> None:
     repos (and the test fixtures that synthesize ``refs/remotes/origin/*``
     without a real remote) have nothing to fetch.
     """
-    probe = subprocess.run(
-        ["git", "-C", str(base_repo), "remote", "get-url", "origin"],
-        capture_output=True,
-    )
-    if probe.returncode != 0:
+    if not _has_origin_remote(base_repo):
         return  # no origin remote — nothing to refresh
     proc = subprocess.run(
         ["git", "-C", str(base_repo), "fetch", "origin"],
@@ -1139,6 +1215,95 @@ def _worktree_branch(worker_dir: Path) -> Optional[str]:
     if not name or name == "HEAD":
         return None
     return name
+
+
+# git-config key (under ``branch.<name>.``) where apply records the ref a
+# task branch was cut from, so a later reuse can detect that the configured
+# base changed underneath it (Issue #808 / Codex Round 1 Major). Stored
+# per-branch rather than per-worktree because the branch is what carries the
+# commits, and ``git branch -d`` cleans the entry up automatically.
+_BRANCH_BASE_CONFIG_KEY = "claudeOrgBase"
+
+
+def _branch_base_config_name(branch: str) -> str:
+    return f"branch.{branch}.{_BRANCH_BASE_CONFIG_KEY}"
+
+
+def _record_worktree_base(base_repo: Path, branch: str, base_ref: str) -> None:
+    """Record the ref ``branch`` was cut from (best-effort).
+
+    A config write failure must not fail an otherwise-successful dispatch —
+    the recorded value only powers the *extra* reuse check in
+    :func:`_assert_reused_worktree_base`, which treats "no record" as
+    "cannot verify, proceed" for backwards compatibility with worktrees
+    created before Issue #808.
+    """
+    subprocess.run(
+        ["git", "-C", str(base_repo), "config",
+         _branch_base_config_name(branch), base_ref],
+        capture_output=True,
+    )
+
+
+def _recorded_worktree_base(base_repo: Path, branch: str) -> Optional[str]:
+    """Read back the ref recorded by :func:`_record_worktree_base`, or None."""
+    proc = subprocess.run(
+        ["git", "-C", str(base_repo), "config", "--get",
+         _branch_base_config_name(branch)],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        return None
+    value = proc.stdout.decode("utf-8", errors="replace").strip()
+    return value or None
+
+
+def _assert_reused_worktree_base(plan: DelegatePlan, branch: str) -> None:
+    """Refuse to reuse a worktree whose branch was cut from a different base.
+
+    Issue #808 / Codex Round 1 Major: :func:`_ensure_worktree` returns early
+    when ``worker_dir`` is already a registered worktree on the planned
+    branch, so the base-branch resolution below it never runs on a retry. If
+    the first attempt cut the branch from ``origin/develop`` and the retry
+    changes ``--base-ref`` (or the registry) to ``main``, the stale branch
+    would be accepted while the fresh ``send_plan.json`` advertises ``main``
+    as the PR base — reintroducing exactly the base/PR mismatch this feature
+    exists to prevent.
+
+    Comparing recorded-vs-configured is what makes both directions of the
+    change detectable; a merge-base heuristic only catches one of them
+    (``origin/main`` is typically an ancestor of a develop-cut branch, so
+    narrowing develop → main would slip through).
+
+    No record (worktree predates Issue #808, or was created by hand) means we
+    cannot verify, so reuse proceeds unchanged — this check only ever adds a
+    refusal where an authoritative record disagrees.
+    """
+    recorded = _recorded_worktree_base(plan.base_repo, branch)
+    if recorded is None:
+        return
+    expected = (
+        f"{_ORIGIN_REF_PREFIX}{plan.base_branch}"
+        if plan.base_branch is not None
+        else None
+    )
+    if expected is None or recorded == expected:
+        # ``expected is None`` = this dispatch is unconfigured (origin/HEAD).
+        # origin/HEAD is a moving symbolic ref, so a recorded concrete branch
+        # is not evidence of disagreement; stay silent rather than churn every
+        # pre-existing worktree.
+        return
+    raise BaseBranchApplyError(
+        f"worker_dir {plan.layout.worker_dir} is an existing worktree whose "
+        f"branch {branch!r} was cut from {recorded}, but this dispatch is "
+        f"configured for {expected} (source={plan.base_branch_source}). "
+        "Refusing to reuse it: the branch would carry the old base's commits "
+        "while the PR targets the new one, which is the diff pollution "
+        "Issue #808 exists to prevent. Remove the worktree (`git -C "
+        f"{plan.base_repo} worktree remove {plan.layout.worker_dir}` plus "
+        f"`git -C {plan.base_repo} branch -D {branch}`) so apply recreates it "
+        f"from {expected}, or restore the original base setting and retry."
+    )
 
 
 def _is_registered_worktree(base_repo: Path, worker_dir: Path) -> bool:
@@ -1332,6 +1497,11 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
                     "(or remove the worktree and let apply recreate it) "
                     "and retry."
                 )
+            # Issue #808: the branch name matching is not enough — the branch
+            # must also have been cut from the base this dispatch is
+            # configured for, or the PR would target a base the branch never
+            # branched from.
+            _assert_reused_worktree_base(plan, actual)
         return
     if worker_dir.exists() and any(worker_dir.iterdir()):
         raise WorktreeApplyError(
@@ -1348,11 +1518,14 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
         )
     # Issue #480: refresh remote-tracking refs first so we branch off the
     # *current* origin/HEAD, not a stale local clone's old origin/main.
-    # Issue #808: the configured branch (if any) is validated inside
-    # ``_resolve_base_ref`` — after the fetch above, so a branch that only
-    # exists on the remote resolves instead of spuriously failing, and a
-    # branch that exists nowhere raises BaseBranchApplyError.
-    _fetch_base_origin(plan.base_repo)
+    # Issue #808: a configured base branch takes the targeted path instead —
+    # ``_resolve_base_ref`` -> ``_materialize_origin_branch`` asks the remote
+    # for that one branch and fetches it with an exact refspec. That is both
+    # fail-closed (same stance as the blanket fetch) and strictly stronger for
+    # the configured ref, so running the blanket fetch first would only pay
+    # for a second round-trip that nothing downstream reads.
+    if plan.base_branch is None:
+        _fetch_base_origin(plan.base_repo)
     base_ref = _resolve_base_ref(
         plan.base_repo,
         base_branch=plan.base_branch,
@@ -1383,6 +1556,9 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
             f"`git worktree add` failed (rc={proc.returncode}) for "
             f"{worker_dir} from {plan.base_repo}: {stderr}"
         )
+    # Issue #808: remember the actual cut point so a later partial-retry apply
+    # can detect a changed base instead of silently reusing the old branch.
+    _record_worktree_base(plan.base_repo, branch, base_ref)
 
 
 def _write_brief(plan: DelegatePlan) -> Path:

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -363,9 +363,21 @@ def normalize_base_branch(value: Optional[str]) -> Optional[str]:
     Note that this deliberately does NOT validate the branch's existence —
     that is an apply-time git question handled by :func:`_resolve_base_ref`,
     so the planner stays pure.
+
+    Raises :class:`TypeError` on a non-string, non-None input. Registry cells
+    are always strings, but ``--from-toml`` can carry ``base_ref = 5``; the
+    CLI catches that earlier with a friendlier message (see
+    :func:`_load_task_args_from_toml`), and this guard keeps a direct
+    :func:`build_delegate_plan` caller from failing later with an opaque
+    ``AttributeError`` inside ``.strip()`` (Codex Round 3 Major).
     """
     if value is None:
         return None
+    if not isinstance(value, str):
+        raise TypeError(
+            f"base branch must be a string, got {type(value).__name__} "
+            f"({value!r})"
+        )
     v = value.strip()
     if not v or v == "-":
         return None
@@ -2139,6 +2151,18 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
     role = (worker.get("role") or "").strip()
     mode_from_toml = "audit" if role == "doc-audit" else "edit"
 
+    # Issue #808 / Codex Round 3 Major: a TOML ``base_ref = 5`` used to reach
+    # ``normalize_base_branch`` and abort preview / apply with a raw
+    # AttributeError traceback. Report it as the configuration error it is,
+    # naming the file and the offending value (mirrors
+    # ``gen_worker_brief.validate``'s type checks on the other task fields).
+    base_ref = task.get("base_ref")
+    if base_ref is not None and not isinstance(base_ref, str):
+        raise SystemExit(
+            f"error: {path}: [task].base_ref must be a string branch name "
+            f"(e.g. \"develop\"), got {type(base_ref).__name__} ({base_ref!r})"
+        )
+
     # Issue #290 defect 1: surface explicit [worker] fields so the resolver
     # honors them instead of silently re-deriving pattern/role/dir/self_edit.
     layout_overrides: dict[str, Any] = {}
@@ -2170,7 +2194,7 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
         # Issue #808: keep the TOML and CLI input forms at parity so a
         # ``--from-toml`` dispatch can pin the base branch too (``--base-ref``
         # still wins per the merge order in ``_gather_plan_kwargs``).
-        "base_ref_override": task.get("base_ref"),
+        "base_ref_override": base_ref,
         "commit_prefix": task.get("commit_prefix"),
         "verification_depth": task.get("verification_depth"),
         "issue_url": task.get("issue_url"),

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -91,6 +91,23 @@ class BaseCloneApplyError(WorktreeApplyError):
     """
 
 
+class BaseBranchApplyError(WorktreeApplyError):
+    """Raised by ``apply`` when the configured base branch (Issue #808) does
+    not exist on the base repo's ``origin`` remote.
+
+    The branch comes from either ``--base-ref`` or the registry's
+    ``base_branch`` column, so a typo (``develp``) or a branch that was never
+    pushed would otherwise silently fall back to the wrong cut point. Failing
+    loud here matches the Issue #480 stale-base guard: both refuse to branch a
+    worktree off a ref we cannot prove is the live remote tip.
+
+    Subclasses :class:`WorktreeApplyError` so existing ``except
+    WorktreeApplyError`` callers still catch it. Like the other worktree
+    errors it fires inside :func:`_ensure_worktree`, i.e. BEFORE the DB
+    reservation, so it never leaks a ``queued`` run row.
+    """
+
+
 class BlockingPreviewWarningError(RuntimeError):
     """Raised by ``apply`` when the plan carries one or more
     ``blocking_warnings`` (Issue #489 surface). Distinct from
@@ -178,6 +195,17 @@ class DelegatePlan:
     # placement flips to CLAUDE.local.md (Issue #712 interaction). None when
     # the project has no registry row.
     project_path: Optional[str] = None
+    # Issue #808: the effective base branch for this dispatch, already
+    # normalized by :func:`normalize_base_branch`. ``None`` means "unconfigured"
+    # and ``_resolve_base_ref`` keeps the historical ``origin/HEAD`` behaviour;
+    # a value means the worktree is cut from ``origin/<base_branch>`` and that
+    # same branch is the default ``gh pr create --base`` for the PR flow.
+    base_branch: Optional[str] = None
+    # Where ``base_branch`` came from: ``"cli"`` (--base-ref), ``"registry"``
+    # (the project's base_branch column), or ``"origin_head"`` (unconfigured).
+    # Carried so the apply-time failure message can name the input the operator
+    # has to fix, and so ``preview`` discloses which precedence tier won.
+    base_branch_source: str = "origin_head"
 
     def to_summary_dict(self) -> dict[str, Any]:
         return {
@@ -195,6 +223,16 @@ class DelegatePlan:
             "settings_args": dict(self.settings_args),
             "artifacts_to_create": [str(p) for p in self.artifacts_to_create],
             "base_repo": str(self.base_repo) if self.base_repo else None,
+            # Issue #808: expose the resolved cut point so Secretary can read
+            # the PR base off the preview instead of re-deriving it. The
+            # ``base_ref`` value is exactly what ``git worktree add`` will use.
+            "base_branch": self.base_branch,
+            "base_branch_source": self.base_branch_source,
+            "base_ref": (
+                f"origin/{self.base_branch}"
+                if self.base_branch is not None
+                else "origin/HEAD"
+            ),
             "warnings": list(self.warnings),
             "blocking_warnings": list(self.blocking_warnings),
             "pending_clone": (
@@ -295,6 +333,45 @@ def _resolve_brief_filename(*, self_edit: bool, repo_dir: Path) -> str:
     if self_edit or _repo_tracks_claude_md(repo_dir):
         return "CLAUDE.local.md"
     return "CLAUDE.md"
+
+
+# Accepted (and stripped) prefix on a configured base branch value, so
+# ``origin/develop`` and ``develop`` mean the same thing (Issue #808). Only
+# ``origin`` is special-cased: the worktree cut point is always resolved
+# against ``refs/remotes/origin/<branch>`` — the single remote the Issue #480
+# freshness guard fetches — so another remote's name would not be a valid
+# branch there and must fail loud rather than be silently rewritten.
+_ORIGIN_REF_PREFIX = "origin/"
+
+
+def normalize_base_branch(value: Optional[str]) -> Optional[str]:
+    """Normalize a configured base-branch value to a bare branch name.
+
+    Issue #808. Applied identically to the ``--base-ref`` CLI flag and the
+    registry ``base_branch`` column so the two inputs cannot disagree on what
+    ``develop`` means:
+
+    - surrounding whitespace is trimmed (markdown table cells are padded);
+    - a leading ``origin/`` is stripped, so an operator who writes the ref the
+      way git prints it (``origin/develop``) gets the same result as the bare
+      branch name;
+    - ``""`` / ``-`` (the registry's "unset" placeholder, matching the ``パス``
+      column's convention) map to ``None`` = "not configured", which keeps the
+      historical ``origin/HEAD`` behaviour for every pre-#808 row.
+
+    Returns the bare branch name, or ``None`` when nothing is configured.
+    Note that this deliberately does NOT validate the branch's existence —
+    that is an apply-time git question handled by :func:`_resolve_base_ref`,
+    so the planner stays pure.
+    """
+    if value is None:
+        return None
+    v = value.strip()
+    if not v or v == "-":
+        return None
+    if v.startswith(_ORIGIN_REF_PREFIX):
+        v = v[len(_ORIGIN_REF_PREFIX):].strip()
+    return v or None
 
 
 def _is_clone_url(path: Optional[str]) -> bool:
@@ -456,8 +533,17 @@ def _format_delegate_body(
     permission_mode: str,
     verification_depth: str,
     brief_filename: str,
+    base_branch: Optional[str] = None,
+    base_branch_source: str = "origin_head",
 ) -> str:
-    """Format the DELEGATE message body per org-delegate Step 2 template."""
+    """Format the DELEGATE message body per org-delegate Step 2 template.
+
+    Issue #808: when a base branch is configured, an extra ``ベース`` line
+    names the cut point and where it came from, so the dispatcher and worker
+    both see the non-default PR base without re-reading the registry. The
+    line is omitted entirely when nothing is configured, keeping the body
+    byte-identical to the pre-#808 output for every existing project.
+    """
     instr_summary = _summarize_description(description)
     branch_line = (
         layout.planned_branch
@@ -467,6 +553,16 @@ def _format_delegate_body(
     # Use the platform-native joiner to avoid the mixed `\\…/CLAUDE.md`
     # output the literal-`/` template produced on Windows (Codex Round 1 Nit).
     brief_full_path = str(Path(layout.worker_dir) / brief_filename)
+    base_line = ""
+    if base_branch is not None:
+        source_label = {
+            "cli": "--base-ref 指定",
+            "registry": "registry base_branch",
+        }.get(base_branch_source, base_branch_source)
+        base_line = (
+            f"\n  - ベース: origin/{base_branch}"
+            f"（{source_label}。PR も `--base {base_branch}` を既定とする）"
+        )
     body = f"""DELEGATE: 以下のワーカーを派遣してください。
 
 タスク一覧:
@@ -474,7 +570,7 @@ def _format_delegate_body(
   - ワーカーディレクトリ: {layout.worker_dir}（{brief_filename}・設定配置済み）
   - ディレクトリパターン: {_pattern_label(layout)}
   - プロジェクト: {_project_label(layout, project_path)}
-  - ブランチ (planned): {branch_line}
+  - ブランチ (planned): {branch_line}{base_line}
   - Permission Mode: {permission_mode}
   - 検証深度: {verification_depth}
   - 指示内容: 詳細は `{brief_full_path}` を参照。要約: {instr_summary or '(none)'}
@@ -496,6 +592,7 @@ def build_delegate_plan(
     description: str = "",
     mode: str = "edit",
     branch_override: Optional[str] = None,
+    base_ref_override: Optional[str] = None,
     commit_prefix: Optional[str] = None,
     verification_depth: str = "full",
     issue_url: Optional[str] = None,
@@ -561,8 +658,10 @@ def build_delegate_plan(
 
     permission_mode = parse_permission_mode(Path(claude_org_root))
 
-    # Look up project.path for the DELEGATE body label.
+    # Look up project.path for the DELEGATE body label, and the Issue #808
+    # ``base_branch`` column for the worktree cut point / PR base default.
     project_path: Optional[str] = None
+    registry_base_branch: Optional[str] = None
     registry_for_meta = registry_path or (
         Path(claude_org_root) / "registry" / "projects.md"
     )
@@ -571,6 +670,17 @@ def build_delegate_plan(
         match = rwl.find_project(rows, project_slug)
         if match is not None:
             project_path = match.path
+            registry_base_branch = normalize_base_branch(match.base_branch)
+
+    # Issue #808 precedence: --base-ref > registry base_branch > origin/HEAD.
+    # Recording the winning tier (not just the value) lets the apply-time
+    # failure point the operator at the input they actually have to fix, and
+    # keeps the three tiers auditable in ``preview --json``.
+    base_branch = normalize_base_branch(base_ref_override)
+    base_branch_source = "cli"
+    if base_branch is None:
+        base_branch = registry_base_branch
+        base_branch_source = "registry" if base_branch is not None else "origin_head"
 
     # Pattern B: figure out which repo `git worktree add` should be run from.
     # live_repo_worktree → Secretary's live claude-org repo;
@@ -716,6 +826,8 @@ def build_delegate_plan(
         permission_mode=permission_mode,
         verification_depth=verification_depth,
         brief_filename=brief_filename,
+        base_branch=base_branch,
+        base_branch_source=base_branch_source,
     )
 
     artifacts = [
@@ -789,6 +901,8 @@ def build_delegate_plan(
         blocking_warnings=blocking_warnings,
         pending_clone=pending_clone,
         project_path=project_path,
+        base_branch=base_branch,
+        base_branch_source=base_branch_source,
     )
 
 
@@ -880,7 +994,13 @@ def _reserve_in_db(
         conn.close()
 
 
-def _resolve_base_ref(base_repo: Path) -> Optional[str]:
+def _resolve_base_ref(
+    base_repo: Path,
+    *,
+    base_branch: Optional[str] = None,
+    base_branch_source: str = "origin_head",
+    project_slug: Optional[str] = None,
+) -> Optional[str]:
     """Pick the starting ref for ``git worktree add -b <branch> <path> <ref>``.
 
     Pattern B is triggered precisely when another active run is occupying
@@ -888,7 +1008,17 @@ def _resolve_base_ref(base_repo: Path) -> Optional[str]:
     other task's feature branch. Branching off it would mix unmerged
     commits into the new worktree.
 
-    The only ref we treat as authoritative is ``origin/HEAD`` (the
+    Issue #808 — when ``base_branch`` is set (``--base-ref`` or the registry
+    ``base_branch`` column, already normalized by
+    :func:`normalize_base_branch`), the cut point is ``origin/<base_branch>``
+    instead of ``origin/HEAD``. That branch must actually exist as a
+    remote-tracking ref: a project on a two-track flow (main = hotfix,
+    develop = feature) that silently fell back to ``origin/HEAD`` would cut
+    every worktree from the wrong trunk and pollute each PR's diff. So a
+    missing branch raises :class:`BaseBranchApplyError` rather than degrading
+    — the same fail-loud stance as the Issue #480 stale-base guard.
+
+    Otherwise the only ref we treat as authoritative is ``origin/HEAD`` (the
     project's default branch as the remote knows it). We deliberately do
     NOT fall back to local ``main`` / ``master`` / ``HEAD`` because:
 
@@ -900,11 +1030,44 @@ def _resolve_base_ref(base_repo: Path) -> Optional[str]:
 
     Returns ``None`` when ``origin/HEAD`` is not set — apply then aborts
     with a recovery hint pointing to ``git remote set-head origin --auto``.
+    (The configured-branch path never returns ``None``: it either resolves or
+    raises, because "unset origin/HEAD" and "configured branch missing" need
+    different recovery instructions.)
 
     Freshness of the returned ref is the caller's job: :func:`_ensure_worktree`
     runs :func:`_fetch_base_origin` immediately before this, so ``origin/HEAD``
-    reflects the live remote tip rather than a stale local clone (Issue #480).
+    — and the existence check below — reflect the live remote tip rather than
+    a stale local clone (Issue #480).
     """
+    if base_branch is not None:
+        ref = f"{_ORIGIN_REF_PREFIX}{base_branch}"
+        probe = subprocess.run(
+            ["git", "-C", str(base_repo), "rev-parse", "--verify", "--quiet",
+             f"refs/remotes/{ref}"],
+            capture_output=True,
+        )
+        if probe.returncode == 0:
+            return ref
+        origin_head = "origin/HEAD"
+        source_hint = {
+            "cli": "the --base-ref flag passed to this dispatch",
+            "registry": (
+                "the `base_branch` column of "
+                f"registry/projects.md for project "
+                f"{project_slug!r}"
+            ),
+        }.get(base_branch_source, f"base_branch_source={base_branch_source!r}")
+        raise BaseBranchApplyError(
+            f"configured base branch {base_branch!r} does not exist on the "
+            f"remote: {ref} is not a remote-tracking ref in {base_repo} (even "
+            f"after `git fetch origin`). It was configured by {source_hint}. "
+            "Refusing to fall back to origin/HEAD, because silently cutting "
+            "the worktree from the default branch is exactly the diff "
+            "pollution a per-project base branch exists to prevent (Issue "
+            "#808). Fix the configured name (typo?), push the branch to "
+            f"origin, or drop the setting to use {origin_head}, then retry "
+            "apply."
+        )
     proc = subprocess.run(
         ["git", "-C", str(base_repo), "symbolic-ref", "--short",
          "refs/remotes/origin/HEAD"],
@@ -1094,6 +1257,8 @@ def _finalize_pending_clone_brief(plan: DelegatePlan) -> DelegatePlan:
         permission_mode=plan.permission_mode,
         verification_depth=plan.verification_depth,
         brief_filename="CLAUDE.local.md",
+        base_branch=plan.base_branch,
+        base_branch_source=plan.base_branch_source,
     )
     return replace(
         plan,
@@ -1183,8 +1348,17 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
         )
     # Issue #480: refresh remote-tracking refs first so we branch off the
     # *current* origin/HEAD, not a stale local clone's old origin/main.
+    # Issue #808: the configured branch (if any) is validated inside
+    # ``_resolve_base_ref`` — after the fetch above, so a branch that only
+    # exists on the remote resolves instead of spuriously failing, and a
+    # branch that exists nowhere raises BaseBranchApplyError.
     _fetch_base_origin(plan.base_repo)
-    base_ref = _resolve_base_ref(plan.base_repo)
+    base_ref = _resolve_base_ref(
+        plan.base_repo,
+        base_branch=plan.base_branch,
+        base_branch_source=plan.base_branch_source,
+        project_slug=plan.project_slug,
+    )
     if base_ref is None:
         raise WorktreeApplyError(
             f"could not resolve `origin/HEAD` in {plan.base_repo}. Refusing "
@@ -1596,6 +1770,21 @@ def _add_task_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--description", default=None)
     p.add_argument("--mode", choices=("edit", "audit"), default=None)
     p.add_argument("--branch", dest="branch_override", default=None)
+    # Issue #808: hotfix escape hatch over the registry's per-project
+    # base_branch. Help text stays ASCII-only so `--help` does not crash a
+    # cp932 Windows console (repo convention).
+    p.add_argument(
+        "--base-ref",
+        dest="base_ref_override",
+        default=None,
+        help=(
+            "Branch on origin to cut the worktree from, e.g. 'develop' "
+            "(an 'origin/' prefix is accepted). Also becomes the default "
+            "`gh pr create --base`. Precedence: this flag > the project's "
+            "base_branch column in registry/projects.md > origin/HEAD. "
+            "Apply fails loud if the branch does not exist on origin."
+        ),
+    )
     p.add_argument("--commit-prefix", default=None)
     p.add_argument(
         "--verification-depth", choices=("full", "minimal"), default=None
@@ -1764,6 +1953,10 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
         "project_slug": project.get("name"),
         "description": task.get("description"),
         "branch_override": task.get("branch"),
+        # Issue #808: keep the TOML and CLI input forms at parity so a
+        # ``--from-toml`` dispatch can pin the base branch too (``--base-ref``
+        # still wins per the merge order in ``_gather_plan_kwargs``).
+        "base_ref_override": task.get("base_ref"),
         "commit_prefix": task.get("commit_prefix"),
         "verification_depth": task.get("verification_depth"),
         "issue_url": task.get("issue_url"),
@@ -1819,6 +2012,9 @@ def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
         "description": args.description,
         "mode": args.mode,
         "branch_override": args.branch_override,
+        # ``getattr`` (not attribute access) for the same reason ``--pattern``
+        # uses it above: callers synthesize partial Namespaces.
+        "base_ref_override": getattr(args, "base_ref_override", None),
         "commit_prefix": args.commit_prefix,
         "verification_depth": args.verification_depth,
         "issue_url": args.issue_url,
@@ -1924,6 +2120,13 @@ def _cmd_apply(args: argparse.Namespace) -> int:
         send_plan_out=args.send_plan_out,
     )
     print(f"reserved (queued) task_id={plan.task_id} pattern={plan.layout.pattern}")
+    # Issue #808: only announced when a non-default cut point is in play, so
+    # the common origin/HEAD dispatch keeps its existing output.
+    if plan.base_branch is not None:
+        print(
+            f"base: origin/{plan.base_branch} "
+            f"(source={plan.base_branch_source}; PR base default)"
+        )
     print(f"brief: {result.brief_path}")
     if result.settings_path is not None:
         print(f"settings: {result.settings_path}")

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -119,6 +119,8 @@ def validate(config: dict[str, Any]) -> None:
     task = config["task"]
     if "issue_url" in task and not isinstance(task["issue_url"], str):
         raise ConfigError("task.issue_url must be a string")
+    if "base_ref" in task and not isinstance(task["base_ref"], str):
+        raise ConfigError("task.base_ref must be a string")
     if "closes_issue" in task:
         v = task["closes_issue"]
         if isinstance(v, bool) or not isinstance(v, int):
@@ -290,6 +292,13 @@ def _build_substitutions(config: dict[str, Any]) -> dict[str, str]:
         "task_id": task["id"],
         "task_description": task["description"].strip(),
         "task_branch": task["branch"],
+        # Issue #808: the ref the worker's Codex self-review diffs against.
+        # Defaults to ``origin/main`` so every pre-#808 brief renders
+        # byte-identically; ``gen_delegate_payload`` overwrites it with
+        # ``origin/<base_branch>`` when the project (or --base-ref) configures
+        # a different cut point, otherwise the review would treat all of the
+        # base branch's own commits as this task's diff.
+        "task_base_ref": task.get("base_ref") or "origin/main",
         "task_verification_depth": task["verification_depth"],
         "task_commit_prefix": task["commit_prefix"],
         "task_issue_url": task.get("issue_url", ""),

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -31,6 +31,7 @@ _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent))
 
 import argparse
 import re
+import shlex
 import sys
 from pathlib import Path
 from string import Template
@@ -298,7 +299,14 @@ def _build_substitutions(config: dict[str, Any]) -> dict[str, str]:
         # ``origin/<base_branch>`` when the project (or --base-ref) configures
         # a different cut point, otherwise the review would treat all of the
         # base branch's own commits as this task's diff.
-        "task_base_ref": task.get("base_ref") or "origin/main",
+        #
+        # ``shlex.quote`` because this lands inside a ```bash fence the worker
+        # copy-pastes, and git permits shell metacharacters in ref names
+        # (``foo;id``, ``foo$(id)`` are valid branch names), so a raw
+        # interpolation would turn a registry cell into command execution
+        # (Codex Round 2 Blocker). Ordinary names quote to themselves, so the
+        # default rendering is unchanged.
+        "task_base_ref": shlex.quote(task.get("base_ref") or "origin/main"),
         "task_verification_depth": task["verification_depth"],
         "task_commit_prefix": task["commit_prefix"],
         "task_issue_url": task.get("issue_url", ""),

--- a/tools/registry_parser.py
+++ b/tools/registry_parser.py
@@ -28,19 +28,20 @@ from typing import Iterator, Optional, Union
 logger = logging.getLogger(__name__)
 
 # The projects table grew from 5 columns (legacy) to 6 columns (Issue #374
-# `mirror_of`) and, in header-mode registries (Issue #729), now carries a
-# trailing `triage` opt-in column too. These positional constants are only
-# consulted by the *positional fallback* path (headerless snippets); when a
-# recognised header row is present the parser maps columns by name instead,
-# so column order and extra columns no longer matter. We still parse 4-column
-# hand-edited tables ('legacy' resolver leniency) and ignore extra trailing
-# columns rather than rejecting the whole row, so a future addition doesn't
-# silently drop registered projects.
+# `mirror_of`) and, in header-mode registries (Issue #729 `triage`, Issue
+# #808 `base_branch`), carries further trailing opt-in columns too. These
+# positional constants are only consulted by the *positional fallback* path
+# (headerless snippets); when a recognised header row is present the parser
+# maps columns by name instead, so column order and extra columns no longer
+# matter. We still parse 4-column hand-edited tables ('legacy' resolver
+# leniency) and ignore extra trailing columns rather than rejecting the whole
+# row, so a future addition doesn't silently drop registered projects.
 #   positional layout: [0]=nickname [1]=name [2]=path [3]=description
 #                       [4]=common_tasks [5]=mirror_of
-# The live registry/projects.md places `triage` as its 6th visible column
-# (there is no mirror_of column in the ja registry); positional mode never
-# populates `triage` — only header mode does.
+# The live registry/projects.md places `triage` as its 6th visible column and
+# `base_branch` as its 7th (there is no mirror_of column in the ja registry);
+# positional mode never populates `triage` / `base_branch` — only header mode
+# does.
 COLUMN_COUNT = 6
 LEGACY_COLUMN_COUNT = 5
 
@@ -62,6 +63,7 @@ _FIELD_ALIASES: dict[str, tuple[str, ...]] = {
     "common_tasks": ("よくある作業例",),
     "mirror_of": ("mirror_of",),
     "triage": ("triage",),
+    "base_branch": ("base_branch", "base branch"),
 }
 _ALIAS_TO_FIELD: dict[str, str] = {
     alias.lower(): field
@@ -96,6 +98,16 @@ class Project:
     # lives in the work-discovery repo resolver, not here, so the parser
     # stays a dumb SoT and forks/tests can assert on the literal cell value.
     triage: str = ""
+    # Issue #808: raw value of the `base_branch` column (header mode only;
+    # positional fallback always leaves this empty). Declares the project's
+    # standard cut point / merge target, e.g. `develop` for a two-track
+    # (main = hotfix, develop = feature) repo. Empty / `-` means "unset" and
+    # the delegation pipeline keeps its historical `origin/HEAD` behaviour,
+    # so every pre-#808 row stays valid with zero edits. Kept verbatim --
+    # normalization (trim, tolerated `origin/` prefix, `-` placeholder) lives
+    # in ``tools.gen_delegate_payload.normalize_base_branch``, not here, so
+    # the parser stays a dumb SoT.
+    base_branch: str = ""
 
 
 # Per-line classification. ``kind`` values:
@@ -156,8 +168,8 @@ def iter_rows(text: str) -> Iterator[ParsedRow]:
       does not shift the meaning of existing columns.
     - **positional fallback** — headerless snippets and legacy/fork tables
       whose header matches no alias fall back to fixed positions
-      (``cells[0]=nickname … cells[5]=mirror_of``). ``triage`` is never
-      populated in this mode.
+      (``cells[0]=nickname … cells[5]=mirror_of``). ``triage`` (Issue #729)
+      and ``base_branch`` (Issue #808) are never populated in this mode.
     """
     text = text.lstrip("﻿")
     in_table = False
@@ -194,8 +206,9 @@ def iter_rows(text: str) -> Iterator[ParsedRow]:
             yield ParsedRow(line_no, raw_line, "header")
             continue
         # Schema check: at least 4 cells (通称/slug/パス/説明) and the slug
-        # column populated. The 5th 「よくある作業例」, 6th `mirror_of`, and
-        # `triage` columns are optional — the legacy resolver accepted
+        # column populated. The 5th 「よくある作業例」, 6th `mirror_of`,
+        # `triage`, and `base_branch` columns are optional — the legacy
+        # resolver accepted
         # 4-column tables, the pre-Issue-#374 registry was 5-column, and a
         # fork that hasn't adopted a new column yet must keep parsing. Extra
         # trailing cells are ignored rather than treated as schema breakage
@@ -213,6 +226,7 @@ def iter_rows(text: str) -> Iterator[ParsedRow]:
                 common_tasks=_cell_by_field(cells, header_map, "common_tasks"),
                 mirror_of=_cell_by_field(cells, header_map, "mirror_of"),
                 triage=_cell_by_field(cells, header_map, "triage"),
+                base_branch=_cell_by_field(cells, header_map, "base_branch"),
             )
             yield ParsedRow(line_no, raw_line, "data", project)
             continue

--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -71,8 +71,8 @@ ${references_knowledge_block}
 追加ゲート: commit 完了後・完了報告前に **`codex` CLI が available なら** `codex exec review`（review surface）で差分セルフレビューを実行する（`codex exec` 直打ちの長文プロンプト形は廃止。review surface は中小 diff で約 2 倍速・安全側 Blocker/Major のパリティは同等）。未導入環境では skip して通常の完了報告に進む。
 
 ```bash
-# --base はブランチのベース（通常 origin/main）。ローカル main は古いと別タスク差分を巻き込むため remote-tracking の origin/main を使う。参照前に git fetch origin を 1 回（fetch 不能でも review は継続）。前景実行して出力（Blocker/Major 相当）を読んでから次へ進む。
-codex exec review --base origin/main -m gpt-5.6-sol -c model_reasoning_effort=medium < /dev/null
+# --base はこのブランチのベース upstream（${task_base_ref}）。ローカルの追跡なしブランチは古いと別タスク差分を巻き込むため remote-tracking ref を使う。参照前に git fetch origin を 1 回（fetch 不能でも review は継続）。前景実行して出力（Blocker/Major 相当）を読んでから次へ進む。
+codex exec review --base ${task_base_ref} -m gpt-5.6-sol -c model_reasoning_effort=medium < /dev/null
 ```
 
 - **前景実行する**（背景化 `&` + ログ redirect は、完了を待たず指摘を読まずに完了報告してゲートを素通りする事故を招く）。応答が長く来ない稀なケースのみ中断して skip 可。

--- a/tools/templates/worker_brief_self_edit.md
+++ b/tools/templates/worker_brief_self_edit.md
@@ -57,8 +57,8 @@ ${references_knowledge_block}
 ## Codex セルフレビュー
 検証深度 full。`codex` available なら commit 後、`codex exec review`（review surface）で差分セルフレビュー（直打ち長文プロンプト形は廃止。中小 diff で約 2 倍速・安全側パリティ同等）:
 ```bash
-# --base はブランチのベース（通常 origin/main）。ローカル main は古いと別タスク差分を巻き込むため remote-tracking の origin/main を使う。参照前に git fetch origin を 1 回（fetch 不能でも review は継続）。前景実行して出力を読んでから次へ進む。
-codex exec review --base origin/main -m gpt-5.6-sol -c model_reasoning_effort=medium < /dev/null
+# --base はこのブランチのベース upstream（${task_base_ref}）。ローカルの追跡なしブランチは古いと別タスク差分を巻き込むため remote-tracking ref を使う。参照前に git fetch origin を 1 回（fetch 不能でも review は継続）。前景実行して出力を読んでから次へ進む。
+codex exec review --base ${task_base_ref} -m gpt-5.6-sol -c model_reasoning_effort=medium < /dev/null
 ```
 - **前景実行する**（背景化 `&` はゲート素通り事故を招く）。Blocker/Major 修正、**round 既定上限 3**（brief の実装ガイダンスで別値指定があればそちら優先）
 - **上限到達で自走継続せず**、残指摘 + 自己評価（設計問題化か収束途中か）を窓口に報告して停止。**同一指摘が 3 round 消えない場合は上限前でも即設計問題として報告**（別問題が各 1 round で順に解消する健全な収束とは区別）


### PR DESCRIPTION
## What

Adds per-project default base branches to the delegation pipeline, so projects adopting a develop-based flow (hotfix → main, features → develop) get correctly-based worktrees and PRs without per-dispatch flags.

Closes #808

## Changes

1. **`registry/projects.md` `base_branch` column**: rows with a value cut worktrees from `origin/<base_branch>` and use it as the default PR base. Empty / `-` keeps today's `origin/HEAD` behavior — existing rows are valid without any edit (header-name mapping, column position free; blank cells added to existing rows are cosmetic only, backward compat pinned by `tests/test_registry_parser.py`).
2. **`--base-ref` one-shot override** (hotfix escape hatch). Precedence: CLI flag > registry column > `origin/HEAD`. Also settable via `--from-toml` (`[task].base_ref`), CLI wins.
3. **Missing configured branch fails loud**, asking the remote directly (`ls-remote` + exact-refspec fetch) rather than trusting remote-tracking cache — `--single-branch` clones would wrongly reject an existing develop, and deleted-upstream branches would wrongly pass. Fires before the DB reservation, so no queued rows leak.
4. **Reused-worktree base guard**: the cut point is recorded in `branch.<name>.claudeOrgBase` at creation and compared on reuse; a changed configuration stops the apply instead of silently advertising a different PR base than the branch was cut from.
5. **Effective base propagates into the worker brief**: the `codex exec review --base` fence now renders `${task_base_ref}` (shlex-quoted; git allows shell metacharacters in ref names and the value lands in a copy-paste bash fence). Unset projects render byte-identical briefs.

## Ripple check

`dashboard/server.py`, `state_db/importer.py`, `work_discovery_repos.py`, `resolve_worker_layout.py` all read the registry through the shared parser and ignore the new field — verified, no changes needed. Skill prose updated via `SKILL.md.in` sources; all other generated skills byte-identical (`gen_skill_prose.py --check` exit 0).

## Verification

- `pytest tests/ tools/` — 1587 passed / 4 skipped (pre-existing skips only)
- SKILL.md drift check — clean
- codex `exec review` × 3 rounds (3 Major / 2 Blocker / 2 Major+config fixed across rounds; round 3's single fix — a TOML type guard — is covered by two dedicated tests but was not re-reviewed, cap reached; shipped per user decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
