### PR TITLE
feat(claude): base_branch 運用リポジトリのマージ済み Issue を triage 候補から除外し理由付きで開示する

### DIFF
--- a/.claude/skills/work-discovery/SKILL.md
+++ b/.claude/skills/work-discovery/SKILL.md
@@ -105,7 +105,7 @@ python3 tools/work_discovery_scan.py --trigger manual --all-registry-repos
 
 | exit | status | 窓口の対応 |
 |---|---|---|
-| `0` | `no_candidates` | 候補ゼロ。「いま着手可能な（依存解決済みの）候補はありません」と人間に伝える。`excluded_blocked[]` が非空なら Step 3 と同じ「除外（依存未解決）: #<issue>（<note>）」の形で**必ず列挙する**（「何を見た結果ゼロなのか」を人間が監査できるように。設計 §5.2「除外枠を必ず見せる」/ §5.1）。さらに `input_truncated.open_issues` / `open_prs` が `true`（取得上限到達）なら Step 3 と同じ「Issue/PR の取得が上限到達のため候補が網羅的でない可能性があります」を**必ず添える**（非網羅な scan を「網羅した結果ゼロ」と誤読させないため）。**ここで停止**。 |
+| `0` | `no_candidates` | 候補ゼロ。「いま着手可能な（依存解決済みの）候補はありません」と人間に伝える。`excluded_blocked[]` / `excluded_merged[]` が非空なら Step 3 と同じ「除外（依存未解決）: …」「除外（マージ済み）: …」の形で**必ず列挙する**（「何を見た結果ゼロなのか」を人間が監査できるように。設計 §5.2「除外枠を必ず見せる」/ §5.1）。さらに `input_truncated.open_issues` / `open_prs` / `base_merges` が `true`（取得上限到達）なら Step 3 と同じ注記を**必ず添える**（非網羅な scan を「網羅した結果ゼロ」と誤読させないため）。**ここで停止**。 |
 | `10` | `candidates_found` | Step 3 で §5.2 形式にレンダリングして提示。 |
 | `2` | `error` | JSON の `error` フィールドの内容をそのまま人間へ伝え、「triage を実行できませんでした」と報告。候補を捏造しない。**候補ゼロと言い換えない**（失敗を silent skip にすると「候補が出ないのが普通」と受け取られ、次タスク提案の仕組みが事実上死ぬ。Issue #829）。repo セット解決の失敗もここに来るので、`repo_resolution.signals` / `skipped` があれば理由（registry 行が無い / `triage_home` off / パスが GitHub URL でない等）も併せて伝える。**ここで停止**。 |
 
@@ -124,6 +124,7 @@ JSON を SoT として、設計 §5.2 の人間可読フォーマットへ整形
 2. #533 Refactor config loader（優先度 medium / 工数 M / 依存解決済み / 並列可(推定)）
 
 除外（依存未解決）: #540（#537 が open のため）
+除外（マージ済み）: aainc/kura-data-aggregator-trial#231（#232 が develop にマージ済み・GitHub の自動クローズ未発火）
 
 着手するものを番号で指定してください。着手判断後に /org-delegate を回します。
 ```
@@ -139,9 +140,11 @@ JSON を SoT として、設計 §5.2 の人間可読フォーマットへ整形
   - **工数**: `effort_estimated == true`（ヒューリスティック推定）なら `工数 <effort>(推定)`。`false`（`size:S/M/L` 等のラベル由来）なら `(推定)` を付けず `工数 <effort>`。
   - **並列可 / 直近マージ起点**: フラグ `parallelizable` / `unblocked_by_recent_merge` が `true` のときだけ該当トークン（`並列可` / `直近マージ起点`）を出す（`false` なら表記自体を出さない）。これらは対応する `*_estimated` が常に推定（`true`）なので、出すときは常に `(推定)` 付き。直近マージ起点は `recommendation.reason` 内（例:「直近マージ #N の follow-up」）にも自然に現れる。
 - **除外枠を必ず見せる**: `excluded_blocked[]` を「除外（依存未解決）: #<issue>（<note>）」の形で列挙する（監査性 + 全部見たうえで N 件、の安心）。空なら除外行を省く。
+- **マージ済み除外は別行で見せる**（設計 §10.5 / Issue #830）: `excluded_merged[]` を「除外（マージ済み）: #<issue>（<note>）」の形で、**依存未解決の除外行とは別の行**に列挙する。`base_branch=develop` 等の二系統運用リポジトリでは、develop にマージ済みでも GitHub の自動クローズが発火せず Issue が open のまま残るため triage が「未着手」と誤読していた枠で、`note` が閉じた PR 番号と base ブランチを名指しする。**「まだ着手できない」（依存未解決）と「もう終わっている」（マージ済み）は人間の次の一手が真逆**なので混ぜない。空なら行を省く。
 - **サイレント truncation をしない**: `truncated_count` が 1 以上なら
   「（他に依存解決済みだが順位外の候補が <truncated_count> 件あります）」の 1 行を添える。
-  `input_truncated` の `open_issues` / `open_prs` が `true`（取得上限到達）なら「Issue/PR の取得が上限到達のため候補が網羅的でない可能性があります」も添える。
+  `input_truncated` の `open_issues` / `open_prs` が `true`（取得上限到達）なら「Issue/PR の取得が上限到達のため候補が網羅的でない可能性があります」も添える。`base_merges` が `true` なら「base ブランチのマージ履歴が上限到達のため、完了済み Issue を取りこぼしている可能性があります」を添える。
+- **base_branch まわりの読み取り異常を添える**: `base_branch_signals[]` が非空なら（registry 不在で完了判定をスキップした / 別ブランチ宛 PR が混じっていた / closing link を無視した等）、「scan 対象の解決メモ:」の並びに 1〜数行で添える。**「除外対象ゼロ」と「そもそも見ていない」を人間が区別できるようにするため**、空でない限り省略しない。
 - **resolver の skip / opt-out / signal を監査のため添える（cross-repo）**: scan 出力の `repo_resolution` の `skipped[]`（scan 対象なのに `パス` が GitHub URL でなく owner/repo を導けず scan 対象から外れた行）や `signals[]`（`triage_home` 由来の org-config 不在 / 不正値、home repo 解決が fallback / 失敗した等）が非空なら、候補提示の末尾に「scan 対象の解決メモ:」として 1〜数行で添える（例「登録行『<通称>』はパスが GitHub URL でないため scan 対象外（skip）」）。**`opted_out[]` が非空なら「opt-out 中の repo」も 1 行添える**（例「opt-out 中: aainc/token-tracking（明示 no）」）。どの repo を意図的に見ていないか・どの repo を見た結果の候補なのかを人間が監査できるようにするため。空なら省略。
 - **毎回必ず**「提案のみ / 着手はあなたの判断です」を出す（INV-1 の運用上の現れ）と、末尾に「番号で指定 → 着手判断後に /org-delegate」を出す。
 

--- a/docs/design/work-discovery-triage.md
+++ b/docs/design/work-discovery-triage.md
@@ -148,6 +148,13 @@ triage を「**計算（どの Issue がどう triage されるか）**」と「
   "excluded_blocked": [
     { "repo": "suisya-systems/claude-org-ja", "issue": 540, "blocking_refs": [537], "note": "#537 が open のため除外" }
   ],
+  "excluded_merged": [
+    { "repo": "aainc/kura-data-aggregator-trial", "issue": 231, "base_branch": "develop", "closed_by_pr": 232, "merged_at": "2026-08-06T02:33:45Z", "note": "#232 が develop にマージ済み（既定ブランチ外のマージなので GitHub の自動クローズが発火せず Issue が open のまま残っている）" }
+  ],
+  "base_branch_scan": [
+    { "repo": "aainc/kura-data-aggregator-trial", "base_branch": "develop", "merged_prs_scanned": 37, "closed_issue_count": 4 }
+  ],
+  "base_branch_signals": [],
   "repo_resolution": null
 }
 ```
@@ -160,6 +167,7 @@ triage を「**計算（どの Issue がどう triage されるか）**」と「
 - `candidate_count`: `candidates[]` の実件数。`truncated_count`: N 件上限で `candidates[]` から落とした「依存解決済みだが順位外」の候補数（**必須フィールド**。`0` でも省略しない。サイレント truncation を禁じるため）。
 - exit code で delivery 側が分岐する。[`tools/check_curate_threshold.py`](../../tools/check_curate_threshold.py) に倣い、**`1` を意味付けに使わない**（Python が未捕捉例外時に既定で返す exit `1` と衝突し、scan のクラッシュが「候補なし」に誤読されて error が窓口に届かなくなるのを防ぐ）。割り当ては `0` = 候補なし（`no_candidates`）、`10` = 候補あり（`candidates_found`）、`2` = error。delivery 層は JSON パース失敗に依存せず exit code で挙動を決める（curator threshold ツールと同方針）。
 - `excluded_blocked` は「依存未解決で除外した Issue」を理由付きで残す。**サイレント truncation をしない**（`truncated_count` で順位外候補の存在も、`excluded_blocked` で依存除外も、ともに人間が監査できるようにする）。
