### PR TITLE
fix(claude): check_runtime_version が測定 interpreter を stderr に開示するようにする

### DIFF
--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -232,9 +232,11 @@ Block A の spawn 発火と並列。`claude-org-runtime` の installed バージ
    ```
 2. **exit code で分岐**する（stdout は drift 行専用、診断は stderr に出る）:
    - **exit 0**（up to date）: installed == pin 窓内 latest。PyPI 到達確認済・drift 無し。**warning 行なし**。
-   - **exit 1**（drift）: stdout の `[runtime drift] ...` 1 行を **そのまま Step 4 起動完了報告の末尾に warning として転記する**。
+   - **exit 1**（drift）: stdout の `[runtime drift] ...` 1 行を **そのまま Step 4 起動完了報告の末尾に warning として転記する**。あわせて stderr の `測定 interpreter:` 行が示す Python パスを転記行に添える（下記「interpreter の併記」を参照）。
    - **exit 2**（未確認）: PyPI 到達不能 / 応答異常 / pin 窓外 / `packaging` 欠如、**または installed が local install（`file://` パス / VCS / editable。PEP 610 `direct_url.json` で判定）で PyPI 照合不能** の場合。stderr に理由診断が出る。**drift は未検証**なので Step 4 報告に「runtime drift: PyPI 未確認（要ホスト再実行）」を明示する（silent にしない）。**local install 起因の場合はホスト再実行では解消しない**（installed の実体がリリース版と限らないため）ので、stderr の診断が `local install -- PyPI 照合不能` を示すときは「runtime: local install のため PyPI 照合不能（要 PyPI 由来インストールで再確認）」と読み替えて報告する。それ以外（オフライン / sandbox 内）は `dangerouslyDisableSandbox: true` で再実行する。
    - **exit 3**（未インストール）: この Python から runtime を import できない（別 venv / 未インストール）。stderr に note。Step 4 報告に「runtime 未インストール（要確認）」を出す。
+
+> **interpreter の併記（バージョン報告は測った Python に相対）**: 本 Block が報告する installed は「このコマンドを実行した Python が解決したバージョン」であって、ホストの状態ではない。ホストには runtime が複数入りうる（プロジェクトの `.venv` とシステム `python3` が別バージョンで同居し、CLI shim `claude-org-runtime` の shebang はそのどちらか片方に束ねられる）。そのため drift 行を interpreter 抜きで転記すると「更新が遅れている」と読めてしまうが、実際には「もう片方を測った」だけということが起こる。script は **毎回・全 outcome で** stderr の 1 行目に `[runtime drift-check] 測定 interpreter: <sys.executable> (installed=<version>)` を出すので、**Step 4 報告で installed / 未インストールに言及するときは必ずこの Python パスを併記する**（例:「system python3 で測って installed=X」）。上の実行例が `python3` / `py -3` である以上、測っているのは既定でシステム側であって ja の `.venv` ではない点に注意する。
 
 > 設計メモ:
 > - latest 取得は PyPI JSON API (`https://pypi.org/pypi/claude-org-runtime/json`) を urllib.request で叩く (timeout 8s)。`pip index versions` は experimental で stderr に warning を吐くため採用しない
