### PR TITLE
feat(claude): duplicate_sidecar attention kind に追随し runtime pin を 0.1.40 へ上げる

### DIFF
--- a/.claude/skills/org-attention-start/SKILL.md
+++ b/.claude/skills/org-attention-start/SKILL.md
@@ -90,6 +90,12 @@ sidecar だけ見ると Step 3 の `spawn_pane(..., name="attention")` が `[nam
 
 ## Step 3: dispatcher を split して watcher を起動
 
+まず broker の state dir を確定する（`duplicate_sidecar` 通知の入力。未設定なら runtime 既定の `<state-dir>/broker` = `.state/broker`）:
+
+```bash
+echo "${ORG_BROKER_STATE_DIR:-}"
+```
+
 dispatcher ペインの右半分（vertical split）に attention watcher 用の pane を作る:
 
 ```
@@ -102,6 +108,17 @@ mcp__renga-peers__spawn_pane(
   command="claude-org-runtime attention watch --state-dir .state --config .state/attention.json"
 )
 ```
+
+- 上の `echo` が**空でない値**を返した場合だけ、`command` の末尾に `--broker-state-dir <その値>` を
+  **リテラルで**足す（例: `... --config .state/attention.json --broker-state-dir /srv/org/broker`）。
+  空なら足さない（runtime 既定の `.state/broker` に解決される）
+- `${ORG_BROKER_STATE_DIR:+--broker-state-dir "$ORG_BROKER_STATE_DIR"}` のようなシェル展開を
+  `command` 文字列に埋め込まないこと。ペインの login shell が zsh だと既定 `SH_WORD_SPLIT` off で
+  1 引数に潰れ、argparse error で watcher が起動しない（#829 と同型の罠）。値は呼び出し側で解決して
+  リテラルに埋める
+- attention watcher は `ORG_BROKER_STATE_DIR` env を自分では読まない（解決順は flag →
+  `<state-dir>/broker` のみ）。非既定 state dir で broker を動かしている環境でフラグを省くと、
+  `duplicate_sidecar` だけが黙って鳴らない（他の kind は `.state/state.db` 経由なので影響を受けない）
 
 - `target="dispatcher"`: org-start Block A-1 で確立した安定名で解決
 - `direction="vertical"`: dispatcher ペイン = 左、attention ペイン = 右

--- a/.claude/skills/org-attention-start/SKILL.md
+++ b/.claude/skills/org-attention-start/SKILL.md
@@ -110,8 +110,11 @@ mcp__renga-peers__spawn_pane(
 ```
 
 - 上の `echo` が**空でない値**を返した場合だけ、`command` の末尾に `--broker-state-dir <その値>` を
-  **リテラルで**足す（例: `... --config .state/attention.json --broker-state-dir /srv/org/broker`）。
-  空なら足さない（runtime 既定の `.state/broker` に解決される）
+  **リテラルで**足す。値は必ず**シングルクォートで囲む**（例:
+  `... --config .state/attention.json --broker-state-dir '/srv/org/broker'`）。空白や `$` などを
+  含むパスを裸で埋めると、ペインのシェルが分割・展開して別のパスが argparse に渡る。値自体に
+  `'` が含まれる場合は `'\''` へ置換してから埋める。空なら足さない（runtime 既定の
+  `.state/broker` に解決される）
 - `${ORG_BROKER_STATE_DIR:+--broker-state-dir "$ORG_BROKER_STATE_DIR"}` のようなシェル展開を
   `command` 文字列に埋め込まないこと。ペインの login shell が zsh だと既定 `SH_WORD_SPLIT` off で
   1 引数に潰れ、argparse error で watcher が起動しない（#829 と同型の罠）。値は呼び出し側で解決して

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,16 @@
   `.state/state.db` ではなく org-broker の journal (`<state-dir>/broker/queue.jsonl`) を入力にすること・
   `--broker-state-dir` (既定 `<state-dir>/broker`、非既定 state dir の daemon でのみ明示が要る)・
   `duplicate_sidecar_window_sec` (既定 300s、継続中の incident だけを鳴らす freshness 判定) を説明した。
