### PR TITLE
feat(claude): renga capability probe server_info を ja の許可面へ同期し runtime pin を 0.1.41 へ上げる

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,7 +29,8 @@
       "mcp__renga-peers__poll_events",
       "mcp__renga-peers__send_keys",
       "mcp__renga-peers__spawn_claude_pane",
-      "mcp__renga-peers__set_pane_identity"
+      "mcp__renga-peers__set_pane_identity",
+      "mcp__renga-peers__server_info"
     ],
     "deny": [
       "Bash(git commit --no-verify*)",

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -37,7 +37,8 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
       "mcp__renga-peers__poll_events",
       "mcp__renga-peers__send_keys",
       "mcp__renga-peers__spawn_claude_pane",
-      "mcp__renga-peers__set_pane_identity"
+      "mcp__renga-peers__set_pane_identity",
+      "mcp__renga-peers__server_info"
     ]
   },
   "env": {
@@ -54,7 +55,7 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 
 ペイン操作（`renga split` / `close` / `list` / `send` / `events` / `inspect` / `new-tab` 等）は MCP ツール (`mcp__renga-peers__*`) 経由で実施する。該当 Bash permission は含めない。
 
-**注意**: `renga-peers` MCP ツール 14 種は `renga mcp install` を一度実行して user-scope に MCP サーバーを登録した後に利用可能になる。登録手順は README「インストール」セクションを参照。
+**注意**: `renga-peers` MCP ツール 15 種は `renga mcp install` を一度実行して user-scope に MCP サーバーを登録した後に利用可能になる。登録手順は README「インストール」セクションを参照。
 
 ### ユーザー共通の sandbox denyRead / denyWrite 補強（`--user-common-sandbox`、Issue #429 Task B + Issue #433）
 
@@ -142,6 +143,7 @@ python tools/org_setup_prune.py --user-common-sandbox  # → "no changes"
       "mcp__renga-peers__poll_events",
       "mcp__renga-peers__send_keys",
       "mcp__renga-peers__set_pane_identity",
+      "mcp__renga-peers__server_info",
 
       "Bash(git add:*)",
       "Bash(git commit:*)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@
 
 ### Added
 
+- renga 2.0.0 の capability probe `mcp__renga-peers__server_info` を ja の許可面へ同期 (#854)。
+  `tools/org_extension_schema.json` の `user_common` / `secretary` の `required_allow` に
+  `set_pane_identity` 直後の位置で追加し (14 → 15 / 12 → 13)、同じエントリを
+  `.claude/settings.json` と `.claude/skills/org-setup/references/permissions.md` の
+  ユーザー共通 / 窓口ブロックへ反映した (permissions.md の「14 種」表記も 15 種へ)。
+  schema と permissions.md は `tools/check_role_configs.py` の `check_docs` が突き合わせるため
+  同一 commit で入れる必要がある。これで `docs/verification.md` 11-a' の live capability 確認
+  (`effective_capabilities` の `caller_scope` / `cross_tab_peers` / `caller_scope_close_identity`
+  を読む唯一の一次経路) と `renga-error-codes.md` の `server_too_old` 復旧手順 step 3 の再 probe が、
+  窓口ロールで承認プロンプトなしに実行できるようになった。`server_info` は runtime 0.1.41 の
+  bundled `role_configs_schema.json` で追加された項目で、ja 側の schema は
+  `tools/check_runtime_schema_drift.py` によりバイト一致を要求されるため、**同 PR で runtime の
+  下限 pin を 0.1.40 → 0.1.41 へ引き上げた** (`pyproject.toml` / `requirements.txt` /
+  `docker/Dockerfile` / `docker/compose.yaml` / `docker/README.md` の image tag 例)。
+  今回は `tools/check_runtime_schema_drift.py` の `RUNTIME_PIN_LOWER_INCLUSIVE` も
+  `(0, 1, 41)` へ同時に引き上げている — 直近 2 回の floor bump では据え置いていたが、
+  今回は schema 自体が変わるため 0.1.40 以下の環境では byte check が skip ではなく
+  **hard fail** になるからである (窓を上げることで意図どおりの skip-with-warning に戻る)。
+  なお同定数は `(0, 1, 17)` のまま長く放置されており、今回の引き上げで pin との既存のずれも解消した。
+  上限 `RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)` は 0.1.41 を含むので不変。
+  `docs/verification.md` / `docs/design/renga-decoupling.md` の「allowlist 未追加・runtime リリース待ち」
+  という記述は解決済みの内容へ書き換え、`docs/design/renga-decoupling.md` / `docs/non-goals.md` の
+  「14 ツール / 14 種」表記も 15 へ揃えた (`docs/operations/attention-watch.md` の下限 pin 記述も追随)。
 - attention watcher の `duplicate_sidecar` kind に ja 側を追随 (#868)。
   `tools/templates/attention.example.json` に `notify.duplicate_sidecar: "urgent"` と日本語文面を追加した
   (未追加だとこの kind だけ runtime 中立の英語 default が出る)。この通知は「同じ owner 宛のメッセージを

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ ARG ORG_UID=1000
 ARG ORG_GID=1000
 # runtime pin（設計 §7.7: 起動時 upgrade はせず、更新は image rebuild）。
 # 既定値は pyproject.toml の claude-org-runtime floor（下限 pin）と同期させること。
-ARG RUNTIME_VERSION=0.1.40
+ARG RUNTIME_VERSION=0.1.41
 # Claude Code ネイティブインストーラに渡すバージョン（stable | latest | x.y.z）
 ARG CLAUDE_CODE_VERSION=stable
 ARG INSTALL_HERDR=1

--- a/docker/README.md
+++ b/docker/README.md
@@ -79,7 +79,7 @@ socket mount はホスト root 相当の権限付与である。オーバーレ�
 docker buildx build -f docker/Dockerfile \
   --platform linux/amd64,linux/arm64 \
   --build-arg REPO_REF="$(git describe --always)" \
-  -t ghcr.io/suisya-systems/claude-org-ja:$(git describe --always)-r0.1.40 \
+  -t ghcr.io/suisya-systems/claude-org-ja:$(git describe --always)-r0.1.41 \
   --push .
 ```
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -14,7 +14,7 @@ services:
         # host bind mount を使う場合はホスト UID に合わせる（設計 §8）
         ORG_UID: "${ORG_UID:-1000}"
         ORG_GID: "${ORG_GID:-1000}"
-        RUNTIME_VERSION: "${RUNTIME_VERSION:-0.1.40}"
+        RUNTIME_VERSION: "${RUNTIME_VERSION:-0.1.41}"
         INSTALL_HERDR: "${INSTALL_HERDR:-1}"
         REPO_REF: "${REPO_REF:-dev}"
     # PID1 は image 内の tini（init: true と等価の機能を image 側で自己完結。設計 §5）

--- a/docs/design/renga-decoupling.md
+++ b/docs/design/renga-decoupling.md
@@ -31,7 +31,7 @@
 
 ## 2. 現状とこの設計の関係
 
-**現行動作（実装済み・運用中）**: 本リポジトリの組織運用は renga-peers MCP サーバー（renga 0.18.0+、14 ツール）を唯一の輸送層として動作している（現行 org の renga transport サポート下限は 2.0.0）。エージェント間メッセージングは renga のチャネル注入（`<channel source="renga-peers">` の in-band 配達）、ペイン操作・観測は `spawn_claude_pane` / `list_panes` / `inspect_pane` / `send_keys` / `poll_events` / `close_pane` 等で行われる。この現行面は [`docs/contracts/backend-interface-contract.md`](../contracts/backend-interface-contract.md)（Set D）が抽象バックエンド契約として批准済みである。
+**現行動作（実装済み・運用中）**: 本リポジトリの組織運用は renga-peers MCP サーバー（renga 0.18.0+、15 ツール）を唯一の輸送層として動作している（現行 org の renga transport サポート下限は 2.0.0）。エージェント間メッセージングは renga のチャネル注入（`<channel source="renga-peers">` の in-band 配達）、ペイン操作・観測は `spawn_claude_pane` / `list_panes` / `inspect_pane` / `send_keys` / `poll_events` / `close_pane` 等で行われる。この現行面は [`docs/contracts/backend-interface-contract.md`](../contracts/backend-interface-contract.md)（Set D）が抽象バックエンド契約として批准済みである。
 
 **この設計（未実装の提案）**: 輸送層を org-broker デーモン + terminal adapter に置き換える計画。本リポジトリに broker / adapter の実装は存在せず、`.claude/skills/` / `.dispatcher/` / `tools/` の現行 prose・コードは引き続き renga-peers を呼ぶ。フォークでの実験が成功し、フェーズ単位の取り込み判断（[§7](#7-phase-計画と移行完了判定基準)）を通過するまで、本体の挙動は一切変わらない。
 
@@ -78,7 +78,7 @@ Phase 2（棚卸し・契約整合）の先行実施として、リポジトリ�
 
 ツール名が allowlist エントリとして列挙されているだけのもの。配線替え時は broker ツール名での再宣言が必要:
 
-- `.claude/settings.json`（14 ツールを allow 宣言。renga 2.0.0 の `server_info` は未追加 — `tools/org_extension_schema.json` が claude-org-runtime の bundled schema とバイト一致を要求されるため、追加には runtime 側のリリースが要る。Refs #823）
+- `.claude/settings.json`（15 ツールを allow 宣言。renga 2.0.0 の `server_info` は claude-org-runtime 0.1.41 の bundled schema 追加を受けて同期済み）
 - `tools/org_extension_schema.json`（ロール別 allow 宣言）
 - `.claude/skills/org-setup/references/permissions.md`（スキーマの文書化）
 

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -90,7 +90,7 @@ bypass モードでも (2) の PreToolUse フックは有効に作動するた�
 
 **理由**: PTY や端末多重化の層は **Layer 3 = `renga`**（`suisya-systems/renga`）に分離されています（ここでの `renga` は**既定運用フレームの** Layer 3。輸送層は両系で、opt-in `broker` では runtime 内蔵の `org-broker` が同じ Layer 3 を担う。両系は併存・切戻し可、§12 host-local 例外を参照）。claude-org-ja は Layer 4 = 「Claude Code を素で叩く運用層」であり、低レイヤの端末制御は依存先に責務を譲ります。同一リポジトリで両方を抱えると、運用規律の改修と PTY 層のバグ修正が干渉してリリース速度が落ちます。
 
-**代替手段**: ペイン操作・構造化ペイン生成・ピア通信は `renga-peers` MCP サーバー（Layer 3 が提供、14 種のツール）を通じて利用してください（既定運用フレーム。opt-in `broker` 選択時は `mcp__org-broker__*` が同等の面を提供する）。
+**代替手段**: ペイン操作・構造化ペイン生成・ピア通信は `renga-peers` MCP サーバー（Layer 3 が提供、15 種のツール）を通じて利用してください（既定運用フレーム。opt-in `broker` 選択時は `mcp__org-broker__*` が同等の面を提供する）。
 
 ---
 

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -229,7 +229,7 @@ claude-org-runtime attention watch --state-dir .state --config .state/attention.
 - journal は末尾から window 分だけ遡って読む。この値を上げると走査範囲もそれに追随して広がるので、busy な daemon でも継続中の incident が視界外へ押し出されることはない
 - dedup key は owner ではなく **競合している instance pair** に対して張られる。片方のセッションを終了させた後に別の instance が入れ替わりで競合を始めた場合は別 incident として扱われ、直前の pair の cooldown に飲まれない
 
-**runtime 版の前提（この kind だけの注意）**: broker journal reader は runtime 0.1.40 で入った経路で、ja の下限 pin もこれに合わせて 0.1.40 に上げてある（`pyproject.toml` / `requirements.txt` の `claude-org-runtime` floor、`docker/Dockerfile` の `RUNTIME_VERSION`）。したがって pin を満たす環境では**この kind は実際に発火する**。手元の runtime に経路があるかを直接確かめたい場合は `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかを見る。**出ない場合は pin より古い runtime が入っている**（floor は下限であって、環境に実際に入っている版とは別物）。その状態ではテンプレートに `notify.duplicate_sidecar` / `templates.duplicate_sidecar` があっても no-op になるだけで、config load エラーにはならない — つまり「設定は正しいのに黙っている」形になるので、二重 sidecar を疑う状況で通知が来ないときは、まずこの `--help` で経路の有無を確かめる。
+**runtime 版の前提（この kind だけの注意）**: broker journal reader は runtime 0.1.40 で入った経路で、ja の下限 pin は現行 0.1.41 とこれを上回っている（`pyproject.toml` / `requirements.txt` の `claude-org-runtime` floor、`docker/Dockerfile` の `RUNTIME_VERSION`）。したがって pin を満たす環境では**この kind は実際に発火する**。手元の runtime に経路があるかを直接確かめたい場合は `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかを見る。**出ない場合は pin より古い runtime が入っている**（floor は下限であって、環境に実際に入っている版とは別物）。その状態ではテンプレートに `notify.duplicate_sidecar` / `templates.duplicate_sidecar` があっても no-op になるだけで、config load エラーにはならない — つまり「設定は正しいのに黙っている」形になるので、二重 sidecar を疑う状況で通知が来ないときは、まずこの `--help` で経路の有無を確かめる。
 
 ## 5. トラブルシューティング
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -627,7 +627,7 @@ claude-org-ja 本体は Issue #429 Task C（本 addendum と同 PR）で共有 `
 
 ### 11-a'. live capability 確認（`server_info`）
 
-> **注意（承認プロンプトが出る）**: `mcp__renga-peers__server_info` は現時点でどの role の permission allowlist にも入っていない。`tools/org_extension_schema.json` が claude-org-runtime の同梱 schema とバイト一致を要求されるため、追加には runtime 側のリリースが先に必要である（[`docs/design/renga-decoupling.md`](design/renga-decoupling.md) 参照）。したがって本手順を MCP ツールとして実行すると許可プロンプトで止まる。**プロンプトを伴わない同等の観測経路は [`tools/check_renga_compat.py`](../tools/check_renga_compat.py)** で、こちらは `renga mcp-peer` を subprocess として起動するため allowlist の影響を受けない。
+> **allowlist 状況**: `mcp__renga-peers__server_info` は `user_common` / `secretary` の permission allowlist に入っており（[`tools/org_extension_schema.json`](../tools/org_extension_schema.json) の同名 role `required_allow`）、この 2 role では本手順を MCP ツールとして承認プロンプトなしで実行できる。同ファイルは claude-org-runtime の同梱 schema とバイト一致を要求されるため、このエントリは runtime 0.1.41 の同梱 schema 追加に追随したものである（下限 pin も 0.1.41）。**allowlist を持たない role（`dispatcher` / `worker` / `curator`）や、プロンプトを伴わない観測経路が要る場面では [`tools/check_renga_compat.py`](../tools/check_renga_compat.py)** を使う。こちらは `renga mcp-peer` を subprocess として起動するため allowlist の影響を受けない。
 
 `server_info`（引数なし）を呼び、`structuredContent` を読む:
 1. `status` を最初に読む（判別子）。`connected` / `detached` / `unreachable` の 3 値

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.40,<0.2",
+    "claude-org-runtime>=0.1.41,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,16 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.41 for the renga 2.0.0 capability probe
+# `mcp__renga-peers__server_info`: 0.1.41 adds that entry to
+# role_configs_schema.json's `user_common` / `secretary` required_allow, and ja
+# mirrors it into tools/org_extension_schema.json in this paired commit. Unlike
+# the two floor bumps below, RUNTIME_PIN_LOWER_INCLUSIVE in
+# tools/check_runtime_schema_drift.py IS raised in step to (0, 1, 41) this time:
+# the schema itself changed, so a 0.1.40-or-older install would now *fail* the
+# byte-identical check rather than pass it. Raising the window floor turns that
+# hard failure into the intended skip-with-warning until the environment
+# catches up. The earlier 0.1.40 floor (below) is subsumed.
 # Floor bumped to 0.1.40 for the attention watcher's `duplicate_sidecar` kind:
 # 0.1.40 adds the broker-journal reader (`attention scan/watch --broker-state-dir`,
 # `duplicate_sidecar_window_sec`) and the `duplicate_sidecar` DEFAULT_NOTIFY entry.
@@ -132,7 +142,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.40,<0.2
+claude-org-runtime>=0.1.41,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).

--- a/tests/test_worker_seed_status_contract.py
+++ b/tests/test_worker_seed_status_contract.py
@@ -29,8 +29,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # **予約台帳が存在するバージョン下限**。``_seed_status`` /
 # ``count_unbound_reservations`` / ``WORKER_BIND_WINDOW_SECONDS`` は 0.1.39 で
 # 初めて入った (0.1.37 / 0.1.38 の wheel を展開して不在を実測)。ja の依存
-# floor は #841 で 0.1.37 → 0.1.39、#868 で 0.1.39 → 0.1.40 と上がっており
-# (pyproject.toml:30 / requirements.txt:135 / docker/Dockerfile:65) 現在は
+# floor は #841 で 0.1.37 → 0.1.39、#868 で 0.1.39 → 0.1.40、#854 で
+# 0.1.40 → 0.1.41 と上がっており
+# (pyproject.toml / requirements.txt の ``claude-org-runtime`` pin および
+# docker/Dockerfile の ``RUNTIME_VERSION``) 現在は
 # floor の方が高い。**この下限は pin ではなく runtime の性質**なので pin に
 # 追随させず独立に持つ。下限未満の runtime
 # では読み手がそもそも居ないので契約に守るべき対象が無く、skip する

--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -62,7 +62,7 @@ from typing import Any, Callable
 # requirements.txt. Keep this constant in sync when widening the pin
 # (Phase 5e+ scope per CLAUDE.local.md). Stored as tuples for ordered
 # comparison; only major.minor.micro are honoured.
-RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 17)
+RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 41)
 RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -76,7 +76,8 @@
         "mcp__renga-peers__poll_events",
         "mcp__renga-peers__send_keys",
         "mcp__renga-peers__spawn_claude_pane",
