### PR TITLE
fix(claude): runtime 0.1.39 の rewrites キー追加による golden drift を解消し CI を復旧 (pin floor / Docker 既定も同期)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ ARG ORG_UID=1000
 ARG ORG_GID=1000
 # runtime pin（設計 §7.7: 起動時 upgrade はせず、更新は image rebuild）。
 # 既定値は pyproject.toml の claude-org-runtime floor（下限 pin）と同期させること。
-ARG RUNTIME_VERSION=0.1.37
+ARG RUNTIME_VERSION=0.1.39
 # Claude Code ネイティブインストーラに渡すバージョン（stable | latest | x.y.z）
 ARG CLAUDE_CODE_VERSION=stable
 ARG INSTALL_HERDR=1

--- a/docker/README.md
+++ b/docker/README.md
@@ -70,7 +70,7 @@ socket mount はホスト root 相当の権限付与である。オーバーレ�
 docker buildx build -f docker/Dockerfile \
   --platform linux/amd64,linux/arm64 \
   --build-arg REPO_REF="$(git describe --always)" \
-  -t ghcr.io/suisya-systems/claude-org-ja:$(git describe --always)-r0.1.37 \
+  -t ghcr.io/suisya-systems/claude-org-ja:$(git describe --always)-r0.1.39 \
   --push .
 ```
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -14,7 +14,7 @@ services:
         # host bind mount を使う場合はホスト UID に合わせる（設計 §8）
         ORG_UID: "${ORG_UID:-1000}"
         ORG_GID: "${ORG_GID:-1000}"
-        RUNTIME_VERSION: "${RUNTIME_VERSION:-0.1.37}"
+        RUNTIME_VERSION: "${RUNTIME_VERSION:-0.1.39}"
         INSTALL_HERDR: "${INSTALL_HERDR:-1}"
         REPO_REF: "${REPO_REF:-dev}"
     # PID1 は image 内の tini（init: true と等価の機能を image 側で自己完結。設計 §5）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.37,<0.2",
+    "claude-org-runtime>=0.1.39,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,18 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.39 to match the regenerated semantic-drift goldens:
+# 0.1.39 adds a `rewrites` array to SandboxMetadata.to_jsonable() (the record of
+# kept deny paths canonicalized across an absolute symlink), and ja's goldens
+# under tests/fixtures/runtime_schema_drift/sandbox_intent/ were regenerated for
+# that shape. A 0.1.37 / 0.1.38 install emits the key-less shape and fails all 14
+# fixtures in tests/test_runtime_schema_drift_semantic.py, so exclude them from
+# the floor (upper bound stays <0.2). The byte-check window constant
+# RUNTIME_PIN_LOWER_INCLUSIVE in tools/check_runtime_schema_drift.py is
+# deliberately NOT raised in step: it gates only the byte-identical schema check,
+# which 0.1.37 / 0.1.38 still pass, and raising it would downgrade those installs
+# to a skip-with-warning for no benefit. The earlier 0.1.37 floor (below) is
+# subsumed.
 # Floor bumped to 0.1.37 for the narrow Docker build allow set in the worker
 # role templates: role_configs_schema.json appends Bash(docker build:*) /
 # Bash(docker buildx build:*) / Bash(docker images:*) /
@@ -108,7 +120,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.37,<0.2
+claude-org-runtime>=0.1.39,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/README.md
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/README.md
@@ -98,6 +98,49 @@ exception cannot leak the fake `$HOME` into other tests.
 
 Fixtures that do not use `anchor: "home"` should omit `home_dir`.
 
+### `rewrites` is empty here by construction, not by definition
+
+`claude-org-runtime` 0.1.39 added a `rewrites` array to
+`SandboxMetadata.to_jsonable()`, so every `expected_explain` in this
+directory carries one. It is **not** a field that is always empty.
+`claude_org_runtime/settings/generator.py` (`SandboxPathRewrite`,
+`_canonicalize_escaping_path`, `_canonicalize_sandbox_deny`,
+`_canonicalize_permission_deny`) records there every *kept* deny path
+whose leading literal prefix crosses an **absolute symlink**: the
+runtime rewrites the path to its realpath — otherwise the unbindable
+path aborts bwrap and takes the whole sandbox down, which is the
+2026-08-06 WSL2 `~/.aws` symlink incident — and reports the
+`(layer, original, rewritten, symlink, realpath)` tuple. Both Layer 3
+(`sandbox.filesystem.deny{Read,Write}`) and Layer 2
+(`permissions.deny` `Read` / `Edit` rules) feed it. Note this is the
+*complement* of suppression: an entry that escapes the read roots is
+suppressed and never reaches the rewrite branch, so a fixture can hold
+suppressions and rewrites only for different entries.
+
+Every fixture here nonetheless renders `"rewrites": []`, and the reason
+is a property of the harness rather than of the runtime:
+`_render_fixture_result()` in
+[`tools/check_runtime_schema_drift.py`](../../../../tools/check_runtime_schema_drift.py)
+injects the fixture's fake `realpath_fn` but leaves `symlink_probe_fn`
+at its default `_absolute_symlink_in_chain`, which reads the **real**
+filesystem through `os.path.islink`. The fixture paths (`/home/u/...`)
+exist on no host, so the probe reports no symlink and the rewrite
+branch is never entered, whatever `realpath_map` claims. (The runtime's
+own docstring calls this half-real seam out: both halves "must describe
+the same world".)
+
+What that means for drift detection:
+
+- A runtime change that emits a rewrite where no symlink exists **is**
+  caught — the committed `[]` stops matching.
+- A regression *inside* the canonicalization (a wrong `rewritten` path,
+  or rewriting silently ceasing) is **not** caught, because no fixture
+  exercises the positive path. Closing that needs a `symlink_probe_fn`
+  seam in `_render_fixture_result` plus a fixture input (e.g.
+  `inputs.symlink_map`) — deliberately out of scope for the Issue #840
+  regeneration, and to be added as coverage rather than by relaxing the
+  comparison.
+
 ## Out-of-scope intentionally
 
 - **`verification_depth`**: this is a delegate-payload / brief

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
@@ -147,7 +147,8 @@
           "/home/u/co/knowledge"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
@@ -60,7 +60,8 @@
           "/home/u/co"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
@@ -59,7 +59,8 @@
           "/home/u/co"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_default_pattern_a.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_default_pattern_a.json
@@ -40,6 +40,7 @@
         "realpath": "/mnt/c/Users/u/wd/secrets.env",
         "sandbox_read_roots": ["/home/u/work/wd"]
       }
-    ]
+    ],
+    "rewrites": []
   }
 }

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_doc_audit.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_doc_audit.json
@@ -31,6 +31,7 @@
     "enabled": true,
     "wsl_detected": false,
     "sandbox_read_roots": ["/home/u/work/wd"],
-    "suppressions": []
+    "suppressions": [],
+    "rewrites": []
   }
 }

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_pattern_b_self_edit.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/sandbox_pattern_b_self_edit.json
@@ -37,6 +37,7 @@
       "/home/u/repo/.git",
       "/home/u/repo/.git/worktrees/T123"
     ],
-    "suppressions": []
+    "suppressions": [],
+    "rewrites": []
   }
 }

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_A.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_A.json
@@ -64,7 +64,8 @@
           "/home/u/co/knowledge/raw"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_B.json
@@ -83,7 +83,8 @@
           "/home/u/co/knowledge/raw"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_C.json
@@ -64,7 +64,8 @@
           "/home/u/co/knowledge/raw"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_A.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_A.json
@@ -64,7 +64,8 @@
           "/home/u/work/wd/.claude/plans"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_B.json
@@ -83,7 +83,8 @@
           "/home/u/workers/proj/.git/packed-refs"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_C.json
@@ -64,7 +64,8 @@
           "/home/u/workers/T123/.claude/plans"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_B.json
@@ -79,7 +79,8 @@
           "/home/u/co/.git/packed-refs"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_C.json
@@ -60,7 +60,8 @@
           "/home/u/co"
         ]
       }
-    ]
+    ],
+    "rewrites": []
   },
   "expected_rendered_sandbox": {
     "enabled": true,


### PR DESCRIPTION
## 概要

Closes #840。**全 PR の CI を止めていたブロッカーの解消。**

claude-org-runtime 0.1.39 が explain 出力に `"rewrites": []` を additive に追加したため、そのキーを持たない golden fixture 14 件が全件 drift し、`FixtureExplainGoldenTest` が失敗していた。ja 側は 1 行も変えていないのに CI が赤に変わった状態（main は 05:26Z の 7bda7af で green、その後 0.1.39 が pin 窓 `>=0.1.37` 内で解決されるようになったため）。

## 変更内容

1. **golden 14 件に `"rewrites": []` を 1 行ずつ追加**（`2909887`）。既存の `suppressions` / `sandbox_read_roots` / `expected_rendered_sandbox` の値は 1 件も変えていない。再生成前に全 14 件で「増えたキー = `rewrites` のみ / 消えたキー = 無し / 共通キーの値差分 = 無し」を機械確認済み。fixture あたり +1 行。
2. **pin floor を 0.1.39 へ**（`312728b`、`pyproject.toml` + `requirements.txt`）。0.1.37 / 0.1.38 の `SandboxMetadata.to_jsonable()` は `rewrites` を持たない（.venv = 0.1.38 で実測）ため、宣言窓 `>=0.1.37` のままだと再生成後の golden と矛盾する。前例 `cf932a6` (#633, runtime 0.1.30 の golden 再生成 + floor bump) と同じ paired 手順。
3. **Docker の `RUNTIME_VERSION` 既定を 0.1.39 へ**（`13c630d`）。`docker/Dockerfile` は `pip install claude-org-runtime==${RUNTIME_VERSION}` で固定焼き込みのため、0.1.37 のままでは配布 image が floor を下回り image 内で同じ 14 件が落ちる。`Dockerfile:63-64` に「pyproject の floor と同期させること」と明記されている不変条件。
4. **fixture README に `rewrites` の意味と検出能力の限界を明文化**。

## `rewrites` とは何か（実装確認済み）

`claude_org_runtime/settings/generator.py` (0.1.39) の `SandboxPathRewrite` / `_canonicalize_escaping_path` / `_canonicalize_sandbox_deny` / `_canonicalize_permission_deny` を直読した。

**「常に空が正」ではなく、条件次第で値が入るフィールド**。中身は「*保持された* deny パスのうち、先頭リテラル部が絶対 symlink を跨ぐものを realpath へ書き換えた記録」で `(layer, original, rewritten, symlink, realpath)` の tuple。Layer 3 (`sandbox.filesystem.deny{Read,Write}`) と Layer 2 (`permissions.deny` の Read/Edit ルール) の両方が供給元。

推測ではなく**実測で確認**した: symlink probe をスタブして再現実験したところ Layer 3 / Layer 2 の両方で非空になり、rendered 側も `/home/u/link/secrets.env` → `/mnt/c/Users/u/link/secrets.env` に書き換わった。suppression とは排他（read roots を逃げる entry は先に suppress され rewrite 分岐に入らない）。

背景としては 2026-08-06 の WSL2 `~/.aws` symlink 事故（symlink 越え deny path で bwrap が bind できず sandbox ごと落ちていた件）への runtime 側の対処にあたる。

## 空配列を焼き付けてよいかの判断

**焼き付けてよい**と判断した。今回の 14 fixture では空が**構造的に確定**しているため:

`tools/check_runtime_schema_drift.py` の `_render_fixture_result()` は fixture の偽 `realpath_fn` だけを注入し、`symlink_probe_fn` は既定（`_absolute_symlink_in_chain` = 実 FS を `os.path.islink` で読む）のまま。fixture のパス (`/home/u/...`) はどのホストにも実在しないので probe は symlink を検出せず、`realpath_map` が何を主張しても rewrite 分岐に入らない。

検出能力への影響（README に明記）:

- symlink が無いのに rewrite を出し始める退行 → **検出できる**（`[]` が一致しなくなる）
- canonicalization 自体の退行（rewritten の値が誤る / 書き換えが黙って止まる）→ **検出できない**。positive path を踏む fixture が 1 件も無いため

後者は 0.1.39 が出た時点で生じたカバレッジの穴であり、空配列を焼いたことで新たに生じたものではないが、**golden が緑なので安心してしまう性質はある**。塞ぐなら比較の緩和ではなく carve 追加で塞ぐべき、と README に out-of-scope として書き残した（follow-up issue で対応）。

## 設計判断

- **手書き整形を壊さないテキスト挿入で再生成**（`json.dump` による全体再フォーマットを却下）。全体再ダンプだと inline オブジェクトの整形が崩れて数百行 diff になり、「値の変更が無いこと」をレビューで確認できなくなるため。挿入前後で `json.loads` 同値性を機械アサートして担保。
- **検出能力を落とす方向の変更は一切していない**（キー増加の無視 / warning 化 / 比較緩和はいずれも不採用）。
- `tools/check_runtime_schema_drift.py` の `RUNTIME_PIN_LOWER_INCLUSIVE` は**据え置き**（上げると 0.1.37/0.1.38 の byte check が skip-with-warning に落ちるだけで検出能力が下がる。前例 `cf932a6` と同様）。

## 検証

- `unittest discover -s tests` 934 OK / `-s tools` 735 OK
- `check_runtime_schema_drift.py` byte OK / `--semantic` OK (0.1.39, 14 fixtures)
- `check_role_configs.py --include-worker-settings .` OK
- Codex 3 round: round 1 で P1 (pin floor)、round 2 で P2 (Docker 既定) → 修正、round 3 クリーン