-  テンプレートは現行 pin (`claude-org-runtime>=0.1.39`) でもそのまま読み込める (未知 kind は
-  config loader の検証対象外)。**ただし発火はしない**: broker journal reader は runtime の後続版で
-  入る経路で、現行 floor には無いため、この kind は runtime pin
-  (`pyproject.toml` / `requirements.txt` の floor と `docker/Dockerfile` の `RUNTIME_VERSION`) を
-  上げるまで no-op のまま待機する (pin 引き上げは runtime リリース側とペアの別変更)。
-  手元の runtime が経路を持つかは `claude-org-runtime attention scan --help` に
-  `--broker-state-dir` が出るかで判別できる。
+  broker journal reader は runtime 0.1.40 で入った経路なので、**同 PR で runtime の下限 pin を
+  0.1.39 → 0.1.40 へ引き上げた** (`pyproject.toml` / `requirements.txt` / `docker/Dockerfile` /
+  `docker/compose.yaml`)。pin を満たす環境ではこの kind は実際に発火する。手元の runtime に
+  経路があるかは `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかで
+  判別できる (出ない場合は pin より古い runtime が入っている。設定は正しいのに黙る形になる)。
+  `/org-attention-start` は watch 起動時に `ORG_BROKER_STATE_DIR` を確認し、値があれば
+  `--broker-state-dir` をリテラルで渡すようになった (watcher 自身はこの env を読まないため、
+  非既定 state dir では誰かが渡す必要がある)。`tests/test_attention_runtime_integration.py` は
+  broker journal の fixture 行を追加して golden に載せ、`duplicate_sidecar` を drift canary
+  (`_EXPECTED_URGENT_KINDS`) に加えた。
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,12 @@
   `--broker-state-dir` (既定 `<state-dir>/broker`、非既定 state dir の daemon でのみ明示が要る)・
   `duplicate_sidecar_window_sec` (既定 300s、継続中の incident だけを鳴らす freshness 判定) を説明した。
   テンプレートは現行 pin (`claude-org-runtime>=0.1.39`) でもそのまま読み込める (未知 kind は
-  config loader の検証対象外)。
+  config loader の検証対象外)。**ただし発火はしない**: broker journal reader は runtime の後続版で
+  入る経路で、現行 floor には無いため、この kind は runtime pin
+  (`pyproject.toml` / `requirements.txt` の floor と `docker/Dockerfile` の `RUNTIME_VERSION`) を
+  上げるまで no-op のまま待機する (pin 引き上げは runtime リリース側とペアの別変更)。
+  手元の runtime が経路を持つかは `claude-org-runtime attention scan --help` に
+  `--broker-state-dir` が出るかで判別できる。
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- attention watcher の `duplicate_sidecar` kind に ja 側を追随 (#868)。
+  `tools/templates/attention.example.json` に `notify.duplicate_sidecar: "urgent"` と日本語文面を追加した
+  (未追加だとこの kind だけ runtime 中立の英語 default が出る)。この通知は「同じ owner 宛のメッセージを
+  2 つの channel sidecar が取り合っている」状態を指し、放置すると報告が読まれない側のセッションへ配送されて
+  沈黙する。runtime 側は自力で復旧できず、余分なセッションを終了できるのは人間だけなので severity は
+  `urgent` で、文面もその行動 (余分なセッションを探して終了する) が読み取れる形にした。
+  `docs/operations/attention-watch.md` には severity 表の 1 行に加えて §4.3 を新設し、この kind だけが
+  `.state/state.db` ではなく org-broker の journal (`<state-dir>/broker/queue.jsonl`) を入力にすること・
+  `--broker-state-dir` (既定 `<state-dir>/broker`、非既定 state dir の daemon でのみ明示が要る)・
+  `duplicate_sidecar_window_sec` (既定 300s、継続中の incident だけを鳴らす freshness 判定) を説明した。
+  テンプレートは現行 pin (`claude-org-runtime>=0.1.39`) でもそのまま読み込める (未知 kind は
+  config loader の検証対象外)。
+
 ### Changed
 
 - `registry/projects.md` を operator-local な生成ファイルへ移行 (#811)。コミット対象は列スキーマ・

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ ARG ORG_UID=1000
 ARG ORG_GID=1000
 # runtime pin（設計 §7.7: 起動時 upgrade はせず、更新は image rebuild）。
 # 既定値は pyproject.toml の claude-org-runtime floor（下限 pin）と同期させること。
-ARG RUNTIME_VERSION=0.1.39
+ARG RUNTIME_VERSION=0.1.40
 # Claude Code ネイティブインストーラに渡すバージョン（stable | latest | x.y.z）
 ARG CLAUDE_CODE_VERSION=stable
 ARG INSTALL_HERDR=1

--- a/docker/README.md
+++ b/docker/README.md
@@ -70,7 +70,7 @@ socket mount はホスト root 相当の権限付与である。オーバーレ�
 docker buildx build -f docker/Dockerfile \
   --platform linux/amd64,linux/arm64 \
   --build-arg REPO_REF="$(git describe --always)" \
-  -t ghcr.io/suisya-systems/claude-org-ja:$(git describe --always)-r0.1.39 \
+  -t ghcr.io/suisya-systems/claude-org-ja:$(git describe --always)-r0.1.40 \
   --push .
 ```
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -14,7 +14,7 @@ services:
         # host bind mount を使う場合はホスト UID に合わせる（設計 §8）
         ORG_UID: "${ORG_UID:-1000}"
         ORG_GID: "${ORG_GID:-1000}"
-        RUNTIME_VERSION: "${RUNTIME_VERSION:-0.1.39}"
+        RUNTIME_VERSION: "${RUNTIME_VERSION:-0.1.40}"
         INSTALL_HERDR: "${INSTALL_HERDR:-1}"
         REPO_REF: "${REPO_REF:-dev}"
     # PID1 は image 内の tini（init: true と等価の機能を image 側で自己完結。設計 §5）

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -198,7 +198,8 @@ claude-org-runtime attention watch --state-dir .state --config .state/attention.
 
 - journal は末尾から window 分だけ遡って読む。この値を上げると走査範囲もそれに追随して広がるので、busy な daemon でも継続中の incident が視界外へ押し出されることはない
 - dedup key は owner ではなく **競合している instance pair** に対して張られる。片方のセッションを終了させた後に別の instance が入れ替わりで競合を始めた場合は別 incident として扱われ、直前の pair の cooldown に飲まれない
-- 手元の runtime がこの経路を持つかは `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかで判別できる（出ない版では journal を読まないので、この kind は発火しない）
+
+**runtime 版の前提（この kind だけの注意）**: broker journal reader は runtime 側でこの経路が入った版以降にしかない。手元の runtime が持つかは `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかで判別でき、**出ない版では journal を読まないのでこの kind は発火しない**（テンプレートに `notify.duplicate_sidecar` / `templates.duplicate_sidecar` を置いてあっても no-op になるだけで、config load エラーにはならない）。ja 側の下限 pin（`pyproject.toml` / `requirements.txt` の `claude-org-runtime` floor と `docker/Dockerfile` の `RUNTIME_VERSION`）がこの版に達するまでは、§4.1 の `duplicate_sidecar` 行は「runtime を上げたら鳴る」予約であって、現に鳴っている保証ではない。二重 sidecar を疑う状況で通知が来ない場合は、まず上記 `--help` で経路の有無を確かめる。
 
 ## 5. トラブルシューティング
 

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -220,14 +220,16 @@ claude-org-runtime attention watch --state-dir .state --config .state/attention.
 
 指定先に journal が無い / 読めない場合は「duplicate は無い」に degrade するだけで watcher は落ちない。裏を返すと、**broker を非既定 state dir で動かしていてこのフラグを付け忘れると、この kind だけが黙って鳴らない**（他の kind は `.state/state.db` 経由なので影響を受けず、欠落に気付きにくい）。
 
