### PR TITLE
docs(claude): runtime-release-with-paired-ja-sync skill を repo 管理下に置き、required_allow 系 schema 追加を発動トリガーへ明記する

### DIFF
--- a/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
+++ b/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
@@ -54,13 +54,12 @@ attention watcher integration test に必ず波及する。
   （`>=X,<0.2`）のため PyPI 公開の瞬間から ja 側の 2 チェックが赤くなる:
   (a) `tools/check_role_configs.py --include-local`（settings 現物に新しい必須項目が無い）、
   (b) `tools/check_runtime_schema_drift.py`（ja の `tools/org_extension_schema.json` と
-  runtime 同梱 `role_configs_schema.json` のバイト比較。installed runtime が pin window 内
-  なら skip されない。CI でも実行される）。
+  runtime 同梱 `role_configs_schema.json` の、ja 固有節を strip した上でのバイト比較。
+  installed runtime が pin window 内なら skip されない）。
+  両チェックの CI 配線は [`.github/workflows/tests.yml`](../../../.github/workflows/tests.yml) を参照。
   実例: renga capability probe `server_info` の `required_allow` 追加（2026-08-08,
-  runtime Issue #161）で露見。詳細は
-  [`knowledge/curated/release-process.md`](../../../knowledge/curated/release-process.md)
-  の「runtime の `required_allow` 等 schema 追加は、runtime 側 green だけでは ja 側の
-  安全性を証明しない」節を参照
+  runtime Issue #161）で露見。経緯の curated note は
+  [`knowledge/curated/release-process.md`](../../../knowledge/curated/release-process.md) を参照
 
 ## Step 1: pre-fetch（リリース worker 派遣前）
 
@@ -106,11 +105,17 @@ brief で明示しない場合 worker は bump 対象を pyproject 系のみと�
 
 ```bash
 # Secretary 側で実行（user の明示承認後）
+# squash / rebase merge の merge commit はローカル未取得の新規オブジェクトなので
+# tag の前に必ず fetch する（Step 1 の fetch は PR 前なので古い）
+git -C <runtime workers_dir> fetch origin
 git -C <runtime workers_dir> tag vX.Y.Z <merge commit sha>
 git -C <runtime workers_dir> push origin vX.Y.Z
 ```
 
-push 後は GitHub Actions の release.yml ジョブを `gh run watch` 等で監視。
+push 後は GitHub Actions の release.yml ジョブを `gh run watch` 等で監視する。
+このとき **`--repo` で runtime リポジトリを必ず明示**する
+（Secretary の cwd は ja root のため、無指定の `gh run watch` は ja 側リポジトリの
+run に解決される）。
 PyPI publish 完了までは Step 4 の ja-side 派遣を待機しない（並走可。むしろ並走推奨）。
 
 ## Step 4: paired ja-sync の計画（並走で起票）
@@ -121,13 +126,22 @@ ja-side 同期 PR を起票する。後回しにしない:
 | runtime 側の変更 | ja-side 同期対象 |
 |---|---|
 | `DEFAULT_NOTIFY` の値変更 / 追加 / 削除 | `tests/test_attention_runtime_integration.py` の expectation 更新 |
-| `org_extension_schema` のフィールド改廃 | `tools/org_extension_schema.json` のバイト一致コピー差し替え |
+| `org_extension_schema` のフィールド改廃 | `tools/org_extension_schema.json` の共有面を runtime 同梱 schema に同期（ja 固有節は保持。下記注意点参照） |
 | classifier vocabulary の追加 / 改名 | `.claude/skills/org-setup/references/permissions.md` の projection 更新 |
 | attention payload の severity / TTL ladder 変更 | `tools/templates/attention.example.json` の severity / TTL 同期 |
+| ja が新 runtime 版の挙動・新 required 項目に依存する場合 | `pyproject.toml` / `requirements.txt` / `docker/Dockerfile` の runtime version floor を atomic に引き上げ |
 
 paired ja-sync は **複数 worker 並列**で派遣して構わない（むしろ推奨）。
 4 つの同期対象は互いに独立しているため、1 worker 1 PR で並走できる。
 窓口は org-delegate の並列委譲ガイダンスに従って分割する（[[parallelize_delegation]]）。
+
+**例外 — `required_allow` / `required_deny` / `required_hook_scripts` / `required_hooks`
+の追加・変更を含む場合は並列分割しない**: schema ミラー
+（`tools/org_extension_schema.json`）・permissions projection
+（`.claude/skills/org-setup/references/permissions.md`）・tracked settings は
+`tools/check_role_configs.py` が相互整合を検証するため独立には land できない
+（片方だけの中間 PR は CI red になる）。この一式は **1 本の atomic PR** にまとめ、
+machine-local settings（`~/.claude/settings.json` 等）は merge 後に `/org-setup` で反映する。
 
 ## Step 5: CI cascade の予測と委譲
 
