### PR TITLE
feat(claude): wire role-config drift preflight into /org-start so silent guard death fails loud

### DIFF
--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -276,7 +276,9 @@ broker transport では過去に「secretary 宛メッセージが claimed/deliv
 
 Block A の spawn 発火と並列。各ロールの `settings.local.json` を schema に対して検証し、drift があれば Step 4 の起動完了報告に 1 行 warning を添える。自動修復は行わず通知のみ（修復は `/org-setup`）。Block C2 と同列の **非 fatal な warning ブロック**であり、drift を検出しても org-start は止めない（Step 0.5 の fatal gate とは責務が違う）。
 
-> **なぜ起動時に見る必要があるのか（guard の無言死）**: `settings.local.json` は gitignored なので、CI の [`.github/workflows/tests.yml`](../../../.github/workflows/tests.yml) が回す `python tools/check_role_configs.py --include-worker-settings .` は `--include-local` を付けておらず、**tracked ファイルしか検証しない**。したがって hook パスのドリフト（`.hooks/*.sh` の rename / 移動で hook command が実在しないパスを指し、guard が発火しないまま無言で無効化される）や必須 allow / deny の欠落は **CI では一切検出されない**。この盲点を塞ぐ唯一の定期的な契機が org-start なので、起動のたびに `--include-local` で 1 回検証する。
+> **なぜ起動時に見る必要があるのか（guard の無言死）**: `settings.local.json` は gitignored なので、CI の [`.github/workflows/tests.yml`](../../../.github/workflows/tests.yml) が回す `python tools/check_role_configs.py --include-worker-settings .` は `--include-local` を付けておらず、**tracked ファイルしか検証しない**。したがって hook パスのドリフト（`.hooks/*.sh` の rename / 移動で hook command が実在しないパスを指し、guard が発火しないまま無言で無効化される）や必須 allow / deny の欠落、さらには **settings ファイルそのものの不在**（そのロールが hook 層ゼロで動く。`bypassPermissions` のディスパッチャーでは hook が唯一の強制層）は **CI では一切検出されない**。この盲点を塞ぐ唯一の定期的な契機が org-start なので、起動のたびに `--include-local` で 1 回検証する。
+
+> **検出される drift の種類**: (a) schema 宣言済みの settings ファイルが**存在しない**（`settings file not found` — `/org-setup` 未実行 / 配布漏れ）、(b) 必須 allow / deny の欠落、(c) schema 未登録の allow エントリ混入、(d) 必須 hook の欠落、(e) hook command が実在しないパスを指す。個別 drift の対処フローは [`docs/getting-started.md`](../../../docs/getting-started.md) の該当節にある。
 
 1. drift チェックを実行する:
    ```bash

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -270,6 +270,30 @@ broker transport では過去に「secretary 宛メッセージが claimed/deliv
 >
 > 1 回限りの動作確認は `claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json`（`--config` を外すと runtime 中立の英語 default が出るので、ja テンプレートの導通確認には必ず付ける）。OS 別 backend 挙動・トラブルシューティング・別ターミナルからの素 CLI 起動手順は [`docs/operations/attention-watch.md`](../../../docs/operations/attention-watch.md) を参照。
 
+### Block C4: role config drift 検出 (Issue #818)
+
+Block A の spawn 発火と並列。各ロールの `settings.local.json` を schema に対して検証し、drift があれば Step 4 の起動完了報告に 1 行 warning を添える。自動修復は行わず通知のみ（修復は `/org-setup`）。Block C2 と同列の **非 fatal な warning ブロック**であり、drift を検出しても org-start は止めない（Step 0.5 の fatal gate とは責務が違う）。
+
+> **なぜ起動時に見る必要があるのか（guard の無言死）**: `settings.local.json` は gitignored なので、CI の [`.github/workflows/tests.yml`](../../../.github/workflows/tests.yml) が回す `python tools/check_role_configs.py --include-worker-settings .` は `--include-local` を付けておらず、**tracked ファイルしか検証しない**。したがって hook パスのドリフト（`.hooks/*.sh` の rename / 移動で hook command が実在しないパスを指し、guard が発火しないまま無言で無効化される）や必須 allow / deny の欠落は **CI では一切検出されない**。この盲点を塞ぐ唯一の定期的な契機が org-start なので、起動のたびに `--include-local` で 1 回検証する。
+
+1. drift チェックを実行する:
+   ```bash
+   py -3 tools/check_role_configs.py --include-local   # Windows
+   python3 tools/check_role_configs.py --include-local # Mac/Linux
+   ```
+2. **exit code で分岐**する（stdout **最終行**が転記用の 1 行、診断は stderr）:
+   - **exit 0**（clean）: schema と一致。**warning 行なし**。
+   - **exit 1**（drift）: stdout 最終行の `[role config drift] ...` 1 行を **そのまま Step 4 起動完了報告の末尾に warning として転記する**。個別の `[ERROR] <path> :: <role> :: <理由>` 行は同じ stdout の上部に出ているので、ユーザーが詳細を求めたらそこから提示する（起動報告に全件は貼らない。実測で数十行になりうる）。
+   - **exit 2**（検証不能）: checker 自体が完走できなかった（schema 不在 / JSON 構文エラー / `core_harness` 解決失敗等）。stderr に traceback と `role_configs: 検証不能 -- ...` 診断が出る。**silent にせず**「role config: 検証不能（guard 未検証・要確認）」の 1 行を報告に添える。drift の有無は **未測定**であって clean ではない、という区別が本 exit code の存在意義である。
+
+> **必ず窓口の cwd（ja live repo root）で実行する**: `--root` の既定はスクリプト位置から導出される repo root なので、worktree 内から叩くとその worktree の `.claude/settings.local.json`（= ワーカー用の設定）を **secretary の schema で**検証してしまい、数十件の false positive になる。ロール別に個別検証したい場合は当該 worktree で `--role worker` を付ける（`--role` は `--include-local` の意味を含む）。
+
+> 設計メモ:
+> - **stdout は転記用の 1 行と `[ERROR]` 明細のみ**（spliceable に保つ）。件数サマリ `role_configs: N error(s)` と exit 2 の traceback / 診断はすべて **stderr** に出す
+> - **exit 1 と exit 2 を分けている理由**: 分けないと「checker が壊れて動かなかった」が「drift を検出した」と同じ signal になり、逆に traceback を素通りさせると壊れた guard が clean と読まれる。#818 が塞ぎたい失敗モードそのものなので、契約として [`tests/test_check_role_configs.py`](../../../tests/test_check_role_configs.py) の `ExitCodeContractTests` で lock している
+> - ネットワークに触れないので Block C2 と違い sandbox 内実行でも判定自体は正しい。ただし読み取りが sandbox の deny に掛かる環境では exit 2 に落ちうるので、その場合は `dangerouslyDisableSandbox: true` でホスト再実行する
+> - スクリプト本体: [`tools/check_role_configs.py`](../../../tools/check_role_configs.py)。drift の修復は [`/org-setup`](../org-setup/SKILL.md)（additive-only なので既存設定を壊さない）、個別の drift 種別ごとの対処は [`docs/getting-started.md`](../../../docs/getting-started.md) の該当節を参照
+
 ### Block D: dispatcher の合流 (Enter / list_peers poll / 挨拶 / DB write / snapshot)
 
 Block A の spawn 成功後、dispatcher ペインで Claude が boot している。
@@ -353,6 +377,8 @@ dispatcher は初回 DELEGATE 完了報告で「/loop 3m で監視します」�
 
 **Block C2 の runtime drift 出力の扱い**: Block C2 は **exit code** で結果を返す（stdout は drift 行専用、診断は stderr）。**exit 1**（drift）なら stdout の `[runtime drift] ...` 1 行を、下記いずれのテンプレートでも **末尾に空行を 1 つ挟んだ上でそのまま転記する**。**exit 0**（PyPI 到達確認済・drift 無し）は warning 行を付けない。**exit 2**（PyPI 未確認 = オフライン / sandbox 内 / 応答異常 / pin 窓外 / `packaging` 欠如、**または installed が local install（`file://` / VCS / editable）で PyPI 照合不能**）は **silent にせず** 「runtime drift: PyPI 未確認（要ホスト再実行）」の 1 行を報告に添える（#119 の silent 誤読を防ぐため）。**ただし stderr 診断が `local install -- PyPI 照合不能` を示す場合はホスト再実行では解消しない**ので「runtime: local install のため PyPI 照合不能（要 PyPI 由来インストールで再確認）」と読み替えて添える（#747: `file://` install が「最新・drift なし」と誤報告された事故の根治）。**exit 3**（runtime 未インストール）は「runtime 未インストール（要確認）」を添える。sandbox 内実行だと exit 2 になりやすいので Block C2 は `dangerouslyDisableSandbox: true` でホスト実行すること。
 
+**Block C4 の role config drift 出力の扱い**: Block C4 も **exit code** で結果を返す（stdout 最終行が転記用、診断は stderr）。**exit 1**（drift）なら stdout 最終行の `[role config drift] ...` 1 行を、下記いずれのテンプレートでも **末尾に空行を 1 つ挟んだ上でそのまま転記する**（Block C2 の warning 行と両方出る場合は 1 行ずつ並べる）。**exit 0**（clean）は warning 行を付けない。**exit 2**（検証不能 = checker 自体が完走できなかった）は **silent にせず**「role config: 検証不能（guard 未検証・要確認）」の 1 行を添える — drift 無しではなく **未測定**なので、clean と読ませてはならない。個別の `[ERROR]` 明細は起動報告には貼らず、ユーザーが詳細を求めたときに stdout 上部から提示する。
+
 > **Sidebar: dispatcher の自己修復ビュー起動案内（broker フレーム時のみ、optional）**
 >
 > broker(tmux) backend では dispatcher ペインは detached tmux session として独立して存在する。窓口の隣のターミナルでこれを 1 回起動しておくと control plane を常に視界に保てる（restart / auto-compact fork でセッション名が変わっても自己修復で再 attach し直す）:
@@ -385,6 +411,14 @@ dispatcher は初回 DELEGATE 完了報告で「/loop 3m で監視します」�
 何をしますか？
 
 [runtime drift] claude-org-runtime: installed={installed} latest={latest_in_window} -- `python -m pip install --upgrade 'claude-org-runtime{pin}'` で更新できます
+```
+
+**role config drift 検出時の warning 添付例** (Block C4 exit 1。`{errors}` / `{findings}` は実行時にスクリプトが決定するもので、本ファイルには hard-code しない。Block C2 の行と両方出るときは 1 行ずつ並べる):
+```
+...
+何をしますか？
+
+[role config drift] {errors} error(s) / {findings} finding(s) -- 詳細は上の [ERROR] 行。再実行: python tools/check_role_configs.py --include-local
 ```
 
 ## Appendix: ClaudeCode 起動コマンド（役割別）

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -21,6 +21,8 @@ allowed-tools:
   - Bash(python3 tools/ensure_projects_registry.py:*)
   - Bash(py -3 tools/secretary_queue_watcher.py:*)
   - Bash(python3 tools/secretary_queue_watcher.py:*)
+  - Bash(py -3 tools/check_role_configs.py:*)
+  - Bash(python3 tools/check_role_configs.py:*)
   - mcp__renga-peers__*
   - mcp__org-broker__* # ORG_TRANSPORT=broker（opt-in）時の機械置換先
 ---
@@ -413,12 +415,12 @@ dispatcher は初回 DELEGATE 完了報告で「/loop 3m で監視します」�
 [runtime drift] claude-org-runtime: installed={installed} latest={latest_in_window} -- `python -m pip install --upgrade 'claude-org-runtime{pin}'` で更新できます
 ```
 
-**role config drift 検出時の warning 添付例** (Block C4 exit 1。`{errors}` / `{findings}` は実行時にスクリプトが決定するもので、本ファイルには hard-code しない。Block C2 の行と両方出るときは 1 行ずつ並べる):
+**role config drift 検出時の warning 添付例** (Block C4 exit 1。`{errors}` / `{findings}` / `{python}` は実行時にスクリプトが決定するもので、本ファイルには hard-code しない。`{python}` は実行に使われた interpreter の実パス（`sys.executable`）がそのまま入る — ホストによって `python` / `python3` / `py -3` のどれが解決するかが違い、貼って動かない再実行コマンドを出さないため。Block C2 の行と両方出るときは 1 行ずつ並べる):
 ```
 ...
 何をしますか？
 
-[role config drift] {errors} error(s) / {findings} finding(s) -- 詳細は上の [ERROR] 行。再実行: python tools/check_role_configs.py --include-local
+[role config drift] {errors} error(s) / {findings} finding(s) -- 詳細は上の [ERROR] 行。再実行: {python} tools/check_role_configs.py --include-local
 ```
 
 ## Appendix: ClaudeCode 起動コマンド（役割別）

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -291,7 +291,7 @@ Block A の spawn 発火と並列。各ロールの `settings.local.json` を sc
 > **必ず窓口の cwd（ja live repo root）で実行する**: `--root` の既定はスクリプト位置から導出される repo root なので、worktree 内から叩くとその worktree の `.claude/settings.local.json`（= ワーカー用の設定）を **secretary の schema で**検証してしまい、数十件の false positive になる。ロール別に個別検証したい場合は当該 worktree で `--role worker` を付ける（`--role` は `--include-local` の意味を含む）。
 
 > 設計メモ:
-> - **stdout は転記用の 1 行と `[ERROR]` 明細のみ**（spliceable に保つ）。件数サマリ `role_configs: N error(s)` と exit 2 の traceback / 診断はすべて **stderr** に出す
+> - **stdout は転記用の 1 行と `[ERROR]` 明細のみ**（spliceable に保つ）。件数サマリ `role_configs: N error(s)` と exit 2 の traceback / 診断はすべて **stderr** に出す。stdout への出力は cp932 / `PYTHONIOENCODING=ascii` 等の非 UTF-8 コンソールでも落ちないよう ASCII 置換フォールバックを通す（転記用の 1 行が `UnicodeEncodeError` で消えると drift を検出したのに warning が付かない、という最悪形になるため）
 > - **exit 1 と exit 2 を分けている理由**: 分けないと「checker が壊れて動かなかった」が「drift を検出した」と同じ signal になり、逆に traceback を素通りさせると壊れた guard が clean と読まれる。#818 が塞ぎたい失敗モードそのものなので、契約として [`tests/test_check_role_configs.py`](../../../tests/test_check_role_configs.py) の `ExitCodeContractTests` で lock している
 > - ネットワークに触れないので Block C2 と違い sandbox 内実行でも判定自体は正しい。ただし読み取りが sandbox の deny に掛かる環境では exit 2 に落ちうるので、その場合は `dangerouslyDisableSandbox: true` でホスト再実行する
 > - スクリプト本体: [`tools/check_role_configs.py`](../../../tools/check_role_configs.py)。drift の修復は [`/org-setup`](../org-setup/SKILL.md)（additive-only なので既存設定を壊さない）、個別の drift 種別ごとの対処は [`docs/getting-started.md`](../../../docs/getting-started.md) の該当節を参照
@@ -415,12 +415,12 @@ dispatcher は初回 DELEGATE 完了報告で「/loop 3m で監視します」�
 [runtime drift] claude-org-runtime: installed={installed} latest={latest_in_window} -- `python -m pip install --upgrade 'claude-org-runtime{pin}'` で更新できます
 ```
 
-**role config drift 検出時の warning 添付例** (Block C4 exit 1。`{errors}` / `{findings}` / `{python}` は実行時にスクリプトが決定するもので、本ファイルには hard-code しない。`{python}` は実行に使われた interpreter の実パス（`sys.executable`）がそのまま入る — ホストによって `python` / `python3` / `py -3` のどれが解決するかが違い、貼って動かない再実行コマンドを出さないため。Block C2 の行と両方出るときは 1 行ずつ並べる):
+**role config drift 検出時の warning 添付例** (Block C4 exit 1。`{errors}` / `{findings}` / `{rerun}` は実行時にスクリプトが決定するもので、本ファイルには hard-code しない。`{rerun}` は **その drift を出した実際の invocation** を `sys.executable` + 渡された引数から再構成したもの — ホストによって `python` / `python3` / `py -3` のどれが解決するかが違い、また `--root` / `--role` 付きで出た drift を既定引数で再実行させると「clean に戻った」と誤読されるため。Block C2 の行と両方出るときは 1 行ずつ並べる):
 ```
 ...
 何をしますか？
 
-[role config drift] {errors} error(s) / {findings} finding(s) -- 詳細は上の [ERROR] 行。再実行: {python} tools/check_role_configs.py --include-local
+[role config drift] {errors} error(s) / {findings} finding(s) -- see the [ERROR] lines above; rerun: {rerun}
 ```
 
 ## Appendix: ClaudeCode 起動コマンド（役割別）

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -417,13 +417,15 @@ dispatcher は初回 DELEGATE 完了報告で「/loop 3m で監視します」�
 [runtime drift] claude-org-runtime: installed={installed} latest={latest_in_window} -- `python -m pip install --upgrade 'claude-org-runtime{pin}'` で更新できます
 ```
 
-**role config drift 検出時の warning 添付例** (Block C4 exit 1。`{errors}` / `{findings}` / `{rerun}` は実行時にスクリプトが決定するもので、本ファイルには hard-code しない。`{rerun}` は **その drift を出した実際の invocation** を `sys.executable` + 渡された引数から再構成したもの — ホストによって `python` / `python3` / `py -3` のどれが解決するかが違い、また `--root` / `--role` 付きで出た drift を既定引数で再実行させると「clean に戻った」と誤読されるため。Block C2 の行と両方出るときは 1 行ずつ並べる):
+**role config drift 検出時の warning 添付例** (Block C4 exit 1。`{errors}` / `{findings}` は実行時にスクリプトが決定するもので、本ファイルには hard-code しない。Block C2 の行と両方出るときは 1 行ずつ並べる):
 ```
 ...
 何をしますか？
 
-[role config drift] {errors} error(s) / {findings} finding(s) -- see the [ERROR] lines above; rerun: {rerun}
+[role config drift] {errors} error(s) / {findings} finding(s) -- see the [ERROR] lines above
 ```
+
+ユーザーが再実行コマンドを求めたら、上の手順 1 のコマンド（`py -3` / `python3` のプラットフォーム別）をそのまま案内する。**スクリプトは再実行コマンドを出力しない**: 貼って動く形は読み手のシェル（cmd.exe / PowerShell / Git Bash）ごとに quoting が非互換で、プロセス側からはどれで読まれるか知りようがないため、誤った形を出すより窓口が固定文で案内する方が確実。
 
 ## Appendix: ClaudeCode 起動コマンド（役割別）
 

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -1097,6 +1097,31 @@ class ExitCodeContractTests(unittest.TestCase):
         self.assertEqual(rc, crc.EXIT_DRIFT)
         self.assertIn("settings file not found", out)
 
+    def test_unstattable_role_config_is_unverified_not_drift(self):
+        # A settings file that exists but cannot be stat'd must not be
+        # reported as "not found". Python 3.14 made Path.is_file() return
+        # False for *any* OSError (3.10-3.13 propagate non-ENOENT ones),
+        # and ja supports >=3.10 -- so under 3.14 a permission-denied
+        # config would read as measured drift (exit 1) instead of
+        # unverified (exit 2), inverting the distinction Block C4 exists
+        # to make.
+        if os.geteuid() == 0:
+            self.skipTest("root bypasses the directory permission bit")
+        with tempfile.TemporaryDirectory() as tmp:
+            locked = Path(tmp) / ".claude"
+            locked.mkdir()
+            (locked / "settings.local.json").write_text("{}", encoding="utf-8")
+            os.chmod(locked, 0o000)
+            try:
+                rc, out, err = self._run_main(
+                    ["--root", tmp, "--include-local"]
+                )
+            finally:
+                os.chmod(locked, 0o755)
+        self.assertEqual(rc, crc.EXIT_UNVERIFIED, msg=out)
+        self.assertNotIn("settings file not found", out)
+        self.assertIn("PermissionError", err)
+
     def test_missing_role_config_is_silent_without_include_local(self):
         # Backward-compat lock for the CI invocation
         # (.github/workflows/tests.yml): it passes neither --include-local

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -1087,6 +1088,53 @@ class ExitCodeContractTests(unittest.TestCase):
         self.assertEqual(rc, crc.EXIT_UNVERIFIED)
         self.assertEqual(out, "", msg=out)
         self.assertIn("FileNotFoundError", err)
+
+    def test_summary_line_survives_an_ascii_only_stdout(self):
+        # The summary line is the Block C4 contract: if it dies on a
+        # cp932 / PYTHONIOENCODING=ascii console, drift is detected but
+        # /org-start attaches no warning -- worse than not checking.
+        env = dict(os.environ, PYTHONIOENCODING="ascii")
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = Path(tmp) / ".claude" / "settings.local.json"
+            settings.parent.mkdir(parents=True)
+            settings.write_text(
+                json.dumps({"permissions": {"allow": ["Bash(rm -rf /:*)"]}}),
+                encoding="utf-8",
+            )
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "tools" / "check_role_configs.py"),
+                    "--root",
+                    tmp,
+                    "--role",
+                    "secretary",
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+        self.assertEqual(proc.returncode, crc.EXIT_DRIFT, msg=proc.stderr)
+        self.assertIn("[role config drift]", proc.stdout)
+
+    def test_rerun_hint_reproduces_the_actual_invocation(self):
+        # A hint that drops --root/--role reruns against the repo default,
+        # can come back clean, and reads as "the drift went away".
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = Path(tmp) / ".claude" / "settings.local.json"
+            settings.parent.mkdir(parents=True)
+            settings.write_text(
+                json.dumps({"permissions": {"allow": ["Bash(rm -rf /:*)"]}}),
+                encoding="utf-8",
+            )
+            rc, out, _ = self._run_main(["--root", tmp, "--role", "secretary"])
+        self.assertEqual(rc, crc.EXIT_DRIFT)
+        summary = out.splitlines()[-1]
+        self.assertIn("--root", summary)
+        self.assertIn("--role", summary)
+        self.assertIn(shlex.quote(tmp), summary)
+        # Quoted so an interpreter path containing spaces stays pasteable.
+        self.assertIn(shlex.quote(sys.executable), summary)
 
     def test_unimportable_core_harness_exits_two(self):
         # Regression lock: the dependency import sits at module level, so

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
@@ -1088,6 +1089,22 @@ class ExitCodeContractTests(unittest.TestCase):
         self.assertEqual(rc, crc.EXIT_UNVERIFIED)
         self.assertEqual(out, "", msg=out)
         self.assertIn("FileNotFoundError", err)
+
+    def test_rerun_hint_quoting_is_platform_correct(self):
+        # ja is supported on Windows (the skill documents a `py -3`
+        # variant). shlex would emit 'C:\\Python311\\python.exe' there,
+        # and cmd.exe takes those single quotes literally -- an unusable
+        # hint on every drift result. Both branches are exercised here
+        # since CI only ever runs one of the two platforms.
+        parts = [r"C:\Python311\python.exe", r"tools\check_role_configs.py"]
+        with unittest.mock.patch.object(sys, "platform", "win32"):
+            windows = crc._join_command(parts)
+        self.assertEqual(windows, r"C:\Python311\python.exe tools\check_role_configs.py")
+        self.assertNotIn("'", windows)
+
+        with unittest.mock.patch.object(sys, "platform", "linux"):
+            posix = crc._join_command(["/usr/bin/python3", "a b.py"])
+        self.assertEqual(posix, "/usr/bin/python3 'a b.py'")
 
     def test_missing_role_config_is_drift_under_include_local(self):
         # The worst case Block C4 must catch: a role whose settings file

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -8,10 +8,12 @@ the real schema + real permissions.md still agree lives in
 
 from __future__ import annotations
 
+import io
 import json
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -1027,6 +1029,70 @@ class NonOrgAuditRootTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as bare:
             rc = crc.main(["--docs-only", "--root", bare])
         self.assertEqual(rc, 0)
+
+
+class ExitCodeContractTests(unittest.TestCase):
+    """``main()``'s exit codes are a consumed contract (Issue #818).
+
+    ``/org-start``'s Block C4 preflight branches on them: 0 = clean (no
+    warning line in the startup report), 1 = drift (transcribe the
+    ``[role config drift]`` stdout line), 2 = the checker never ran. If
+    2 collapses back into 1, a broken checker reports as measured drift
+    and the whole point of the preflight -- surfacing a guard that died
+    silently -- is lost. stdout must stay spliceable, so the exit-2
+    diagnosis belongs on stderr only.
+    """
+
+    def _run_main(self, argv):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = crc.main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_clean_run_exits_zero_without_drift_line(self):
+        rc, out, _ = self._run_main(["--docs-only"])
+        self.assertEqual(rc, crc.EXIT_OK)
+        self.assertNotIn("[role config drift]", out)
+
+    def test_drift_exits_one_with_spliceable_summary_line(self):
+        # A settings file whose allow list is pure garbage relative to the
+        # schema guarantees findings without depending on any particular
+        # real-world drift.
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = Path(tmp) / ".claude" / "settings.local.json"
+            settings.parent.mkdir(parents=True)
+            settings.write_text(
+                json.dumps({"permissions": {"allow": ["Bash(rm -rf /:*)"]}}),
+                encoding="utf-8",
+            )
+            rc, out, err = self._run_main(
+                ["--root", tmp, "--role", "secretary"]
+            )
+        self.assertEqual(rc, crc.EXIT_DRIFT)
+        summary = [
+            ln for ln in out.splitlines() if ln.startswith("[role config drift]")
+        ]
+        self.assertEqual(len(summary), 1, msg=out)
+        # Step 4 transcribes the last stdout line verbatim.
+        self.assertEqual(out.splitlines()[-1], summary[0])
+        self.assertIn("error(s)", summary[0])
+        self.assertIn("role_configs:", err)
+
+    def test_unreadable_schema_exits_two_with_clean_stdout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "does-not-exist.json"
+            rc, out, err = self._run_main(["--schema", str(missing)])
+        self.assertEqual(rc, crc.EXIT_UNVERIFIED)
+        self.assertEqual(out, "", msg=out)
+        self.assertIn("FileNotFoundError", err)
+
+    def test_malformed_schema_exits_two(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            broken = Path(tmp) / "broken.json"
+            broken.write_text("{not json", encoding="utf-8")
+            rc, out, _ = self._run_main(["--schema", str(broken)])
+        self.assertEqual(rc, crc.EXIT_UNVERIFIED)
+        self.assertEqual(out, "", msg=out)
 
 
 class RealRepoSmokeTests(unittest.TestCase):

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -11,12 +11,10 @@ from __future__ import annotations
 import io
 import json
 import os
-import shlex
 import subprocess
 import sys
 import tempfile
 import unittest
-import unittest.mock
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
@@ -1090,22 +1088,6 @@ class ExitCodeContractTests(unittest.TestCase):
         self.assertEqual(out, "", msg=out)
         self.assertIn("FileNotFoundError", err)
 
-    def test_rerun_hint_quoting_is_platform_correct(self):
-        # ja is supported on Windows (the skill documents a `py -3`
-        # variant). shlex would emit 'C:\\Python311\\python.exe' there,
-        # and cmd.exe takes those single quotes literally -- an unusable
-        # hint on every drift result. Both branches are exercised here
-        # since CI only ever runs one of the two platforms.
-        parts = [r"C:\Python311\python.exe", r"tools\check_role_configs.py"]
-        with unittest.mock.patch.object(sys, "platform", "win32"):
-            windows = crc._join_command(parts)
-        self.assertEqual(windows, r"C:\Python311\python.exe tools\check_role_configs.py")
-        self.assertNotIn("'", windows)
-
-        with unittest.mock.patch.object(sys, "platform", "linux"):
-            posix = crc._join_command(["/usr/bin/python3", "a b.py"])
-        self.assertEqual(posix, "/usr/bin/python3 'a b.py'")
-
     def test_missing_role_config_is_drift_under_include_local(self):
         # The worst case Block C4 must catch: a role whose settings file
         # was never distributed runs with no hook layer at all. Skipping
@@ -1160,9 +1142,12 @@ class ExitCodeContractTests(unittest.TestCase):
         self.assertEqual(proc.returncode, crc.EXIT_DRIFT, msg=proc.stderr)
         self.assertIn("[role config drift]", proc.stdout)
 
-    def test_rerun_hint_reproduces_the_actual_invocation(self):
-        # A hint that drops --root/--role reruns against the repo default,
-        # can come back clean, and reads as "the drift went away".
+    def test_summary_line_carries_no_rerun_command(self):
+        # The summary deliberately stops at counts. A rerun command cannot
+        # be made correct here: the pasteable form depends on the shell the
+        # reader happens to use (cmd.exe / PowerShell / Git Bash all want
+        # incompatible quoting) and the process cannot know which. The
+        # canonical command is fixed text in org-start's SKILL.md instead.
         with tempfile.TemporaryDirectory() as tmp:
             settings = Path(tmp) / ".claude" / "settings.local.json"
             settings.parent.mkdir(parents=True)
@@ -1173,11 +1158,9 @@ class ExitCodeContractTests(unittest.TestCase):
             rc, out, _ = self._run_main(["--root", tmp, "--role", "secretary"])
         self.assertEqual(rc, crc.EXIT_DRIFT)
         summary = out.splitlines()[-1]
-        self.assertIn("--root", summary)
-        self.assertIn("--role", summary)
-        self.assertIn(shlex.quote(tmp), summary)
-        # Quoted so an interpreter path containing spaces stays pasteable.
-        self.assertIn(shlex.quote(sys.executable), summary)
+        self.assertNotIn("rerun", summary)
+        self.assertNotIn(sys.executable, summary)
+        self.assertNotIn("--include-local", summary)
 
     def test_unimportable_core_harness_exits_two(self):
         # Regression lock: the dependency import sits at module level, so

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -1089,6 +1089,32 @@ class ExitCodeContractTests(unittest.TestCase):
         self.assertEqual(out, "", msg=out)
         self.assertIn("FileNotFoundError", err)
 
+    def test_missing_role_config_is_drift_under_include_local(self):
+        # The worst case Block C4 must catch: a role whose settings file
+        # was never distributed runs with no hook layer at all. Skipping
+        # it silently made an org with zero guards report "OK".
+        with tempfile.TemporaryDirectory() as tmp:
+            rc, out, _ = self._run_main(["--root", tmp, "--include-local"])
+        self.assertEqual(rc, crc.EXIT_DRIFT)
+        self.assertIn("settings file not found", out)
+
+    def test_missing_role_config_is_silent_without_include_local(self):
+        # Backward-compat lock for the CI invocation
+        # (.github/workflows/tests.yml): it passes neither --include-local
+        # nor --role, and every settings.local.json is gitignored, so a
+        # missing one is the normal state in a fresh checkout. Reporting it
+        # there would turn CI permanently red.
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = crc.run(
+                schema_path=crc.DEFAULT_SCHEMA,
+                permissions_md=crc.DEFAULT_PERMISSIONS_MD,
+                root=Path(tmp),
+                include_on_disk=True,
+            )
+        self.assertEqual(
+            findings, [], msg="\n".join(f.format() for f in findings)
+        )
+
     def test_summary_line_survives_an_ascii_only_stdout(self):
         # The summary line is the Block C4 contract: if it dies on a
         # cp932 / PYTHONIOENCODING=ascii console, drift is detected but

--- a/tests/test_check_role_configs.py
+++ b/tests/test_check_role_configs.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -1085,6 +1087,32 @@ class ExitCodeContractTests(unittest.TestCase):
         self.assertEqual(rc, crc.EXIT_UNVERIFIED)
         self.assertEqual(out, "", msg=out)
         self.assertIn("FileNotFoundError", err)
+
+    def test_unimportable_core_harness_exits_two(self):
+        # Regression lock: the dependency import sits at module level, so
+        # it fails *before* main()'s try block. Left unguarded, a missing
+        # core_harness exits 1 with empty stdout -- which Block C4 would
+        # read as "drift detected" while the guard never actually ran.
+        # Shadow the package with one that raises on import so the check
+        # holds regardless of how core_harness is installed here.
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "core_harness"
+            shadow.mkdir()
+            (shadow / "__init__.py").write_text(
+                'raise ImportError("simulated missing dependency")',
+                encoding="utf-8",
+            )
+            env = dict(os.environ)
+            env["PYTHONPATH"] = tmp + os.pathsep + env.get("PYTHONPATH", "")
+            proc = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "tools" / "check_role_configs.py")],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+        self.assertEqual(proc.returncode, crc.EXIT_UNVERIFIED, msg=proc.stderr)
+        self.assertEqual(proc.stdout, "", msg=proc.stdout)
+        self.assertIn("core_harness", proc.stderr)
 
     def test_malformed_schema_exits_two(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -875,6 +875,22 @@ def run(
     return findings
 
 
+def _join_command(parts: list) -> str:
+    """Serialise an argv list into a command the *local* shell can run.
+
+    ja is supported on Windows too, where ``shlex.join`` is wrong: it
+    applies POSIX rules and wraps an ordinary ``C:\\Python311\\python.exe``
+    in single quotes, which cmd.exe passes through literally (and which
+    PowerShell will not invoke without ``&``). ``subprocess.list2cmdline``
+    is the Windows counterpart -- it emits the quoting CreateProcess
+    actually parses. Either way the rerun hint stays pasteable, including
+    for interpreter paths containing spaces.
+    """
+    if sys.platform == "win32":
+        return subprocess.list2cmdline(parts)
+    return shlex.join(parts)
+
+
 def _print_encodable(line: str) -> None:
     """Print to stdout, degrading gracefully on a console that cannot
     encode the text (cp932 / ``PYTHONIOENCODING=ascii`` / a legacy
@@ -989,7 +1005,7 @@ def main(argv: list | None = None) -> int:
     # them; Windows goes through ``py -3``).
     invocation = list(sys.argv[1:] if argv is None else argv)
     script = sys.argv[0] if argv is None else str(Path(__file__))
-    rerun = shlex.join([sys.executable, script, *invocation])
+    rerun = _join_command([sys.executable, script, *invocation])
     _print_encodable(
         f"[role config drift] {errors} error(s) / {len(findings)} finding(s) "
         f"-- see the [ERROR] lines above; rerun: {rerun}"

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -38,9 +38,9 @@ module is a thin CLI shim that:
   worker-tracked settings file walk).
 
 Exit codes: 0 = OK, 1 = drift detected, 2 = the checker itself could
-not run (schema unreadable, merge failure, ``core_harness`` missing).
-1 and 2 are kept distinct
-so callers can branch on "config drift" versus "the guard never ran"
+not run (schema unreadable, merge failure, ``core_harness`` missing, a
+settings file that cannot be stat'd). 1 and 2 are kept distinct so
+callers can branch on "config drift" versus "the guard never ran"
 -- conflating them is how a broken checker reads as a clean org
 (Issue #818, which wires this into ``/org-start``'s startup preflight).
 
@@ -53,6 +53,7 @@ import argparse
 import json
 import posixpath
 import re
+import stat
 import subprocess
 import sys
 import traceback
@@ -210,6 +211,25 @@ def load_schema(path: Path) -> dict:
         org_extension = json.load(fh)
     framework = load_framework_schema()
     return merge_schemas(framework, org_extension)
+
+
+def _is_regular_file(path: Path) -> bool:
+    """``Path.is_file()`` that refuses to hide an access failure.
+
+    Python 3.14 changed ``is_file()`` (and ``exists()`` and friends) to
+    return False for *any* OSError, where 3.10-3.13 let non-ENOENT errors
+    propagate. ja supports ``>=3.10`` (pyproject.toml), so both behaviours
+    are in range -- and under the 3.14 rule a settings file that exists but
+    cannot be stat'd (permissions, a sandboxed path, an I/O error) would be
+    reported as ``settings file not found``: measured drift (exit 1) rather
+    than unverified (exit 2). That inverts the very distinction Block C4
+    consumes, so classify explicitly instead: genuinely absent is False,
+    anything else propagates to main() and becomes EXIT_UNVERIFIED.
+    """
+    try:
+        return stat.S_ISREG(path.stat().st_mode)
+    except (FileNotFoundError, NotADirectoryError):
+        return False
 
 
 def _load_override_allow(settings_path: Path) -> set:
@@ -703,7 +723,7 @@ def check_on_disk(
         checked_any = False
         for rel in candidate_paths:
             path = Path(root) / rel
-            if not path.is_file():
+            if not _is_regular_file(path):
                 continue
             checked_any = True
             try:
@@ -751,7 +771,7 @@ def check_on_disk(
     for role_name, role_schema in schema["roles"].items():
         for rel in role_schema.get("settings_paths", []):
             path = Path(root) / rel
-            if not path.is_file():
+            if not _is_regular_file(path):
                 # An entirely absent config is the most severe form of the
                 # drift this checker exists to catch: the role runs with no
                 # hook layer at all (the dispatcher's only enforcement, given

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -38,7 +38,8 @@ module is a thin CLI shim that:
   worker-tracked settings file walk).
 
 Exit codes: 0 = OK, 1 = drift detected, 2 = the checker itself could
-not run (schema unreadable / merge failure). 1 and 2 are kept distinct
+not run (schema unreadable, merge failure, ``core_harness`` missing).
+1 and 2 are kept distinct
 so callers can branch on "config drift" versus "the guard never ran"
 -- conflating them is how a broken checker reads as a clean org
 (Issue #818, which wires this into ``/org-start``'s startup preflight).
@@ -57,13 +58,40 @@ import sys
 import traceback
 from pathlib import Path
 
-from core_harness.schema import load_framework_schema, merge_schemas
-from core_harness.validator import (
-    Finding,
-    check_worker_settings,
-    validate_config,
-    validate_schema_integrity,
-)
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_UNVERIFIED = 2
+
+try:
+    from core_harness.schema import load_framework_schema, merge_schemas
+    from core_harness.validator import (
+        Finding,
+        check_worker_settings,
+        validate_config,
+        validate_schema_integrity,
+    )
+except ImportError:
+    # An unresolvable ``core_harness`` is the checker failing to run, not
+    # drift: as a CLI it must exit EXIT_UNVERIFIED so /org-start's Block
+    # C4 can say "the guard never ran" instead of misreading a broken
+    # install as measured drift (the whole point of Issue #818). Without
+    # this the failure lands on the module-level import, before main()'s
+    # try block, and Python exits 1 -- indistinguishable from drift.
+    #
+    # As an imported module (tools/org_setup_prune.py, the test suite)
+    # the ImportError must still propagate, so callers fail loudly at
+    # import time rather than hitting NameError on the re-exported
+    # symbols much later.
+    if __name__ != "__main__":
+        raise
+    traceback.print_exc()
+    print(
+        "role_configs: 検証不能 -- core_harness を解決できませんでした"
+        "（ja repo で `pip install -e .` を実行して依存を入れてください。"
+        "上の traceback を参照）",
+        file=sys.stderr,
+    )
+    raise SystemExit(EXIT_UNVERIFIED)
 
 
 # Issue #340: ja → en heading aliases. Keys are the ja heading strings
@@ -816,11 +844,6 @@ def run(
             )
         )
     return findings
-
-
-EXIT_OK = 0
-EXIT_DRIFT = 1
-EXIT_UNVERIFIED = 2
 
 
 def main(argv: list | None = None) -> int:

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -37,7 +37,11 @@ module is a thin CLI shim that:
   read from the ja repo layout (permissions.md docs projection, the
   worker-tracked settings file walk).
 
-Exit codes: 0 = OK, non-zero = drift detected.
+Exit codes: 0 = OK, 1 = drift detected, 2 = the checker itself could
+not run (schema unreadable / merge failure). 1 and 2 are kept distinct
+so callers can branch on "config drift" versus "the guard never ran"
+-- conflating them is how a broken checker reads as a clean org
+(Issue #818, which wires this into ``/org-start``'s startup preflight).
 
 Run ``python tools/check_role_configs.py --help`` for options.
 """
@@ -50,6 +54,7 @@ import posixpath
 import re
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 
 from core_harness.schema import load_framework_schema, merge_schemas
@@ -813,6 +818,11 @@ def run(
     return findings
 
 
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_UNVERIFIED = 2
+
+
 def main(argv: list | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Validate per-role settings.local.json against the schema."
@@ -861,19 +871,36 @@ def main(argv: list | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    findings = run(
-        schema_path=args.schema,
-        permissions_md=args.permissions_md,
-        root=args.root,
-        include_on_disk=not args.docs_only,
-        include_untracked=args.include_local or args.role is not None,
-        role_override=args.role,
-        worker_settings_base=args.include_worker_settings,
-    )
+    try:
+        findings = run(
+            schema_path=args.schema,
+            permissions_md=args.permissions_md,
+            root=args.root,
+            include_on_disk=not args.docs_only,
+            include_untracked=args.include_local or args.role is not None,
+            role_override=args.role,
+            worker_settings_base=args.include_worker_settings,
+        )
+    except Exception:
+        # The checker could not complete -- missing or malformed schema
+        # JSON, a framework-schema merge failure, an unreadable
+        # permissions.md. These used to escape as a traceback plus
+        # SystemExit(1), indistinguishable from real drift. Callers that
+        # branch on the exit code (``/org-start`` Block C4) must be able
+        # to say "the guard never ran" instead of reporting drift that
+        # was never actually measured. The traceback stays on stderr so
+        # CI keeps full diagnosability and stdout stays spliceable.
+        traceback.print_exc()
+        print(
+            "role_configs: 検証不能 -- checker 自体が完走できませんでした"
+            "（schema 不在 / JSON 構文エラー等。上の traceback を参照）",
+            file=sys.stderr,
+        )
+        return EXIT_UNVERIFIED
 
     if not findings:
         print("role_configs: OK")
-        return 0
+        return EXIT_OK
 
     for f in findings:
         try:
@@ -881,8 +908,17 @@ def main(argv: list | None = None) -> int:
         except UnicodeEncodeError:
             print(f.format().encode("ascii", "replace").decode("ascii"))
     errors = sum(1 for f in findings if f.severity == "ERROR")
+    # One-line spliceable summary, mirroring check_runtime_version.py's
+    # ``[runtime drift]`` line: /org-start Step 4 transcribes exactly
+    # this line into the startup report rather than the (in practice
+    # dozens of) per-finding lines above.
+    print(
+        f"[role config drift] {errors} error(s) / {len(findings)} finding(s) "
+        "-- 詳細は上の [ERROR] 行。再実行: "
+        "python tools/check_role_configs.py --include-local"
+    )
     print(f"role_configs: {errors} error(s)", file=sys.stderr)
-    return 1 if errors else 0
+    return EXIT_DRIFT if errors else EXIT_OK
 
 
 if __name__ == "__main__":

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -753,6 +753,34 @@ def check_on_disk(
         for rel in role_schema.get("settings_paths", []):
             path = Path(root) / rel
             if not path.is_file():
+                # An entirely absent config is the most severe form of the
+                # drift this checker exists to catch: the role runs with no
+                # hook layer at all (the dispatcher's only enforcement, given
+                # bypassPermissions). Silently skipping it let /org-start's
+                # Block C4 preflight report "OK" for an org whose guards were
+                # never installed. ``--role`` already errors on this; the
+                # sweep now agrees with it (Issue #818), and
+                # docs/getting-started.md already documents a missing
+                # settings.local.json as expected checker output.
+                #
+                # Gated on include_untracked: without --include-local the
+                # sweep deliberately audits git-tracked files only, and every
+                # settings.local.json is gitignored -- so "missing" is the
+                # normal state in CI and a fresh clone. Reporting it there
+                # would break the CI invocation, which passes neither
+                # --include-local nor --role.
+                if include_untracked:
+                    findings.append(
+                        Finding(
+                            str(path),
+                            role_name,
+                            "ERROR",
+                            (
+                                "settings file not found; run /org-setup to "
+                                "distribute it"
+                            ),
+                        )
+                    )
                 continue
             if not include_untracked:
                 try:

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -53,7 +53,6 @@ import argparse
 import json
 import posixpath
 import re
-import shlex
 import subprocess
 import sys
 import traceback
@@ -875,22 +874,6 @@ def run(
     return findings
 
 
-def _join_command(parts: list) -> str:
-    """Serialise an argv list into a command the *local* shell can run.
-
-    ja is supported on Windows too, where ``shlex.join`` is wrong: it
-    applies POSIX rules and wraps an ordinary ``C:\\Python311\\python.exe``
-    in single quotes, which cmd.exe passes through literally (and which
-    PowerShell will not invoke without ``&``). ``subprocess.list2cmdline``
-    is the Windows counterpart -- it emits the quoting CreateProcess
-    actually parses. Either way the rerun hint stays pasteable, including
-    for interpreter paths containing spaces.
-    """
-    if sys.platform == "win32":
-        return subprocess.list2cmdline(parts)
-    return shlex.join(parts)
-
-
 def _print_encodable(line: str) -> None:
     """Print to stdout, degrading gracefully on a console that cannot
     encode the text (cp932 / ``PYTHONIOENCODING=ascii`` / a legacy
@@ -995,20 +978,19 @@ def main(argv: list | None = None) -> int:
     # this line into the startup report rather than the (in practice
     # dozens of) per-finding lines above.
     #
-    # The rerun hint is rebuilt from the invocation that produced these
-    # findings instead of a fixed ``--include-local`` string: a run that
-    # passed --root/--role/--schema audits a different target, and a hint
-    # that silently reruns against the repo default could come back clean
-    # and read as "the drift went away". shlex.join also keeps an
-    # interpreter path with spaces pasteable, and sys.executable avoids
-    # hard-coding ``python`` vs ``python3`` (ja hosts resolve only one of
-    # them; Windows goes through ``py -3``).
-    invocation = list(sys.argv[1:] if argv is None else argv)
-    script = sys.argv[0] if argv is None else str(Path(__file__))
-    rerun = _join_command([sys.executable, script, *invocation])
+    # Deliberately carries no rerun command. Earlier revisions emitted one
+    # and it could not be made correct: the interpreter name differs per
+    # host (python / python3 / py -3), the arguments differ per invocation,
+    # and the quoting a pasteable command needs depends on the shell the
+    # reader pastes into -- cmd.exe, PowerShell and Git Bash all want
+    # mutually incompatible forms, and the process cannot know which one
+    # it is being read in. Counts plus the exit code are the whole Block
+    # C4 contract; the canonical command lives as fixed text in
+    # .claude/skills/org-start/SKILL.md, where the platform variants are
+    # already written out.
     _print_encodable(
         f"[role config drift] {errors} error(s) / {len(findings)} finding(s) "
-        f"-- see the [ERROR] lines above; rerun: {rerun}"
+        "-- see the [ERROR] lines above"
     )
     print(f"role_configs: {errors} error(s)", file=sys.stderr)
     return EXIT_DRIFT if errors else EXIT_OK

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -934,11 +934,16 @@ def main(argv: list | None = None) -> int:
     # One-line spliceable summary, mirroring check_runtime_version.py's
     # ``[runtime drift]`` line: /org-start Step 4 transcribes exactly
     # this line into the startup report rather than the (in practice
-    # dozens of) per-finding lines above.
+    # dozens of) per-finding lines above. The rerun hint uses
+    # sys.executable rather than a hard-coded ``python``/``python3``:
+    # ja runs on hosts where only one of those names resolves (Windows
+    # goes through ``py -3``, and plenty of Linux boxes ship no bare
+    # ``python``), and a remediation command that fails on paste is
+    # worse than no hint.
     print(
         f"[role config drift] {errors} error(s) / {len(findings)} finding(s) "
         "-- 詳細は上の [ERROR] 行。再実行: "
-        "python tools/check_role_configs.py --include-local"
+        f"{sys.executable} tools/check_role_configs.py --include-local"
     )
     print(f"role_configs: {errors} error(s)", file=sys.stderr)
     return EXIT_DRIFT if errors else EXIT_OK

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -53,6 +53,7 @@ import argparse
 import json
 import posixpath
 import re
+import shlex
 import subprocess
 import sys
 import traceback
@@ -846,6 +847,23 @@ def run(
     return findings
 
 
+def _print_encodable(line: str) -> None:
+    """Print to stdout, degrading gracefully on a console that cannot
+    encode the text (cp932 / ``PYTHONIOENCODING=ascii`` / a legacy
+    non-Japanese terminal).
+
+    Block C4 treats the ``[role config drift]`` line as the contract:
+    if that print raises, the drift is detected but never surfaced and
+    /org-start attaches no warning. Everything written to stdout goes
+    through here so an unencodable character degrades to ``?`` instead
+    of taking the whole run down.
+    """
+    try:
+        print(line)
+    except UnicodeEncodeError:
+        print(line.encode("ascii", "replace").decode("ascii"))
+
+
 def main(argv: list | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Validate per-role settings.local.json against the schema."
@@ -926,24 +944,27 @@ def main(argv: list | None = None) -> int:
         return EXIT_OK
 
     for f in findings:
-        try:
-            print(f.format())
-        except UnicodeEncodeError:
-            print(f.format().encode("ascii", "replace").decode("ascii"))
+        _print_encodable(f.format())
     errors = sum(1 for f in findings if f.severity == "ERROR")
     # One-line spliceable summary, mirroring check_runtime_version.py's
     # ``[runtime drift]`` line: /org-start Step 4 transcribes exactly
     # this line into the startup report rather than the (in practice
-    # dozens of) per-finding lines above. The rerun hint uses
-    # sys.executable rather than a hard-coded ``python``/``python3``:
-    # ja runs on hosts where only one of those names resolves (Windows
-    # goes through ``py -3``, and plenty of Linux boxes ship no bare
-    # ``python``), and a remediation command that fails on paste is
-    # worse than no hint.
-    print(
+    # dozens of) per-finding lines above.
+    #
+    # The rerun hint is rebuilt from the invocation that produced these
+    # findings instead of a fixed ``--include-local`` string: a run that
+    # passed --root/--role/--schema audits a different target, and a hint
+    # that silently reruns against the repo default could come back clean
+    # and read as "the drift went away". shlex.join also keeps an
+    # interpreter path with spaces pasteable, and sys.executable avoids
+    # hard-coding ``python`` vs ``python3`` (ja hosts resolve only one of
+    # them; Windows goes through ``py -3``).
+    invocation = list(sys.argv[1:] if argv is None else argv)
+    script = sys.argv[0] if argv is None else str(Path(__file__))
+    rerun = shlex.join([sys.executable, script, *invocation])
+    _print_encodable(
         f"[role config drift] {errors} error(s) / {len(findings)} finding(s) "
-        "-- 詳細は上の [ERROR] 行。再実行: "
-        f"{sys.executable} tools/check_role_configs.py --include-local"
+        f"-- see the [ERROR] lines above; rerun: {rerun}"
     )
     print(f"role_configs: {errors} error(s)", file=sys.stderr)
     return EXIT_DRIFT if errors else EXIT_OK


### PR DESCRIPTION
Closes #818. Refs #768.

## Problem

The real per-role `settings.local.json` files are gitignored, so CI can never validate them, and nothing on the operator machine ran `check_role_configs.py --include-local` routinely. A guard hook registered with a relative path silently no-oped for every role whose cwd is not the org root (observed 2026-08-03: the dispatcher pane's `block-workers-delete.sh` guard was dead while dispatch proceeded normally) — the exact defect class of #768, surviving precisely because no routine gate could see it.

## Changes

- **`/org-start` Block C4 (role config drift preflight)**: runs `check_role_configs.py --include-local` at startup alongside Block C2 (runtime drift). Non-fatal: on drift it splices a one-line warning into the Step 4 startup report; clean runs add nothing. The canonical rerun commands live as fixed prose in SKILL.md (`python3` / `py -3`), deliberately not emitted by the script (shell-dependent quoting cannot be made portable from the process side — cmd.exe / PowerShell / Git Bash disagree).
- **Exit-code contract**: 0 = clean / 1 = drift / 2 = could-not-verify. Previously a broken checker (missing schema, unresolvable `core_harness`) exited 1 — indistinguishable from real drift, i.e. the same silent-guard-death failure mode this issue targets. `core_harness` import failure converts to exit 2 in CLI runs only (library imports still raise). Locked by new `ExitCodeContractTests`.
- **Missing settings file is drift, not OK** (Codex round 4, P1): schema-declared settings files that don't exist previously skipped silently, so `--include-local` reported a guard-less org as clean. Now an ERROR — but only under `--include-local` / `--role` (in CI, gitignored files are legitimately absent; CI behavior unchanged, verified exit 0 on the CI invocation).
- **Unstat-able settings is could-not-verify, not drift**: only `FileNotFoundError` / `NotADirectoryError` count as absent; other `OSError`s propagate to exit 2. Forward-compat with Python 3.14 where `Path.is_file()` returns False on any OSError (per official docs); on 3.10-3.13 the exception path already yields exit 2 (verified live on 3.10).
- **stdout kept spliceable**: summary line is ASCII-safe (`_print_encodable()`), detailed `[ERROR]` lines unchanged, diagnostics on stderr.

## Verification

- unittest: 923 (tests/) + 715 (tools/) OK; ruff clean; `--help` smoke OK
- CI-identical invocation `--include-worker-settings .`: exit 0 (backward compatible)
- Live ja repo `--include-local`: clean, exit 0 (no false positives)
- Codex review: 7 rounds total, zero Blocker/Major throughout; the recurring rerun-hint findings (rounds 3/5/6) were resolved by removing the hint line entirely; each remaining finding fixed in one round with no carry-overs.