-**非既定 state dir では推奨経路 (§2.1) を使えない点に注意**: [`/org-attention-start`](../../.claude/skills/org-attention-start/SKILL.md) が起動する watch コマンドは固定文字列で `--broker-state-dir` を渡さず、attention watcher 自身も broker の `ORG_BROKER_STATE_DIR` env を読まない（解決順は flag → `<state-dir>/broker` のみ）。したがって broker daemon を非既定 state dir で動かしている環境では、skill 経由で起動した watcher はこの kind を拾わない。この場合は §2.4 の手動起動でフラグを明示する。
+**推奨経路 (§2.1) での扱い**: attention watcher は broker の `ORG_BROKER_STATE_DIR` env を自分では読まない（解決順は flag → `<state-dir>/broker` のみ）ため、非既定 state dir では誰かがフラグを渡す必要がある。[`/org-attention-start`](../../.claude/skills/org-attention-start/SKILL.md) は Step 3 でこの env を確認し、値があれば `--broker-state-dir <値>` を watch コマンドに**リテラルで**足す（`${VAR:+...}` のシェル展開を command 文字列に埋めると、ペインの login shell が zsh のとき 1 引数に潰れて argparse error になるため）。env が未設定なら足さず、runtime 既定の `.state/broker` に解決される。
+
+したがって skill 経由・手動起動のどちらでも非既定 state dir に追随できる。**ただし env が未設定のまま broker だけを非既定 state dir で起動している環境**（例: daemon の起動側だけにパスを直書きしている）では、skill も値を復元できないので §2.4 の手動起動でフラグを明示する。
 
 **`duplicate_sidecar_window_sec`（既定 300）**: journal 行を「いま起きている incident」とみなす freshness window（秒）。この window より古い行は捨てる。broker は競合が続いている限り instance pair ごとに lease window 周期で同じ行を再 emit するので、window を lease window より十分大きく取っておけば **継続中の incident は鳴り続け、解消済みの incident は自然に黙る**。既定 300 は `cooldown_sec` と同値で、「1 回の通知 cooldown の間 1 度も再発していない incident は終わっている」という読みに対応する。
 
 - journal は末尾から window 分だけ遡って読む。この値を上げると走査範囲もそれに追随して広がるので、busy な daemon でも継続中の incident が視界外へ押し出されることはない
 - dedup key は owner ではなく **競合している instance pair** に対して張られる。片方のセッションを終了させた後に別の instance が入れ替わりで競合を始めた場合は別 incident として扱われ、直前の pair の cooldown に飲まれない
 
-**runtime 版の前提（この kind だけの注意）**: broker journal reader は runtime 側でこの経路が入った版以降にしかない。手元の runtime が持つかは `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかで判別でき、**出ない版では journal を読まないのでこの kind は発火しない**（テンプレートに `notify.duplicate_sidecar` / `templates.duplicate_sidecar` を置いてあっても no-op になるだけで、config load エラーにはならない）。ja 側の下限 pin（`pyproject.toml` / `requirements.txt` の `claude-org-runtime` floor と `docker/Dockerfile` の `RUNTIME_VERSION`）がこの版に達するまでは、§4.1 の `duplicate_sidecar` 行は「runtime を上げたら鳴る」予約であって、現に鳴っている保証ではない。二重 sidecar を疑う状況で通知が来ない場合は、まず上記 `--help` で経路の有無を確かめる。
+**runtime 版の前提（この kind だけの注意）**: broker journal reader は runtime 0.1.40 で入った経路で、ja の下限 pin もこれに合わせて 0.1.40 に上げてある（`pyproject.toml` / `requirements.txt` の `claude-org-runtime` floor、`docker/Dockerfile` の `RUNTIME_VERSION`）。したがって pin を満たす環境では**この kind は実際に発火する**。手元の runtime に経路があるかを直接確かめたい場合は `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかを見る。**出ない場合は pin より古い runtime が入っている**（floor は下限であって、環境に実際に入っている版とは別物）。その状態ではテンプレートに `notify.duplicate_sidecar` / `templates.duplicate_sidecar` があっても no-op になるだけで、config load エラーにはならない — つまり「設定は正しいのに黙っている」形になるので、二重 sidecar を疑う状況で通知が来ないときは、まずこの `--help` で経路の有無を確かめる。
 
 ## 5. トラブルシューティング
 

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -220,6 +220,8 @@ claude-org-runtime attention watch --state-dir .state --config .state/attention.
 
 指定先に journal が無い / 読めない場合は「duplicate は無い」に degrade するだけで watcher は落ちない。裏を返すと、**broker を非既定 state dir で動かしていてこのフラグを付け忘れると、この kind だけが黙って鳴らない**（他の kind は `.state/state.db` 経由なので影響を受けず、欠落に気付きにくい）。
 
+**非既定 state dir では推奨経路 (§2.1) を使えない点に注意**: [`/org-attention-start`](../../.claude/skills/org-attention-start/SKILL.md) が起動する watch コマンドは固定文字列で `--broker-state-dir` を渡さず、attention watcher 自身も broker の `ORG_BROKER_STATE_DIR` env を読まない（解決順は flag → `<state-dir>/broker` のみ）。したがって broker daemon を非既定 state dir で動かしている環境では、skill 経由で起動した watcher はこの kind を拾わない。この場合は §2.4 の手動起動でフラグを明示する。
+
 **`duplicate_sidecar_window_sec`（既定 300）**: journal 行を「いま起きている incident」とみなす freshness window（秒）。この window より古い行は捨てる。broker は競合が続いている限り instance pair ごとに lease window 周期で同じ行を再 emit するので、window を lease window より十分大きく取っておけば **継続中の incident は鳴り続け、解消済みの incident は自然に黙る**。既定 300 は `cooldown_sec` と同値で、「1 回の通知 cooldown の間 1 度も再発していない incident は終わっている」という読みに対応する。
 
 - journal は末尾から window 分だけ遡って読む。この値を上げると走査範囲もそれに追随して広がるので、busy な daemon でも継続中の incident が視界外へ押し出されることはない

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -7,6 +7,7 @@
 - **入力**:
   - `.state/state.db` の `events` テーブル（`notify_sent` / `ci_completed` / `worker_completed` / `pr_merged` など）
   - `.state/pending_decisions.json`（人間判断仰ぎ register）