@@ -162,8 +176,9 @@ Secretary 自身のセッションが context 上限に達すると、paired ja-
 ## 成果物
 
 - runtime 側: リリース PR + v-タグ + PyPI 発行 + release.yml ジョブ green
-- ja-side: 4 種の paired sync PR（DEFAULT_NOTIFY expectation / schema バイト同期 /
-  permissions projection / attention template）
+- ja-side: 4 種の paired sync PR（DEFAULT_NOTIFY expectation / schema 共有面同期 /
+  permissions projection / attention template。required_* 系は atomic 1 PR、
+  必要時は version floor bump を追加）
 - CI: ja-side main の CI が new runtime 版で green
 
 ## 判断基準・閾値
@@ -189,8 +204,11 @@ Secretary 自身のセッションが context 上限に達すると、paired ja-
 - `tests/test_attention_runtime_integration.py` は paired PR が main に入る前に
   runtime 新版を解決しに行く可能性があるため、ja-side の同期 PR は release.yml 完了直前
   〜直後の数時間でランドさせる時間圧がある
-- `tools/org_extension_schema.json` はバイト一致が前提。手書きの format 差で diff が出ると
-  worker レビューで弾かれる
+- `tools/org_extension_schema.json` は runtime 同梱 schema の**丸ごと byte コピーで
+  差し替えてはならない**。ja 固有の `sandbox` / `sandbox_by_pattern` ボディと Layer-2
+  credential mirror の deny は ja 側 org policy であり、`tools/check_runtime_schema_drift.py`
+  はこれら（と `$comment` キー）を strip した上で残りの共有面をバイト比較する。
+  共有面のみを追加位置・順序まで runtime に揃え、ja 固有節は保持する
 - 本 skill は窓口専属。worker 側 SKILL ではない
 
 ## 履歴的背景

--- a/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
+++ b/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
@@ -5,8 +5,9 @@ description: >
   claude-org-runtime のリリース (release-* タスク / vX.Y.Z タグ発行) を、
   同 PyPI 発行を受ける claude-org-ja 側の expectation 同期と
   ペアで設計・委譲・完了させるためのワークフロー。
-  DEFAULT_NOTIFY 値・classifier vocabulary・org_extension_schema・
-  attention.example.json テンプレ等が変わるリリースで発動する。
+  DEFAULT_NOTIFY 値・classifier vocabulary・role_configs_schema
+  (ja 側ミラー: org_extension_schema)・attention.example.json テンプレ等が
+  変わるリリースで発動する。
   CI cascade を予測・予防し、ja-side の red を回避することを目的とする。
 ---
 
@@ -22,8 +23,9 @@ attention watcher integration test に必ず波及する。
 
 ## なぜこの skill が必要か
 
-`claude-org-runtime` 側で `DEFAULT_NOTIFY` の値や classifier 語彙・`org_extension_schema.json`
-の項目を更新してリリースすると、PyPI publish 後に `claude-org-ja` 側の以下が同時に古くなる:
+`claude-org-runtime` 側で `DEFAULT_NOTIFY` の値や classifier 語彙・`role_configs_schema.json`
+（runtime 同梱 schema。ja 側ミラーが `tools/org_extension_schema.json`）の項目を
+更新してリリースすると、PyPI publish 後に `claude-org-ja` 側の以下が同時に古くなる:
 
 - `tests/test_attention_runtime_integration.py` の expectation
 - `tools/org_extension_schema.json` のバイト一致コピー
@@ -46,8 +48,8 @@ attention watcher integration test に必ず波及する。
 
 - task_id に `release` を含む、または `vX.Y.Z` 形式のタグを発行するリリース系タスク
 - chore release 系のユーザー指示プロンプト（「runtime のリリース」「PyPI 上げ」等）
-- runtime 側の `DEFAULT_NOTIFY` / classifier mapping / `org_extension_schema` / attention テンプレ
-  のいずれかを触る変更が land 寸前
+- runtime 側の `DEFAULT_NOTIFY` / classifier mapping / `role_configs_schema.json` /
+  attention テンプレのいずれかを触る変更が land 寸前
 - runtime 側の `role_configs_schema.json` にある `required_allow` / `required_deny` /
   `required_hook_scripts` / `required_hooks` への追加・変更を含むリリース。
   これらは「settings ファイルに必ず存在すべき項目」を増やす変更であり、runtime 側 CI が