-        "mcp__renga-peers__set_pane_identity"
+        "mcp__renga-peers__set_pane_identity",
+        "mcp__renga-peers__server_info"
       ],
       "allowed_allow_regex": [],
       "required_deny": [],
@@ -102,6 +103,7 @@
         "mcp__renga-peers__poll_events",
         "mcp__renga-peers__send_keys",
         "mcp__renga-peers__set_pane_identity",
+        "mcp__renga-peers__server_info",
         "Bash(git add:*)",
         "Bash(git commit:*)",
         "Bash(git status:*)",


### PR DESCRIPTION
## 概要

runtime 0.1.41（renga surface に `server_info` が入ったリリース）を受けた ja 側同期。**このPR のマージで、0.1.41 公開以降開いていた CI cascade 窓（floating pin の CI が 0.1.41 を解決 → schema byte 比較 / settings 現物チェックの 2 ジョブが赤くなる状態）が閉じる**。Epic #859 の子 Issue。

- `tools/org_extension_schema.json`: `user_common.required_allow` (14→15) と `secretary.required_allow` (12→13) に `mcp__renga-peers__server_info` を追加。位置は runtime 0.1.41 bundled schema と同一（`set_pane_identity` 直後）で byte 一致
- `.claude/settings.json` / org-setup `references/permissions.md` に同エントリ + 「14 種」→「15 種」（`check_docs` 突き合わせのため schema と同一 commit）
- runtime pin 下限 0.1.40 → **0.1.41**（`pyproject.toml` / `requirements.txt`。Issue 本文の 0.1.40 は起票時スナップショットで、`server_info` が入ったのは 0.1.41）。上限 `<0.2` 不変
- `RUNTIME_PIN_LOWER_INCLUSIVE` を (0,1,41) へ。過去 2 回の floor bump では据え置いた定数だが、今回は schema 自体が変わるため据え置くと 0.1.40 環境が byte check で hard fail する（skip-with-warning に戻すための同時引き上げ。判断理由は requirements.txt のコメントに記録）
- Docker 固定版（`Dockerfile` ARG / `compose.yaml` / `README.md`）を 0.1.41 へ（Dockerfile 自身が pyproject floor と同期と規定）
- prose 陳腐化解消: `docs/verification.md:630` / `docs/design/renga-decoupling.md` の「allowlist 未追加・runtime リリース待ち」を解決済みへ、`renga-decoupling.md` / `docs/non-goals.md` の 14 種表記を 15 へ、`attention-watch.md` の下限 pin 記述追随

## Test plan（すべて runtime 0.1.41 を import する環境で実測）

- `python3 tools/check_runtime_schema_drift.py` → OK (claude-org-runtime **0.1.41** bundled schema matches) — 受入条件（出力版数 0.1.41）充足
- `python3 tools/check_runtime_schema_drift.py --semantic` → semantic OK (0.1.41, 14 fixture)。`required_allow` のみの変更のため fixture 再生成不要を実測確認
- `python3 tools/check_role_configs.py` → OK / `python3 tools/check_renga_compat.py` → 15/15 tools + capability probe connected
- `python3 -m pytest tests/ -q` → 995 passed, 2 skipped（Codex のリポジトリ全体実行では 1861 passed, 6 skipped）
- Codex design review（事前・Major 2 反映）+ self-review round 1 で findings ゼロ

## マージ後の operator 作業（PR 外・窓口実施）

- ja root `.venv` の runtime を 0.1.41 へ upgrade（現在 system user-site のみ 0.1.41）
- `tools/org_setup_prune.py` で窓口 `settings.local.json` を permissions.md から再生成（gitignored のため PR に含まれない）

Closes #854
Refs #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mWGY93JcrmJ7mYnBFqK9Q