+  - org-broker の journal `.state/broker/queue.jsonl` の `duplicate_sidecar_detected` 行（既定の参照先は `<state-dir>/broker`、`--broker-state-dir` で上書き。§4.3 参照）
   - optional config: `.state/attention.json`（`tools/templates/attention.example.json` を雛形にする）
 - **出力**:
   - desktop notification（OS 別 backend は §3 参照）
@@ -130,6 +131,7 @@ Issue #25 / PR #27 以前は、WSL / Windows native とも「PowerShell `Write-H
 | `pending_decision_max` | `1440` | urgent 期間の上限（分）。これを超えた pending は normal に降格する（24h） |
 | `pending_decision_drop` | `10080` | normal 通知の終端（分）。これを超えた pending は通知抑止され `--json` 出力にのみ残る（7d） |
 | `user_replied_min` | `15` | user replied だが worker 未転送の状態を urgent と判定する経過分 |
+| `duplicate_sidecar_window_sec` | `300` | broker journal の `duplicate_sidecar_detected` 行を「いま起きている」とみなす freshness window（秒）。§4.3 参照 |
 | `max_title_chars` / `max_body_chars` | `80` / `240` | template 出力の truncation 上限（secret-safe formatting の一環） |
 | `notify.<kind>` | §4.1 参照 | event kind ごとの severity（`urgent` / `normal` の 2 値のみ、`off` は不可。完全に止めたい場合は全体 `desktop: false` を使う） |
 | `templates.<kind>.{title,body}` | ja 既定文面 | placeholder allowlist は `{task_id} {worker} {kind} {status} {pr} {summary}` |
@@ -145,6 +147,7 @@ Issue #25 / PR #27 以前は、WSL / Windows native とも「PowerShell `Write-H
 | `pending_decision` | urgent | action-required | worker から判断仰ぎ。Secretary は人間に上げる責務（CLAUDE.md 参照） |
 | `user_reply_not_forwarded` | urgent | action-required | ユーザーは返答済みだが worker に未転送。Secretary の運用ギャップ |
 | `pane_crashed` | urgent | action-required | ペインが予期せず終了。再起動判断にユーザーが必要 |
+| `duplicate_sidecar` | urgent | action-required | 同じ owner の channel を 2 つの sidecar が取り合っている。runtime 側は復旧できず、余分なセッションを終了できるのは人間だけ（§4.3 参照） |
 | `relay_gap_suspected` | normal | anomaly / 予兆 | dispatcher monitoring の予兆検出。自己復旧する場合が多く urgent muting の主因だったため demote |
 | `silent_worker_output` | normal | anomaly / 予兆 | ペイン出力ありだが peer message 未着。同上 |
 | `pane_silent` | normal | anomaly / 予兆 | ペインが無反応。dispatcher 側で自己復旧する場合あり |
@@ -175,6 +178,27 @@ Issue #25 / PR #27 以前は、WSL / Windows native とも「PowerShell `Write-H
 - **長い audit trail を残したい**: `pending_decision_drop` を上げる（例: 7d → 30d）。完全 suppress までの猶予を伸ばし、長期 backlog を `attention scan --json` で監査可能にする
 - **判断仰ぎが頻繁で 15 分の grace が短い**: `pending_decision_min` を伸ばす（例: 15 → 60）。Secretary の relay 余裕を見たい運用で urgent 過多を抑える
 - `pending_decision_drop = pending_decision_max` に揃えると normal/visual 段が消え、超過時に即 suppressed になる。短い lifecycle の運用で「降格中の表示」が要らないチーム向け
+
+### 4.3 duplicate_sidecar — broker journal 経路（`--broker-state-dir` / `duplicate_sidecar_window_sec`）
+
+`duplicate_sidecar` だけは `.state/state.db` ではなく **org-broker の journal** を入力にする。broker daemon は、同じ owner（`secretary` / `dispatcher` / `worker-<task_id>`）のキューを 2 つの channel sidecar instance が poll している状態を検出して `duplicate_sidecar_detected` 行を journal に書く。watcher はその行を拾って通知にする。
+
+放置したときの実害は「静かに壊れる」型である。owner 宛のメッセージが 2 つの読み手に分割され、報告が誰も見ていない側のセッションへ配送されて沈黙する。runtime 側は自力で復旧できない（どちらが本物かを知っているのは人間だけ）ため既定 severity は `urgent` で、**オペレータの取るべき行動は「余分なセッションを見つけて終了させる」**。通知本文には owner (`{worker}`) と競合している 2 つの instance id (`{summary}`) が載るので、journal を開かずにどのセッションを見ればよいかが分かる。
+
+**`--broker-state-dir`**: journal (`queue.jsonl`) を置く broker の state dir を指すフラグ。既定は `<state-dir>/broker`（= `--state-dir .state` なら `.state/broker/queue.jsonl`）で、broker daemon の既定 state dir と一致するため通常運用では指定不要。**非既定の state dir で daemon を起動している場合のみ**明示する:
+
+```bash
+claude-org-runtime attention watch --state-dir .state --config .state/attention.json \
+  --broker-state-dir /path/to/broker-state
+```
+
+指定先に journal が無い / 読めない場合は「duplicate は無い」に degrade するだけで watcher は落ちない。裏を返すと、**broker を非既定 state dir で動かしていてこのフラグを付け忘れると、この kind だけが黙って鳴らない**（他の kind は `.state/state.db` 経由なので影響を受けず、欠落に気付きにくい）。
+
+**`duplicate_sidecar_window_sec`（既定 300）**: journal 行を「いま起きている incident」とみなす freshness window（秒）。この window より古い行は捨てる。broker は競合が続いている限り instance pair ごとに lease window 周期で同じ行を再 emit するので、window を lease window より十分大きく取っておけば **継続中の incident は鳴り続け、解消済みの incident は自然に黙る**。既定 300 は `cooldown_sec` と同値で、「1 回の通知 cooldown の間 1 度も再発していない incident は終わっている」という読みに対応する。
+
+- journal は末尾から window 分だけ遡って読む。この値を上げると走査範囲もそれに追随して広がるので、busy な daemon でも継続中の incident が視界外へ押し出されることはない
+- dedup key は owner ではなく **競合している instance pair** に対して張られる。片方のセッションを終了させた後に別の instance が入れ替わりで競合を始めた場合は別 incident として扱われ、直前の pair の cooldown に飲まれない
+- 手元の runtime がこの経路を持つかは `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかで判別できる（出ない版では journal を読まないので、この kind は発火しない）
 
 ## 5. トラブルシューティング
 

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -42,6 +42,32 @@ cp tools/templates/attention.example.json .state/attention.json
 
 OS 通知や音の挙動を変えたい場合は `.state/attention.json` を編集する（template strings の上書き、`sound` の切替、`cooldown_sec` の調整など）。テンプレートの placeholder allowlist は `{task_id}` / `{worker}` / `{kind}` / `{status}` / `{pr}` / `{summary}` の 6 種で、未知 placeholder は literal のまま残るか runtime の fallback template で補われる（設計 §6 参照）。
 
+#### 既に `.state/attention.json` がある場合の追随（新しい kind が増えたとき）
+
+`cp` も [`/org-attention-start`](../../.claude/skills/org-attention-start/SKILL.md) も **既存の `.state/attention.json` は上書きしない**（skill は未配置時のみコピーする）。ユーザー個別の overlay を守るための挙動だが、裏返すと **tracked template に新しい kind が追加されても、既存 overlay には入らない**。その kind だけ runtime 中立の英語 default 文面が出るようになる（ja 文面が消えるのではなく、新しい kind が最初から英語で来る）。
+
+overlay の自分の設定を保ったまま、**不足しているキーだけ**足すには次を実行する（既にあるキーには一切触らない）:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+tmpl = json.loads(pathlib.Path("tools/templates/attention.example.json").read_text(encoding="utf-8"))
+path = pathlib.Path(".state/attention.json")
+cfg = json.loads(path.read_text(encoding="utf-8"))
+added = []
+for section in ("notify", "templates"):
+    dst = cfg.setdefault(section, {})
+    for key, value in tmpl.get(section, {}).items():
+        if key not in dst:
+            dst[key] = value
+            added.append(f"{section}.{key}")
+path.write_text(json.dumps(cfg, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+print("added:", added or "(none)")
+PY
+```
+
+追加後は §2.3 の `scan --dry-run --json` で構文を確認する。**`watch` を常駐させている場合は再起動が必要**: runtime は config を watch ループ開始前に 1 回だけ読み、ループ内で再読み込みしないため、編集しただけでは反映されない（[`/org-attention-stop`](../../.claude/skills/org-attention-stop/SKILL.md) → [`/org-attention-start`](../../.claude/skills/org-attention-start/SKILL.md)、手動起動なら Ctrl-C → 再実行）。
+
 ### 2.3 1 回限りの動作確認 (`scan`)
 
 `watch` を常駐させる前に、現状の `.state/` から想定どおりに attention event が抽出されるか確認する:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.39,<0.2",