@@ -242,7 +244,8 @@ Block A の spawn 発火と並列。`claude-org-runtime` の installed バージ
 > - **local install 検出 (Issue #747)**: installed が `file://` パス / VCS チェックアウト / editable から入っている場合、その version はリリース版と対応する保証がない（ローカルビルドは任意の version を名乗れる）。PEP 610 `direct_url.json`（`importlib.metadata.Distribution.read_text` で読む。dist-info の直接 glob ではない）で判定し、該当時は PyPI 到達前に **exit 2 + stderr 診断（`local install -- PyPI 照合不能`）** に落とす。`file://` install を「最新・drift なし」と誤報告した事故の根治。https アーカイブ等の非ローカル direct URL は通常の PyPI 照合に委ねる
 > - yanked release / prerelease は候補から除外する（pip が通常選ばないバージョンを latest にしないため）
 > - 「drift = 古い」も「drift = preview 入り (installed > latest の release channel ずれ)」も同じく **exit 1** の 1 行で通知する。auto-upgrade はせず、対応はユーザー判断に委ねる
-> - **stdout は drift 行のみ**（Step 4 へ verbatim 転記できる）。offline / 未確認 / 未インストールの診断はすべて **stderr** に出す（spliceable な stdout を汚さない）
+> - **stdout は drift 行のみ**（Step 4 へ verbatim 転記できる）。offline / 未確認 / 未インストールの診断、および `測定 interpreter` の provenance 行はすべて **stderr** に出す（spliceable な stdout を汚さない）
+> - **interpreter provenance**: `測定 interpreter` 行は outcome に依らず毎回 stderr の先頭に出る（exit 0 も含む）。up to date も drift と同じく「測った Python に相対な判定」なので、片方だけ silent にすると同じ取り違えが exit 0 側で起きるため。判定そのものには影響しない開示専用の 1 行で、exit code 契約は不変
 > - 警告コマンドには `pyproject.toml` から読み取った pin 制約をそのまま埋め込むので、ユーザーが貼り付けても窓外への upgrade にはならない
 > - スクリプト本体: [`tools/check_runtime_version.py`](../../../tools/check_runtime_version.py)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@
 
 ### Fixed
 
+- runtime drift 報告が「どの interpreter で測ったか」を伏せていたため、片側だけの測定が
+  「更新が遅れている」と誤読された問題を根治 (#863)。`tools/check_runtime_version.py` は
+  **毎回・全 outcome で** stderr の 1 行目に
+  `[runtime drift-check] 測定 interpreter: <sys.executable> (installed=<version>)` を出すようになった。
+  この script が報告する installed は常に「実行した Python が解決したバージョン」であって
+  ホストの状態ではなく、ホストにはプロジェクトの `.venv` とシステム `python3` が別バージョンで
+  同居しうる (CLI shim の shebang はそのどちらか片方に束ねられる)。exit 0 (up to date) でも
+  出すのは、「最新」判定も drift 判定と同じく測った Python に相対で、片方だけ silent にすると
+  同じ取り違えが exit 0 側で起きるため。**開示専用の変更**であり、stdout は drift 行専用のまま
+  (spliceable)、exit code 契約 (0/1/2/3) も不変。`/org-start` Block C2 には、installed / 未インストールに
+  言及する際に interpreter を併記する手順を追記した。
+
 - worker クローズ時の triage scan が zsh で常に失敗し、候補提示が黙ってスキップされていた問題を根治 (#829)。
   旧手順は `REPO_FLAGS=$(tools/work_discovery_repos.py --format flags)` の結果を未クォートで
   `tools/work_discovery_scan.py` へ渡していたが、フラグ列が複数引数になるかは呼び出し元シェルの単語分割次第で、

--- a/tools/check_runtime_version.py
+++ b/tools/check_runtime_version.py
@@ -21,6 +21,16 @@ Outcome contract:
 * Every "couldn't verify" and "not installed" outcome prints a human
   diagnostic to **stderr** (never stdout) so the reason is visible
   without polluting the spliceable stdout line.
+* Every run -- every outcome, including the silent-stdout OK one --
+  first prints an **interpreter provenance** line to stderr naming
+  ``sys.executable`` and the version that particular interpreter
+  resolves. Every version this script reports is relative to the Python
+  it runs under, and a host can carry more than one install of the
+  package: a project ``.venv`` and the system ``python3`` can sit on
+  different versions, with the CLI shim's shebang binding the entry
+  point to one of them. Without the provenance line a drift report
+  reads as "the install is behind" when it actually means "the other
+  interpreter was measured" -- the misread this line exists to prevent.
 * The process exit code distinguishes the outcomes:
 
     0  EXIT_OK             installed is the pin-window latest (or a
@@ -130,6 +140,38 @@ def _installed_version() -> str | None:
         return None
     except Exception:
         return None
+
+
+def _interpreter_label() -> str:
+    """Return the path of the running interpreter for the provenance
+    line. ``sys.executable`` is an empty string (or absent) when Python
+    cannot determine its own binary -- an embedded interpreter, say --
+    so fall back to a label rather than printing a blank path."""
+    executable = getattr(sys, "executable", None)
+    if not isinstance(executable, str) or not executable:
+        return "(不明)"
+    return executable
+
+
+def _emit_interpreter_diagnostic(installed: str | None) -> None:
+    """Print the interpreter provenance line to stderr (never stdout,
+    which stays reserved for the drift line).
+
+    Every version this script reports is whatever *this* Python
+    resolves, so the measurement is only interpretable together with the
+    interpreter that produced it. Emitted on every outcome, including
+    the OK one: "up to date" is just as interpreter-relative as a drift
+    verdict, and a reader who cannot see which Python was measured can
+    misread either verdict as a statement about the host."""
+    if installed is None:
+        seen = "なし -- この Python から import 不可"
+    else:
+        seen = installed or "(不明)"
+    print(
+        f"[runtime drift-check] 測定 interpreter: {_interpreter_label()} "
+        f"(installed={seen})",
+        file=sys.stderr,
+    )
 
 
 def _direct_url_local_reason() -> str | None:
@@ -353,6 +395,10 @@ def _emit_diagnostic(reason: str | None, pin: str | None) -> None:
 
 def main() -> int:
     installed = _installed_version()
+    # Provenance first, before any outcome branch: whichever verdict
+    # follows on stdout/stderr, the reader sees which interpreter (and
+    # which install) produced it.
+    _emit_interpreter_diagnostic(installed)
     if installed is None:
         print(
             f"[runtime drift-check] {PACKAGE} をこの Python から import できません"

--- a/tools/test_check_runtime_version.py
+++ b/tools/test_check_runtime_version.py
@@ -6,6 +6,10 @@ The script is invoked by /org-start Block C2. Its outcome contract:
 * stdout carries the single ``[runtime drift]`` line ONLY on drift
   (exit 1); every other non-OK outcome puts its diagnostic on stderr,
   keeping stdout empty and spliceable.
+* every run prints an interpreter provenance line to stderr (which
+  Python measured, and the version that Python resolves) so a verdict
+  is never read as a statement about the host when the host carries
+  more than one install.
 * exit codes distinguish the outcomes so a sandboxed/offline run is no
   longer read as "up to date": 0 up-to-date, 1 drift, 2 could-not-
   verify (offline / PyPI error / JSON parse / no in-window release /
@@ -70,6 +74,26 @@ def _payload(*versions: str, yanked: tuple[str, ...] = ()) -> dict:
     }
 
 
+def _sole_stderr_line(test: unittest.TestCase, err: str) -> str:
+    """Return the single non-empty stderr line, asserting there is
+    exactly one. The provenance line rides on every run, so "no failure
+    diagnostic" now means "exactly one stderr line", not "stderr is
+    empty"."""
+    lines = [ln for ln in err.splitlines() if ln.strip()]
+    test.assertEqual(len(lines), 1, f"unexpected stderr: {err!r}")
+    return lines[0]
+
+
+def _assert_is_provenance_line(
+    test: unittest.TestCase, line: str, installed: str
+) -> None:
+    """Assert ``line`` is the interpreter provenance diagnostic naming
+    this Python and the version it resolves."""
+    test.assertIn("測定 interpreter", line)
+    test.assertIn(check_runtime_version._interpreter_label(), line)
+    test.assertIn(f"installed={installed}", line)
+
+
 class MainCliTest(unittest.TestCase):
     def setUp(self):
         # Neutralise the PEP 610 local-install short-circuit for the
@@ -105,10 +129,11 @@ class MainCliTest(unittest.TestCase):
         self.assertIn("[runtime drift]", lines[0])
         self.assertIn("installed=0.1.2", lines[0])
         self.assertIn("latest=0.1.11", lines[0])
-        # drift is a clean result: nothing on stderr.
-        self.assertEqual(err, "")
+        # drift is a clean result: the only stderr line is the
+        # interpreter provenance one, no failure diagnostic.
+        _assert_is_provenance_line(self, _sole_stderr_line(self, err), "0.1.2")
 
-    def test_match_is_ok_and_silent(self):
+    def test_match_is_ok_and_stdout_silent(self):
         with mock.patch.object(
             check_runtime_version, "_installed_version", return_value="0.1.11"
         ), mock.patch.object(
@@ -119,7 +144,9 @@ class MainCliTest(unittest.TestCase):
             code, out, err = self._run_main()
         self.assertEqual(code, check_runtime_version.EXIT_OK)
         self.assertEqual(out, "")
-        self.assertEqual(err, "")
+        # Up-to-date is silent on stdout (no warning to splice) but still
+        # discloses which interpreter reached that verdict.
+        _assert_is_provenance_line(self, _sole_stderr_line(self, err), "0.1.11")
 
     def test_package_not_installed_reports_on_stderr(self):
         with mock.patch.object(
@@ -333,7 +360,9 @@ class UpgradeCommandShapeTest(unittest.TestCase):
             check_runtime_version,
             "_latest_version_with_reason",
             return_value=("0.1.11", None),
-        ), mock.patch.object(sys, "stdout", buf):
+        ), mock.patch.object(sys, "stdout", buf), mock.patch.object(
+            sys, "stderr", io.StringIO()
+        ):
             check_runtime_version.main()
         return buf.getvalue()
 
@@ -481,6 +510,140 @@ class MainLocalInstallTest(unittest.TestCase):
         self.assertIn("照合不能", err)
         # The verdict doesn't depend on the network: PyPI is never hit.
         latest_mock.assert_not_called()
+
+
+class InterpreterProvenanceTest(unittest.TestCase):
+    """Every version this script reports is whatever the interpreter it
+    runs under resolves, and a host can carry more than one install of
+    the package (a project ``.venv`` and the system ``python3`` on
+    different versions, with the CLI shim's shebang binding the entry
+    point to one of them). Reporting a version without naming the
+    interpreter lets a drift verdict be read as "the install is behind"
+    when it really means "the other interpreter was measured", so
+    ``main()`` discloses the interpreter on every outcome."""
+
+    def _run_main(self, installed, latest_result=("0.1.11", None)):
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value=installed
+        ), mock.patch.object(
+            check_runtime_version, "_direct_url_local_reason", return_value=None
+        ), mock.patch.object(
+            check_runtime_version,
+            "_latest_version_with_reason",
+            return_value=latest_result,
+        ), mock.patch.object(sys, "stdout", out), mock.patch.object(
+            sys, "stderr", err
+        ):
+            code = check_runtime_version.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def _outcomes(self):
+        """(label, installed, latest_result, expected exit code) for all
+        four outcomes of the exit-code contract."""
+        return (
+            ("ok", "0.1.11", ("0.1.11", None), check_runtime_version.EXIT_OK),
+            ("drift", "0.1.2", ("0.1.11", None), check_runtime_version.EXIT_DRIFT),
+            (
+                "unverified",
+                "0.1.2",
+                (None, check_runtime_version.REASON_OFFLINE),
+                check_runtime_version.EXIT_UNVERIFIED,
+            ),
+            (
+                "not_installed",
+                None,
+                ("0.1.11", None),
+                check_runtime_version.EXIT_NOT_INSTALLED,
+            ),
+        )
+
+    def test_emitted_on_every_outcome_including_ok(self):
+        """The disclosure is unconditional: an "up to date" verdict is
+        exactly as interpreter-relative as a drift verdict."""
+        for label, installed, latest, expected_code in self._outcomes():
+            with self.subTest(outcome=label):
+                code, _out, err = self._run_main(installed, latest)
+                self.assertEqual(code, expected_code)
+                self.assertIn("測定 interpreter", err)
+                self.assertIn(check_runtime_version._interpreter_label(), err)
+
+    def test_never_reaches_stdout(self):
+        """stdout stays reserved for the spliceable drift line, so the
+        provenance diagnostic must never appear there -- on any
+        outcome."""
+        for label, installed, latest, _code in self._outcomes():
+            with self.subTest(outcome=label):
+                _code_, out, _err = self._run_main(installed, latest)
+                self.assertNotIn("測定 interpreter", out)
+
+    def test_exit_codes_are_unchanged_by_the_diagnostic(self):
+        """The provenance line is disclosure only: it must not perturb
+        the 0/1/2/3 outcome contract /org-start branches on."""
+        for label, installed, latest, expected_code in self._outcomes():
+            with self.subTest(outcome=label):
+                code, _out, _err = self._run_main(installed, latest)
+                self.assertEqual(code, expected_code)
+
+    def test_reports_the_running_interpreter_not_a_fixed_path(self):
+        """The path comes from ``sys.executable`` at run time -- that is
+        the whole point, since the same source measured from a different
+        Python must report that other Python."""
+        fake = "/home/x/ja/.venv/bin/python"
+        with mock.patch.object(sys, "executable", fake):
+            _code, _out, err = self._run_main("0.1.2")
+        self.assertIn(fake, err)
+
+    def test_pairs_the_interpreter_with_the_version_it_resolves(self):
+        """Naming the interpreter is only half the fix: the version that
+        interpreter sees must ride on the same line, so the pairing is
+        unambiguous when two installs disagree."""
+        fake = "/usr/bin/python3"
+        with mock.patch.object(sys, "executable", fake):
+            _code, _out, err = self._run_main("0.1.36")
+        line = _sole_stderr_line(self, err)
+        self.assertIn(fake, line)
+        self.assertIn("installed=0.1.36", line)
+
+    def test_not_installed_says_the_version_is_unresolvable(self):
+        """With nothing importable there is no version to pair, so the
+        line says so instead of printing an empty value."""
+        _code, _out, err = self._run_main(None)
+        provenance = [ln for ln in err.splitlines() if "測定 interpreter" in ln]
+        self.assertEqual(len(provenance), 1)
+        self.assertIn("なし", provenance[0])
+        self.assertNotIn("installed=)", provenance[0])
+
+    def test_precedes_the_outcome_diagnostic(self):
+        """Provenance is printed before the outcome branch, so a reader
+        scanning stderr top-down knows which interpreter the diagnostic
+        below it is talking about."""
+        _code, _out, err = self._run_main(
+            "0.1.2", (None, check_runtime_version.REASON_OFFLINE)
+        )
+        lines = [ln for ln in err.splitlines() if ln.strip()]
+        self.assertGreaterEqual(len(lines), 2)
+        self.assertIn("測定 interpreter", lines[0])
+        self.assertIn("PyPI", lines[1])
+
+    def test_empty_sys_executable_falls_back_to_a_label(self):
+        """An interpreter that cannot name its own binary (embedded
+        Python) must still emit a readable line, not a blank path."""
+        with mock.patch.object(sys, "executable", ""):
+            _code, _out, err = self._run_main("0.1.2")
+            self.assertEqual(check_runtime_version._interpreter_label(), "(不明)")
+        line = _sole_stderr_line(self, err)
+        self.assertIn("(不明)", line)
+        self.assertIn("installed=0.1.2", line)
+
+    def test_line_is_cp932_encodable(self):
+        """Windows consoles run cp932; a character outside it (an
+        em-dash, say) crashes the run with UnicodeEncodeError on the
+        very host the diagnostic is meant to help."""
+        with mock.patch.object(sys, "executable", "C:\\Python310\\python.exe"):
+            _code, _out, err = self._run_main("0.1.2")
+        line = _sole_stderr_line(self, err)
+        line.encode("cp932")  # raises UnicodeEncodeError if not cp932-safe
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

2026-08-08 の `/org-start` が `[runtime drift] claude-org-runtime: installed=0.1.36 latest=0.1.39` を報告したが、これは「更新が遅れている」のではなく **どの interpreter で測ったかの反映**だった。実際にはホストに 2 つ入っていた:

```
.venv/bin/python   -> 0.1.39
/usr/bin/python3   -> 0.1.36   (CLI shim ~/.local/bin/claude-org-runtime の shebang もこちら)
```

`/org-start` Block C2 の実行例は `python3` / `py -3` なので、既定で測っているのはシステム側。窓口は片側の値を「installed」として報告し、前セッションの記録（0.1.39）と矛盾する報告になった。バージョン差そのものは両方 0.1.39 に揃えて解消済みだが、**同じ測り方をしている限り同じ誤読が再発する**ため、出力から provenance が読めるようにする。

## 変更

- `check_runtime_version.py` が **毎回・全 outcome で** stderr の 1 行目に測定 interpreter を出す:
  `[runtime drift-check] 測定 interpreter: /usr/bin/python3 (installed=0.1.36)`
- **exit 0（drift 無し）でも出す**。up to date も drift と同じく「測った Python に相対な判定」なので、片方だけ silent にすると exit 0 側で同じ取り違えが起きる
- `/org-start` Block C2 に「interpreter の併記」手順を追記（報告で installed / 未インストールに言及するときは Python パスを併記する）

## 契約は不変

- stdout は drift 行専用（spliceable な転記契約）
- 診断は stderr のみ
- exit code 0 / 1 / 2 / 3 の意味は不変

provenance は判定に一切影響しない開示専用の 1 行で、この不変性を専用テストで固定している。

## 検証

- `pytest tools/` 848 passed / 4 skipped
- `bash tests/run-all.sh` 824 passed / 0 failed
- `python tools/check_role_configs.py --include-worker-settings .` OK
- system python3 と `.venv/bin/python` の両方で実機スモーク（それぞれ自分のパスを出力、`2>/dev/null` で stdout が空であることも確認）
- 4 outcome を mock で再現し stdout / stderr の分離と exit code を確認
- Windows の cp932 コンソール対策として出力は ASCII のみ。`line.encode("cp932")` の回帰テストあり
- Codex レビュー 2 round、Blocker / Major / Minor いずれも指摘なし

## スコープ外

Issue #863 に挙がっている「2 箇所の install が将来また食い違ったときに気づける仕組み」（`/org-start` が両 interpreter を測って差分を warning に出す）は判断が要るため本 PR では扱っていない。本 PR の provenance は「開示」であって「検出」ではない。

Refs #863