@@ -130,13 +132,16 @@ ja-side 同期 PR を起票する。後回しにしない:
 | runtime 側の変更 | ja-side 同期対象 |
 |---|---|
 | `DEFAULT_NOTIFY` の値変更 / 追加 / 削除 | `tests/test_attention_runtime_integration.py` の expectation と golden fixture `tests/fixtures/attention/expected_scan.json` の更新（新ポリシーを ja が採用する場合は `tools/templates/attention.example.json` も） |
-| `org_extension_schema` のフィールド改廃 | `tools/org_extension_schema.json` の共有面を runtime 同梱 schema に同期（ja 固有節は保持。下記注意点参照） |
+| runtime `role_configs_schema.json` のフィールド改廃 | ja 側ミラー `tools/org_extension_schema.json` の共有面を runtime 同梱 schema に同期（ja 固有節は保持。下記注意点参照） |
 | classifier vocabulary の追加 / 改名 | attention 系 artifacts の更新 — `tests/fixtures/attention/` の fixture / golden・`tests/test_attention_runtime_integration.py` の expectation・`tools/templates/attention.example.json`（permissions projection は classifier 語彙を持たないため対象外） |
-| attention payload の severity / TTL ladder 変更 | `tools/templates/attention.example.json` の severity / TTL 同期 |
+| attention payload の severity / TTL ladder 変更 | `tools/templates/attention.example.json` の severity / TTL 同期＋`tests/test_attention_runtime_integration.py` の TTL 前提（fixture の経過時間セットアップ・severity 期待）と golden の整合 |
 | ja が新 runtime 版の挙動・新 required 項目に依存する場合 | `pyproject.toml` / `requirements.txt` / `docker/Dockerfile` / `docker/compose.yaml`（`RUNTIME_VERSION` 既定値。Dockerfile の ARG を上書きするためここが古いと旧版が焼かれる）の runtime version floor を atomic に引き上げ |
 
 paired ja-sync は **複数 worker 並列**で派遣して構わない（むしろ推奨）。
-4 つの同期対象は互いに独立しているため、1 worker 1 PR で並走できる。
+ただし並列分割してよいのは**行間で対象ファイルが重ならない場合に限る**。
+classifier kind と `DEFAULT_NOTIFY` が同時に動くリリースでは attention 系 artifacts
+（integration test / golden / template）が行をまたいで重なるため、attention 系は
+まとめて 1 本の PR にする。重ならない対象は 1 worker 1 PR で並走してよく、
 窓口は org-delegate の並列委譲ガイダンスに従って分割する（[[parallelize_delegation]]）。
 
 **例外 — permissions projection が変わる schema 変更は並列分割しない**:
@@ -147,13 +152,28 @@ CI でも走るため、projection に影響する schema 変更（`required_all
 （`tools/org_extension_schema.json`）・permissions projection・tracked settings は
 独立には land できない（片方だけの中間 PR は CI red になる）。この一式は
 **1 本の atomic PR** にまとめ、machine-local settings（`~/.claude/settings.json` 等）は
-merge 後に `/org-setup` で反映する。
+merge 後に `/org-setup` で反映する。さらに:
+
+- `required_*` の追加はそれ自体が新 runtime 版への依存なので、**version floor 4 ファイル
+  （上表の `pyproject.toml` / `requirements.txt` / `docker/Dockerfile` /
+  `docker/compose.yaml`）も同じ atomic PR に含める**。floor だけ先行させると CI が
+  新 runtime を解決して旧ミラーとの drift red になり、schema 側だけ先行させると
+  旧 floor が旧 runtime を許容したまま残る — どちらの順でも中間状態が壊れる
+- `required_hook_scripts` / `required_hooks` が新規 guard を導入する場合は、
+  `.hooks/` の実体 script（とその test）も同 PR スコープに含める
+  （`tools/check_role_configs.py` は hook command を `.hooks/<script>` の実ファイルに
+  解決し、欠落・相対パス形を報告する）
 
 ## Step 5: CI cascade の予測と委譲
 
-PyPI publish が完了してから 1〜数時間以内に、ja-side リポジトリの CI が新 runtime 版を
-解決しに行く。Step 4 の paired PR が間に合わずに main にマージされた古い ja-side が
-CI red になることが多い。
+ja の CI（`.github/workflows/tests.yml`）は push / pull_request でのみ走り、
+**PyPI publish では再実行されない**。このため 2 つの帰結がある:
+
+- Step 4 の paired PR を publish 前に開いた場合、初回 CI run は旧 runtime を解決した
+  ままで、放置しても新版で再検証されない。publish 確認後に明示的な rerun
+  （`gh run rerun` / head 更新）で新版を解決させてから merge する
+- publish 後に走る他の ja PR / main push の CI run は新版を解決するため、
+  paired PR が未 land のままだとそれらが red になる
 
 このとき **Secretary は CI failure を自分で調査しない**。
 [[secretary_does_not_investigate_ci]] に従い、paired ja-sync worker に

--- a/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
+++ b/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
@@ -59,8 +59,11 @@ attention watcher integration test に必ず波及する。
   との整合で検証する。CI 配線は `--include-worker-settings`
   （[`.github/workflows/tests.yml`](../../../.github/workflows/tests.yml)）で、machine-local
   settings（`~/.claude/settings.json` 等）は CI 対象外。CI green でも local は stale に
-  なり得るため、merge 後に `/org-setup` で反映し `--include-local` 実行で検証する
-  （post-merge の別ゲート）。
+  なり得るため、merge 後に `/org-setup` で反映する。なお `--include-local` は schema に
+  `settings_paths` が宣言された role の settings.local.json しか見ず（`user_common` は
+  `settings_paths: []`）、参照 schema も checked-in の ja ミラーなので、home レベル
+  （`~/.claude/settings.json`）の allowlist 検証ゲートにはならない — user_common の
+  現物反映は `/org-setup` 適用後に settings 現物を直接確認する。
   (b) `tools/check_runtime_schema_drift.py` — ja の `tools/org_extension_schema.json` と
   runtime 同梱 `role_configs_schema.json` の、ja 固有節を strip した上でのバイト比較
   （CI で実行。installed runtime が pin window 内なら skip されない）。

--- a/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
+++ b/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: runtime-release-with-paired-ja-sync
+description: >
+  claude-org-runtime のリリース (release-* タスク / vX.Y.Z タグ発行) を、
+  同 PyPI 発行を受ける claude-org-ja 側の expectation 同期と
+  ペアで設計・委譲・完了させるためのワークフロー。
+  DEFAULT_NOTIFY 値・classifier vocabulary・org_extension_schema・
+  attention.example.json テンプレ等が変わるリリースで発動する。
+  CI cascade を予測・予防し、ja-side の red を回避することを目的とする。
+---
+
+# runtime-release-with-paired-ja-sync: runtime リリース＋ja-side 同期ワークフロー
+
+claude-org-runtime のリリースは PyPI 発行を経由して claude-org-ja の
+attention watcher integration test に必ず波及する。
+本 skill はそのカスケードを「リリース起票時に予測し、paired ja-sync を同一 Secretary
+セッション内で land しきる」ためのチェックリスト。
+
+> **本 SKILL のスコープ**: 窓口が runtime release 系タスクを受領した際の
+> 委譲設計と paired ja-sync 計画。実 commit / テスト修正はワーカー側であり本 skill ではない。
+
+## なぜこの skill が必要か
+
+`claude-org-runtime` 側で `DEFAULT_NOTIFY` の値や classifier 語彙・`org_extension_schema.json`
+の項目を更新してリリースすると、PyPI publish 後に `claude-org-ja` 側の以下が同時に古くなる:
+
+- `tests/test_attention_runtime_integration.py` の expectation
+- `tools/org_extension_schema.json` のバイト一致コピー
+- `.claude/skills/org-setup/references/permissions.md` の projection
+- `tools/templates/attention.example.json` の severity / TTL
+
+過去のリリースサイクルでは「runtime release は無事だったが ja-side CI が翌日に red」になる
+カスケードが観測されており、これを毎回観測してから後追いで直すと、
+
+- Secretary セッションが切れて context を失う
+- ja-side worker に「なぜこの変更が必要か」の経路を再構築させる
+- 修正の paired-ness が暗黙的になり次回も同じカスケードを踏む
+
+の 3 重コストが発生する。本 skill は paired-ness を**リリース起票時に明示化**し、
+同一 Secretary セッション内で land しきる規律を提供する。
+
+## 発動条件
+
+以下のいずれかに該当する場合、Secretary は org-delegate より前にこの skill を確認する:
+
+- task_id に `release` を含む、または `vX.Y.Z` 形式のタグを発行するリリース系タスク
+- chore release 系のユーザー指示プロンプト（「runtime のリリース」「PyPI 上げ」等）
+- runtime 側の `DEFAULT_NOTIFY` / classifier mapping / `org_extension_schema` / attention テンプレ
+  のいずれかを触る変更が land 寸前
+- runtime 側の `role_configs_schema.json` にある `required_allow` / `required_deny` /
+  `required_hook_scripts` / `required_hooks` への追加・変更を含むリリース。
+  これらは「settings ファイルに必ず存在すべき項目」を増やす変更であり、runtime 側 CI が
+  full green・Codex 指摘ゼロでも ja 側の安全性は証明されない。ja は floating pin
+  （`>=X,<0.2`）のため PyPI 公開の瞬間から ja 側の 2 チェックが赤くなる:
+  (a) `tools/check_role_configs.py --include-local`（settings 現物に新しい必須項目が無い）、
+  (b) `tools/check_runtime_schema_drift.py`（ja の `tools/org_extension_schema.json` と
+  runtime 同梱 `role_configs_schema.json` のバイト比較。installed runtime が pin window 内
+  なら skip されない。CI でも実行される）。
+  実例: renga capability probe `server_info` の `required_allow` 追加（2026-08-08,
+  runtime Issue #161）で露見。詳細は
+  [`knowledge/curated/release-process.md`](../../../knowledge/curated/release-process.md)
+  の「runtime の `required_allow` 等 schema 追加は、runtime 側 green だけでは ja 側の
+  安全性を証明しない」節を参照
+
+## Step 1: pre-fetch（リリース worker 派遣前）
+
+リリース系タスクは workers_dir 側が古い main から派生すると tag 衝突や stale base
+を引き起こすため、ワーカー派遣の直前に必ず以下を窓口が実行する:
+
+```bash
+cd <runtime workers_dir>
+git fetch origin
+git pull --ff-only origin main
+```
+
+`--ff-only` を必ず付ける。non-fast-forward になる場合は誰か別経路で main を動かしている
+合図なので、worker を派遣せず人間に報告する。
+
+> **cross-link**: workers_dir 側の pre-dispatch 整合性は [`.claude/skills/org-delegate/SKILL.md`](../org-delegate/SKILL.md)
+> の派遣前チェックリストと同質の責務であり、本 skill は release-class 限定の上乗せ。
+
+## Step 2: リリース worker への impl-guidance
+
+リリース worker への brief 組み立て時、以下を **必ず** impl-guidance に明示する:
+
+- `test_smoke.py` 内の version リテラル（あるいは同等の version 文字列を見るテスト）
+  の更新を「known-required な co-update」として列挙する
+- リリース本体の bump 操作と version リテラルが両方 commit に含まれることを完了条件にする
+
+過去のリリースサイクルでは `test_smoke.py` の version リテラル更新漏れが
+リリース直後の CI red 原因として観測されている（cascade の入口）。
+brief で明示しない場合 worker は bump 対象を pyproject 系のみと解釈し、
+テスト側のリテラルを取りこぼす。
+
+## Step 3: リリース land + tag push
+
+リリース PR がマージされた後、release.yml を発火させるための v-タグ push は
+**Secretary が手動で実行**する。理由:
+
+- tag push は GitHub Actions の release publishing pipeline を起動する破壊的操作で、
+  撤回が事実上不可能（PyPI yank はあるが版番号は焼かれる）
+- worker の自動 push 不可制約と整合させる必要がある
+
+実施前に必ずユーザーに「v-タグを push して release.yml を起動します」という
+明示的 OS 承認を取る（チャットの「OK」「進めて」で十分。 [[chat_auth_is_enough]]）。
+
+```bash
+# Secretary 側で実行（user の明示承認後）
+git -C <runtime workers_dir> tag vX.Y.Z <merge commit sha>
+git -C <runtime workers_dir> push origin vX.Y.Z
+```
+
+push 後は GitHub Actions の release.yml ジョブを `gh run watch` 等で監視。
+PyPI publish 完了までは Step 4 の ja-side 派遣を待機しない（並走可。むしろ並走推奨）。
+
+## Step 4: paired ja-sync の計画（並走で起票）
+
+runtime release が以下のいずれかの変更を含むなら、**同一 Secretary セッションで**
+ja-side 同期 PR を起票する。後回しにしない:
+
+| runtime 側の変更 | ja-side 同期対象 |
+|---|---|
+| `DEFAULT_NOTIFY` の値変更 / 追加 / 削除 | `tests/test_attention_runtime_integration.py` の expectation 更新 |
+| `org_extension_schema` のフィールド改廃 | `tools/org_extension_schema.json` のバイト一致コピー差し替え |
+| classifier vocabulary の追加 / 改名 | `.claude/skills/org-setup/references/permissions.md` の projection 更新 |
+| attention payload の severity / TTL ladder 変更 | `tools/templates/attention.example.json` の severity / TTL 同期 |
+
+paired ja-sync は **複数 worker 並列**で派遣して構わない（むしろ推奨）。
+4 つの同期対象は互いに独立しているため、1 worker 1 PR で並走できる。
+窓口は org-delegate の並列委譲ガイダンスに従って分割する（[[parallelize_delegation]]）。
+
+## Step 5: CI cascade の予測と委譲
+
+PyPI publish が完了してから 1〜数時間以内に、ja-side リポジトリの CI が新 runtime 版を
+解決しに行く。Step 4 の paired PR が間に合わずに main にマージされた古い ja-side が
+CI red になることが多い。
+
+このとき **Secretary は CI failure を自分で調査しない**。
+[[secretary_does_not_investigate_ci]] に従い、paired ja-sync worker に
+「PR #N の CI 失敗を調査して直して」とだけ渡し、詳細 brief は書かない。
+gh api / log / diff / source 読解は worker の責務。
+
+予測される red の代表例:
+
+- `tests/test_attention_runtime_integration.py` が `DEFAULT_NOTIFY` の旧値を期待して fail
+- `tools/org_extension_schema.json` の hash mismatch
+- attention template の severity 不一致による smoke test fail
+
+これらは Step 4 で同期 PR が先行 land していれば回避可能。先行できないリリーススケジュール
+の場合は、Step 5 で worker に投げる前提で release.yml 完了直後にスタンバイ。
+
+## Step 6: 同一セッションでの land
+
+Secretary 自身のセッションが context 上限に達すると、paired ja-sync の意図が
+[`/secretary-handover`](../secretary-handover/SKILL.md) を経ても暗黙化しやすい。
+本 skill の全 Step は**できる限り同一 Secretary セッション内で完了**させる:
+
+- リリース worker 完了 → tag push → ja-sync worker 4 並列派遣 → 各 PR レビュー & merge
+- 1 セッションで land しきれない場合は handover に「runtime vX.Y.Z リリース後の paired ja-sync が
+  残タスク」と明示し、resume 後の最初のターンで本 skill を再読する
+
+## 成果物
+
+- runtime 側: リリース PR + v-タグ + PyPI 発行 + release.yml ジョブ green
+- ja-side: 4 種の paired sync PR（DEFAULT_NOTIFY expectation / schema バイト同期 /
+  permissions projection / attention template）
+- CI: ja-side main の CI が new runtime 版で green
+
+## 判断基準・閾値
+
+| 基準 | 値 | 根拠 |
+|---|---|---|
+| paired ja-sync の起票タイミング | release worker 派遣と並走（同セッション） | カスケード遅延を最小化 |
+| `git pull --ff-only` の挙動異常 | 即 user 報告 | 別経路で main が動いた可能性 |
+| Secretary CI 調査 | しない | worker への委譲が標準（[[secretary_does_not_investigate_ci]]） |
+
+## 応用・バリエーション
+
+- **schema 変更のみ・DEFAULT_NOTIFY 不変**: Step 4 の対象は schema / permissions 同期の
+  2 系統のみで足りる（test expectation は影響しない場合がある）
+- **DEFAULT_NOTIFY だけ動く・schema 不変**: test expectation 更新のみで完結することが多い
+- **classifier vocabulary を新規追加**: 4 系統全てに波及する典型ケース。Step 4 のうち
+  4 worker 並列を強く推奨
+
+## 注意点
+
+- v-タグ push は user 明示承認なしで実行しない。release.yml は一度焼くと PyPI 版番号が消費される
+- workers_dir の `git pull --ff-only` で non-fast-forward を踏んだら worker 派遣を中断
+- `tests/test_attention_runtime_integration.py` は paired PR が main に入る前に
+  runtime 新版を解決しに行く可能性があるため、ja-side の同期 PR は release.yml 完了直前
+  〜直後の数時間でランドさせる時間圧がある
+- `tools/org_extension_schema.json` はバイト一致が前提。手書きの format 差で diff が出ると
+  worker レビューで弾かれる
+- 本 skill は窓口専属。worker 側 SKILL ではない
+
+## 履歴的背景
+
+本 skill は claude-org-runtime v0.1.11 リリースサイクルで観測されたカスケードを
+ベースに、Issue #25 / #26 / #28 / Backlog #32 / #33 の議論を通じて結晶化した
+ワークフロー。

--- a/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
+++ b/.claude/skills/runtime-release-with-paired-ja-sync/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: runtime-release-with-paired-ja-sync
+owner: secretary
 description: >
   claude-org-runtime のリリース (release-* タスク / vX.Y.Z タグ発行) を、
   同 PyPI 発行を受ける claude-org-ja 側の expectation 同期と
@@ -51,15 +52,18 @@ attention watcher integration test に必ず波及する。
   `required_hook_scripts` / `required_hooks` への追加・変更を含むリリース。
   これらは「settings ファイルに必ず存在すべき項目」を増やす変更であり、runtime 側 CI が
   full green・Codex 指摘ゼロでも ja 側の安全性は証明されない。ja は floating pin
-  （`>=X,<0.2`）のため PyPI 公開の瞬間から ja 側の 2 チェックが赤くなる:
-  (a) `tools/check_role_configs.py --include-local`（settings 現物に新しい必須項目が無い）、
-  (b) `tools/check_runtime_schema_drift.py`（ja の `tools/org_extension_schema.json` と
-  runtime 同梱 `role_configs_schema.json` の、ja 固有節を strip した上でのバイト比較。
-  installed runtime が pin window 内なら skip されない）。
-  両チェックの CI 配線は [`.github/workflows/tests.yml`](../../../.github/workflows/tests.yml) を参照。
-  実例: renga capability probe `server_info` の `required_allow` 追加（2026-08-08,
-  runtime Issue #161）で露見。経緯の curated note は
-  [`knowledge/curated/release-process.md`](../../../knowledge/curated/release-process.md) を参照
+  （`>=X,<0.2`）のため PyPI 公開の瞬間から ja 側の 2 系統のチェックが赤くなる:
+  (a) `tools/check_role_configs.py` — permissions projection と tracked settings を schema
+  との整合で検証する。CI 配線は `--include-worker-settings`
+  （[`.github/workflows/tests.yml`](../../../.github/workflows/tests.yml)）で、machine-local
+  settings（`~/.claude/settings.json` 等）は CI 対象外。CI green でも local は stale に
+  なり得るため、merge 後に `/org-setup` で反映し `--include-local` 実行で検証する
+  （post-merge の別ゲート）。
+  (b) `tools/check_runtime_schema_drift.py` — ja の `tools/org_extension_schema.json` と
+  runtime 同梱 `role_configs_schema.json` の、ja 固有節を strip した上でのバイト比較
+  （CI で実行。installed runtime が pin window 内なら skip されない）。
+  実例: renga capability probe `server_info` の `required_allow` 追加
+  （2026-08-08, runtime Issue #161）で露見
 
 ## Step 1: pre-fetch（リリース worker 派遣前）
 
@@ -125,23 +129,25 @@ ja-side 同期 PR を起票する。後回しにしない:
 
 | runtime 側の変更 | ja-side 同期対象 |
 |---|---|
-| `DEFAULT_NOTIFY` の値変更 / 追加 / 削除 | `tests/test_attention_runtime_integration.py` の expectation 更新 |
+| `DEFAULT_NOTIFY` の値変更 / 追加 / 削除 | `tests/test_attention_runtime_integration.py` の expectation と golden fixture `tests/fixtures/attention/expected_scan.json` の更新（新ポリシーを ja が採用する場合は `tools/templates/attention.example.json` も） |
 | `org_extension_schema` のフィールド改廃 | `tools/org_extension_schema.json` の共有面を runtime 同梱 schema に同期（ja 固有節は保持。下記注意点参照） |
-| classifier vocabulary の追加 / 改名 | `.claude/skills/org-setup/references/permissions.md` の projection 更新 |
+| classifier vocabulary の追加 / 改名 | attention 系 artifacts の更新 — `tests/fixtures/attention/` の fixture / golden・`tests/test_attention_runtime_integration.py` の expectation・`tools/templates/attention.example.json`（permissions projection は classifier 語彙を持たないため対象外） |
 | attention payload の severity / TTL ladder 変更 | `tools/templates/attention.example.json` の severity / TTL 同期 |
-| ja が新 runtime 版の挙動・新 required 項目に依存する場合 | `pyproject.toml` / `requirements.txt` / `docker/Dockerfile` の runtime version floor を atomic に引き上げ |
+| ja が新 runtime 版の挙動・新 required 項目に依存する場合 | `pyproject.toml` / `requirements.txt` / `docker/Dockerfile` / `docker/compose.yaml`（`RUNTIME_VERSION` 既定値。Dockerfile の ARG を上書きするためここが古いと旧版が焼かれる）の runtime version floor を atomic に引き上げ |
 
 paired ja-sync は **複数 worker 並列**で派遣して構わない（むしろ推奨）。
 4 つの同期対象は互いに独立しているため、1 worker 1 PR で並走できる。
 窓口は org-delegate の並列委譲ガイダンスに従って分割する（[[parallelize_delegation]]）。
 
-**例外 — `required_allow` / `required_deny` / `required_hook_scripts` / `required_hooks`
-の追加・変更を含む場合は並列分割しない**: schema ミラー
-（`tools/org_extension_schema.json`）・permissions projection
-（`.claude/skills/org-setup/references/permissions.md`）・tracked settings は
-`tools/check_role_configs.py` が相互整合を検証するため独立には land できない
-（片方だけの中間 PR は CI red になる）。この一式は **1 本の atomic PR** にまとめ、
-machine-local settings（`~/.claude/settings.json` 等）は merge 後に `/org-setup` で反映する。
+**例外 — permissions projection が変わる schema 変更は並列分割しない**:
+`tools/check_role_configs.py` は permissions projection
+（`.claude/skills/org-setup/references/permissions.md`）を schema との整合で常時検証し
+CI でも走るため、projection に影響する schema 変更（`required_allow` / `required_deny` /
+`required_hook_scripts` / `required_hooks` の追加・変更を含む）では、schema ミラー
+（`tools/org_extension_schema.json`）・permissions projection・tracked settings は
+独立には land できない（片方だけの中間 PR は CI red になる）。この一式は
+**1 本の atomic PR** にまとめ、machine-local settings（`~/.claude/settings.json` 等）は
+merge 後に `/org-setup` で反映する。
 
 ## Step 5: CI cascade の予測と委譲
 
@@ -166,10 +172,11 @@ gh api / log / diff / source 読解は worker の責務。
 ## Step 6: 同一セッションでの land
 
 Secretary 自身のセッションが context 上限に達すると、paired ja-sync の意図が
-[`/secretary-handover`](../secretary-handover/SKILL.md) を経ても暗黙化しやすい。
+[`.claude/skills/secretary-handover/SKILL.md`](../secretary-handover/SKILL.md) を経ても暗黙化しやすい。
 本 skill の全 Step は**できる限り同一 Secretary セッション内で完了**させる:
 
-- リリース worker 完了 → tag push → ja-sync worker 4 並列派遣 → 各 PR レビュー & merge
+- リリース worker 派遣と並走で ja-sync worker を起票（Step 4）→ リリース PR merge →
+  tag push → ja-sync PR を release.yml 完了前後で land・merge
 - 1 セッションで land しきれない場合は handover に「runtime vX.Y.Z リリース後の paired ja-sync が
   残タスク」と明示し、resume 後の最初のターンで本 skill を再読する
 


### PR DESCRIPTION
## 概要

curator の改善提案（ユーザー承認済み）の反映。`runtime-release-with-paired-ja-sync` skill の発動条件に「`role_configs_schema.json` の `required_allow` / `required_deny` / `required_hook_scripts` / `required_hooks` の追加・変更を含むリリース」を明示追加する。

背景は runtime#161 (0.1.41) で実害寸前まで行った構造的盲点: これらは「settings ファイルに存在必須」の要件追加であり、runtime 側 CI が full green・Codex 指摘ゼロでも、PyPI 公開の瞬間から ja CI の 2 ジョブ（`check_role_configs` の settings 現物チェック / `check_runtime_schema_drift` の `org_extension_schema.json` byte 比較）が赤くなる。ja は floating pin のため公開即 cascade で、既存トリガー（DEFAULT_NOTIFY 値 / classifier vocabulary / org_extension_schema / attention.example.json）はこのケースを拾わなかった。

**副次的発見**: この skill の SKILL.md は promote commit が未マージブランチにのみ存在し、運用実体は `~/.claude/skills/` のコピーだった（repo 未管理）。本 PR で運用コピー（dangling 参照を in-repo 出典へ差し替えたもの）を repo にランドさせた上でトリガーを追記している — **skill 全体が初めて repo 管理下に入る**。

## 既知事項（スコープ外・Issue #884）

diff にファイル全体（2026-05 作の legacy runbook 約 200 行）が入るため、Codex レビューが legacy 部分の運用ギャップ（tag 前 SHA 検証・version floor bump の適用範囲・evaluator drift 行の欠落等、P1 4 件 + P2 3 件）を検出した。これらはトリガー追記とは独立した既存内容の問題のため、follow-up Issue に切り出す（本文は verify round で全件裏取り済み）。

## Test plan

- Codex self-review round 1-3（全指摘修正）+ 汚染排除後の検証 round（トリガー hunk 起因 P1 1 件を修正、最終状態でトリガー hunk 起因の指摘ゼロ）
- 出典は全て in-repo 実ファイルで裏取り（check_runtime_schema_drift.py docstring / check_role_configs.py / tests.yml / pyproject.toml の floating pin）

Refs #859（belt 実走の副産物として発見された盲点の再発防止）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mWGY93JcrmJ7mYnBFqK9Q