+    "claude-org-runtime>=0.1.40,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,18 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.40 for the attention watcher's `duplicate_sidecar` kind:
+# 0.1.40 adds the broker-journal reader (`attention scan/watch --broker-state-dir`,
+# `duplicate_sidecar_window_sec`) and the `duplicate_sidecar` DEFAULT_NOTIFY entry.
+# ja's template (tools/templates/attention.example.json) and the golden in
+# tests/test_attention_runtime_integration.py both depend on that path: a 0.1.39
+# install ignores the broker journal, so the fixture's duplicate row never reaches
+# the scan output and the golden comparison fails. Raising the floor also keeps
+# docs/operations/attention-watch.md §4.3 honest — it documents the kind as live
+# rather than as a reservation. The earlier 0.1.39 floor (below) is subsumed.
+# RUNTIME_PIN_LOWER_INCLUSIVE in tools/check_runtime_schema_drift.py is again NOT
+# raised in step, for the same reason recorded below: it gates only the
+# byte-identical schema check, which older installs still pass.
 # Floor bumped to 0.1.39 to match the regenerated semantic-drift goldens:
 # 0.1.39 adds a `rewrites` array to SandboxMetadata.to_jsonable() (the record of
 # kept deny paths canonicalized across an absolute symlink), and ja's goldens
@@ -120,7 +132,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.39,<0.2
+claude-org-runtime>=0.1.40,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).

--- a/tests/fixtures/attention/broker_journal.json
+++ b/tests/fixtures/attention/broker_journal.json
@@ -1,0 +1,43 @@
+{
+  "_comment": [
+    "org-broker journal (queue.jsonl) rows for the attention integration test.",
+    "The runtime reader (attention/readers.py read_broker_duplicates) keeps only",
+    "rows whose 'ts' falls inside duplicate_sidecar_window_sec (300s by default),",
+    "so 'ts' cannot be checked in as a literal - it would age out and the golden",
+    "would silently lose the event. The test stamps it in setUp from",
+    "'age_sec' (seconds before now) instead; everything else here is verbatim",
+    "what the daemon writes via broker/store.py _journal().",
+    "'noise' rows exercise the reader's filters and must NOT reach the output."
+  ],
+  "rows": [
+    {
+      "age_sec": 60,
+      "event": "duplicate_sidecar_detected",
+      "owner": "worker-T-duplicate",
+      "instances": ["b2c3d4e5f6a7b8c9", "a1b2c3d4e5f6a7b8"]
+    },
+    {
+      "age_sec": 60,
+      "event": "lease_reaped",
+      "id": "row-1",
+      "reclaim": 1,
+      "_why": "noise: a different journal event kind, filtered by the reader"
+    },
+    {
+      "age_sec": 4000,
+      "event": "duplicate_sidecar_detected",
+      "owner": "secretary",
+      "instances": ["deadbeefdeadbeef", "cafebabecafebabe"],
+      "_why": "noise: older than the 300s freshness window, so it is stale and dropped"
+    }
+  ],
+  "override_rows": [
+    {
+      "age_sec": 60,
+      "event": "duplicate_sidecar_detected",
+      "owner": "dispatcher",
+      "instances": ["1111222233334444", "5555666677778888"],
+      "_why": "written to a NON-default broker state dir; only reachable via --broker-state-dir"
+    }
+  ]
+}

