### PR TITLE
fix(claude): renga 2.0 サイドバーの Ctrl+B が内側 tmux prefix を横取りする件を運用ドキュメントに記載

### DIFF
--- a/.claude/skills/pr-watch-pane/SKILL.md
+++ b/.claude/skills/pr-watch-pane/SKILL.md
@@ -221,6 +221,13 @@ mcp__org-broker__spawn_pane(
   exit して broker pane が即時掃除され、watcher が孤児化する（pane が無いので `/org-attach` /
   `Ctrl-b s` でも覗けない）。`--no-detach` で前景動作させ、`tee` と末尾 self-close の
   自己終了サイクルを成立させる。
+  - **`Ctrl-b s` は tmux prefix の既定値前提**: prefix を変更している場合は設定した prefix に
+    読み替える。さらに、**覗く端末が renga の場合はこの打鍵が届かない** — renga の org
+    サイドバーは既定で有効なあいだ `Ctrl+B`（tmux prefix `Ctrl-b` と同じ物理入力）を消費して
+    PTY へ渡さないため、pane が生きていても `Ctrl-b s` でセッション切替できない。回避策
+    （renga 設定 `[ui] org_sidebar = "off"` または tmux prefix の変更）は
+    [`docs/operations/dispatcher-view.md`](../../../docs/operations/dispatcher-view.md) の
+    「外側フレームが renga の場合」を参照。
 - `command`: pr-watch を前景実行し、stdout/stderr を `.state/pr-watch-<PR>.log` に `tee -a`
   （tmux スクロールバッファにも出る二段）。先頭 `mkdir -p .state` で fresh clone でも tee の
   出力先を確保する。pr-watch 終了後に `tmux kill-pane -t "$TMUX_PANE"`

--- a/.claude/skills/pr-watch-pane/SKILL.md.in
+++ b/.claude/skills/pr-watch-pane/SKILL.md.in
@@ -215,6 +215,13 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
   exit して broker pane が即時掃除され、watcher が孤児化する（pane が無いので `/org-attach` /
   `Ctrl-b s` でも覗けない）。`--no-detach` で前景動作させ、`tee` と末尾 self-close の
   自己終了サイクルを成立させる。
+  - **`Ctrl-b s` は tmux prefix の既定値前提**: prefix を変更している場合は設定した prefix に
+    読み替える。さらに、**覗く端末が renga の場合はこの打鍵が届かない** — renga の org
+    サイドバーは既定で有効なあいだ `Ctrl+B`（tmux prefix `Ctrl-b` と同じ物理入力）を消費して
+    PTY へ渡さないため、pane が生きていても `Ctrl-b s` でセッション切替できない。回避策
+    （renga 設定 `[ui] org_sidebar = "off"` または tmux prefix の変更）は
+    [`docs/operations/dispatcher-view.md`](../../../docs/operations/dispatcher-view.md) の
+    「外側フレームが renga の場合」を参照。
 - `command`: pr-watch を前景実行し、stdout/stderr を `.state/pr-watch-<PR>.log` に `tee -a`
   （tmux スクロールバッファにも出る二段）。先頭 `mkdir -p .state` で fresh clone でも tee の
   出力先を確保する。pr-watch 終了後に `tmux kill-pane -t "$TMUX_PANE"`

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,9 @@ docker exec -it claude-org org-shell --setup
 docker exec -it claude-org org-shell
 ```
 
-デタッチは `Ctrl-b d`、再接続は `docker exec -it claude-org org-shell`。
+デタッチは `Ctrl-b d`、再接続は `docker exec -it claude-org org-shell`。`Ctrl-b` は tmux prefix の既定値なので、変更している場合は設定した prefix に読み替える。
+
+> **ホスト側の端末が renga の場合は先に回避策が要る**: renga の org サイドバーは既定で有効で `Ctrl+B`（= tmux prefix `Ctrl-b` と同じ物理入力）を消費するため、`Ctrl-b d` がコンテナ内の tmux まで届かない。回避策と原因は [`docs/operations/dispatcher-view.md`](../docs/operations/dispatcher-view.md) の「外側フレームが renga の場合」を参照。
 
 ## 環境変数（compose）
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,6 +34,13 @@ docker exec -it claude-org org-shell
 デタッチは `Ctrl-b d`、再接続は `docker exec -it claude-org org-shell`。`Ctrl-b` は tmux prefix の既定値なので、変更している場合は設定した prefix に読み替える。
 
 > **ホスト側の端末が renga の場合は先に回避策が要る**: renga の org サイドバーは既定で有効で `Ctrl+B`（= tmux prefix `Ctrl-b` と同じ物理入力）を消費するため、`Ctrl-b d` がコンテナ内の tmux まで届かない。回避策と原因は [`docs/operations/dispatcher-view.md`](../docs/operations/dispatcher-view.md) の「外側フレームが renga の場合」を参照。
+>
+> ただし prefix 変更で回避する場合、**この導線の socket は `org-shell`** であり broker socket ではない（[`docker/org-shell.sh`](org-shell.sh):39, :49-54）。参照先の例は broker socket 向けなので、コンテナ内で次のように読み替える:
+>
+> ```bash
+> tmux -L org-shell set -g prefix C-a
+> tmux -L org-shell bind C-a send-prefix
+> ```
 
 ## 環境変数（compose）
 

--- a/docs/design/org-app-packaging-options.md
+++ b/docs/design/org-app-packaging-options.md
@@ -176,7 +176,7 @@ attention watcher（`claude-org-runtime attention watch`）は `state.db` と `p
 
 **これはユーザーが明示的に重視した要件である。** 現状の実体は次の 2 経路:
 
-- **broker / tmux フレーム** — 各ペインは `claude-org-broker-{pid}-{seq}` という独立した detached tmux session（1 ペイン = 1 session）として存在し、人間が自分の端末から `/usr/bin/tmux -L claude-org-broker attach -r -t <session>` で入る。`-r` は read-only attach、`Ctrl-b d` でデタッチ（ペインは動いたまま）。[`.claude/skills/org-attach/SKILL.md`](../../.claude/skills/org-attach/SKILL.md):33-42, :161-172 がこの attach コマンド**文字列を生成するだけ**の read-only スキル。
+- **broker / tmux フレーム** — 各ペインは `claude-org-broker-{pid}-{seq}` という独立した detached tmux session（1 ペイン = 1 session）として存在し、人間が自分の端末から `/usr/bin/tmux -L claude-org-broker attach -r -t <session>` で入る。`-r` は read-only attach、`Ctrl-b d` でデタッチ（ペインは動いたまま。`Ctrl-b` は tmux prefix の既定値で、変更していれば設定した prefix に読み替える。**attach する端末が renga の場合は org サイドバーが `Ctrl+B` を消費してこの打鍵が届かない** — 回避策は [`docs/operations/dispatcher-view.md`](../operations/dispatcher-view.md) の「外側フレームが renga の場合」）。[`.claude/skills/org-attach/SKILL.md`](../../.claude/skills/org-attach/SKILL.md):33-42, :161-172 がこの attach コマンド**文字列を生成するだけ**の read-only スキル。
 - **renga フレーム** — 単一画面のタイリングモデルで、ペインは 1 つのライブウィンドウ内のタイル。「detached session へ attach し直す」概念が写像せず、**画面をそのまま見ればよい**（同 :37-41）。
 
 加えて [`tools/org-dispatcher-view.sh`](../../tools/org-dispatcher-view.sh):195-236 が「dispatcher の自己修復する read-only ビュー」を提供し、dispatcher の restart / auto-compact fork でセッション名が変わっても自動再探索・再 attach する。

--- a/docs/operations/broker-dogfood-runbook.md
+++ b/docs/operations/broker-dogfood-runbook.md
@@ -582,12 +582,14 @@ tmux -L claude-org-broker list-sessions
 tmux -L claude-org-broker attach -r -t claude-org-broker-12345-1
 ```
 
-attach 後の操作（prefix は既定 `Ctrl-b`）:
+attach 後の操作（prefix は既定 `Ctrl-b`。変更している場合は設定した prefix に読み替える）:
 
 | 操作 | キー | 用途 |
 |---|---|---|
 | detach（観察をやめて抜ける） | `Ctrl-b` → `d` | セッションは生かしたまま離脱（プロセスに影響しない） |
 | 別セッションへ切替 | `Ctrl-b` → `s` | セッション一覧から選択。**現状は per-session なので全体を見るには切替が要る** |
+
+> **attach する端末が renga の場合は先に回避策が要る**: renga の org サイドバーは既定で有効で `Ctrl+B`（= tmux prefix `Ctrl-b` と同じ物理入力）を消費し PTY へ渡さないため、上表の打鍵が attach 先の tmux に届かない。detach できず抜けられなくなるので、attach する前に [`docs/operations/dispatcher-view.md`](dispatcher-view.md) の「外側フレームが renga の場合」の回避策（renga 設定 `[ui] org_sidebar = "off"`、または tmux prefix の変更）を適用すること。
 
 > **read-only `-r` を既定にする理由**: 独立セッションへの attach は worker の生 TUI に直接つながる。`-r` なしで attach すると観察中の打鍵が worker セッションに入りうる（介入は窓口/ディスパッチャーの `send_keys` 経路に閉じる設計のため、人間の手 attach は観察に限定する）。
 

--- a/docs/operations/dispatcher-view.md
+++ b/docs/operations/dispatcher-view.md
@@ -25,6 +25,8 @@
 
 WezTerm 側でペインを分割し、新ペインで本ビューアを起動する。WezTerm の split キーと内側 dispatcher 側の `Ctrl-b` プレフィックスは別系統なので **キー衝突が起きない**（後述の tmux 手順と比較した最大の利点）。
 
+> **ただし、その WezTerm をさらに renga の中で開いている場合はこの限りでない。** renga の org サイドバーは既定で有効で `Ctrl+B` を消費するため、内側 dispatcher へ `Ctrl-b` が届かない。§4 の回避策を先に適用すること。
+
 1. 窓口セッションの WezTerm ペインにフォーカスがある状態で、ペインを分割する:
    - 左右に分割: `Ctrl+Shift+Alt+%`
    - 上下に分割: `Ctrl+Shift+Alt+"`
@@ -44,9 +46,51 @@ WezTerm 側でペインを分割し、新ペインで本ビューアを起動す
 | 内側 dispatcher を detach する（自分だけ抜ける） | `Ctrl-b d` |
 | ビューア自体を終了する | `Ctrl-b d` で detach → 再探索プロンプトに戻ったところで `Ctrl-C` → `exit` |
 
-WezTerm の既定キーバインドが上記である前提。`.wezterm.lua` 等でカスタム設定をしている場合は当該キーに読み替えること。`cd` のパス例は本リポジトリの clone 先に応じて読み替える。
+WezTerm の既定キーバインドが上記である前提。`.wezterm.lua` 等でカスタム設定をしている場合は当該キーに読み替えること。表中の `Ctrl-b` も内側 tmux prefix の既定値なので、prefix を変更している場合は **設定した prefix** に読み替える。`cd` のパス例は本リポジトリの clone 先に応じて読み替える。
 
-## 4. tmux 手順（衝突注意）
+## 4. 外側フレームが renga の場合（`Ctrl+B` 衝突）
+
+本ビューアや broker セッションへの attach を **renga の画面の中で** 行う場合、renga の org サイドバーが `Ctrl+B` を消費するため内側 tmux の prefix が届かない。§3 / §5 の手順に入る前に、下記いずれかの回避策を適用すること。
+
+renga 側 UI キーの `Ctrl+B`（org サイドバーのトグル）と tmux prefix の `Ctrl-b` は、**表記が違うだけで同じ物理入力**（`Ctrl` + `b`）である。以下、renga の機能として押す場合を `Ctrl+B`、tmux の prefix として押す場合を `Ctrl-b` と書き分ける。
+
+### 4.1 何が起きるか
+
+renga 2.0 の org サイドバーは **既定で有効**（`OrgSidebarMode::Coexist` が `Default`。renga `src/config.rs:58`）で、有効な間は `Ctrl+B` を消費して PTY へ渡さない（renga `src/app/keyboard_input.rs:339-345` が `toggle_org_sidebar()` して `return Ok(true)` するため、renga `src/main.rs:492-493` の `if !consumed` に入らない）。エラーも出ずサイドバーがトグルするだけなので、人間からは「押しても効かない」ようにしか見えない。
+
+**§5 の「`Ctrl-b` を 2 回押す」とは原因が別物である。** 外側が tmux の場合は、1 回目を外側 tmux が prefix として処理したうえで 2 回目を内側セッションへ送れる（だから連打が回避策になる）。renga は最初の `Ctrl+B` の時点で consume して PTY へ 1 バイトも流さないため、**何回押しても内側 tmux には 1 文字も届かない**。§5 の 2 回押し手順が成立するのは、下記の回避策を適用して `Ctrl+B` が PTY へ落ちるようになってからである。
+
+**`Ctrl+B` でサイドバーを非表示にトグルしても解決しない。** 消費するかどうかの判定は表示状態ではなく機能の enable 状態（`org_sidebar_enabled()` = モードが `off` 以外。renga `src/app/org_sidebar.rs:67-69`）で行われるため、非表示にしてもキーは消費され続ける（renga `src/app/tests/org_sidebar.rs:514-524` が「非表示状態でも consumed」を挙動として固定している）。`coexist` / `replace` はいずれも「有効」であり、消費を止められるのは `off` だけである（同 `:494-512` が `off` のときだけ PTY へ通ることを固定している）。
+
+### 4.2 回避策 (i): renga の org サイドバーを無効化する
+
+renga の設定ファイル（Unix は `${XDG_CONFIG_HOME:-~/.config}/renga/config.toml`、Windows は `%APPDATA%/renga/config.toml`。renga `src/config.rs:2-3`, `:329-330`）に次を書く。**値は引用符付きの文字列**である:
+
+```toml
+[ui]
+org_sidebar = "off"
+```
+
+これは renga 側が「shell / tmux / readline で `Ctrl+B` が要る利用者向けの documented escape hatch」として明示的に用意しているもの（renga `src/app/keyboard_input.rs:334-338` のコメント）。設定は renga 起動時に一度だけ読まれる（renga `src/main.rs:146`）ため、**変更後は renga を起動し直す**。同等の CLI フラグは無く（CLI override が受け取るのは ime / lang / fps 系のみ。renga `src/main.rs:147-153`）、経路は設定ファイルのみである。
+
+トレードオフ: org サイドバーは全タブとその中のペインを一覧する cross-tab パネル（renga `src/app/org_sidebar.rs:1-3`）なので、`off` にするとその可視性を丸ごと失う。サイドバーを残したい場合は 4.3 を選ぶ。
+
+### 4.3 回避策 (ii): 内側 tmux の prefix を変更する
+
+サイドバーを残したい場合は、内側 tmux 側の prefix を `Ctrl-b` 以外へ動かして物理キーの衝突自体を無くす。`~/.tmux.conf` に:
+
+```tmux
+set -g prefix C-a
+bind C-a send-prefix
+```
+
+以後、本ドキュメントおよび `tools/org-dispatcher-view.sh` の出力に出てくる `Ctrl-b` は、**設定した prefix**（上例なら `Ctrl-a`）に読み替える。
+
+### 4.4 runtime の capacity escalation が案内する `Ctrl+B` について
+
+runtime のディスパッチャーは容量不足時の escalate 文面に「Reclaim them with Ctrl+B or `[ui] org_sidebar = "off"` and re-run.」を含める（runtime `src/claude_org_runtime/dispatcher/runner.py:1506-1513`）。この `Ctrl+B` は **renga のサイドバー操作の案内であり、内側 tmux prefix の送信案内ではない**。内側 tmux を触っている最中にこの文面を読んでも、その打鍵で prefix が届くようになるわけではない。
+
+## 5. tmux 手順（衝突注意）
 
 外側 tmux のペインから入れ子 attach する形になるため、**2 つの注意点** がある。
 
@@ -73,11 +117,11 @@ WezTerm の既定キーバインドが上記である前提。`.wezterm.lua` 等
 | 内側 dispatcher を detach する（自分だけ抜ける） | `Ctrl-b Ctrl-b d` |
 | ビューア自体を終了する | `Ctrl-b Ctrl-b d` で detach → 再探索プロンプトに戻ったところで `Ctrl-C` → `exit` |
 
-内側 prefix を `Ctrl-b` 2 回で送る点が WezTerm 経路との最大の違い。外側 tmux の prefix を別キー（例: `Ctrl-a`）に再設定している場合は、そちらと `Ctrl-b` の組み合わせに読み替える。
+内側 prefix を `Ctrl-b` 2 回で送る点が WezTerm 経路との最大の違い。外側 tmux の prefix を別キー（例: `Ctrl-a`）に再設定している場合は、そちらと `Ctrl-b` の組み合わせに読み替える。**この 2 回押しが成立するのは、外側が tmux の場合に限る**。外側フレームが renga の場合は 1 回目の時点で消費されるため 2 回押しでも届かない（§4）。
 
-## 5. オプション
+## 6. オプション
 
-### 5.1 `--rw`（読み書き attach）
+### 6.1 `--rw`（読み書き attach）
 
 既定は read-only（`-r`）で安全だが、dispatcher のペインに **直接打鍵したい** ときだけ `--rw` を付ける:
 
@@ -87,7 +131,7 @@ tools/org-dispatcher-view.sh --rw
 
 dispatcher ペインへの誤入力は control plane を壊しうる（worker 監視ループや handover フローを破る可能性がある）。常時可視化の用途では `--rw` は付けず、書き込みが本当に必要なときだけスポットで起動するのが望ましい。
 
-### 5.2 環境変数 `ORG_BROKER_SOCKET`
+### 6.2 環境変数 `ORG_BROKER_SOCKET`
 
 broker の tmux socket 名（既定 `claude-org-broker`）。runtime 側で socket 名を変えている場合のみ設定する:
 
@@ -97,17 +141,17 @@ ORG_BROKER_SOCKET=my-broker tools/org-dispatcher-view.sh
 
 通常運用では設定不要。
 
-## 6. 自己修復の挙動
+## 7. 自己修復の挙動
 
 - **dispatcher 不在時の再探索**: socket は繋がるが `.dispatcher` cwd のペインが無い場合、「dispatcher の tmux ペインが見つかりません（degraded / 未起動）。再探索中…」と出て 2 秒ごとに再探索する
 - **socket 不通時の再試行**: broker daemon が未起動などで tmux socket に繋がらない場合、「broker tmux socket (...) に繋がりません」と出て 2 秒ごとに再試行する
 - **attach 後の自動復帰**: dispatcher が restart / auto-compact fork して session 名が変わると、tmux 側で attach が切れる。本ビューアはそれを検知してループ先頭に戻り、新しい session 名を再解決して再 attach する
 - **複数候補警告**: 同一 broker socket 上に複数 org / 複数 `.dispatcher` ペインが居る稀ケースでは、「dispatcher 候補が N 件見つかりました」と警告し 1 件目を採用する。意図しない dispatcher に attach しうるので broker daemon の状態を確認すること
-- **終了動作の注意**: attach 中の `Ctrl-C` は tmux クライアント / dispatcher ペイン側に渡るので、本ビューアの SIGINT trap には届かない（`--rw` では dispatcher へ `^C` を送ってしまう）。終了は必ず **detach（`Ctrl-b d` または `Ctrl-b Ctrl-b d`）→ 再探索プロンプト → `Ctrl-C`** の順で行う
+- **終了動作の注意**: attach 中の `Ctrl-C` は tmux クライアント / dispatcher ペイン側に渡るので、本ビューアの SIGINT trap には届かない（`--rw` では dispatcher へ `^C` を送ってしまう）。終了は必ず **detach（`Ctrl-b d` または `Ctrl-b Ctrl-b d`）→ 再探索プロンプト → `Ctrl-C`** の順で行う。ここの `Ctrl-b` は tmux prefix の既定値であり、prefix を変更している場合は **設定した prefix** に読み替える。外側フレームが renga の場合は、この detach 打鍵自体が届かないので先に §4 の回避策を適用すること（適用しないとビューアから抜ける手段が無くなる）
 
-## 7. トラブルシューティング
+## 8. トラブルシューティング
 
-### 7.1 起動しても何も映らない / すぐ「見つかりません」になる
+### 8.1 起動しても何も映らない / すぐ「見つかりません」になる
 
 broker socket にセッションが居るかを直接確認する:
 
@@ -118,11 +162,15 @@ broker socket にセッションが居るかを直接確認する:
 - 何も出ない → broker daemon が起動していない / dispatcher がまだ立ち上がっていない。`/org-start` 直後で broker が ready になる前のタイミングや、`/org-suspend` 後の状態
 - セッションは出るが `.dispatcher` cwd のペインが無い → dispatcher が degraded（bg-pty フォールバック）か未起動。dispatcher 復元を別経路で確認する
 
-### 7.2 `sessions should be nested with care` が出る
+### 8.2 `sessions should be nested with care` が出る
 
-外側 tmux の中から起動しているのに `TMUX=` を付け忘れている。tmux 手順（§4）の起動コマンドどおり、先頭に `TMUX=` を付け直す。
+外側 tmux の中から起動しているのに `TMUX=` を付け忘れている。tmux 手順（§5）の起動コマンドどおり、先頭に `TMUX=` を付け直す。
 
-### 7.3 「dispatcher 候補が N 件見つかりました」と警告が出る
+### 8.3 `Ctrl-b` を押しても内側 dispatcher に何も起きない / detach できない
+
+外側フレームが renga で、org サイドバー（既定で有効）が `Ctrl+B` を消費している可能性が高い。サイドバーの表示がトグルするだけでエラーは出ない。§4 の回避策（renga 設定 `[ui] org_sidebar = "off"`、または内側 tmux の prefix 変更）を適用する。外側が tmux の場合は原因が別で、`Ctrl-b` を 2 回押す（§5）。
+
+### 8.4 「dispatcher 候補が N 件見つかりました」と警告が出る
 
 同一 broker socket に `.dispatcher` cwd のペインが複数居る状態。本ビューアは 1 件目を採用するが、意図したものか確認する:
 
@@ -133,11 +181,11 @@ broker socket にセッションが居るかを直接確認する:
 
 `ORG_BROKER_SOCKET` を分けるか、不要な dispatcher セッションを片付けることで解消できる。
 
-### 7.4 `tmux` コマンドが alias 化けする
+### 8.5 `tmux` コマンドが alias 化けする
 
 本スクリプトは内部で `/usr/bin/tmux` を実体パスで叩くため、zsh + oh-my-zsh の tmux プラグインによる alias は無視される（影響を受けない）。手動で `tmux -L ... list-panes` を実行する場合のみ alias 化けに注意（実体パスを使うか `command tmux ...` で剥がす）。
 
-## 8. 関連
+## 9. 関連
 
 - スクリプト本体: [`tools/org-dispatcher-view.sh`](../../tools/org-dispatcher-view.sh)
 - broker 運用全般: [`docs/operations/broker-dogfood-runbook.md`](broker-dogfood-runbook.md)

--- a/docs/operations/dispatcher-view.md
+++ b/docs/operations/dispatcher-view.md
@@ -97,7 +97,9 @@ prefix は **tmux server ごとの設定**なので、2 段階で入れる。
 
    `ORG_BROKER_SOCKET` で socket 名を変えている場合はその名前に読み替える。既に attach して抜けられなくなっている場合も、この経路なら別端末から prefix を差し替えて detach できる。
 
-読み替えの範囲: 以後 **内側 tmux（broker socket 側）を指す** `Ctrl-b` — 本ドキュメントの detach / セッション切替、および `tools/org-dispatcher-view.sh` の出力 — を、設定した prefix（上例なら `Ctrl-a`）に読み替える。**§5 の外側 tmux 用のキー**（ペイン分割、および 2 回押しの 1 回目）は別 server の prefix なので、外側を変更していない限り `Ctrl-b` のままである。
+読み替えの範囲: 変更したのは **内側 tmux（broker socket 側）の prefix だけ**なので、読み替えるのも内側を指すキーに限る — 本ドキュメントの detach / セッション切替、および `tools/org-dispatcher-view.sh` の出力に出てくる `Ctrl-b` である。**§5 の外側 tmux 用のキー**（ペイン分割など）は別 server の設定なので、外側を変更していない限り `Ctrl-b` のままである。
+
+**入れ子運用では 2 回押しが不要になる**（§5 の手順からの差分）。内側だけを `Ctrl-a` にした場合、`Ctrl-a` は外側 tmux の prefix ではないため通常入力として素通しされ、内側 tmux にそのまま届く。したがって detach は **`Ctrl-a d` の 1 回**でよい。`Ctrl-b Ctrl-a d` は誤りで、外側が 1 回目の `Ctrl-b` を自分の prefix として食ったうえで、続く `Ctrl-a` を自分の prefix key table で解釈してしまうため内側には届かない。
 
 ### 4.4 runtime の capacity escalation が案内する `Ctrl+B` について
 
@@ -160,7 +162,7 @@ ORG_BROKER_SOCKET=my-broker tools/org-dispatcher-view.sh
 - **socket 不通時の再試行**: broker daemon が未起動などで tmux socket に繋がらない場合、「broker tmux socket (...) に繋がりません」と出て 2 秒ごとに再試行する
 - **attach 後の自動復帰**: dispatcher が restart / auto-compact fork して session 名が変わると、tmux 側で attach が切れる。本ビューアはそれを検知してループ先頭に戻り、新しい session 名を再解決して再 attach する
 - **複数候補警告**: 同一 broker socket 上に複数 org / 複数 `.dispatcher` ペインが居る稀ケースでは、「dispatcher 候補が N 件見つかりました」と警告し 1 件目を採用する。意図しない dispatcher に attach しうるので broker daemon の状態を確認すること
-- **終了動作の注意**: attach 中の `Ctrl-C` は tmux クライアント / dispatcher ペイン側に渡るので、本ビューアの SIGINT trap には届かない（`--rw` では dispatcher へ `^C` を送ってしまう）。終了は必ず **detach（`Ctrl-b d` または `Ctrl-b Ctrl-b d`）→ 再探索プロンプト → `Ctrl-C`** の順で行う。ここの `Ctrl-b` は各 tmux server の prefix の既定値であり、変更している場合は §4.3 の読み替え範囲に従う（入れ子形 `Ctrl-b Ctrl-b d` は 1 回目が外側 server、2 回目以降が内側 server の prefix）。外側フレームが renga の場合は、この detach 打鍵自体が届かないので先に §4 の回避策を適用すること（適用しないとビューアから抜ける手段が無くなる）
+- **終了動作の注意**: attach 中の `Ctrl-C` は tmux クライアント / dispatcher ペイン側に渡るので、本ビューアの SIGINT trap には届かない（`--rw` では dispatcher へ `^C` を送ってしまう）。終了は必ず **detach → 再探索プロンプト → `Ctrl-C`** の順で行う。detach の打鍵は prefix 設定で変わる: 内外とも既定なら WezTerm 等からの単独 attach で `Ctrl-b d`、外側 tmux からの入れ子で `Ctrl-b Ctrl-b d`（1 回目を外側が食い、2 回目が内側へ送られる）。§4.3 で内側 prefix だけを変えた場合は入れ子でも 2 回押しは不要になり、変更後の prefix + `d`（例 `Ctrl-a d`）になる。外側フレームが renga の場合は、この detach 打鍵自体が届かないので先に §4 の回避策を適用すること（適用しないとビューアから抜ける手段が無くなる）
 
 ## 8. トラブルシューティング
 

--- a/docs/operations/dispatcher-view.md
+++ b/docs/operations/dispatcher-view.md
@@ -64,7 +64,7 @@ renga 2.0 の org サイドバーは **既定で有効**（`OrgSidebarMode::Coex
 
 ### 4.2 回避策 (i): renga の org サイドバーを無効化する
 
-renga の設定ファイル（Unix は `${XDG_CONFIG_HOME:-~/.config}/renga/config.toml`、Windows は `%APPDATA%/renga/config.toml`。renga `src/config.rs:2-3`, `:329-330`）に次を書く。**値は引用符付きの文字列**である:
+renga の設定ファイルに次を書く。パスは Unix が `$XDG_CONFIG_HOME/renga/config.toml`（`XDG_CONFIG_HOME` 未設定なら `$HOME/.config/renga/config.toml`）、Windows が `%APPDATA%\renga\config.toml`（renga `src/config.rs:2-3`, `:329-330`）。**値は引用符付きの文字列**である:
 
 ```toml
 [ui]
@@ -77,14 +77,27 @@ org_sidebar = "off"
 
 ### 4.3 回避策 (ii): 内側 tmux の prefix を変更する
 
-サイドバーを残したい場合は、内側 tmux 側の prefix を `Ctrl-b` 以外へ動かして物理キーの衝突自体を無くす。`~/.tmux.conf` に:
+サイドバーを残したい場合は、内側 tmux（= attach 先の broker socket 上の tmux server）の prefix を `Ctrl-b` 以外へ動かして物理キーの衝突自体を無くす。
 
-```tmux
-set -g prefix C-a
-bind C-a send-prefix
-```
+prefix は **tmux server ごとの設定**なので、2 段階で入れる。
 
-以後、本ドキュメントおよび `tools/org-dispatcher-view.sh` の出力に出てくる `Ctrl-b` は、**設定した prefix**（上例なら `Ctrl-a`）に読み替える。
+1. 今後起動する server 向けに `~/.tmux.conf` へ永続化する:
+
+   ```tmux
+   set -g prefix C-a
+   bind C-a send-prefix
+   ```
+
+2. **既に走っている broker server には上記の編集は反映されない。** 衝突に気付くのは大抵 server が走っている最中なので、その場で効かせるには socket を指定して直接設定する（attach していない別のペイン / 端末から実行してよい）:
+
+   ```bash
+   /usr/bin/tmux -L claude-org-broker set -g prefix C-a
+   /usr/bin/tmux -L claude-org-broker bind C-a send-prefix
+   ```
+
+   `ORG_BROKER_SOCKET` で socket 名を変えている場合はその名前に読み替える。既に attach して抜けられなくなっている場合も、この経路なら別端末から prefix を差し替えて detach できる。
+
+読み替えの範囲: 以後 **内側 tmux（broker socket 側）を指す** `Ctrl-b` — 本ドキュメントの detach / セッション切替、および `tools/org-dispatcher-view.sh` の出力 — を、設定した prefix（上例なら `Ctrl-a`）に読み替える。**§5 の外側 tmux 用のキー**（ペイン分割、および 2 回押しの 1 回目）は別 server の prefix なので、外側を変更していない限り `Ctrl-b` のままである。
 
 ### 4.4 runtime の capacity escalation が案内する `Ctrl+B` について
 
@@ -147,7 +160,7 @@ ORG_BROKER_SOCKET=my-broker tools/org-dispatcher-view.sh
 - **socket 不通時の再試行**: broker daemon が未起動などで tmux socket に繋がらない場合、「broker tmux socket (...) に繋がりません」と出て 2 秒ごとに再試行する
 - **attach 後の自動復帰**: dispatcher が restart / auto-compact fork して session 名が変わると、tmux 側で attach が切れる。本ビューアはそれを検知してループ先頭に戻り、新しい session 名を再解決して再 attach する
 - **複数候補警告**: 同一 broker socket 上に複数 org / 複数 `.dispatcher` ペインが居る稀ケースでは、「dispatcher 候補が N 件見つかりました」と警告し 1 件目を採用する。意図しない dispatcher に attach しうるので broker daemon の状態を確認すること
-- **終了動作の注意**: attach 中の `Ctrl-C` は tmux クライアント / dispatcher ペイン側に渡るので、本ビューアの SIGINT trap には届かない（`--rw` では dispatcher へ `^C` を送ってしまう）。終了は必ず **detach（`Ctrl-b d` または `Ctrl-b Ctrl-b d`）→ 再探索プロンプト → `Ctrl-C`** の順で行う。ここの `Ctrl-b` は tmux prefix の既定値であり、prefix を変更している場合は **設定した prefix** に読み替える。外側フレームが renga の場合は、この detach 打鍵自体が届かないので先に §4 の回避策を適用すること（適用しないとビューアから抜ける手段が無くなる）
+- **終了動作の注意**: attach 中の `Ctrl-C` は tmux クライアント / dispatcher ペイン側に渡るので、本ビューアの SIGINT trap には届かない（`--rw` では dispatcher へ `^C` を送ってしまう）。終了は必ず **detach（`Ctrl-b d` または `Ctrl-b Ctrl-b d`）→ 再探索プロンプト → `Ctrl-C`** の順で行う。ここの `Ctrl-b` は各 tmux server の prefix の既定値であり、変更している場合は §4.3 の読み替え範囲に従う（入れ子形 `Ctrl-b Ctrl-b d` は 1 回目が外側 server、2 回目以降が内側 server の prefix）。外側フレームが renga の場合は、この detach 打鍵自体が届かないので先に §4 の回避策を適用すること（適用しないとビューアから抜ける手段が無くなる）
 
 ## 8. トラブルシューティング
 

--- a/docs/operations/dispatcher-view.md
+++ b/docs/operations/dispatcher-view.md
@@ -86,7 +86,14 @@ prefix は **tmux server ごとの設定**である。broker server だけを狙
 /usr/bin/tmux -L claude-org-broker bind C-a send-prefix
 ```
 
-`ORG_BROKER_SOCKET` で socket 名を変えている場合はその名前に読み替える。この形は **走っている broker server に即時反映され、他の tmux server には触らない**ので、入れ子運用でも副作用が無い。
+この形は **指定した server に即時反映され、他の tmux server には触らない**ので、入れ子運用でも副作用が無い。
+
+**`-L` には「自分が attach している server の socket」を渡すこと**（上例は本ビューアの対象である broker server）。socket は経路ごとに異なるので、本節を他の運用手順から参照した場合は読み替える:
+
+| 経路 | socket |
+|---|---|
+| 本ビューア / broker セッションへの attach | `claude-org-broker`（`ORG_BROKER_SOCKET` で変更可） |
+| コンテナ配布の `org-shell`（[`docker/README.md`](../../docker/README.md)） | `org-shell`（broker socket とは別。[`docker/org-shell.sh`](../../docker/org-shell.sh):39, :49-54） |
 
 永続化する場合の注意: `~/.tmux.conf` に `set -g prefix C-a` を書くと **以後起動するすべての tmux server** に効く。外側 tmux をその後に起動すると内外とも `Ctrl-a` になり、下記の「1 回で届く」前提が崩れる（外側が食ってしまう）。永続化するなら、broker 用の別 conf を `-f` で読ませるか、外側と内側で **必ず異なる prefix になるようにする**。
 

--- a/docs/operations/dispatcher-view.md
+++ b/docs/operations/dispatcher-view.md
@@ -79,27 +79,29 @@ org_sidebar = "off"
 
 サイドバーを残したい場合は、内側 tmux（= attach 先の broker socket 上の tmux server）の prefix を `Ctrl-b` 以外へ動かして物理キーの衝突自体を無くす。
 
-prefix は **tmux server ごとの設定**なので、2 段階で入れる。
+prefix は **tmux server ごとの設定**である。broker server だけを狙って変えるには socket を指定する（attach していない別のペイン / 端末から実行してよい。既に attach して抜けられなくなっている場合も、別端末からこれを打てば detach できるようになる）:
 
-1. 今後起動する server 向けに `~/.tmux.conf` へ永続化する:
+```bash
+/usr/bin/tmux -L claude-org-broker set -g prefix C-a
+/usr/bin/tmux -L claude-org-broker bind C-a send-prefix
+```
 
-   ```tmux
-   set -g prefix C-a
-   bind C-a send-prefix
-   ```
+`ORG_BROKER_SOCKET` で socket 名を変えている場合はその名前に読み替える。この形は **走っている broker server に即時反映され、他の tmux server には触らない**ので、入れ子運用でも副作用が無い。
 
-2. **既に走っている broker server には上記の編集は反映されない。** 衝突に気付くのは大抵 server が走っている最中なので、その場で効かせるには socket を指定して直接設定する（attach していない別のペイン / 端末から実行してよい）:
+永続化する場合の注意: `~/.tmux.conf` に `set -g prefix C-a` を書くと **以後起動するすべての tmux server** に効く。外側 tmux をその後に起動すると内外とも `Ctrl-a` になり、下記の「1 回で届く」前提が崩れる（外側が食ってしまう）。永続化するなら、broker 用の別 conf を `-f` で読ませるか、外側と内側で **必ず異なる prefix になるようにする**。
 
-   ```bash
-   /usr/bin/tmux -L claude-org-broker set -g prefix C-a
-   /usr/bin/tmux -L claude-org-broker bind C-a send-prefix
-   ```
+#### 打鍵の読み替え
 
-   `ORG_BROKER_SOCKET` で socket 名を変えている場合はその名前に読み替える。既に attach して抜けられなくなっている場合も、この経路なら別端末から prefix を差し替えて detach できる。
+**満たすべき不変条件は「内側 tmux の prefix が外側 tmux の prefix と異なること」**である。これが満たされている限り、内側 prefix は外側にとって通常入力なので素通しされ、内側へ直接届く:
 
-読み替えの範囲: 変更したのは **内側 tmux（broker socket 側）の prefix だけ**なので、読み替えるのも内側を指すキーに限る — 本ドキュメントの detach / セッション切替、および `tools/org-dispatcher-view.sh` の出力に出てくる `Ctrl-b` である。**§5 の外側 tmux 用のキー**（ペイン分割など）は別 server の設定なので、外側を変更していない限り `Ctrl-b` のままである。
+| 構成 | detach の打鍵 |
+|---|---|
+| 内外とも既定（WezTerm 等からの単独 attach） | `Ctrl-b d` |
+| 内外とも既定（外側 tmux からの入れ子） | `Ctrl-b Ctrl-b d`（1 回目を外側が食い、2 回目が内側へ送られる） |
+| 内側のみ `Ctrl-a` に変更（外側は `Ctrl-b`） | **`Ctrl-a d`** — 2 回押しは不要。`Ctrl-b Ctrl-a d` は誤り（外側が 1 回目の `Ctrl-b` を自分の prefix として食い、続く `Ctrl-a` も自分の prefix key table で解釈するため内側に届かない） |
+| 内外とも同じ値に変更してしまった場合 | 入れ子では再び 2 回押しが要る（`Ctrl-a Ctrl-a d`）。不変条件が崩れているので、どちらかを別の値にするのが望ましい |
 
-**入れ子運用では 2 回押しが不要になる**（§5 の手順からの差分）。内側だけを `Ctrl-a` にした場合、`Ctrl-a` は外側 tmux の prefix ではないため通常入力として素通しされ、内側 tmux にそのまま届く。したがって detach は **`Ctrl-a d` の 1 回**でよい。`Ctrl-b Ctrl-a d` は誤りで、外側が 1 回目の `Ctrl-b` を自分の prefix として食ったうえで、続く `Ctrl-a` を自分の prefix key table で解釈してしまうため内側には届かない。
+読み替えの対象は **内側 tmux（broker socket 側）を指すキー**に限る — 本ドキュメントの detach / セッション切替、および `tools/org-dispatcher-view.sh` の出力に出てくる `Ctrl-b` である。**§5 の外側 tmux 用のキー**（ペイン分割など）は別 server の設定なので、外側を変更していない限り `Ctrl-b` のままである。
 
 ### 4.4 runtime の capacity escalation が案内する `Ctrl+B` について
 
@@ -162,7 +164,7 @@ ORG_BROKER_SOCKET=my-broker tools/org-dispatcher-view.sh
 - **socket 不通時の再試行**: broker daemon が未起動などで tmux socket に繋がらない場合、「broker tmux socket (...) に繋がりません」と出て 2 秒ごとに再試行する
 - **attach 後の自動復帰**: dispatcher が restart / auto-compact fork して session 名が変わると、tmux 側で attach が切れる。本ビューアはそれを検知してループ先頭に戻り、新しい session 名を再解決して再 attach する
 - **複数候補警告**: 同一 broker socket 上に複数 org / 複数 `.dispatcher` ペインが居る稀ケースでは、「dispatcher 候補が N 件見つかりました」と警告し 1 件目を採用する。意図しない dispatcher に attach しうるので broker daemon の状態を確認すること
-- **終了動作の注意**: attach 中の `Ctrl-C` は tmux クライアント / dispatcher ペイン側に渡るので、本ビューアの SIGINT trap には届かない（`--rw` では dispatcher へ `^C` を送ってしまう）。終了は必ず **detach → 再探索プロンプト → `Ctrl-C`** の順で行う。detach の打鍵は prefix 設定で変わる: 内外とも既定なら WezTerm 等からの単独 attach で `Ctrl-b d`、外側 tmux からの入れ子で `Ctrl-b Ctrl-b d`（1 回目を外側が食い、2 回目が内側へ送られる）。§4.3 で内側 prefix だけを変えた場合は入れ子でも 2 回押しは不要になり、変更後の prefix + `d`（例 `Ctrl-a d`）になる。外側フレームが renga の場合は、この detach 打鍵自体が届かないので先に §4 の回避策を適用すること（適用しないとビューアから抜ける手段が無くなる）
+- **終了動作の注意**: attach 中の `Ctrl-C` は tmux クライアント / dispatcher ペイン側に渡るので、本ビューアの SIGINT trap には届かない（`--rw` では dispatcher へ `^C` を送ってしまう）。終了は必ず **detach → 再探索プロンプト → `Ctrl-C`** の順で行う。detach の打鍵は prefix 設定で変わる（構成別の一覧は §4.3 の「打鍵の読み替え」表）。内外とも既定なら単独 attach で `Ctrl-b d`、外側 tmux からの入れ子で `Ctrl-b Ctrl-b d`。外側フレームが renga の場合は、この detach 打鍵自体が届かないので先に §4 の回避策を適用すること（適用しないとビューアから抜ける手段が無くなる）
 
 ## 8. トラブルシューティング
 

--- a/tools/org-dispatcher-view.sh
+++ b/tools/org-dispatcher-view.sh
@@ -42,6 +42,14 @@
 #   しまう）。本ビューワーを止めるには、まず `Ctrl-b d` で **detach** してから、再探索プロンプト
 #   に戻ったところで Ctrl-C を押す（detach 中 / degraded 中 / socket 不通中の sleep ループでは
 #   Ctrl-C が trap に届きクリーンに終了する）。busy-loop は各分岐の sleep で防いでいる。
+#
+#   キー表記: 本スクリプトが案内する `Ctrl-b` は tmux prefix の **既定値** であり、prefix を
+#   変更している場合は設定した prefix に読み替える。加えて、**本ビューワーを renga の画面の中で
+#   動かす場合は先に回避策が要る**: renga の org サイドバーは既定で有効なあいだ `Ctrl+B`
+#   （tmux prefix `Ctrl-b` と同じ物理入力）を消費して PTY へ渡さないため、detach 打鍵が内側
+#   tmux に届かず、上記の終了手順が実行不能になる。回避策は renga 設定 `[ui] org_sidebar = "off"`
+#   か内側 tmux の prefix 変更の 2 つ。詳細は docs/operations/dispatcher-view.md の
+#   「外側フレームが renga の場合」を参照。
 # ============================================================================
 
 set -u
@@ -156,6 +164,11 @@ attach 中のキー操作 / 終了:
   終了するには   まず Ctrl-b d で detach し、再探索プロンプトに戻ってから Ctrl-C を押す。
                 （attach 中の Ctrl-C は tmux / dispatcher ペイン側に渡り、本ビューワーは
                  止まらない。--rw では dispatcher へ ^C を送ってしまうので特に注意）
+  Ctrl-b は tmux prefix の既定値。変更している場合は設定した prefix に読み替える。
+  renga の中で本ビューワーを動かす場合は、org サイドバー（既定で有効）が Ctrl+B を
+  消費して detach 打鍵が内側 tmux に届かないため、先に renga 設定 [ui] org_sidebar = "off"
+  か tmux prefix の変更が要る。詳細は docs/operations/dispatcher-view.md の
+  「外側フレームが renga の場合」。
 
 注意:
   broker の Windows backend は wezterm（tmux でない）ため本スクリプトは tmux backend 専用。
@@ -197,6 +210,7 @@ if [ "$ATTACH_RO" -eq 0 ]; then
 fi
 printf 'org-dispatcher-view 起動（socket=%s, mode=%s）。終了は detach (Ctrl-b d) 後にプロンプトで Ctrl-C。\n' \
 	"$SOCKET" "$([ "$ATTACH_RO" -eq 1 ] && echo read-only || echo read-write)" >&2
+printf '   ※ Ctrl-b は tmux prefix の既定値。変更時は設定した prefix に読み替え（renga の中で使う場合は --help の注記を参照）。\n' >&2
 
 while [ "$RUNNING" -eq 1 ]; do
 	session="$(discover_dispatcher)"
@@ -219,7 +233,7 @@ while [ "$RUNNING" -eq 1 ]; do
 
 	# attach 直前のヘッダ（何に attach しているか）。
 	mode_label="$([ "$ATTACH_RO" -eq 1 ] && echo 'read-only' || echo 'read-write')"
-	printf '>>> dispatcher を発見: session=%s に %s attach します（抜ける: Ctrl-b d、その後プロンプトで Ctrl-C で終了）\n' \
+	printf '>>> dispatcher を発見: session=%s に %s attach します（抜ける: Ctrl-b d、その後プロンプトで Ctrl-C で終了。Ctrl-b は既定 prefix）\n' \
 		"$session" "$mode_label" >&2
 
 	# read-only attach は detach / セッション死亡までブロックする。


### PR DESCRIPTION
## 概要

renga 2.0 の org サイドバー（既定 `coexist`）は `Ctrl+B` を消費し PTY へ渡さないため、renga を外側フレームにして内側 tmux を触る運用手順（dispatcher-view / docker org-shell / broker dogfood attach / pr-watch ペイン覗き）の `Ctrl-b` 打鍵が無反応になる。この衝突と回避策を運用ドキュメントに記載する（コード変更なし・prose のみ）。Epic #859 の子 Issue。

- `docs/operations/dispatcher-view.md` に独立した新 §4「外側フレームが renga の場合」を新設（以降の節を繰り下げ）。renga v2.0.0 実ソース出典付き
- 「Ctrl+B でサイドバーを非表示にすれば直る」という誤解を明示的に否定（消費判定は表示状態でなく enable 状態。`coexist`/`replace` とも消費し、止まるのは `[ui] org_sidebar = "off"` のみ）
- tmux 2 回押しとの因果差を明記(renga は 1 回目で consume するため連打しても内側へ届かない。既存の 2 回押し手順は回避策適用後にのみ成立)
- 回避策 (ii)（内側 tmux prefix 変更）を「不変条件 + 構成 4 種の打鍵表」に構造化。適用は socket 指定を主経路に
- `docker/README.md` / `broker-dogfood-runbook.md` / `org-app-packaging-options.md` / `pr-watch-pane/SKILL.md.in`（+ 再 render 生成物）にポインタ 1 行ずつ
- サイドバー幅の減算式は書いていない（renga が carve 済みのため二重減算になる。diff 全行で数値・減算表現ゼロを確認済み）

## 既知事項（Codex round 5 の P2、未修正のまま記載）

`docker/README.md` の prefix 読み替えコマンドは「org-shell 起動（attach）後・`org` ユーザー実行」が前提。tmux server 未起動での予防適用、root のままの別 `docker exec` からの実行、の 2 経路では通らない。主シナリオ（attach 後に抜けられない状態からの復旧）では成立する。

## スコープ外残件

`org-attach` / `org-start` に残る素の `Ctrl-b` 案内は Issue #876 として起票済み。

## Test plan

- `python3 tools/gen_skill_prose.py --manifest tools/skill_src/manifest.json --transport broker --check` → exit 0（編集前に同条件で drift を確認済みで no-op ではない）
- `pytest tests/ tools/test_gen_skill_prose.py` → 1057 passed, 2 skipped
- `bash -n tools/org-dispatcher-view.sh` OK / `--help` 実端末スモーク OK
- 出典は renga v2.0.0 (3f2a123) の実ソースで全数確認（keyboard_input.rs / config.rs / main.rs / org_sidebar.rs / tests/org_sidebar.rs）
- Codex design review（事前）+ self-review round 1-5（round 5 で P1 ゼロ確定）

Closes #857
Refs #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mWGY93JcrmJ7mYnBFqK9Q