+- `excluded_merged` / `base_branch_scan` / `base_branch_signals`（Issue #830、[§10.5](#105-二系統base_branch運用リポジトリの完了判定)）: `base_branch` 宣言済みリポジトリで「その base ブランチへマージ済み = 完了」と判定して候補から外した Issue を、**閉じた PR 名 + base ブランチ名付き**で残す（`excluded_blocked` とは別枠 — 除外理由の種類が違う）。`base_branch_scan` は「どの repo にどの base ブランチを適用し、マージ済み PR を何件読んだか」の監査で、**何も除外しなかった scan と、そもそも見ていない scan を区別できる**ようにする。`base_branch_signals` は読み取り時の異常（registry 不在 / 別ブランチ宛 PR の混入 / 整合しない closing link）。3 キーとも**固定スキーマ前提**で常に存在し、非該当時は `[]`。`input_truncated` にも `base_merges`（base ブランチのマージ窓が上限到達）が加わる。
 - `repo_resolution`（Issue #829）: `--all-registry-repos` で registry から repo セットを解決した場合、resolver の結果（`repos` / `home_repo` / `triage_home` / `included` / `opted_out` / `skipped` / `signals`、失敗時は `error` も）をそのまま echo する。`--repo` 明示 / `--from-file` では `null`。**固定スキーマ前提**なのでキーは常に存在し、`null | object` の 2 値を取る。error envelope（exit 2）にも同じキーが載るので、「どの repo を見た結果か / なぜ 1 つも解決できなかったのか」を scan 出力だけで監査できる（delivery 層が resolver を二度呼ぶ必要がない）。
 - `effort_model`: 学習された effort モデルの要約（[§10](#10-スコープ外--将来課題) 工数見積もりの高度化）、または学習無効 / オフライン時は `null`。**固定スキーマ前提**なので `effort_model: null | object` の 2 値を常に取り、object 形では `sample_size` / `applies`（データ駆動ゲートの上書き可否）/ `predictor_correlation` / `realized_cutpoints` / `realized_median_lines` / `coverage`（学習データの網羅性: single-issue-linked PR 数・採用サンプル数・body 欠落で落とした数）/ `reason` などを持つ。`applies==false` の時は静的ヒューリスティックが維持され、各候補の `signals[]` に理由＋実工数コンテキストが明示される。本リポジトリでは body 長が実工数と相関しないため常に `applies==false`（gated OFF）。
 
@@ -176,6 +184,7 @@ triage を「**計算（どの Issue がどう triage されるか）**」と「
 3. #529 ...（優先度 medium / 工数 S / 依存解決済み / 並列可）
 
 除外（依存未解決）: #540（#537 が open のため）
+除外（マージ済み）: kura#231（#232 が develop にマージ済み・GitHub の自動クローズ未発火）
 
 着手するものを番号で指定してください。着手判断後に /org-delegate を回します。
 ```
@@ -183,7 +192,7 @@ triage を「**計算（どの Issue がどう triage されるか）**」と「
 - 推奨は先頭に `[推奨]` を付け 1 件だけ。
 - 工数が機械推定なら `(推定)` を必ず付す。
 - 「提案のみ / 着手はあなたの判断」を毎回明示する（INV-1 の運用上の現れ）。
-- 除外枠を必ず見せる（監査性 + 「全部見たうえで N 件」という安心）。
+- 除外枠を必ず見せる（監査性 + 「全部見たうえで N 件」という安心）。依存未解決（`excluded_blocked`）とマージ済み（`excluded_merged`、[§10.5](#105-二系統base_branch運用リポジトリの完了判定)）は**別行**で出す — 前者は「まだ着手できない」、後者は「もう終わっている」で、人間の次の一手が真逆になるため。
 - **クロスリポジトリ scan（[§10](#10-クロスリポジトリ-triage実装済み)）時**: 候補の `repo` が `null` でない（複数 repo 横断）なら、`#N` の代わりに `repo#N`（例 `runtime#531`）で表示し、出自 repo の曖昧さを無くす。単一 repo scan（`repo: null`）では従来どおり `#N`。delivery 層（窓口 skill）でこのレンダリング分岐を実装する（[§9](#9-段階導入と検証提案) と同様に `.claude/` 編集を伴うため計算層ワーカーのスコープ外・別タスク）。**実装済み**: この repo 修飾レンダリングは、delivery 層が [`registry/projects.md`](../../registry/projects.md) の triage 列（既定 include / 明示 opt-out）と [`registry/org-config.md`](../../registry/org-config.md) の `triage_home`（既定 off）から scan 対象 repo セットを解決する経路（[§10.4](#104-registry-駆動の-repo-セット解決)）と組で有効になる。登録された GitHub URL 行は既定で scan 対象なので、複数の登録 repo が並ぶ既定状態で `repo` が `null` でなくなり、この分岐が発火する（`repo: null` に畳まれるのは scan 対象が 1 件のときだけ）。resolver（[`tools/work_discovery_repos.py`](../../tools/work_discovery_repos.py)）の `opted_out` / `skipped` / `signals` も併せて人間提示に添え、「どの repo を見た結果の候補か・どの repo を意図的に見ていないか」を監査可能にする。
 
 ## 6. delivery 方式 3 案比較
@@ -330,6 +339,37 @@ triage を「**計算（どの Issue がどう triage されるか）**」と「
 - **供給経路（Issue #829）**: delivery 層は resolver を**別コマンドとして起動しない**。scan の `--all-registry-repos` が `resolve_repos()` をプロセス内で呼び、解決結果（`repos` / `home_repo` / `triage_home` / `included` / `opted_out` / `skipped` / `signals`）を scan 出力の **`repo_resolution`** に echo する（フラグ未使用時は `null`）。**解決失敗は scan の exit 2**（error envelope にも `repo_resolution` が載る）で、`--repo` 無し＝gh カレントリポジトリの暗黙 scan へフォールバック**しない**（解決失敗が「候補ゼロ」に化けて silent skip になるのを機構で塞ぐ。従来はこの分岐を呼び出し側 prose の `if … else` に依存していた）。層分離は保たれる: 供給を決めるのは依然 registry + org-config であって engine のランキング計算ではなく、engine は解決済み repo 列を受け取って走るだけである。
 - **出力**: `--format json`（既定、`repos` / `home_repo` / `triage_home` / `included` / `opted_out` / `skipped` / `signals`）と `--format flags`（`--repo a/b --repo c/d` の 1 行。skip / signal は stderr に出し stdout は flags 純粋）。**`--format flags` を scan の起動に使ってはならない**（上記のシェル単語分割依存。zsh では `${=VAR}` が要る＝可搬でない）。対話での確認・手貼り用に残している。旧キー `opted_in` は**廃止**し、`included`（scan 対象に入った登録行）と `opted_out`（明示 opt-out された登録行）へ分割した（意味が反転したキーを別名で残すと誤読を生むため後方互換エイリアスは置かない）。`triage_home` は home を見たか見なかったかを出力だけで監査できるようにする真偽値。exit code は `0`（repos が 1 件以上）/ `2`（error）。
 - **`recommendation_ref` の journal 統一**: dispatcher の worker_close 経路は journal イベント `work_discovery_scanned` の payload を `recommendation_issue=<番号>` から **`recommendation_ref=owner/repo#N`** に統一する（`recommendation.repo` が null＝scan 対象が 1 件で表示が畳まれた場合は scan 出力の **`repo_resolution.repos[0]`** で補完する）。補完元が `home_repo` ではなく `repos[0]` なのは、[`tools/work_discovery_scan.py`](../../tools/work_discovery_scan.py) が単一 repo scan のとき `collapse_repo = repos[0]` として**表示だけ**を単一 repo 形（`repo: null`）に畳む（`tools/work_discovery_scan.py:2237-2238`）ため、`recommendation.repo` が null になるのは「`--repo` が 1 つだけのとき」であり、その実 repo は常に resolver の `repos[0]` だからである（home が既定で先頭に来なくなった以上、`home_repo` での補完は誤った repo 名を生む）。cross-repo で `ja#60` と `runtime#60` が journal 上で衝突しないようにするのが本統一の目的。
+
+### 10.5 二系統（base_branch）運用リポジトリの完了判定
+
+> ステータス: **実装済み**（Issue #830）。`base_branch` 未設定のプロジェクトの挙動は完全に不変。
+
+**症状**: `base_branch=develop` を宣言した kura（[§10.4](#104-registry-駆動の-repo-セット解決) の registry 行）で、**完了済みの Issue が候補の第 1 位に出た**（2026-08-06 の worker_close scan: `aainc/kura-data-aggregator-trial#231` が rank 1、同日 PR #232 を develop へマージ済み）。
+
+**原因の連鎖**:
+
+1. feature PR は `develop` 宛にマージされる。GitHub の `Closes #N` **自動クローズは既定ブランチ（main）へのマージでしか発火しない**ので、Issue は次の develop→main 昇格まで open のまま残る。
+2. triage は Issue の open / closed しか見ていないため、これを「未着手」と読む。
+3. さらに `unblocked_by_recent_merge`（[§4.2](#42-補助軸ランク付けに使う)）が**逆に効く**: その Issue を閉じる PR が直近マージされたことで「直近マージ起点の follow-up」と判定され、**完了直後ほどランクが上がる**。post-merge の next-dispatch はまさにマージ直後に走るので、最も踏みやすいタイミングで最悪の候補が推奨される。
+
+**判定手段の実測（2026-08-06 / gh 2.74.0 / `aainc/kura-data-aggregator-trial`）** — Issue 本文が挙げた `closingIssuesReferences` / `linked:` 検索は**いずれも使えない**ことが実測で判明した:
+
+| 手段 | 実測結果 |
+|---|---|
+| `gh pr view 232 --json closingIssuesReferences`（base=develop） | `[]` — GitHub は既定ブランチ外の PR に対して**リンク自体を作らない**（同 repo の base=main の PR #219 / #222 は populated） |
+| `gh pr list --search "linked:231"` | `[]` |
+| Issue #231 の timeline | `cross-referenced` イベント 1 件のみ（単なる言及と区別できない） |
+| PR #232 の body 本文 | `Closes #231` を含む ← **唯一の確かな証拠** |
+
+したがって判定は **マージ済み PR 自身の title / body の closing キーワード**で行う。既存の直近マージ軸が使っている抽出器（`_pr_close_refs` / `_cross_keyword_refs`、[§11-3](#11-未解決の論点実装前に人間判断が要る点) のキーワードゲート + leading-run anchored + 否定ガード）をそのまま再利用するので、`Refs` / `Re`（単なる言及）や `does not close #N` は完了と読まない。
+
+**機構**:
+
+- 対象は **`registry/projects.md` の `base_branch` 列（Issue #808）が設定された行だけ**。未設定行は fetch すら行わず、挙動は 1 ビットも変わらない。base ブランチの解決は `--all-registry-repos`（resolver の `base_branches`）と `--repo` 明示の**両方**で行う（同じ repo を手打ちしただけでバグが復活しては根治にならない）。registry を読めなかった場合は非 fatal に縮退し、理由を `base_branch_signals` に残す（「除外対象ゼロ」と「そもそも見ていない」を出力から区別できるようにする）。
+- fetch は `gh pr list --base <base_branch> --state merged --limit <--base-merges>`（既定 100、`0` で無効化）。`closingIssuesReferences` は上表の理由で**要求しない**。窓は「develop にマージ済みだが main へ未昇格」の期間 = 1 リリースサイクルを覆う必要があるため、直近マージ軸の K（既定 10）より大きく取る。上限到達は `input_truncated.base_merges` で開示する。
+- 完了と判定した Issue は候補から外し、**`excluded_merged` に「閉じた PR 名 + base ブランチ名」付きで出す**（silent 除外にしない）。同一 Issue を複数の PR が閉じている場合は**最新のマージ**を引用する。
+- 完了した ref は **open blocker 集合からも外す**。GitHub 上はまだ open なので、放置すると「完了済みの作業にブロックされている」扱いで依存側が誤除外され続ける。依存側の候補は `signals[]` に「ブロッカー #N は #M（develop マージ）で解決済み」と明示する。
+- **サニティガード**: 「マージより後に作成された Issue」はそのマージでは閉じられ得ないので除外しない（番号再利用・`Closes` の書き間違い対策）。両タイムスタンプが揃わないときはガードを棄権する（順序を捏造しない）。**意図的な非カバレッジ**: 正当なクローズ後に再オープンされた Issue は除外されたままになる — だからこそ黙って落とさず PR 名付きで提示し、人間が覆せる形にしている。
 
 ## 10'. スコープ外 / 将来課題
 

--- a/registry/projects.example.md
+++ b/registry/projects.example.md
@@ -54,6 +54,7 @@ claude-org-ja 自身（self-edit）は本レジストリに載せない。`tools
 - 値はブランチ名（`develop`）。git が表示する形の `origin/develop` と書いても同じものとして扱う（前後空白は trim）。
 - 単発の逸脱（hotfix を `main` から切る等）は本列を書き換えず `gen_delegate_payload.py --base-ref main` で上書きする。**優先順位は `--base-ref` > 本列 > `origin/HEAD`**。
 - 設定したブランチが `origin` に存在しない場合、派遣は apply 時に fail loud で停止する（既定ブランチへ黙って落ちない。Issue #480 の stale-base ガードと同じ立場）。
+- **work-discovery triage の完了判定にも使われる（Issue #830）**: 値を書いた行は、triage scan がそのブランチ宛のマージ済み PR を読み、`Closes #N` で閉じられた Issue を候補から外して `excluded_merged` に理由付きで出す。GitHub の自動クローズは既定ブランチへのマージでしか発火しないため、develop にマージ済みの Issue は open のまま残り、これが無いと完了済みの作業が「次の仕事」の第 1 位に出る。未設定行はこの判定を一切行わない（挙動不変）。
 
 下の行は列の書き方を示すサンプルである。実際の運用では自分のプロジェクトに置き換えてよい（サンプル行を全て削除しても、パーサーは 0 行の表を有効として扱う）。
 

--- a/tests/test_work_discovery_repos.py
+++ b/tests/test_work_discovery_repos.py
@@ -85,6 +85,24 @@ def _write_registry(
     return path
 
 
+def _write_base_branch_registry(root: Path, data_rows: list[str]) -> Path:
+    """Write a registry whose header carries the Issue #808 ``base_branch``
+    column (7 columns), for the Issue #830 base-branch tests."""
+    reg_dir = root / "registry"
+    reg_dir.mkdir(exist_ok=True)
+    lines = [
+        "# Projects Registry",
+        "",
+        "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | triage "
+        "| base_branch |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    lines += [f"| {body} |" for body in data_rows]
+    path = reg_dir / "projects.md"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
 def _write_org_config(root: Path, body: str) -> Path:
     """Write ``root/registry/org-config.md`` with ``body`` verbatim."""
     reg_dir = root / "registry"
@@ -129,7 +147,9 @@ class ResolveReposTest(unittest.TestCase):
         self.assertEqual(result["repos"], ["o/ok"])
         self.assertEqual(
             result["included"],
-            [{"nickname": "ok", "repo": "o/ok", "path": url}],
+            # `base_branch: None` = the row declares no base branch (Issue
+            # #830); the key is always present so the shape is fixed.
+            [{"nickname": "ok", "repo": "o/ok", "path": url, "base_branch": None}],
         )
 
     def test_explicit_no_is_opted_out(self) -> None:
@@ -716,6 +736,86 @@ class FormatOutputTest(unittest.TestCase):
         with redirect_stdout(out), redirect_stderr(err):
             rc = wdr.main(argv)
         return out.getvalue(), err.getvalue(), rc
+
+
+class BaseBranchesTest(unittest.TestCase):
+    """The ``base_branch`` column feeds the triage scan's two-track
+    completion check (Issue #830, over the Issue #808 column)."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.root = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_declared_base_branch_is_mapped(self) -> None:
+        reg = _write_base_branch_registry(
+            self.root,
+            [
+                "kura | kura | https://github.com/aainc/kura | d | x |  "
+                "| develop |",
+                "ja | ja | https://github.com/o/ja | d | x |  |  |",
+            ],
+        )
+        self.assertEqual(
+            wdr.resolve_base_branches(reg), {"aainc/kura": "develop"}
+        )
+        result = wdr.resolve_repos(
+            registry_path=reg, claude_org_root=self.root
+        )
+        self.assertEqual(result["base_branches"], {"aainc/kura": "develop"})
+        rows = {row["repo"]: row["base_branch"] for row in result["included"]}
+        self.assertEqual(rows, {"aainc/kura": "develop", "o/ja": None})
+
+    def test_origin_prefix_and_placeholder_are_normalized(self) -> None:
+        # Same normalization as the delegation pipeline (Issue #808): the ref
+        # may be written the way git prints it, and `-` means "unset".
+        reg = _write_base_branch_registry(
+            self.root,
+            [
+                "a | a | https://github.com/o/a | d | x |  | origin/develop |",
+                "b | b | https://github.com/o/b | d | x |  | - |",
+                "c | c | https://github.com/o/c | d | x |  |   main   |",
+            ],
+        )
+        self.assertEqual(
+            wdr.resolve_base_branches(reg),
+            {"o/a": "develop", "o/c": "main"},
+        )
+
+    def test_opted_out_row_still_reports_its_base_branch(self) -> None:
+        # `triage` governs auto-scanning, not what the branch *is*: an
+        # explicit `--repo` scan of an opted-out repo must still get it.
+        reg = _write_base_branch_registry(
+            self.root,
+            ["k | k | https://github.com/o/k | d | x | no | develop |"],
+        )
+        result = wdr.resolve_repos(
+            registry_path=reg, claude_org_root=self.root
+        )
+        self.assertEqual(result["repos"], [])
+        self.assertEqual(result["base_branches"], {"o/k": "develop"})
+
+    def test_legacy_table_has_no_base_branches(self) -> None:
+        # Positional fallback never populates base_branch, so pre-#808 forks
+        # keep the historical behaviour with zero edits.
+        reg = _write_registry(
+            self.root,
+            ["ok | okproj | https://github.com/o/ok | d | x"],
+            with_triage_column=False,
+        )
+        self.assertEqual(wdr.resolve_base_branches(reg), {})
+        result = wdr.resolve_repos(
+            registry_path=reg, claude_org_root=self.root
+        )
+        self.assertEqual(result["base_branches"], {})
+
+    def test_missing_registry_yields_empty_map(self) -> None:
+        self.assertEqual(
+            wdr.resolve_base_branches(self.root / "registry" / "projects.md"),
+            {},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -2845,6 +2845,43 @@ class TestBaseBranchCompletionCli(unittest.TestCase):
         self.assertIn("base_merges", data["input_truncated"])
 
 
+class TestFetchBaseBranchMerges(unittest.TestCase):
+    """The fetch window is merge-time-exact, not update-time-approximate."""
+
+    def test_overfetches_then_slices_by_merged_at(self):
+        # `gh pr list --limit` pages under `sort:updated-desc`, so an old
+        # merged PR with a fresh comment can crowd a just-merged closing PR
+        # off the page — and that is exactly the PR this check needs. Mirror
+        # fetch_recent_merges: over-fetch, then take the mergedAt top-K.
+        page = [
+            {"number": 1, "mergedAt": "2026-01-01T00:00:00Z"},
+            {"number": 2, "mergedAt": "2026-08-06T00:00:00Z"},
+            {"number": 3, "mergedAt": "2026-05-01T00:00:00Z"},
+        ]
+        seen = {}
+
+        def _fake(args):
+            seen["args"] = args
+            return list(page)
+
+        with mock.patch.object(wds, "_run_gh_json_list", _fake):
+            out = wds.fetch_base_branch_merges(KURA, "develop", 2)
+        self.assertEqual([p["number"] for p in out], [2, 3])
+        args = seen["args"]
+        self.assertIn("--base", args)
+        self.assertEqual(args[args.index("--base") + 1], "develop")
+        # The requested page is larger than the window it returns.
+        self.assertEqual(
+            args[args.index("--limit") + 1],
+            str(2 * wds._RECENT_MERGE_OVERFETCH),
+        )
+        # closingIssuesReferences is deliberately not requested (empty for
+        # non-default-branch PRs — measured; the closing keyword is the SoT).
+        self.assertNotIn(
+            "closingIssuesReferences", args[args.index("--json") + 1]
+        )
+
+
 class TestBaseBranchFromRegistry(unittest.TestCase):
     """The registry (`base_branch` column) drives which repos get the check."""
 

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -2748,6 +2748,25 @@ class TestBaseBranchCompletion(unittest.TestCase):
         self.assertEqual(entry["issue"], 77)
         self.assertEqual(entry["closed_by_pr"], f"{KURA}#232")
 
+    def test_cross_repo_close_matches_case_insensitively(self):
+        # GitHub slugs are case-insensitive and a PR author writes whatever
+        # casing they like, while the registry-driven scan set is lowercased.
+        # Missing on case alone would leave finished work in the list.
+        pr = dict(KURA_PR_232, body="Closes Suisya-Systems/Claude-Org-JA#77\n")
+        other = {
+            "repo": "suisya-systems/claude-org-ja",
+            "issues": [_issue(77, body="b")],
+            "open_pr_numbers": set(),
+            "recent_merges": [],
+        }
+        result = self._scan(
+            [_kura_bundle(issues=[], base_merges=[pr], recent_merges=[]), other]
+        )
+        self.assertEqual(result["candidates"], [])
+        self.assertEqual(
+            result["excluded_merged"][0]["repo"], "suisya-systems/claude-org-ja"
+        )
+
     def test_origin_prefixed_and_padded_base_branch_cell(self):
         # Registry cells are padded and an operator may write the ref the way
         # git prints it; the scan compares against baseRefName either way.
@@ -2812,6 +2831,29 @@ class TestBaseBranchCompletionCli(unittest.TestCase):
         data = json.loads(proc.stdout)
         self.assertEqual(data["candidates"], [])
         self.assertEqual(data["excluded_merged"][0]["issue"], 231)
+
+    def test_base_merges_zero_also_disables_the_offline_path(self):
+        # "0 disables the check" has to mean the same thing offline: a bundle
+        # carrying its own base inputs must stop excluding once the caller
+        # switched the check off, or the flag lies about what it does.
+        bundle = {
+            "repos": [
+                {
+                    "repo": KURA,
+                    "issues": [KURA_ISSUE_231],
+                    "open_pr_numbers": [],
+                    "recent_merges": [],
+                    "base_branch": "develop",
+                    "base_merges": [KURA_PR_232],
+                }
+            ]
+        }
+        proc = self._run(bundle, ["--base-merges", "0"])
+        self.assertEqual(proc.returncode, wds.EXIT_CANDIDATES_FOUND)
+        data = json.loads(proc.stdout)
+        self.assertEqual([c["issue"] for c in data["candidates"]], [231])
+        self.assertEqual(data["excluded_merged"], [])
+        self.assertEqual(data["base_branch_scan"], [])
 
     def test_non_string_base_branch_is_a_pinpointed_error(self):
         bundle = {"issues": [], "base_branch": 5}

--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -927,7 +927,10 @@ class TestCliWiring(unittest.TestCase):
         data = json.loads(proc.stdout)
         self.assertIn("input_truncated", data)
         self.assertEqual(
-            data["input_truncated"], {"open_issues": False, "open_prs": False}
+            data["input_truncated"],
+            # `base_merges` joined the coverage flags with Issue #830 (the
+            # base-branch completion window can cut off older merges).
+            {"open_issues": False, "open_prs": False, "base_merges": False},
         )
 
     def test_top_n_zero_rejected_as_error(self):
@@ -2486,6 +2489,518 @@ class TestAllRegistryRepos(unittest.TestCase):
             seen[shell] = json.loads(proc.stdout)
         self.assertEqual(seen["zsh"], seen["bash"])
         self.assertEqual(seen["zsh"]["generated_for"], "worker_close")
+
+
+# ----------------------------------------------------------------------
+# Two-track base_branch completion (Issue #830)
+# ----------------------------------------------------------------------
+
+KURA = "aainc/kura-data-aggregator-trial"
+
+# The real shapes behind Issue #830, captured from GitHub on 2026-08-06
+# (gh 2.74.0). Kept verbatim-ish so the regression reproduces the reported
+# case rather than an idealized version of it: PR #232 targets `develop`,
+# carries `Closes #231` in its body, and reports NO closingIssuesReferences
+# (GitHub only links closing issues for default-branch PRs) — which is why
+# Issue #231 was still `open` and got triaged as untouched.
+KURA_ISSUE_231 = {
+    "number": 231,
+    "title": "MCP トークン TTL 暫定値 (8h) を既定 900s へ戻す (refresh rotation の本番確認後)",
+    "body": "refresh token が本番で回ることを確認してから暫定 TTL を外す。",
+    "labels": [],
+    "createdAt": "2026-08-05T01:20:00Z",
+    "updatedAt": "2026-08-06T02:33:45Z",
+}
+KURA_PR_232 = {
+    "number": 232,
+    "title": "fix(kura): MCP アクセストークン TTL の暫定 8 時間を外し既定 900s へ戻す",
+    "body": (
+        "## 概要\n\n"
+        "#226 の後始末。refresh token (#228) が本番稼働していることを確認できたので、"
+        "#227 で入れた暫定 TTL を削除し、アプリ側の既定 900s へ戻す。\n\n"
+        "Closes #231\n"
+    ),
+    "baseRefName": "develop",
+    "mergedAt": "2026-08-06T02:33:45Z",
+}
+
+
+def _kura_bundle(**over):
+    bundle = {
+        "repo": KURA,
+        "issues": [KURA_ISSUE_231],
+        "open_pr_numbers": set(),
+        # The merge that finished #231 is also in the recent-merge window —
+        # that is what made `unblocked_by_recent_merge` fire and pushed the
+        # finished Issue to rank 1 (the reported symptom).
+        "recent_merges": [KURA_PR_232],
+        "base_branch": "develop",
+        "base_merges": [KURA_PR_232],
+    }
+    bundle.update(over)
+    return bundle
+
+
+class TestBaseBranchCompletion(unittest.TestCase):
+    """Issues finished by a merge into a declared non-default base branch are
+    excluded with a reason, not ranked first (Issue #830).
+
+    On a `base_branch=develop` repo GitHub's auto-close never fires, so the
+    Issue stays `open`; the pre-#830 scan read that as untouched AND lit up
+    `unblocked_by_recent_merge` off the very merge that completed it. Every
+    test here drives the pure core with fixture data — no `gh`, no network.
+    """
+
+    def _scan(self, bundles, **cfg):
+        config = wds.ScanConfig(
+            top_n=cfg.pop("top_n", 3),
+            free_panes=cfg.pop("free_panes", None),
+            trigger=cfg.pop("trigger", "post_merge"),
+        )
+        return wds.scan_repos(bundles, config, **cfg)
+
+    def test_pre_fix_symptom_without_base_branch(self):
+        # Pins the bug being fixed: with no base_branch configured, the
+        # completed Issue is not just present — it is rank 1, boosted by the
+        # merge that finished it. This is the state kura#231 was reported in.
+        result = self._scan(
+            [_kura_bundle(base_branch=None, base_merges=[])],
+            collapse_repo=KURA,
+        )
+        self.assertEqual(result["status"], "candidates_found")
+        top = result["candidates"][0]
+        self.assertEqual(top["issue"], 231)
+        self.assertEqual(top["rank"], 1)
+        self.assertTrue(top["unblocked_by_recent_merge"])
+        self.assertEqual(result["excluded_merged"], [])
+
+    def test_kura_231_is_excluded_with_a_reason(self):
+        # The fix: same input + `base_branch=develop` → not a candidate, and
+        # the exclusion names PR #232 and the branch it landed on.
+        result = self._scan([_kura_bundle()], collapse_repo=KURA)
+        self.assertEqual([c["issue"] for c in result["candidates"]], [])
+        self.assertEqual(result["status"], "no_candidates")
+        self.assertEqual(len(result["excluded_merged"]), 1)
+        entry = result["excluded_merged"][0]
+        self.assertEqual(entry["issue"], 231)
+        self.assertIsNone(entry["repo"])  # collapsed single-repo display
+        self.assertEqual(entry["base_branch"], "develop")
+        self.assertEqual(entry["closed_by_pr"], 232)
+        self.assertEqual(entry["merged_at"], "2026-08-06T02:33:45Z")
+        self.assertIn("#232", entry["note"])
+        self.assertIn("develop", entry["note"])
+        # Not silent, and not conflated with the dependency exclusion枠.
+        self.assertEqual(result["excluded_blocked"], [])
+
+    def test_excluded_issue_is_not_recommended(self):
+        # The recommendation is derived from the ranked list, so a completed
+        # Issue must not reappear there either.
+        result = self._scan([_kura_bundle()], collapse_repo=KURA)
+        self.assertIsNone(result["recommendation"])
+
+    def test_base_branch_scan_audit_is_emitted(self):
+        result = self._scan([_kura_bundle()], collapse_repo=KURA)
+        self.assertEqual(
+            result["base_branch_scan"],
+            [
+                {
+                    "repo": None,
+                    "base_branch": "develop",
+                    "merged_prs_scanned": 1,
+                    "closed_issue_count": 1,
+                }
+            ],
+        )
+        self.assertEqual(result["base_branch_signals"], [])
+
+    def test_repo_without_base_branch_is_unchanged(self):
+        # Acceptance criterion: projects with no base_branch behave exactly
+        # as before, even when a merged PR closing the Issue is in the data.
+        result = self._scan(
+            [
+                {
+                    "repo": "o/plain",
+                    "issues": [_issue(7, body="b")],
+                    "open_pr_numbers": set(),
+                    "recent_merges": [{"number": 8, "body": "Closes #7"}],
+                }
+            ],
+            collapse_repo="o/plain",
+        )
+        self.assertEqual([c["issue"] for c in result["candidates"]], [7])
+        self.assertEqual(result["excluded_merged"], [])
+        self.assertEqual(result["base_branch_scan"], [])
+
+    def test_mere_reference_does_not_exclude(self):
+        # `Refs #N` is a mention, not a completion — excluding on it would
+        # drop live work (the §11-3 over-matching risk, applied to merges).
+        pr = dict(KURA_PR_232, body="Refs #231\n")
+        result = self._scan(
+            [_kura_bundle(base_merges=[pr], recent_merges=[pr])],
+            collapse_repo=KURA,
+        )
+        self.assertEqual([c["issue"] for c in result["candidates"]], [231])
+        self.assertEqual(result["excluded_merged"], [])
+
+    def test_negated_close_keyword_does_not_exclude(self):
+        pr = dict(KURA_PR_232, body="This does not close #231 yet.\n")
+        result = self._scan(
+            [_kura_bundle(base_merges=[pr], recent_merges=[])],
+            collapse_repo=KURA,
+        )
+        self.assertEqual([c["issue"] for c in result["candidates"]], [231])
+        self.assertEqual(result["excluded_merged"], [])
+
+    def test_merge_targeting_another_branch_is_not_counted(self):
+        # An offline bundle can carry unfiltered merges; a baseRefName that
+        # contradicts the configured branch must not widen the exclusion, and
+        # the mismatch is reported rather than dropped.
+        pr = dict(KURA_PR_232, baseRefName="feature/x")
+        result = self._scan(
+            [_kura_bundle(base_merges=[pr], recent_merges=[])],
+            collapse_repo=KURA,
+        )
+        self.assertEqual([c["issue"] for c in result["candidates"]], [231])
+        self.assertEqual(result["excluded_merged"], [])
+        self.assertTrue(
+            any("target a different branch" in s
+                for s in result["base_branch_signals"]),
+            result["base_branch_signals"],
+        )
+
+    def test_issue_created_after_the_merge_is_not_excluded(self):
+        # Sanity guard: a merge cannot have completed an Issue that did not
+        # exist yet (number reuse / a hand-written `Closes` typo).
+        issue = dict(KURA_ISSUE_231, createdAt="2026-08-07T00:00:00Z")
+        result = self._scan(
+            [_kura_bundle(issues=[issue], recent_merges=[])],
+            collapse_repo=KURA,
+        )
+        self.assertEqual([c["issue"] for c in result["candidates"]], [231])
+        self.assertEqual(result["excluded_merged"], [])
+        self.assertTrue(
+            any("closing link ignored" in s
+                for s in result["base_branch_signals"]),
+            result["base_branch_signals"],
+        )
+
+    def test_missing_created_at_still_excludes(self):
+        # The guard abstains when it cannot compare, rather than inventing an
+        # ordering that would resurrect the bug.
+        issue = {k: v for k, v in KURA_ISSUE_231.items() if k != "createdAt"}
+        result = self._scan(
+            [_kura_bundle(issues=[issue], recent_merges=[])],
+            collapse_repo=KURA,
+        )
+        self.assertEqual(result["candidates"], [])
+        self.assertEqual(result["excluded_merged"][0]["issue"], 231)
+
+    def test_newest_closing_merge_is_the_one_cited(self):
+        older = {
+            "number": 100,
+            "title": "t",
+            "body": "Closes #231",
+            "baseRefName": "develop",
+            "mergedAt": "2026-07-01T00:00:00Z",
+        }
+        result = self._scan(
+            [_kura_bundle(base_merges=[older, KURA_PR_232], recent_merges=[])],
+            collapse_repo=KURA,
+        )
+        self.assertEqual(result["excluded_merged"][0]["closed_by_pr"], 232)
+
+    def test_dependent_unblocks_when_its_blocker_was_merged(self):
+        # A completed Issue is still `open` on GitHub, so leaving it in the
+        # open-blocker set would keep its dependents excluded as blocked by
+        # finished work. It unblocks — and says why.
+        dependent = _issue(240, body="Blocked by #231")
+        result = self._scan(
+            [_kura_bundle(issues=[KURA_ISSUE_231, dependent])],
+            collapse_repo=KURA,
+        )
+        self.assertEqual([c["issue"] for c in result["candidates"]], [240])
+        self.assertEqual(result["excluded_blocked"], [])
+        signals = result["candidates"][0]["signals"]
+        self.assertTrue(
+            any("#231" in s and "#232" in s and "develop" in s
+                for s in signals),
+            signals,
+        )
+
+    def test_cross_repo_close_from_a_base_branch_merge(self):
+        # A develop PR that closes another scanned repo's Issue keeps that
+        # Issue's repo, and the exclusion cites the merging repo's PR.
+        pr = dict(
+            KURA_PR_232, body=f"Closes suisya-systems/claude-org-ja#77\n"
+        )
+        other = {
+            "repo": "suisya-systems/claude-org-ja",
+            "issues": [_issue(77, body="b")],
+            "open_pr_numbers": set(),
+            "recent_merges": [],
+        }
+        result = self._scan(
+            [_kura_bundle(issues=[], base_merges=[pr], recent_merges=[]), other]
+        )
+        self.assertEqual(result["candidates"], [])
+        entry = result["excluded_merged"][0]
+        self.assertEqual(entry["repo"], "suisya-systems/claude-org-ja")
+        self.assertEqual(entry["issue"], 77)
+        self.assertEqual(entry["closed_by_pr"], f"{KURA}#232")
+
+    def test_origin_prefixed_and_padded_base_branch_cell(self):
+        # Registry cells are padded and an operator may write the ref the way
+        # git prints it; the scan compares against baseRefName either way.
+        result = self._scan(
+            [_kura_bundle(base_branch="  develop  ")], collapse_repo=KURA
+        )
+        self.assertEqual(result["excluded_merged"][0]["issue"], 231)
+
+    def test_scan_shim_accepts_base_branch_inputs(self):
+        result = wds.scan(
+            [KURA_ISSUE_231],
+            set(),
+            [KURA_PR_232],
+            wds.ScanConfig(top_n=3, free_panes=None, trigger="manual"),
+            base_branch="develop",
+            base_merges=[KURA_PR_232],
+        )
+        self.assertEqual(result["candidates"], [])
+        self.assertEqual(result["excluded_merged"][0]["closed_by_pr"], 232)
+
+    def test_scan_is_still_pure(self):
+        # Same input → same output (design §4 再現性契約).
+        a = self._scan([_kura_bundle()], collapse_repo=KURA)
+        b = self._scan([_kura_bundle()], collapse_repo=KURA)
+        self.assertEqual(a, b)
+
+
+class TestBaseBranchCompletionCli(unittest.TestCase):
+    """The `--from-file` / CLI surface of Issue #830."""
+
+    def _run(self, bundle, extra_argv=()):
+        fd, name = tempfile.mkstemp(suffix=".json", prefix="wds_bb_")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(bundle, f)
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--from-file", name,
+                 *extra_argv],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+            )
+        finally:
+            os.unlink(name)
+        return proc
+
+    def test_from_file_bundle_excludes_and_exits_0(self):
+        bundle = {
+            "repos": [
+                {
+                    "repo": KURA,
+                    "issues": [KURA_ISSUE_231],
+                    "open_pr_numbers": [],
+                    "recent_merges": [KURA_PR_232],
+                    "base_branch": "develop",
+                    "base_merges": [KURA_PR_232],
+                }
+            ]
+        }
+        proc = self._run(bundle)
+        self.assertEqual(proc.returncode, wds.EXIT_NO_CANDIDATES)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["candidates"], [])
+        self.assertEqual(data["excluded_merged"][0]["issue"], 231)
+
+    def test_non_string_base_branch_is_a_pinpointed_error(self):
+        bundle = {"issues": [], "base_branch": 5}
+        proc = self._run(bundle)
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertIn("base_branch", data["error"])
+
+    def test_non_object_base_merge_row_is_a_pinpointed_error(self):
+        bundle = {"issues": [], "base_branch": "develop", "base_merges": ["x"]}
+        proc = self._run(bundle)
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)
+        self.assertIn("base_merges[0]", data["error"])
+
+    def test_negative_base_merges_rejected(self):
+        proc = self._run({"issues": []}, ["--base-merges", "-1"])
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        self.assertIn("--base-merges must be >= 0", json.loads(proc.stdout)["error"])
+
+    def test_error_envelope_carries_the_new_keys(self):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--from-file", "/no/such/file.json"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        data = json.loads(proc.stdout)
+        for key in ("excluded_merged", "base_branch_scan", "base_branch_signals"):
+            self.assertIn(key, data)
+        self.assertIn("base_merges", data["input_truncated"])
+
+
+class TestBaseBranchFromRegistry(unittest.TestCase):
+    """The registry (`base_branch` column) drives which repos get the check."""
+
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.root = Path(self._td.name)
+        (self.root / "registry").mkdir()
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def _write_registry(self, rows):
+        lines = [
+            "# Projects Registry",
+            "",
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | triage "
+            "| base_branch |",
+            "|---|---|---|---|---|---|---|",
+        ]
+        lines += [f"| {row} |" for row in rows]
+        (self.root / "registry" / "projects.md").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+
+    def _run(self, argv, issues_by_repo=None):
+        """main() with every fetcher mocked; returns (rc, json, base_calls)."""
+        base_calls = []
+
+        def _base(repo, branch, limit):
+            base_calls.append((repo, branch, limit))
+            return [KURA_PR_232] if branch == "develop" else []
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with mock.patch.object(
+                 wds, "fetch_open_issues",
+                 lambda r, limit=wds.DEFAULT_OPEN_LIMIT:
+                     (issues_by_repo or {}).get(r, [])), \
+             mock.patch.object(
+                 wds, "fetch_open_pr_numbers",
+                 lambda r, limit=wds.DEFAULT_OPEN_LIMIT: set()), \
+             mock.patch.object(wds, "fetch_recent_merges", lambda r, k: []), \
+             mock.patch.object(wds, "fetch_base_branch_merges", _base), \
+             mock.patch.object(wds, "build_effort_model", lambda r, n: None):
+            with redirect_stdout(buf):
+                rc = wds.main(argv)
+        return rc, json.loads(buf.getvalue()), base_calls
+
+    def test_explicit_repo_still_gets_the_registry_base_branch(self):
+        # Naming the repo by hand must not reintroduce the bug: the registry
+        # is the SoT for base_branch regardless of how the repo set was built.
+        self._write_registry(
+            [f"kura | kura | https://github.com/{KURA} | d | x |  | develop |"]
+        )
+        rc, data, calls = self._run(
+            ["--repo", KURA, "--claude-org-root", str(self.root)],
+            {KURA: [KURA_ISSUE_231]},
+        )
+        self.assertEqual(rc, wds.EXIT_NO_CANDIDATES)
+        self.assertEqual(calls, [(KURA, "develop", wds.DEFAULT_BASE_MERGE_LIMIT)])
+        self.assertEqual(data["excluded_merged"][0]["issue"], 231)
+
+    def test_all_registry_repos_uses_the_resolver_map(self):
+        self._write_registry(
+            [
+                f"kura | kura | https://github.com/{KURA} | d | x |  | develop |",
+                f"ja | ja | https://github.com/{JA} | d | x |  |  |",
+            ]
+        )
+        rc, data, calls = self._run(
+            ["--all-registry-repos", "--claude-org-root", str(self.root)],
+            {KURA: [KURA_ISSUE_231]},
+        )
+        # Only the base_branch row is fetched; the unset row is untouched.
+        self.assertEqual(calls, [(KURA, "develop", wds.DEFAULT_BASE_MERGE_LIMIT)])
+        self.assertEqual(rc, wds.EXIT_NO_CANDIDATES)
+        self.assertEqual(data["excluded_merged"][0]["repo"], KURA)
+        self.assertEqual(
+            data["repo_resolution"]["base_branches"], {KURA: "develop"}
+        )
+
+    def test_origin_prefixed_registry_cell_is_normalized(self):
+        self._write_registry(
+            [f"kura | kura | https://github.com/{KURA} | d | x |  | origin/develop |"]
+        )
+        _, _, calls = self._run(
+            ["--repo", KURA, "--claude-org-root", str(self.root)],
+            {KURA: [KURA_ISSUE_231]},
+        )
+        self.assertEqual(calls, [(KURA, "develop", wds.DEFAULT_BASE_MERGE_LIMIT)])
+
+    def test_base_merges_zero_disables_the_check(self):
+        self._write_registry(
+            [f"kura | kura | https://github.com/{KURA} | d | x |  | develop |"]
+        )
+        rc, data, calls = self._run(
+            ["--repo", KURA, "--claude-org-root", str(self.root),
+             "--base-merges", "0"],
+            {KURA: [KURA_ISSUE_231]},
+        )
+        self.assertEqual(calls, [])
+        self.assertEqual(rc, wds.EXIT_CANDIDATES_FOUND)
+        self.assertEqual(data["excluded_merged"], [])
+
+    def test_unset_base_branch_column_scans_nothing(self):
+        self._write_registry(
+            [f"kura | kura | https://github.com/{KURA} | d | x |  | - |"]
+        )
+        rc, data, calls = self._run(
+            ["--repo", KURA, "--claude-org-root", str(self.root)],
+            {KURA: [KURA_ISSUE_231]},
+        )
+        self.assertEqual(calls, [])
+        self.assertEqual(rc, wds.EXIT_CANDIDATES_FOUND)
+
+    def test_missing_registry_degrades_without_failing(self):
+        # No registry at all: the scan still runs (pre-#830 behaviour), it
+        # just cannot exclude anything this way — and says so, because
+        # "nothing to exclude" and "never looked" must not read the same.
+        rc, data, calls = self._run(
+            ["--repo", KURA, "--claude-org-root", str(self.root)],
+            {KURA: [KURA_ISSUE_231]},
+        )
+        self.assertEqual(calls, [])
+        self.assertEqual(rc, wds.EXIT_CANDIDATES_FOUND)
+        self.assertTrue(
+            any("registry not found" in s for s in data["base_branch_signals"]),
+            data["base_branch_signals"],
+        )
+
+    def test_unreadable_registry_is_reported_not_swallowed(self):
+        (self.root / "registry" / "projects.md").write_bytes(bytes([255]))
+        rc, data, calls = self._run(
+            ["--repo", KURA, "--claude-org-root", str(self.root)],
+            {KURA: [KURA_ISSUE_231]},
+        )
+        self.assertEqual(calls, [])
+        self.assertEqual(rc, wds.EXIT_CANDIDATES_FOUND)
+        self.assertTrue(
+            any("base-branch completion check skipped" in s
+                for s in data["base_branch_signals"]),
+            data["base_branch_signals"],
+        )
+
+    def test_truncated_base_merge_window_is_flagged(self):
+        self._write_registry(
+            [f"kura | kura | https://github.com/{KURA} | d | x |  | develop |"]
+        )
+        rc, data, _ = self._run(
+            ["--repo", KURA, "--claude-org-root", str(self.root),
+             "--base-merges", "1"],
+            {KURA: [KURA_ISSUE_231]},
+        )
+        self.assertTrue(data["input_truncated"]["base_merges"])
 
 
 if __name__ == "__main__":

--- a/tools/work_discovery_repos.py
+++ b/tools/work_discovery_repos.py
@@ -30,7 +30,7 @@ Output (stdout):
 
 - ``--format json`` (default): one JSON object with ``repos``,
   ``home_repo``, ``triage_home``, ``included``, ``opted_out``,
-  ``skipped``, ``signals`` (and ``error`` on failure).
+  ``skipped``, ``base_branches``, ``signals`` (and ``error`` on failure).
 - ``--format flags``: ``--repo a/b --repo c/d`` on a single line for shell
   splicing; ``skipped`` / ``signals`` go to stderr so stdout stays pure.
 
@@ -118,6 +118,67 @@ def _owner_repo_from_url(url: Optional[str]) -> Optional[str]:
     if not m:
         return None
     return f"{m.group(1)}/{m.group(2)}"
+
+
+def _normalize_base_branch(value: Optional[str]) -> Optional[str]:
+    """Normalize a registry ``base_branch`` cell to a bare branch name.
+
+    Delegates to :func:`tools.gen_delegate_payload.normalize_base_branch` —
+    the single source of truth for that normalization since Issue #808 (trim,
+    tolerated ``origin/`` prefix, ``""`` / ``-`` = unset) — so the triage scan
+    and the delegation pipeline can never disagree on what ``develop`` means.
+
+    The import is **lazy** on purpose: ``gen_delegate_payload`` is the heavy
+    delegation planner (it pulls in the brief generator, the layout resolver
+    and the transport module), and this file is a read-only resolver imported
+    by the scan on every run. Importing it at module scope would make the
+    triage path depend on the whole delegation stack loading cleanly for a
+    three-line string normalization.
+    """
+    from tools.gen_delegate_payload import normalize_base_branch
+
+    return normalize_base_branch(value)
+
+
+def _base_branches_from_projects(projects) -> dict[str, str]:
+    """Map ``owner/repo`` -> normalized ``base_branch`` over parsed rows.
+
+    Issue #830. Only rows that (a) yield an ``owner/repo`` from their path and
+    (b) declare a non-empty ``base_branch`` appear; every other row is absent,
+    which is what "unset = historical behaviour" means downstream.
+
+    Rows opted out of triage are **still** mapped: the ``triage`` column
+    governs whether a repo is auto-scanned, not what its base branch *is*, so
+    an explicit ``--repo`` scan of an opted-out repo still gets the correct
+    base branch. The first row for a repo wins (deterministic on duplicates).
+    """
+    out: dict[str, str] = {}
+    for proj in projects:
+        repo = _owner_repo_from_url(proj.path)
+        if repo is None or repo in out:
+            continue
+        branch = _normalize_base_branch(proj.base_branch)
+        if branch:
+            out[repo] = branch
+    return out
+
+
+def resolve_base_branches(registry_path: Path) -> dict[str, str]:
+    """Read ``registry/projects.md`` and return ``{owner/repo: base_branch}``.
+
+    Issue #830. Standalone entry point for callers that already know their
+    repo set (``work_discovery_scan.py --repo …``) and only need the base
+    branches; ``resolve_repos`` computes the same map from the rows it has
+    already parsed. A missing registry yields ``{}`` (no base branches
+    configured), matching the resolver's own "no registry rows" degradation.
+    Read-only.
+    """
+    path = Path(registry_path)
+    if not path.exists():
+        return {}
+    return _base_branches_from_projects(
+        parse_projects_text(path.read_text(encoding="utf-8"))
+    )
 
 
 def _read_triage_home(org_config_path: Path, signals: list[str]) -> bool:
@@ -249,6 +310,9 @@ def resolve_repos(
             "scan"
         )
 
+    # Issue #830: computed from the rows already parsed above (no second read).
+    base_branches = _base_branches_from_projects(projects)
+
     for proj in projects:
         raw = proj.triage.strip()
         val = raw.lower()
@@ -283,7 +347,16 @@ def resolve_repos(
             signals.append(reason)
             continue
         included.append(
-            {"nickname": proj.nickname, "repo": repo, "path": proj.path}
+            {
+                "nickname": proj.nickname,
+                "repo": repo,
+                "path": proj.path,
+                # Issue #830: the row's declared cut point / merge target
+                # (``None`` when unset). Carried per row so the audit shows
+                # *which registration* supplied a base branch, not just that
+                # one exists somewhere.
+                "base_branch": base_branches.get(repo),
+            }
         )
 
     # Dedup preserving order; home first when it is included at all.
@@ -303,6 +376,12 @@ def resolve_repos(
         "included": included,
         "opted_out": opted_out,
         "skipped": skipped,
+        # Issue #830: {owner/repo: base_branch} for every registry row that
+        # declares one (including opted-out rows — see
+        # ``_base_branches_from_projects``). The triage scan uses it to detect
+        # Issues already closed by a PR merged into a non-default base branch,
+        # which GitHub's auto-close never fires for.
+        "base_branches": base_branches,
         "signals": signals,
     }
     if not repos:
@@ -410,6 +489,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             "included": [],
             "opted_out": [],
             "skipped": [],
+            "base_branches": {},
             "signals": [],
             "error": f"failed to resolve repos: {e}",
         }

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -1937,11 +1937,17 @@ def fetch_base_branch_merges(
     ``base_merge_closed_refs``). The closing keyword in the PR's own
     title/body is the signal, so only ``title`` / ``body`` are needed.
 
-    Newest-first by ``mergedAt``, mirroring ``fetch_recent_merges``' exact
-    client-side ordering (the server's ``sort:updated-desc`` only
-    approximates merge recency), so the ``limit`` window is the genuinely
-    most-recent merges into the base branch.
+    Two-layer ordering, exactly as ``fetch_recent_merges`` does it, and for a
+    sharper reason here: the server applies its ``--limit`` page under
+    ``sort:updated-desc``, which is merge recency only *approximately* — an
+    old merged PR that later gets a comment has its ``updatedAt`` bumped and
+    can crowd a genuinely-recent merge off the page. Slicing the returned page
+    by ``mergedAt`` cannot recover a PR the server never sent, and the one it
+    would drop is precisely a just-merged closing PR — i.e. the bug this
+    function exists to prevent. So over-fetch a few × the window first, then
+    take the exact ``mergedAt`` top-K client-side.
     """
+    fetch_limit = max(limit, limit * _RECENT_MERGE_OVERFETCH)
     merges = _run_gh_json_list(
         [
             "pr",
@@ -1954,13 +1960,13 @@ def fetch_base_branch_merges(
             "--search",
             "sort:updated-desc",
             "--limit",
-            str(limit),
+            str(fetch_limit),
             "--json",
             "number,title,body,baseRefName,mergedAt",
         ]
     )
     merges.sort(key=lambda p: p.get("mergedAt") or "", reverse=True)
-    return merges
+    return merges[:limit]
 
 
 # ----------------------------------------------------------------------

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -38,6 +38,23 @@ single-repo result. The resolver's audit fields (``repos`` / ``included`` /
 ``repo_resolution`` (``null`` when the flag was not used) so the delivery layer
 gets them without a second resolver call — success and failure alike.
 
+Two-track (``base_branch``) completion, Issue #830: a project whose
+``registry/projects.md`` row declares a ``base_branch`` (Issue #808 — e.g.
+kura's ``develop``) merges feature PRs into that branch, and GitHub's
+``Closes #N`` auto-close **only fires for merges into the default branch**.
+Finished Issues therefore stay ``open`` until the next promotion, and the
+pre-#830 triage read them as untouched — worse, the recent merge that
+finished one lit up ``unblocked_by_recent_merge``, so completed work ranked
+*first* right after it was completed (the reported symptom: kura#231 ranked 1
+the same day PR #232 closed it into ``develop``). The scan now reads the
+merged PRs targeting each such base branch and drops the Issues their closing
+keywords name into ``excluded_merged``, citing the PR; those refs also stop
+counting as open blockers, so their dependents unblock. Repos with no
+``base_branch`` behave exactly as before. Measured constraint behind the
+design: ``closingIssuesReferences`` and ``gh pr list --search linked:N`` are
+both empty for non-default-branch PRs, so the PR's own closing keyword is the
+only usable evidence (see ``base_merge_closed_refs``).
+
 Invariants enforced here (design §7):
 
 * **INV-1 / INV-3 — read-only, side effects zero.** Only ``gh`` *read*
@@ -156,6 +173,12 @@ DEFAULT_RECENT_MERGES = 10
 # this many rows the result may be truncated, which is surfaced via the
 # output's `input_truncated` flags (never silent — design §5.1).
 DEFAULT_OPEN_LIMIT = 500
+# How many merged PRs targeting a project's `base_branch` are inspected for
+# closing keywords (Issue #830). Configurable via --base-merges; 0 disables
+# the base-branch completion check entirely. The window has to cover
+# "merged into develop but not yet promoted to main", i.e. one release
+# cadence, so it is much larger than DEFAULT_RECENT_MERGES.
+DEFAULT_BASE_MERGE_LIMIT = 100
 
 # --- dependency notation (design §4.1, calibrated §11-3) ---------------
 # Match a blocking *keyword* (anywhere — body or comment, inline or list-led,
@@ -1075,6 +1098,118 @@ def estimate_unblocked_by_recent_merge(
     )
 
 
+def base_merge_closed_refs(
+    repo: str | None, base_branch: str, base_merges: list[dict]
+) -> tuple[dict[QualRef, dict], list[str]]:
+    """Issues already *done* via a merge into a non-default base branch (#830).
+
+    On a two-track repo (``base_branch=develop`` in ``registry/projects.md``)
+    feature PRs are merged into ``develop``, and GitHub's ``Closes #N``
+    auto-close **only fires for merges into the repository's default branch**.
+    Such an Issue therefore stays ``open`` until the next develop→main
+    promotion, and a triage that reads only open/closed calls finished work
+    "untouched".
+
+    Measured on ``aainc/kura-data-aggregator-trial`` (2026-08-06, gh 2.74.0):
+    PR #232 (``base=develop``, merged, body contains ``Closes #231``) reports
+    ``closingIssuesReferences: []``, while #219/#222 (``base=main``) report
+    populated ones — GitHub does not even create the *link* off the default
+    branch. ``gh pr list --search "linked:231"`` likewise returns ``[]`` and
+    Issue #231's timeline carries only a weak ``cross-referenced`` event. So
+    the linked-issue API cannot answer this question; the closing keyword in
+    the merged PR's own title/body is the only reliable evidence, and it is
+    read here with the same extractors the recent-merge axis already uses
+    (``_pr_close_refs`` / ``_cross_keyword_refs``) — never ``Refs``/``Re``,
+    which are mentions, not completions.
+
+    Returns ``({closed_ref: {"pr": QualRef, "merged_at": str,
+    "base_branch": str}}, signals)``. When two merged PRs close the same
+    Issue the newest merge wins (``mergedAt`` then PR number), so the note a
+    human reads names the merge that actually finished it. A PR whose
+    ``baseRefName`` contradicts ``base_branch`` is not counted and says so in
+    a signal (the gh fetch filters server-side; an offline ``--from-file``
+    bundle might not). Pure function — no I/O.
+    """
+    out: dict[QualRef, dict] = {}
+    signals: list[str] = []
+    mismatched = 0
+    unnamed = 0
+    for pr in base_merges or []:
+        if not isinstance(pr, dict):
+            continue
+        base_ref = pr.get("baseRefName")
+        # Absent baseRefName = trusted (the gh fetch already filtered by
+        # --base); a *present* one that disagrees is a bundle/fetch bug and
+        # must not silently widen the exclusion.
+        if isinstance(base_ref, str) and base_ref.strip() != base_branch:
+            mismatched += 1
+            continue
+        number = pr.get("number")
+        if not _is_int(number):
+            # An exclusion has to name the merge that justifies it (§5.1
+            # 「除外は理由付きで」); a PR we cannot cite is dropped, loudly.
+            unnamed += 1
+            continue
+        merged_at = pr.get("mergedAt") or ""
+        text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+        pr_ref: QualRef = (repo, number)
+        closed: set[QualRef] = {(repo, n) for n in _pr_close_refs(text)}
+        # A develop PR that closes *another* repo's Issue keeps that repo.
+        closed |= _cross_keyword_refs(text, _PR_CLOSE_KEYWORD_RE)
+        for ref in closed:
+            prev = out.get(ref)
+            key = (merged_at, number)
+            if prev is None or key > prev["_key"]:
+                out[ref] = {
+                    "pr": pr_ref,
+                    "merged_at": merged_at,
+                    "base_branch": base_branch,
+                    "_key": key,
+                }
+    if mismatched:
+        signals.append(
+            f"{mismatched} merged PR(s) supplied for base branch "
+            f"'{base_branch}' target a different branch — not counted"
+        )
+    if unnamed:
+        signals.append(
+            f"{unnamed} merged PR(s) for base branch '{base_branch}' had no "
+            f"integer number — not counted (an exclusion must cite its PR)"
+        )
+    return out, signals
+
+
+def _base_merge_survives_issue(issue: dict, done: dict) -> bool:
+    """False when the merge cannot possibly have completed ``issue`` (#830).
+
+    Guard against a stale/mis-parsed link closing the wrong Issue: an Issue
+    *created after* the merge that supposedly closed it was not closed by it
+    (number reuse across a fork, a hand-written ``Closes`` typo). Both
+    timestamps are ISO-8601 UTC (``gh`` emits ``Z``), so a lexicographic
+    compare is chronological. When either timestamp is missing the guard
+    abstains (returns True) rather than inventing an ordering.
+
+    Deliberately NOT covered: an Issue reopened after a genuine closing merge
+    — the exclusion still fires, which is why it is reported with the closing
+    PR named rather than dropped silently, so a human can overrule it.
+    """
+    created = issue.get("createdAt")
+    merged_at = done.get("merged_at")
+    if not isinstance(created, str) or not created or not merged_at:
+        return True
+    return created <= merged_at
+
+
+def _merged_note(done: dict, collapse_repo=None) -> str:
+    """Visible exclusion reason for a base-branch-completed Issue (#830)."""
+    return (
+        f"{_ref_to_disp(done['pr'], collapse_repo)} が "
+        f"{done['base_branch']} にマージ済み"
+        f"（既定ブランチ外のマージなので GitHub の自動クローズが発火せず "
+        f"Issue が open のまま残っている）"
+    )
+
+
 def extract_summary(body: str | None, title: str) -> str:
     """One-line machine summary from the body (design §5.1 `summary`).
 
@@ -1114,6 +1249,7 @@ def build_candidate(
     scanned_repos: set,
     collapse_repo=None,
     effort_model: dict | None = None,
+    base_done_refs: dict[QualRef, dict] | None = None,
 ) -> dict | None:
     """Build one candidate dict, or ``None`` if the Issue is blocked.
 
@@ -1163,9 +1299,23 @@ def build_candidate(
         if repo is not None and repo not in scanned_repos
     ]
 
+    # Issue #830: a blocker that a base-branch merge already finished is not
+    # an open blocker, but it is still *open* on GitHub — so say why it was
+    # treated resolved instead of letting the dependency silently look clean.
+    base_signals = [
+        f"blocker {_ref_to_disp(ref, collapse_repo)} closed by "
+        f"{_ref_to_disp((base_done_refs or {})[ref]['pr'], collapse_repo)} "
+        f"merged into {(base_done_refs or {})[ref]['base_branch']} "
+        f"— treated resolved"
+        for ref in sorted(
+            (r for r in all_blocking if r in (base_done_refs or {})),
+            key=_ref_sort_key,
+        )
+    ]
+
     signals = (
         prio_signals + effort_signals + par_signals + merge_signals
-        + cross_signals
+        + cross_signals + base_signals
     )
 
     # Coerce `title` to a string here so the candidate JSON always satisfies
@@ -1313,7 +1463,19 @@ def scan_repos(
         {"repo": "owner/repo" | None,   # None = gh current-repo (single-repo)
          "issues": [...],               # open Issues for that repo
          "open_pr_numbers": [...]|set,  # open PR numbers for that repo
-         "recent_merges": [...]}        # recent merged PRs for that repo
+         "recent_merges": [...],        # recent merged PRs for that repo
+         "base_branch": "develop"|None, # registry base_branch (Issue #830)
+         "base_merges": [...]}          # merged PRs targeting base_branch
+
+    Base-branch completion (Issue #830): on a repo whose registry row declares
+    a ``base_branch``, an Issue closed by a PR merged into that branch stays
+    ``open`` on GitHub (auto-close only fires on the default branch), so it
+    would be triaged as untouched — and the ``unblocked_by_recent_merge`` axis
+    would push it *up* the ranking precisely because the merge that finished
+    it was recent. Such Issues are removed from the candidate pool into
+    ``excluded_merged`` with the closing PR named, and are dropped from the
+    open-blocker set so their dependents unblock (each dependent says so in
+    ``signals[]``). Repos with no ``base_branch`` are untouched.
 
     Every open Issue/PR, blocker and recent-merge link is keyed by a
     qualified ``(repo, number)`` ref — always the *real* repo name — so a ja
@@ -1339,6 +1501,15 @@ def scan_repos(
     recent_merge_pr_refs: set[QualRef] = set()
     recent_merge_closed_refs: set[QualRef] = set()
     recent_merge_referenced_refs: set[QualRef] = set()
+    # Issue #830: refs finished by a merge into a declared non-default base
+    # branch, plus the per-repo audit of which base branches were applied.
+    base_done_refs: dict[QualRef, dict] = {}
+    base_branch_scan: list[dict] = []
+    base_signals: list[str] = []
+
+    # First open Issue seen per ref, for the base-merge sanity guard below
+    # (the candidate loop's `seen` de-dup uses the same first-wins rule).
+    issue_by_ref: dict[QualRef, dict] = {}
 
     for bundle in repo_bundles:
         repo = bundle.get("repo")
@@ -1346,6 +1517,7 @@ def scan_repos(
         for issue in bundle.get("issues") or []:
             if _is_int(issue.get("number")):
                 open_refs_q.add((repo, issue["number"]))
+                issue_by_ref.setdefault((repo, issue["number"]), issue)
         for num in bundle.get("open_pr_numbers") or ():
             if _is_int(num):
                 open_refs_q.add((repo, num))
@@ -1366,9 +1538,53 @@ def scan_repos(
             recent_merge_referenced_refs.update(
                 _cross_keyword_refs(text, _PR_REF_KEYWORD_RE)
             )
+        raw_base = bundle.get("base_branch")
+        base_branch = raw_base.strip() if isinstance(raw_base, str) else ""
+        if not base_branch:
+            continue
+        done, sigs = base_merge_closed_refs(
+            repo, base_branch, bundle.get("base_merges") or []
+        )
+        base_signals.extend(sigs)
+        for ref, info in done.items():
+            prev = base_done_refs.get(ref)
+            if prev is None or info["_key"] > prev["_key"]:
+                base_done_refs[ref] = info
+        base_branch_scan.append(
+            {
+                "repo": None if _is_home_disp(repo, collapse_repo) else repo,
+                "base_branch": base_branch,
+                "merged_prs_scanned": len(bundle.get("base_merges") or []),
+                "closed_issue_count": len(done),
+            }
+        )
+
+    # Drop links the sanity guard rejects (an Issue created after the merge
+    # that allegedly closed it) *before* anything consumes the map, so the
+    # exclusion and the open-blocker removal below can never disagree about
+    # which Issues are done.
+    for ref in [
+        r
+        for r, info in base_done_refs.items()
+        if r in issue_by_ref
+        and not _base_merge_survives_issue(issue_by_ref[r], info)
+    ]:
+        info = base_done_refs.pop(ref)
+        base_signals.append(
+            f"{_ref_to_disp(ref, collapse_repo)} is newer than "
+            f"{_ref_to_disp(info['pr'], collapse_repo)} "
+            f"({info['merged_at']}) — closing link ignored"
+        )
+
+    # A ref a base-branch merge already finished is *done*, not an open
+    # blocker — leaving it in `open_refs_q` would keep its dependents excluded
+    # as blocked by work that is complete. Dependents disclose the swap in
+    # their own `signals[]` (see build_candidate).
+    open_refs_q -= set(base_done_refs)
 
     candidates: list[dict] = []
     excluded_blocked: list[dict] = []
+    excluded_merged: list[dict] = []
     # Identity is (repo, number); de-dup so a repo appearing twice (a duplicate
     # bundle in `--from-file`'s `repos[]`, or the same Issue listed twice) never
     # double-counts a candidate / excluded entry (which would corrupt
@@ -1384,6 +1600,29 @@ def scan_repos(
                 if key in seen:
                     continue
                 seen.add(key)
+                # Issue #830: already finished by a base-branch merge. Checked
+                # before the dependency classification because "done" outranks
+                # "blocked" — a completed Issue is not a candidate either way,
+                # and its exclusion reason must name the merge, not a blocker.
+                done = base_done_refs.get(key)
+                if done is not None:
+                    excluded_merged.append(
+                        {
+                            "repo": (
+                                None
+                                if _is_home_disp(repo, collapse_repo)
+                                else repo
+                            ),
+                            "issue": number,
+                            "base_branch": done["base_branch"],
+                            "closed_by_pr": _ref_to_json(
+                                done["pr"], collapse_repo
+                            ),
+                            "merged_at": done["merged_at"],
+                            "note": _merged_note(done, collapse_repo),
+                        }
+                    )
+                    continue
             status, open_blocking, _all = _classify_dependency_q(
                 issue, repo, open_refs_q
             )
@@ -1413,6 +1652,7 @@ def scan_repos(
                 scanned_repos=scanned_repos,
                 collapse_repo=collapse_repo,
                 effort_model=effort_model,
+                base_done_refs=base_done_refs,
             )
             if cand is not None:
                 candidates.append(cand)
@@ -1427,14 +1667,19 @@ def scan_repos(
 
     # Deterministic order on (repo, issue) — repo string disambiguates a
     # cross-repo issue-number collision; a None issue number sorts last.
-    excluded_blocked.sort(
-        key=lambda e: (
-            e.get("repo") or "",
-            (e["issue"] is None, e["issue"] if _is_int(e["issue"]) else 0),
+    def _excl_sort_key(entry: dict) -> tuple:
+        return (
+            entry.get("repo") or "",
+            (
+                entry["issue"] is None,
+                entry["issue"] if _is_int(entry["issue"]) else 0,
+            ),
         )
-    )
 
-    truncation = {"open_issues": False, "open_prs": False}
+    excluded_blocked.sort(key=_excl_sort_key)
+    excluded_merged.sort(key=_excl_sort_key)
+
+    truncation = {"open_issues": False, "open_prs": False, "base_merges": False}
     if input_truncated:
         truncation.update(
             {k: bool(v) for k, v in input_truncated.items() if k in truncation}
@@ -1458,6 +1703,17 @@ def scan_repos(
         "candidates": top,
         "recommendation": recommendation,
         "excluded_blocked": excluded_blocked,
+        # Issue #830. Always present (``[]`` when nothing was excluded this
+        # way, and on every repo without a configured `base_branch`) so the
+        # delivery layer reads one shape. Each entry names the merged PR and
+        # the base branch, so "why isn't this in the list any more" is
+        # answerable from the scan output alone.
+        "excluded_merged": excluded_merged,
+        # Which repos had a base_branch applied, how many merged PRs were
+        # inspected, and any anomaly found while reading them — so a scan that
+        # excluded nothing can be told apart from one that never looked.
+        "base_branch_scan": base_branch_scan,
+        "base_branch_signals": base_signals,
     }
 
 
@@ -1468,6 +1724,8 @@ def scan(
     config: ScanConfig,
     input_truncated: dict | None = None,
     effort_model: dict | None = None,
+    base_branch: str | None = None,
+    base_merges: list[dict] | None = None,
 ) -> dict:
     """Single-repo triage core (design §5.1).
 
@@ -1478,7 +1736,10 @@ def scan(
     numbers to resolve blocking refs); ``recent_merges`` — recent merged PRs
     for the unblocked-by-recent-merge heuristic; ``input_truncated`` — optional
     ``{"open_issues": bool, "open_prs": bool}``; ``effort_model`` — optional
-    learned effort model (Issue #529). Candidates carry ``repo: null``.
+    learned effort model (Issue #529); ``base_branch`` / ``base_merges`` —
+    optional two-track completion inputs (Issue #830; omitted = the repo has
+    no configured base branch and nothing is excluded that way).
+    Candidates carry ``repo: null``.
     Cross-repo blockers (if any) resolve against the empty cross set, i.e.
     treated resolved — matching the prior single-repo behaviour. No I/O.
     """
@@ -1489,6 +1750,8 @@ def scan(
                 "issues": issues,
                 "open_pr_numbers": open_pr_numbers,
                 "recent_merges": recent_merges,
+                "base_branch": base_branch,
+                "base_merges": base_merges or [],
             }
         ],
         config,
@@ -1655,6 +1918,49 @@ def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
     # (treated as oldest). The slice takes the genuine 直近 K 件.
     merges.sort(key=lambda p: p.get("mergedAt") or "", reverse=True)
     return merges[:limit]
+
+
+def fetch_base_branch_merges(
+    repo: str | None, base_branch: str, limit: int
+) -> list[dict]:
+    """Merged PRs that targeted ``base_branch`` (Issue #830). Read-only.
+
+    Server-side filtered with ``--base`` (verified against
+    ``aainc/kura-data-aggregator-trial`` on 2026-08-06, gh 2.74.0: the flag
+    returns exactly the ``baseRefName == develop`` merges). ``baseRefName`` is
+    still requested and re-checked in ``base_merge_closed_refs`` so the pure
+    core does not have to trust the fetch.
+
+    ``closingIssuesReferences`` is deliberately NOT requested: GitHub only
+    creates that link for PRs targeting the *default* branch, so on exactly
+    the repos this feature exists for it comes back empty (measured; see
+    ``base_merge_closed_refs``). The closing keyword in the PR's own
+    title/body is the signal, so only ``title`` / ``body`` are needed.
+
+    Newest-first by ``mergedAt``, mirroring ``fetch_recent_merges``' exact
+    client-side ordering (the server's ``sort:updated-desc`` only
+    approximates merge recency), so the ``limit`` window is the genuinely
+    most-recent merges into the base branch.
+    """
+    merges = _run_gh_json_list(
+        [
+            "pr",
+            "list",
+            *_repo_args(repo),
+            "--state",
+            "merged",
+            "--base",
+            base_branch,
+            "--search",
+            "sort:updated-desc",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,body,baseRefName,mergedAt",
+        ]
+    )
+    merges.sort(key=lambda p: p.get("mergedAt") or "", reverse=True)
+    return merges
 
 
 # ----------------------------------------------------------------------
@@ -1949,8 +2255,16 @@ def _validate_repo_bundle(src: dict, prefix: str) -> dict:
             f"{type(repo).__name__}"
         )
 
+    base_branch = src.get("base_branch")
+    if base_branch is not None and not isinstance(base_branch, str):
+        raise GhError(
+            f"--from-file `{prefix}base_branch` must be a string or null, got "
+            f"{type(base_branch).__name__}"
+        )
+
     issues = _list_field("issues")
     recent_merges = _list_field("recent_merges")
+    base_merges = _list_field("base_merges")
     pr_raw = _list_field("open_pr_numbers")
     for i, item in enumerate(issues):
         if not isinstance(item, dict):
@@ -1966,12 +2280,16 @@ def _validate_repo_bundle(src: dict, prefix: str) -> dict:
             raise GhError(
                 f"--from-file {prefix}issues[{i}] must have an integer `number`"
             )
-    for i, item in enumerate(recent_merges):
-        if not isinstance(item, dict):
-            raise GhError(
-                f"--from-file {prefix}recent_merges[{i}] must be an object, got "
-                f"{type(item).__name__}"
-            )
+    for name, rows in (
+        ("recent_merges", recent_merges),
+        ("base_merges", base_merges),
+    ):
+        for i, item in enumerate(rows):
+            if not isinstance(item, dict):
+                raise GhError(
+                    f"--from-file {prefix}{name}[{i}] must be an object, got "
+                    f"{type(item).__name__}"
+                )
     open_pr_numbers: set[int] = set()
     for i, n in enumerate(pr_raw):
         if not isinstance(n, int) or isinstance(n, bool):
@@ -1985,6 +2303,8 @@ def _validate_repo_bundle(src: dict, prefix: str) -> dict:
         "issues": issues,
         "open_pr_numbers": open_pr_numbers,
         "recent_merges": recent_merges,
+        "base_branch": base_branch,
+        "base_merges": base_merges,
     }
 
 
@@ -2089,11 +2409,18 @@ def _error_payload(
         "generated_for": trigger,
         "candidate_count": 0,
         "truncated_count": 0,
-        "input_truncated": {"open_issues": False, "open_prs": False},
+        "input_truncated": {
+            "open_issues": False,
+            "open_prs": False,
+            "base_merges": False,
+        },
         "effort_model": None,
         "candidates": [],
         "recommendation": None,
         "excluded_blocked": [],
+        "excluded_merged": [],
+        "base_branch_scan": [],
+        "base_branch_signals": [],
         "repo_resolution": repo_resolution,
         "error": message,
     }
@@ -2151,6 +2478,74 @@ def _resolve_registry_repos(claude_org_root=None) -> dict:
             "signals": [],
             "error": f"failed to resolve repos: {type(exc).__name__}: {exc}",
         }
+
+
+def _resolve_base_branches(
+    claude_org_root=None, repo_resolution: dict | None = None
+) -> tuple[dict[str, str], list[str]]:
+    """``{owner/repo: base_branch}`` for the two-track completion check (#830).
+
+    ``registry/projects.md`` is the single source of truth for a project's
+    base branch (Issue #808), so the map is read from there for **both** repo-
+    set modes: ``--all-registry-repos`` reuses the ``base_branches`` the
+    resolver already produced (no second read), and an explicit ``--repo`` run
+    reads the registry directly — otherwise naming the same repo by hand would
+    silently reintroduce the bug this check exists to fix.
+
+    Keys are lowercased (the resolver lowercases derived slugs) so a
+    differently-cased ``--repo aainc/Kura`` still matches.
+
+    Never raises and never fatal: a repo whose base branch cannot be resolved
+    simply keeps the pre-#830 behaviour. The reason is returned as a signal
+    and echoed in ``base_branch_signals`` rather than swallowed — a scan that
+    silently stopped consulting the registry would look exactly like a scan
+    that found nothing to exclude.
+    """
+    if repo_resolution is not None:
+        mapping = repo_resolution.get("base_branches")
+        if isinstance(mapping, dict):
+            return (
+                {
+                    str(k).lower(): v
+                    for k, v in mapping.items()
+                    if isinstance(v, str) and v
+                },
+                [],
+            )
+        return {}, [
+            "registry resolver returned no base_branches map — base-branch "
+            "completion check skipped"
+        ]
+    root = Path(__file__).resolve().parent.parent
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    org_root = Path(claude_org_root).resolve() if claude_org_root else root
+    registry = org_root / "registry" / "projects.md"
+    if not registry.exists():
+        # Not fatal (an explicit `--repo` run needs no registry to triage),
+        # but not silent either: "no base branch configured anywhere" and "the
+        # file that declares them was not found" look identical in the output
+        # otherwise, and the second one is how this check quietly dies.
+        return {}, [
+            f"registry not found at {registry} — base-branch completion "
+            f"check skipped (no base_branch column to read)"
+        ]
+    try:
+        from tools.work_discovery_repos import resolve_base_branches
+
+        return (
+            {
+                k.lower(): v
+                for k, v in resolve_base_branches(registry).items()
+            },
+            [],
+        )
+    except Exception as exc:  # noqa: BLE001 — degrade, but say so
+        return {}, [
+            f"could not read base_branch column from {registry}: "
+            f"{type(exc).__name__}: {exc} — base-branch completion check "
+            f"skipped"
+        ]
 
 
 class _JsonErrorParser(argparse.ArgumentParser):
@@ -2237,8 +2632,9 @@ def main(argv=None) -> int:
     parser.add_argument(
         "--claude-org-root",
         default=None,
-        help="Repo root the registry is read from with --all-registry-repos "
-        "(default: this tool's own repo root). Ignored otherwise.",
+        help="Repo root the registry is read from, both for "
+        "--all-registry-repos and for the base_branch column used by the "
+        "two-track completion check (default: this tool's own repo root).",
     )
     parser.add_argument(
         "--top-n",
@@ -2276,6 +2672,17 @@ def main(argv=None) -> int:
         help=f"How many recent merged PRs to learn realized effort from "
         f"(design §10); 0 disables effort learning (static heuristic only). "
         f"Default {DEFAULT_EFFORT_HISTORY}.",
+    )
+    parser.add_argument(
+        "--base-merges",
+        type=int,
+        default=DEFAULT_BASE_MERGE_LIMIT,
+        help=f"How many merged PRs targeting a project's registry "
+        f"base_branch are inspected for closing keywords, so Issues already "
+        f"finished on a non-default branch are excluded instead of ranked "
+        f"first (Issue #830); 0 disables the check. Only repos whose "
+        f"registry/projects.md row sets base_branch are affected. "
+        f"Default {DEFAULT_BASE_MERGE_LIMIT}.",
     )
     parser.add_argument(
         "--from-file",
@@ -2317,6 +2724,10 @@ def main(argv=None) -> int:
         # learning, negative is nonsense.
         if args.effort_history < 0:
             raise ValueError("--effort-history must be >= 0")
+        # `--base-merges` feeds `gh pr list --limit`; 0 disables the check,
+        # negative is nonsense.
+        if args.base_merges < 0:
+            raise ValueError("--base-merges must be >= 0")
         # `--all-registry-repos` *is* the repo-set source; combining it with an
         # explicit set (or with an offline bundle that carries its own repos)
         # is ambiguous, and silently letting one win would hide half of what
@@ -2332,9 +2743,14 @@ def main(argv=None) -> int:
                 "--all-registry-repos cannot be combined with --from-file "
                 "(the bundle already carries its own repos)"
             )
-        input_truncated = {"open_issues": False, "open_prs": False}
+        input_truncated = {
+            "open_issues": False,
+            "open_prs": False,
+            "base_merges": False,
+        }
         effort_model: dict | None = None
         collapse_repo = None
+        base_branch_signals: list[str] = []
         if args.from_file:
             bundles, effort_model = _load_bundle(args.from_file)
         else:
@@ -2379,17 +2795,42 @@ def main(argv=None) -> int:
             # keeps real repo strings in the output.
             if len(repos) == 1:
                 collapse_repo = repos[0]
+            # Issue #830: registry base_branch per repo. Resolved once, from
+            # the resolver's own map when the registry drove the repo set.
+            base_branches: dict[str, str] = {}
+            if args.base_merges > 0:
+                base_branches, base_branch_signals = _resolve_base_branches(
+                    args.claude_org_root, repo_resolution
+                )
             bundles = []
             for repo in repos:
                 issues = fetch_open_issues(repo)
                 open_pr_numbers = fetch_open_pr_numbers(repo)
                 recent_merges = fetch_recent_merges(repo, args.recent_merges)
+                # `repo is None` = the implicit gh-current-repo scan: there is
+                # no slug to look up, so no base branch applies (name the repo
+                # with --repo / --all-registry-repos to get the check).
+                base_branch = (
+                    base_branches.get(repo.lower()) if repo else None
+                )
+                base_merges: list[dict] = []
+                if base_branch:
+                    base_merges = fetch_base_branch_merges(
+                        repo, base_branch, args.base_merges
+                    )
+                    # Full page = the window may have cut off older merges, so
+                    # an Issue finished before it could be mis-triaged as
+                    # untouched. Never silent (design §5.1).
+                    if len(base_merges) >= args.base_merges:
+                        input_truncated["base_merges"] = True
                 bundles.append(
                     {
                         "repo": repo,
                         "issues": issues,
                         "open_pr_numbers": open_pr_numbers,
                         "recent_merges": recent_merges,
+                        "base_branch": base_branch,
+                        "base_merges": base_merges,
                     }
                 )
                 # A full page (== cap) means a fetch may have dropped rows; the
@@ -2428,6 +2869,12 @@ def main(argv=None) -> int:
         # scan actually look at, and which did it deliberately skip" is
         # answerable from the scan output alone — no second resolver call.
         result["repo_resolution"] = repo_resolution
+        # Resolution-side notes (registry unreadable, no base_branches map)
+        # join the core's own reading anomalies; both must reach the human.
+        if base_branch_signals:
+            result["base_branch_signals"] = (
+                base_branch_signals + result["base_branch_signals"]
+            )
     except Exception as exc:  # noqa: BLE001 — report any failure as error/exit 2
         # Keep the fixed schema (design §5.1) so the delivery layer parses
         # the error branch the same way; the audit fields are present (empty)

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -1504,6 +1504,7 @@ def scan_repos(
     # Issue #830: refs finished by a merge into a declared non-default base
     # branch, plus the per-repo audit of which base branches were applied.
     base_done_refs: dict[QualRef, dict] = {}
+    raw_base_done: list[dict] = []
     base_branch_scan: list[dict] = []
     base_signals: list[str] = []
 
@@ -1546,10 +1547,7 @@ def scan_repos(
             repo, base_branch, bundle.get("base_merges") or []
         )
         base_signals.extend(sigs)
-        for ref, info in done.items():
-            prev = base_done_refs.get(ref)
-            if prev is None or info["_key"] > prev["_key"]:
-                base_done_refs[ref] = info
+        raw_base_done.append(done)
         base_branch_scan.append(
             {
                 "repo": None if _is_home_disp(repo, collapse_repo) else repo,
@@ -1558,6 +1556,23 @@ def scan_repos(
                 "closed_issue_count": len(done),
             }
         )
+
+    # A cross-repo closing keyword carries whatever casing the PR author
+    # typed (`Closes Owner/CamelRepo#77`), while the registry-driven scan set
+    # is lowercased — so the join would miss on case alone and leave finished
+    # work in the candidate list. Fold each closing ref's repo onto the
+    # scanned repo it case-insensitively names (GitHub slugs are
+    # case-insensitive); a ref naming an un-scanned repo keeps its own casing
+    # and simply matches nothing, as before.
+    canonical_repo = {r.lower(): r for r in scanned_repos if isinstance(r, str)}
+    for done in raw_base_done:
+        for (ref_repo, num), info in done.items():
+            if isinstance(ref_repo, str):
+                ref_repo = canonical_repo.get(ref_repo.lower(), ref_repo)
+            ref = (ref_repo, num)
+            prev = base_done_refs.get(ref)
+            if prev is None or info["_key"] > prev["_key"]:
+                base_done_refs[ref] = info
 
     # Drop links the sanity guard rejects (an Issue created after the merge
     # that allegedly closed it) *before* anything consumes the map, so the
@@ -2759,6 +2774,16 @@ def main(argv=None) -> int:
         base_branch_signals: list[str] = []
         if args.from_file:
             bundles, effort_model = _load_bundle(args.from_file)
+            # `--base-merges 0` is documented as "disables the check", so it
+            # has to mean the same thing offline: a bundle that carries its
+            # own base_branch / base_merges must not keep excluding Issues
+            # after the caller switched the check off (the gh path simply
+            # skips the fetch). Cleared here rather than inside scan_repos so
+            # the pure core stays a function of the bundles it is handed.
+            if args.base_merges == 0:
+                for bundle in bundles:
+                    bundle["base_branch"] = None
+                    bundle["base_merges"] = []
         else:
             if args.all_registry_repos:
                 # Registry-driven set (Issue #829): resolved in-process, so no


### PR DESCRIPTION
## 概要

Closes #830。

work-discovery の triage が、**すでに完了した Issue を「次にやるべき仕事」の第 1 位として提示する**問題を根治する。

> **注**: この PR の CI は #840 (PR #841) がマージされるまで、既存の golden drift 14 件で赤になります。本 PR の変更とは無関係です。

## 症状と原因

kura のように `registry/projects.md` で `base_branch=develop` を宣言している二系統運用のリポジトリでは、feature PR が develop 宛にマージされる。GitHub の `Closes #N` 自動クローズは**既定ブランチ (main) へのマージでしか発火しない**ため、develop にマージ済みの Issue は次の昇格リリースまで open のまま残る。

triage は Issue の open/closed しか見ていないのでこれを「未着手」と読み、さらに `unblocked_by_recent_merge` シグナルが**逆に効いて**「直近マージで unblock された follow-up」と判定するため、**完了直後ほどランクが上がる**。post-merge の next-dispatch は「マージ直後」に走るので、最も踏みやすいタイミングで最も高いランクに出る。

## 判定手段は実測で決め直した (Issue 本文の案は使えなかった)

Issue は `closingIssuesReferences` / `gh pr list --search "linked:N"` での判定を提案していたが、**実測 (2026-08-06 / gh 2.74.0 / aainc/kura-data-aggregator-trial) でどちらも空**だった。GitHub は既定ブランチ外の PR に対して **closing link 自体を作らない** (PR #232 base=develop → `[]` / PR #219・#222 base=main → populated)。timeline も `cross-referenced` 1 件のみ。

**唯一の確かな証拠はマージ済み PR 自身の body の `Closes #231`** だったので、そこを読む実装にした。判定の中核 `base_merge_closed_refs` の docstring に実測結果を記録してある。

## 変更内容

1. **`base_branch` 宣言済み repo だけ、その base ブランチ宛のマージ済み PR を読んで完了 Issue を除外**。既存の直近マージ軸と同じ抽出器 (キーワードゲート + 否定ガード) を再利用しているので、`Refs #N` (単なる言及) や `does not close #N` は完了と読まない。`base_branch` 未設定の repo は fetch すら行わず**挙動不変**。
2. **除外は silent にせず `excluded_merged` に「閉じた PR 名 + base ブランチ名」付きで出す**。さらに `base_branch_scan` (どの repo にどのブランチを適用し何件読んだか) と `base_branch_signals` (registry 不在・異常) を出し、**「除外ゼロ」と「そもそも見ていない」を人間が区別できる**ようにした。
3. **完了した ref は open blocker 集合からも外す**。GitHub 上はまだ open なので、放置すると依存側が「完了済みの作業にブロックされている」扱いで誤除外され続ける。依存側候補の `signals[]` に理由を明示する。
4. **`--repo` 明示でも registry の `base_branch` を読む**。`--all-registry-repos` だけ直すと、同じ repo を手打ちしただけでバグが復活するため。registry が読めない場合は非 fatal に縮退し理由を signal に残す。

## 実機での再現と修正の確認 (live scan)

- 修正前相当 (`--base-merges 0`): `rank 1: kura#231`、signals `['leaf in dependency graph', 'referenced by a recently-merged PR']` ← 報告された症状そのまま
- 修正後 (`--all-registry-repos` = 実運用の起動経路): 候補は kura#35 / #34 / #36、`excluded_merged` に `(kura, 231, kura#232, develop)`、`base_branch_scan` に `merged_prs_scanned: 11 / closed_issue_count: 7`

## 設計判断

- **PR 本文のキーワード解析を採用** (linked API は却下)。上記の実測どおり API 側に情報が無いため。既存抽出器の再利用で精度規律 (過剰一致回避) も引き継ぐ。
- **fetch 窓は既定 100** (直近マージ軸の 10 より大きい)。「develop にマージ済みだが main へ未昇格」= 1 リリースサイクルを覆う必要があるため。上限到達は `input_truncated.base_merges` で開示する。
- **サニティガードは「マージより後に作成された Issue は除外しない」だけに留めた**。再オープンされた Issue までは救えないが、そこを推測で救うと誤除外が増える。だからこそ PR 名付きで提示し**人間が覆せる形**にしてある (非カバレッジとして設計書に明記)。
- **base ブランチの正規化は `gen_delegate_payload.normalize_base_branch` を lazy import で共用**。#808 と「develop の意味」がずれないようにするため (重い委譲プランナを triage 経路に常時ロードしないよう遅延)。
- `.claude/skills/work-discovery/SKILL.md` の Step 3 で「除外 (依存未解決)」と「除外 (マージ済み)」を**別行**にした。人間の次の一手が真逆になるため。

## 検証

- 対象テスト 290 passed (新規 34 件。**kura #231 の状況を fixture でオフライン再現する回帰テスト**を含む。GitHub API は叩かない)
- CI 相当フルラン: `unittest discover -s tests` 971 / `-s tools` 735 OK
- markdown link audit: 新規指摘ゼロ (baseline と diff)
- `--help` 実端末スモーク OK (新フラグ `--base-merges` の help は ASCII のみ)
- Codex 3 round: round 1 で mergedAt によるマージ窓の取得、round 2 で `--base-merges 0` の offline 経路と cross-repo closing ref の大小文字非依存突合を修正、round 3 クリーン