--- a/tests/fixtures/attention/expected_scan.json
+++ b/tests/fixtures/attention/expected_scan.json
@@ -65,5 +65,16 @@
     "task_id": "T-relay-gap",
     "summary": "Codex review round 3 done; OK to merge?",
     "created_at": "__DYNAMIC__"
+  },
+  {
+    "key": "broker:duplicate_sidecar:worker-T-duplicate:a1b2c3d4e5f6a7b8+b2c3d4e5f6a7b8c9",
+    "kind": "duplicate_sidecar",
+    "severity": "urgent",
+    "title": "Duplicate channel sidecar",
+    "body": "worker-T-duplicate: two sessions are claiming the same channel (a1b2c3d4e5f6a7b8, b2c3d4e5f6a7b8c9).",
+    "source": "broker.queue.jsonl",
+    "worker": "worker-T-duplicate",
+    "summary": "a1b2c3d4e5f6a7b8, b2c3d4e5f6a7b8c9",
+    "created_at": "__DYNAMIC__"
   }
 ]

--- a/tests/test_attention_runtime_integration.py
+++ b/tests/test_attention_runtime_integration.py
@@ -21,6 +21,7 @@ import shutil
 import sqlite3
 import subprocess
 import tempfile
+import time
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -28,7 +29,17 @@ from pathlib import Path
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "attention"
 STATE_EVENTS_JSON = FIXTURE_DIR / "state_events.json"
 PENDING_JSON = FIXTURE_DIR / "pending_decisions.json"
+BROKER_JOURNAL_JSON = FIXTURE_DIR / "broker_journal.json"
 GOLDEN_JSON = FIXTURE_DIR / "expected_scan.json"
+
+# Subdirectory of ``--state-dir`` the runtime scans for the org-broker
+# journal when ``--broker-state-dir`` is not given (runtime
+# ``attention/cli.py`` BROKER_SUBDIR). Hard-coding it here is the point:
+# if the runtime ever renames the default location, ja's normal
+# operation (which passes no flag) would stop seeing duplicate_sidecar
+# signals, and this fixture is what catches that.
+_BROKER_SUBDIR = "broker"
+_BROKER_JOURNAL_NAME = "queue.jsonl"
 
 # Mirrors the attention-relevant columns of tools/state_db/schema.sql.
 # Projecting only what the runtime reader touches keeps a non-attention
