### PR TITLE
chore(skills): add owner field to all 8 work-skill frontmatters

### DIFF
--- a/.claude/skills/dispatcher-handover/SKILL.md
+++ b/.claude/skills/dispatcher-handover/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: dispatcher-handover
+owner: dispatcher
 description: >
   ディスパッチャーのコンテキストを圧迫したまま session を続けるのを避けるため、
   monitoring 状態（active workers / 直近 polling cursor / pending escalations）を

--- a/.claude/skills/dispatcher-handover/SKILL.md.in
+++ b/.claude/skills/dispatcher-handover/SKILL.md.in
@@ -1,5 +1,6 @@
 ---
 name: dispatcher-handover
+owner: dispatcher
 description: >
   ディスパッチャーのコンテキストを圧迫したまま session を続けるのを避けるため、
   monitoring 状態（active workers / 直近 polling cursor / pending escalations）を

--- a/.claude/skills/dispatcher-resume/SKILL.md
+++ b/.claude/skills/dispatcher-resume/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: dispatcher-resume
+owner: dispatcher
 description: >
   /dispatcher-handover で書き出した handover ファイルを読み込み、
   ディスパッチャーを新しい session で復帰させる。/clear 直後の最初のターンで使う。

--- a/.claude/skills/dispatcher-resume/SKILL.md.in
+++ b/.claude/skills/dispatcher-resume/SKILL.md.in
@@ -1,5 +1,6 @@
 ---
 name: dispatcher-resume
+owner: dispatcher
 description: >
   /dispatcher-handover で書き出した handover ファイルを読み込み、
   ディスパッチャーを新しい session で復帰させる。/clear 直後の最初のターンで使う。

--- a/.claude/skills/pr-watch-pane/SKILL.md
+++ b/.claude/skills/pr-watch-pane/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pr-watch-pane
+owner: secretary
 description: >
   PR の CI / マージ監視 (tools/pr-watch.sh) を broker tmux セッション内の専用ペイン
   pr-watch-<PR> で回す。窓口が PR 作成直後に `/pr-watch-pane <PR>` で起動すると、

--- a/.claude/skills/pr-watch-pane/SKILL.md.in
+++ b/.claude/skills/pr-watch-pane/SKILL.md.in
@@ -1,5 +1,6 @@
 ---
 name: pr-watch-pane
+owner: secretary
 description: >
   PR の CI / マージ監視 (tools/pr-watch.sh) を broker tmux セッション内の専用ペイン
   pr-watch-<PR> で回す。窓口が PR 作成直後に `/pr-watch-pane <PR>` で起動すると、

--- a/.claude/skills/secretary-handover/SKILL.md
+++ b/.claude/skills/secretary-handover/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: secretary-handover
+owner: secretary
 description: >
   窓口のコンテキストを圧迫したまま session を続けるのを避けるため、
   直近のやり取り・進行中ワーク・組織状態を handover ファイルに書き出し、

--- a/.claude/skills/secretary-resume/SKILL.md
+++ b/.claude/skills/secretary-resume/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: secretary-resume
+owner: secretary
 description: >
   /secretary-handover で書き出した handover ファイルを読み込み、
   窓口を新しいセッションで復帰させる。/clear 直後の最初のターンで使う。

--- a/.claude/skills/secretary-resume/SKILL.md.in
+++ b/.claude/skills/secretary-resume/SKILL.md.in
@@ -1,5 +1,6 @@
 ---
 name: secretary-resume
+owner: secretary
 description: >
   /secretary-handover で書き出した handover ファイルを読み込み、
   窓口を新しいセッションで復帰させる。/clear 直後の最初のターンで使う。

--- a/.claude/skills/skill-audit/SKILL.md
+++ b/.claude/skills/skill-audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-audit
+owner: curator
 description: >
   skill の棚卸し（廃止候補 / 重複統合 / owner 明記チェック）。
   状態ベースで発火する: 候補キュー knowledge/skill-candidates.md の pending が 5 件以上、

--- a/.claude/skills/skill-audit/SKILL.md.in
+++ b/.claude/skills/skill-audit/SKILL.md.in
@@ -1,5 +1,6 @@
 ---
 name: skill-audit
+owner: curator
 description: >
   skill の棚卸し（廃止候補 / 重複統合 / owner 明記チェック）。
   状態ベースで発火する: 候補キュー knowledge/skill-candidates.md の pending が 5 件以上、

--- a/.claude/skills/skill-eligibility-check/SKILL.md
+++ b/.claude/skills/skill-eligibility-check/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-eligibility-check
+owner: curator
 description: >
   作業パターンを skill 化すべきか判定する共通スキル。org-retro と org-curate から呼ばれ、
   「skill 化推奨 / 候補止まり / curated ノートのまま」の 3 値と根拠を返す。

--- a/.claude/skills/work-discovery/SKILL.md
+++ b/.claude/skills/work-discovery/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: work-discovery
+owner: secretary
 description: >
   open Issue を triage して「次の仕事候補（N 件 + 推奨 1 件）」を窓口が人間へ提示する。
   決定的ツール tools/work_discovery_scan.py を 1 回実行し、その候補 JSON を


### PR DESCRIPTION
## Summary

Backfills the `owner:` frontmatter field flagged by the initial skill-audit run (all 8 work-skills were missing it; user-approved 2026-08-03). Owners assigned by responsibility: `dispatcher-*` → dispatcher; `secretary-*`, `pr-watch-pane`, `work-discovery` → secretary; `skill-audit`, `skill-eligibility-check` → curator.

5 skills are rendered from `SKILL.md.in` — those were edited at the source and regenerated with the renderer; the 3 plain ones edited directly. `--check` drift run rc=0, `tools/test_gen_skill_prose.py` 62 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)