@@ -60,11 +71,16 @@ _DISPATCH_ONLY_KEYS = frozenset({
 # that keeps pending_decision / user_reply_not_forwarded urgent only
 # inside the min..max window. The fixture refreshes the latter pair's
 # timestamps in setUp() so they fall inside that window.
+# ``duplicate_sidecar`` (runtime 0.1.40) arrives from the broker journal
+# rather than the events table, so it also pins that second input path:
+# if the reader stops resolving ``<state-dir>/broker`` the kind vanishes
+# from the scan and this canary fails alongside the golden.
 _EXPECTED_URGENT_KINDS = frozenset({
     "approval_blocked",
     "ci_failed",
     "pending_decision",
     "user_reply_not_forwarded",
+    "duplicate_sidecar",
 })
 
 # Placeholder ``created_at`` value used in the golden file for events
@@ -93,6 +109,49 @@ def _build_state_db(db_path: Path, events: list[dict]) -> None:
         conn.commit()
     finally:
         conn.close()
+
+
+def _duplicate_key(row: dict) -> str:
+    """Rebuild the runtime's dedup key for a duplicate_sidecar row.
+
+    Mirrors ``classifier.classify_duplicate_sidecar``: the key is keyed
+    on the contesting *pair* (sorted), not just the owner, so replacing
+    one session starts a new incident instead of being swallowed by the
+    previous pair's cooldown.
+    """
+    instances = "+".join(sorted(row["instances"]))
+    return f"broker:duplicate_sidecar:{row['owner']}:{instances}"
+
+
+def _iso_from_epoch(epoch: float) -> str:
+    """Render epoch seconds the way the runtime classifier does."""
+    return datetime.fromtimestamp(epoch, timezone.utc).isoformat().replace(
+        "+00:00", "Z",
+    )
+
+
+def _write_broker_journal(
+    journal_dir: Path, rows: list[dict], now_epoch: float,
+) -> None:
+    """Write fixture rows as the broker's append-only ``queue.jsonl``.
+
+    ``age_sec`` becomes an absolute ``ts`` relative to *now* because the
+    reader's freshness window (``duplicate_sidecar_window_sec``, 300s)
+    would age out any literal timestamp checked into the fixture. Keys
+    starting with ``_`` are fixture annotations and are not written.
+    """
+    journal_dir.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for row in rows:
+        rec = {"ts": now_epoch - row["age_sec"]}
+        rec.update({
+            k: v for k, v in row.items()
+            if k != "age_sec" and not k.startswith("_")
+        })
+        lines.append(json.dumps(rec, ensure_ascii=False))
+    (journal_dir / _BROKER_JOURNAL_NAME).write_text(
+        "\n".join(lines) + "\n", encoding="utf-8",
+    )
 
 
 def _normalize(events: list[dict]) -> list[dict]:
@@ -140,6 +199,9 @@ class AttentionRuntimeIntegrationTests(unittest.TestCase):
         cls.golden = json.loads(
             GOLDEN_JSON.read_text(encoding="utf-8"),
         )
+        cls.broker_journal = json.loads(
+            BROKER_JOURNAL_JSON.read_text(encoding="utf-8"),
+        )
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -147,6 +209,18 @@ class AttentionRuntimeIntegrationTests(unittest.TestCase):
         self.state_dir = Path(self._tmpdir.name) / ".state"
         self.state_dir.mkdir()
         _build_state_db(self.state_dir / "state.db", self.events_spec)
+
+        # Broker journal at the runtime's *default* location, so the
+        # scan below finds it without passing --broker-state-dir — that
+        # is how ja runs it in normal operation. Whole seconds keep the
+        # classifier's ISO rendering free of microseconds so the golden
+        # stays comparable.
+        self._now_epoch = float(int(time.time()))
+        _write_broker_journal(
+            self.state_dir / _BROKER_SUBDIR,
+            self.broker_journal["rows"],
+            self._now_epoch,
+        )
 
         # claude-org-runtime v0.1.11 enforces a TTL ladder on
         # pending_decision / user_reply_not_forwarded rows: only the
@@ -181,14 +255,31 @@ class AttentionRuntimeIntegrationTests(unittest.TestCase):
             json.dumps(pending, indent=2), encoding="utf-8",
         )
 
-    def _run_scan(self) -> list[dict]:
+        # The broker row's created_at is derived from the ts stamped
+        # above, so the golden carries the placeholder and the actual
+        # value is registered here alongside the pending ones.
+        for row in self.broker_journal["rows"]:
+            if row["event"] != "duplicate_sidecar_detected":
+                continue
+            self._fresh_created_at[_duplicate_key(row)] = _iso_from_epoch(
+                self._now_epoch - row["age_sec"],
+            )
+
+    def _run_scan(self, broker_state_dir: Path | None = None) -> list[dict]:
+        argv = [
+            "claude-org-runtime", "attention", "scan",
+            "--state-dir", str(self.state_dir),
+            "--dry-run", "--json",
+        ]
+        # No --broker-state-dir by default: the unflagged invocation is
+        # what /org-attention-start runs when ORG_BROKER_STATE_DIR is
+        # unset, so leaving it off here keeps the golden pinned to the
+        # default resolution. The flag is exercised separately by
+        # :meth:`test_broker_state_dir_flag_overrides_default`.
+        if broker_state_dir is not None:
+            argv += ["--broker-state-dir", str(broker_state_dir)]
         result = subprocess.run(
-            [
-                "claude-org-runtime", "attention", "scan",
-                "--state-dir", str(self.state_dir),
-                "--dry-run", "--json",
-            ],
-            check=False, capture_output=True, text=True, timeout=30,
+            argv, check=False, capture_output=True, text=True, timeout=30,
         )
         self.assertEqual(
             result.returncode, 0,
@@ -258,6 +349,40 @@ class AttentionRuntimeIntegrationTests(unittest.TestCase):
         self.assertEqual(ev["kind"], "user_reply_not_forwarded")
         self.assertEqual(ev["severity"], "urgent")
 
+    def test_duplicate_sidecar_from_broker_journal_is_urgent(self) -> None:
+        row = self.broker_journal["rows"][0]
+        ev = self._find_event(self._run_scan(), key=_duplicate_key(row))
+        self.assertEqual(ev["kind"], "duplicate_sidecar")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["worker"], "worker-T-duplicate")
+        self.assertEqual(ev["source"], "broker.queue.jsonl")
+        # Both contesting instance ids ride into the text, sorted, so the
+        # operator can tell which sessions to end without opening the
+        # journal.
+        self.assertEqual(ev["summary"], ", ".join(sorted(row["instances"])))
+
+    def test_broker_state_dir_flag_overrides_default(self) -> None:
+        """``--broker-state-dir`` redirects the scan away from the default.
+
+        /org-attention-start passes this flag when ORG_BROKER_STATE_DIR is
+        set, because the watcher does not read that env var itself. The
+        override journal names a different owner, so a runtime that
+        ignored the flag would surface the default dir's owner instead
+        and fail here rather than passing by coincidence.
+        """
+        override_dir = Path(self._tmpdir.name) / "broker-elsewhere"
+        _write_broker_journal(
+            override_dir,
+            self.broker_journal["override_rows"],
+            self._now_epoch,
+        )
+        events = self._run_scan(broker_state_dir=override_dir)
+        owners = {
+            ev.get("worker") for ev in events
+            if ev.get("kind") == "duplicate_sidecar"
+        }
+        self.assertEqual(owners, {"dispatcher"})
+
     # ------------------------------------------------------------------
     # (3) Progress-only and below-threshold cases are dropped.
     # ------------------------------------------------------------------
@@ -269,6 +394,13 @@ class AttentionRuntimeIntegrationTests(unittest.TestCase):
         self.assertNotIn("event:3", keys)
         # ci_completed status=success (filtered by classifier)
         self.assertNotIn("event:7", keys)
+        # broker journal row older than duplicate_sidecar_window_sec
+        # (300s) — stale incidents must fall silent rather than re-alert
+        self.assertNotIn(
+            "broker:duplicate_sidecar:secretary"
+            ":cafebabecafebabe+deadbeefdeadbeef",
+            keys,
+        )
         # pending decision whose received_at is far in the future —
         # _minutes_since returns negative so the entry stays below the
         # urgent threshold; this exercises the negative-delta branch

--- a/tests/test_worker_seed_status_contract.py
+++ b/tests/test_worker_seed_status_contract.py
@@ -29,9 +29,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # **予約台帳が存在するバージョン下限**。``_seed_status`` /
 # ``count_unbound_reservations`` / ``WORKER_BIND_WINDOW_SECONDS`` は 0.1.39 で
 # 初めて入った (0.1.37 / 0.1.38 の wheel を展開して不在を実測)。ja の依存
-# floor は #841 で 0.1.37 → 0.1.39 に上がり (pyproject.toml:30 /
-# requirements.txt:123 / docker/Dockerfile:65) 現時点では一致するが、**この
-# 下限は pin ではなく runtime の性質**なので独立に持つ。下限未満の runtime
+# floor は #841 で 0.1.37 → 0.1.39、#868 で 0.1.39 → 0.1.40 と上がっており
+# (pyproject.toml:30 / requirements.txt:135 / docker/Dockerfile:65) 現在は
+# floor の方が高い。**この下限は pin ではなく runtime の性質**なので pin に
+# 追随させず独立に持つ。下限未満の runtime
 # では読み手がそもそも居ないので契約に守るべき対象が無く、skip する
 # (pin が admit しなくなった今も、古い runtime が入った手元環境で hard fail
 # させないための防御として分岐を残す)。

--- a/tools/templates/attention.example.json
+++ b/tools/templates/attention.example.json
@@ -23,7 +23,8 @@
     "worker_error": "normal",
     "worker_completed": "normal",
     "pr_merged": "normal",
-    "secretary_awaiting_user": "urgent"
+    "secretary_awaiting_user": "urgent",
+    "duplicate_sidecar": "urgent"
   },
   "templates": {
     "approval_blocked": {
@@ -81,6 +82,10 @@
     "secretary_awaiting_user": {
       "title": "窓口が判断待ちです",
       "body": "{task_id} で窓口がユーザー入力を待っています。"
+    },
+    "duplicate_sidecar": {
+      "title": "channel sidecar が二重に走っています",
+      "body": "{worker} 宛のメッセージを 2 つのセッションが取り合っています。報告が読まれない側へ流れて沈黙するので、余分なセッションを探して終了してください ({summary})。"
     }
   }
 }


### PR DESCRIPTION
runtime 0.1.40 で入った `duplicate_sidecar` attention kind に ja 側を追随させる。あわせて runtime pin の floor を 0.1.40 へ引き上げる。

## 背景

runtime 側（[claude-org-runtime#170](https://github.com/suisya-systems/claude-org-runtime/pull/170)）で、attention watcher が org-broker journal を読んで `duplicate_sidecar` を通知するようになった。検知自体は #125 から daemon にあったが consumer が無く、**オペレータは「報告が来なくなった」ことでしか二重 sidecar に気づけなかった**——その signal が可視化しようとした失敗モードそのものが起きていた。

ja 側で追随が要るのは、テンプレートに日本語文面が無いとこの kind だけ英語の既定文面が出るため。

## 変更

**1. `tools/templates/attention.example.json`** — `notify.duplicate_sidecar: "urgent"` と日本語文面を追加。文面は「状態 → 放置したときの帰結 → 取るべき行動」の順:

> title: channel sidecar が二重に走っています
> body: {worker} 宛のメッセージを 2 つのセッションが取り合っています。報告が読まれない側へ流れて沈黙するので、余分なセッションを探して終了してください ({summary})。

instance id を末尾に置いたのは、`max_body_chars` (240) の truncation で削られるのが id 側になるようにするため（最悪でも 153 文字で truncation しない）。severity が urgent なのは、runtime 側は二重 claimer を自力で解消できず、**余分なセッションを見つけて終了させられるのは人間だけ**だから。

**2. `docs/operations/attention-watch.md`** — §4.3 を新設。この kind だけが `.state/state.db` ではなく broker journal (`<state-dir>/broker/queue.jsonl`) を入力にすること、`--broker-state-dir`、`duplicate_sidecar_window_sec`（既定 300s、継続中の incident だけ鳴らす freshness 判定）を説明。§2.2 に「既に `.state/attention.json` がある場合の追随」手順も追加した（cp も `/org-attention-start` も既存 overlay を上書きしないため、テンプレートに kind が増えても既存ユーザーには入らない——本 PR が塞ごうとしている状態が既存インストールでだけ再現する）。

**3. runtime pin の floor を 0.1.40 へ** — grep で 5 箇所を確定して同期: `pyproject.toml` / `requirements.txt` / `docker/Dockerfile` の `ARG RUNTIME_VERSION` / `docker/compose.yaml` の既定値 / `docker/README.md` の image tag 例（tag 規約が `<repo-ref>-r<runtime-version>` のため）。

`tools/check_runtime_schema_drift.py` の `RUNTIME_PIN_LOWER_INCLUSIVE` は**追随させていない**。byte-identical schema check だけを gate するもので、上げると古い install を無意味に skip に落とすため（判断の根拠は requirements.txt の既存コメントにある）。同様に `_LEDGER_MIN` も pin ではなく runtime の性質なので据え置き。

**4. `/org-attention-start` が `--broker-state-dir` を渡すようにした** — 非既定 state dir で broker を動かしている環境では、推奨経路で起動した watcher がこの kind だけ黙って拾わなかった。`ORG_BROKER_STATE_DIR` を確認し、値があればリテラルで足す形。**シェル展開（`${VAR:+...}`）は command 文字列に埋めていない**——ペインの login shell が zsh だと SH_WORD_SPLIT off で 1 引数に潰れ argparse error になる（#829 と同型）。値はシングルクォートで囲う（空白や `$` を含むパス対策）。

## テスト設計

`_run_scan` に `--broker-state-dir` を**渡さないまま据え置いた**。ja の通常運用（`ORG_BROKER_STATE_DIR` 未設定）はフラグ無しで runtime 既定の `<state-dir>/broker` に解決される経路であり、常時渡すとその既定解決が壊れても気付けないため。代わりに二本立てにした:

- golden 側: journal を既定位置に置きフラグ無しで scan → **既定解決を pin**
- `test_broker_state_dir_flag_overrides_default`: 非既定 dir に**別 owner** の journal を置きフラグ指定 → 出てくる owner がそちらだけであることを assert。フラグを無視する実装なら既定側の owner が出て落ちる

fixture の `ts` は checked-in できない（freshness window 300s で必ず古くなる）ので `age_sec` から `setUp` で刻む。noise 行 2 本（別 event kind / window 外）で reader の filter 側も押さえた。`_EXPECTED_URGENT_KINDS` に `duplicate_sidecar` を追加。

**negative control**: journal を `<state-dir>/broker` から別名に移すと duplicate イベントが 0 件になることを確認した（既定解決を実際に pin できている裏取り）。

## 検証

- `tests/` 全体 995 passed / 2 skipped（新規 2 件込み）。golden は実行結果から生成し、既存 6 件は無改変の追記のみ
- 実測の runtime は 3 系統（system python3 / `.venv` / CLI shim）すべて 0.1.40、`--broker-state-dir` は scan / watch 両方に存在
- Codex review: P1 ゼロ。P2 1 件（`ORG_BROKER_STATE_DIR` に空白・メタ文字を含むパスのクォート漏れ）を修正済み

## 申し送り

`docs/contracts/state-schema-contract.md` が floor を括弧内で引用しており（`>=0.1.39` / `requirements.txt:123` / `ARG RUNTIME_VERSION=0.1.39`）、pin 引き上げで現物と食い違う。**契約の適用範囲自体は無傷**（0.1.40 は 0.1.39〜<0.2 の内側）で、引用は「as of #841」と時点が明記されているため歴史的記述として読める余地はある。ratified 本文の編集はこの PR のスコープ外としたので、別途扱う。

Closes #868
