### PR TITLE
feat(claude): renga の「単一画面タイリング」記述 11 箇所をタブモデル + org 同一タブ規則の 2 段記述へ書き換える

### DIFF
--- a/.claude/skills/org-attach/SKILL.md
+++ b/.claude/skills/org-attach/SKILL.md
@@ -35,11 +35,22 @@ role + name(task_id) ラベル付きで印字するだけ。コピーした人�
 > 前提とする。**broker フレーム**: 各 broker ペインは `claude-org-broker-{pid}-{seq}` という独立した detached
 > tmux session（1 ペイン = 1 session）として存在し、`tmux attach -t <session>` で入れる ―
 > 本スキルの attach モデルが意味を持つ主フレームはこちら。**renga フレーム（opt-in,
-> `ORG_TRANSPORT=renga`）は概念が異なる**: renga は**単一画面のタイリング**モデルで、ペインは 1 つの
-> 生きたウィンドウ内の**タイル**であって、独立した detached session ではない。「detached session へ
-> attach し直す」概念がそのまま写像せず、ペイン単位の `tmux attach -t <session>` は存在しない。
-> よって renga 下では本スキルの attach 形は**適用外**で、画面そのものを直接見ればよい（attach 不要）。
-> 本スキルは renga フレームでは「broker(tmux) 専用ツールです」と明示して停止する（下記 Step 0）。
+> `ORG_TRANSPORT=renga`）は概念が異なる**: renga のペインは**所属タブ内のタイル**であって、独立した
+> detached session ではない。「detached session へ attach し直す」概念がそのまま写像せず、ペイン単位の
+> `tmux attach -t <session>` は存在しない。よって **`ORG_TRANSPORT=renga` では**本スキルの broker/tmux
+> attach 形は**適用外**で、org のペインが並ぶタブを表示して直接見る。org が全ペインを同一タブへ置くのは
+> org 側の配置規則であり、規範の正本は契約
+> [`docs/contracts/backend-interface-contract.md`](../../../docs/contracts/backend-interface-contract.md)
+> §4.2 の SINGLE-TAB MUST（本スキルはこれを再掲せず参照する）。したがって**その org のタブを表示している
+> 間は** 1 画面で全ペインが見えるが、別のタブを表示している間は org のペインは視界に入らない。そのときは
+> org のタブへ切り替えるか、renga の org サイドバー（全タブ横断でタブとペインを一覧する cross-tab パネル。
+> renga `src/app/org_sidebar.rs:1-3`）から該当ペインを選ぶ。
+> **この適用外は transport が renga の場合に限る**: 外側フレームが renga でも `ORG_TRANSPORT` が broker の
+> 構成では detached tmux session が実在するので本スキルは**適用される**（その場合に必要なのは attach 打鍵の
+> `Ctrl+B` 衝突回避で、手順は
+> [`docs/operations/dispatcher-view.md`](../../../docs/operations/dispatcher-view.md)「外側フレームが renga の
+> 場合」）。本スキルは `ORG_TRANSPORT=renga` のときだけ「broker(tmux) 専用ツールです」と明示して停止する
+> （下記 Step 0）。
 >
 > （**既定の二フレーム注記（Refs #604）**: org-attach は本質的に broker/tmux ツールなので header を
 > **broker 主軸**で書く。輸送層全体の既定は二つのフレームで指す対象が異なる ― **運用既定**は renga
@@ -73,12 +84,14 @@ _zsh_tmux_plugin_run`）。素の `tmux ...` を出力すると、人間の zsh 
 printenv ORG_TRANSPORT
 ```
 
-renga フレームならこのスキルは適用外なので attach コマンドを生成せず停止する。
+renga transport（`ORG_TRANSPORT=renga`）ならこのスキルは適用外なので attach コマンドを生成せず停止する。
 
 - **`ORG_TRANSPORT=renga`（明示）の場合** → 次の旨を伝えて停止する（attach コマンドは生成しない）:
-  「現在は renga（単一画面タイリング）で稼働しています。renga ではペインは 1 つのライブウィンドウ内の
-  タイルで、detached tmux session への attach という概念がそのまま適用されません。ペイン状況の一覧は
-  [`/org-dashboard`](../org-dashboard/SKILL.md) を使ってください。」
+  「現在は renga transport（`ORG_TRANSPORT=renga`）で稼働しています。renga のペインは所属タブ内のタイルで、
+  detached tmux session への attach という概念がそのまま適用されません。組織のペインはすべて同じタブに
+  置かれるので、その組織のタブを表示している間はそのまま画面で見られます。別のタブを表示中なら、組織の
+  タブへ切り替えるか、renga の org サイドバー（全タブ横断でタブとペインを一覧するパネル）から該当ペインを
+  選んでください。ペイン状況の一覧は [`/org-dashboard`](../org-dashboard/SKILL.md) を使ってください。」
 - **それ以外（無設定 / `broker`）** → broker(tmux) フレームとして Step 1 へ進む。
 
 ## Step 1: 論理ペイン一覧を取得（broker）

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ claude-org-runtime org up --backend herdr
 
 ### renga で起動する場合
 
-通常は `claude-org-runtime org up` で起動します。renga は、claude-org-ja に合わせて開発された、Windows・Linux・macOS 対応のターミナル作業環境です（[GitHub](https://github.com/suisya-systems/renga) / [npm](https://www.npmjs.com/package/@suisya-systems/renga)）。複数の Claude Code ペインを 1 つの画面に並べ、窓口・ディスパッチャー・ワーカーのペイン管理と、ペイン同士の連絡を扱います。画面全体でペインの動きを見ながら起動したい場合は、renga を使って起動できます。renga は npm パッケージなので、別途 Node.js（LTS 推奨）のインストールが必要です。クローン後のディレクトリで次を実行します。
+通常は `claude-org-runtime org up` で起動します。renga は、claude-org-ja に合わせて開発された、Windows・Linux・macOS 対応のターミナル作業環境です（[GitHub](https://github.com/suisya-systems/renga) / [npm](https://www.npmjs.com/package/@suisya-systems/renga)）。複数の Claude Code ペインを 1 つのタブに並べ、窓口・ディスパッチャー・ワーカーのペイン管理と、ペイン同士の連絡を扱います。renga はタブを複数持てますが、組織のペインはすべて同じタブに置かれるので、そのタブを表示している間は 1 画面で全体を見渡せます。画面全体でペインの動きを見ながら起動したい場合は、renga を使って起動できます。renga は npm パッケージなので、別途 Node.js（LTS 推奨）のインストールが必要です。クローン後のディレクトリで次を実行します。
 
 ```bash
 # macOS / Linux
@@ -95,7 +95,7 @@ renga で窓口を開いた場合も、Claude Code 上で実行する手順は�
   </tr>
 </table>
 
-上の画像は、renga で組織を起動したときの画面例です。左は起動直後、右は窓口・ディスパッチャー・ワーカーが並んで動いている状態です。
+上の画像は、renga で組織を起動したときの画面例です（いずれも組織のタブを表示した状態です）。左は起動直後、右は窓口・ディスパッチャー・ワーカーが並んで動いている状態です。
 
 ## 主な特長
 
@@ -138,7 +138,7 @@ renga で窓口を開いた場合も、Claude Code 上で実行する手順は�
 | 通知監視を使う | `/org-attention-start` / `/org-attention-stop` | 承認待ちや停止を別ペインで監視し、必要に応じて通知音を鳴らす |
 | スキル構成を点検する | `/skill-eligibility-check` / `/skill-audit` | 蓄積した知見からスキル化候補や棚卸しを確認する |
 
-`tools/org-dispatcher-view.sh` と `/org-attach` は broker/tmux 用の読み取り専用の補助ツールです。renga を代替手段として使う場合は 1 つの画面に各ペインが並ぶため、attach ではなくその画面を直接見ます。ディスパッチャーを表示し続けたい場合の詳しい手順は [`docs/operations/dispatcher-view.md`](docs/operations/dispatcher-view.md) を参照してください。
+`tools/org-dispatcher-view.sh` と `/org-attach` は broker/tmux 用の読み取り専用の補助ツールです。renga を代替手段として使う場合、組織のペインはすべて同じタブに並ぶため、attach ではなくそのタブを表示して直接見ます（別のタブを表示している間は見えないので、組織のタブに切り替えるか、renga のサイドバーから選びます）。ディスパッチャーを表示し続けたい場合の詳しい手順は [`docs/operations/dispatcher-view.md`](docs/operations/dispatcher-view.md) を参照してください。
 
 ## もっと知る
 

--- a/docs/design/org-app-packaging-options.md
+++ b/docs/design/org-app-packaging-options.md
@@ -20,6 +20,8 @@
 > - [`docs/contracts/sandbox-launcher-contract.md`](../contracts/sandbox-launcher-contract.md)（権限モデルの外部依存）
 > - [`docs/contracts/state-fixture-scrub-policy.md`](../contracts/state-fixture-scrub-policy.md)（公開資産と operator 固有情報の境界）
 > - [`renga`](https://github.com/suisya-systems/renga) v1.4.0 のソース（[§4.4](#44-案-d--org-native-な専用マルチプレクサrenga-の-org-native-化) 案 D の棚卸し対象。読み取りのみ・変更なし。パスは renga リポジトリのルート相対で示す）
+>
+> **renga の版に関する読み方の境界**: 上の v1.4.0 は **§4.4 の棚卸しが対象にした版**であって、本ドキュメント全体がその版を前提にしているという意味ではない。[§2.8.3](#283-operator-が-worker-の作業画面を直接覗ける可視性) の可視性の記述（および [§5.3](#53-可視性の保全--最重要要件) の backend 比較表の renga 行）は**現行 renga 2.0 の運用事実**に更新済みだが、§4.4 の機能棚卸しは 2.0 に対して**再調査していない**。
 
 ---
 
@@ -176,14 +178,14 @@ attention watcher（`claude-org-runtime attention watch`）は `state.db` と `p
 
 **これはユーザーが明示的に重視した要件である。** 現状の実体は次の 2 経路:
 
-- **broker / tmux フレーム** — 各ペインは `claude-org-broker-{pid}-{seq}` という独立した detached tmux session（1 ペイン = 1 session）として存在し、人間が自分の端末から `/usr/bin/tmux -L claude-org-broker attach -r -t <session>` で入る。`-r` は read-only attach、`Ctrl-b d` でデタッチ（ペインは動いたまま。`Ctrl-b` は tmux prefix の既定値で、変更していれば設定した prefix に読み替える。**attach する端末が renga の場合は org サイドバーが `Ctrl+B` を消費してこの打鍵が届かない** — 回避策は [`docs/operations/dispatcher-view.md`](../operations/dispatcher-view.md) の「外側フレームが renga の場合」）。[`.claude/skills/org-attach/SKILL.md`](../../.claude/skills/org-attach/SKILL.md):33-42, :161-172 がこの attach コマンド**文字列を生成するだけ**の read-only スキル。
-- **renga フレーム** — 単一画面のタイリングモデルで、ペインは 1 つのライブウィンドウ内のタイル。「detached session へ attach し直す」概念が写像せず、**画面をそのまま見ればよい**（同 :37-41）。
+- **broker / tmux フレーム** — 各ペインは `claude-org-broker-{pid}-{seq}` という独立した detached tmux session（1 ペイン = 1 session）として存在し、人間が自分の端末から `/usr/bin/tmux -L claude-org-broker attach -r -t <session>` で入る。`-r` は read-only attach、`Ctrl-b d` でデタッチ（ペインは動いたまま。`Ctrl-b` は tmux prefix の既定値で、変更していれば設定した prefix に読み替える。**attach する端末が renga の場合は org サイドバーが `Ctrl+B` を消費してこの打鍵が届かない** — 回避策は [`docs/operations/dispatcher-view.md`](../operations/dispatcher-view.md) の「外側フレームが renga の場合」）。[`.claude/skills/org-attach/SKILL.md`](../../.claude/skills/org-attach/SKILL.md):33-53, :174-185 がこの attach コマンド**文字列を生成するだけ**の read-only スキル。
+- **renga フレーム**（transport が renga = `ORG_TRANSPORT=renga` のケース） — ペインは**所属タブ内のタイル**であって独立した detached session ではなく、「detached session へ attach し直す」概念が写像しない。org は全ペインを同一タブへ置くので（これは renga の性質ではなく org 側の配置規則で、規範の正本は契約 [`docs/contracts/backend-interface-contract.md`](../contracts/backend-interface-contract.md) §4.2 の SINGLE-TAB MUST）、**その org のタブを表示している間は画面をそのまま見ればよい**。別のタブを表示している間は org のペインが視界に入らないため、org のタブへ切り替えるか、renga の org サイドバー（全タブ横断でタブとペインを一覧する cross-tab パネル）から該当ペインを選ぶ（同 :37-53）。
 
 加えて [`tools/org-dispatcher-view.sh`](../../tools/org-dispatcher-view.sh):195-236 が「dispatcher の自己修復する read-only ビュー」を提供し、dispatcher の restart / auto-compact fork でセッション名が変わっても自動再探索・再 attach する。
 
-> **重要な例外 — 窓口（root secretary）は attach 対象外**。窓口は broker 起動時に logical pane（bookkeeping entry）として登録されるだけで **adapter 実ペインを持たず `pane_id` が `null`** であり、broker socket の detached session に出現しない（[`.claude/skills/org-attach/SKILL.md`](../../.claude/skills/org-attach/SKILL.md):101-107）。これは `org up` が対話型 `claude` TUI を **`os.execvpe` で呼び出し元プロセスに置換して**起動するためで（`claude_org_runtime/broker/launcher.py:342-344`）、窓口は「org を起動した人間の手元 terminal」そのものに住んでいる。**つまり `worker` / `dispatcher` は埋め込めても、人間が最も長く見る窓口セッションだけは既存の tmux 経路では埋め込めない。** [§6.2](#62-段階ロードマップ) Phase 4 はこの穴を明示的に埋める必要がある。
+> **重要な例外 — 窓口（root secretary）は attach 対象外**。窓口は broker 起動時に logical pane（bookkeeping entry）として登録されるだけで **adapter 実ペインを持たず `pane_id` が `null`** であり、broker socket の detached session に出現しない（[`.claude/skills/org-attach/SKILL.md`](../../.claude/skills/org-attach/SKILL.md):114-119）。これは `org up` が対話型 `claude` TUI を **`os.execvpe` で呼び出し元プロセスに置換して**起動するためで（`claude_org_runtime/broker/launcher.py:342-344`）、窓口は「org を起動した人間の手元 terminal」そのものに住んでいる。**つまり `worker` / `dispatcher` は埋め込めても、人間が最も長く見る窓口セッションだけは既存の tmux 経路では埋め込めない。** [§6.2](#62-段階ロードマップ) Phase 4 はこの穴を明示的に埋める必要がある。
 
-> **backend による差**: 上記の「1 ペイン = 1 detached tmux session」は **broker × tmux backend に固有**である。Windows 正準の WezTerm backend と herdr backend は tmux socket を持たないため `tmux attach` の経路が存在せず、renga は単一画面タイリングで detached session の概念自体がない。可視性の実装は backend ごとに別の話になる（[§5.3](#53-可視性の保全--最重要要件)）。
+> **backend による差**: 上記の「1 ペイン = 1 detached tmux session」は **broker × tmux backend に固有**である。Windows 正準の WezTerm backend と herdr backend は tmux socket を持たないため `tmux attach` の経路が存在せず、renga transport もペインが所属タブ内のタイルであって detached session の概念自体を持たない。可視性の実装は backend ごとに別の話になる（[§5.3](#53-可視性の保全--最重要要件)）。
 
 **この可視性が実際に人間へ与えているもの**を分解すると:
 
@@ -406,7 +408,7 @@ claude-org の中核と重なる機能が、公式側で相次いで提供され
 
 #### 4.4.1 renga が既に持っているもの（実コード棚卸し）
 
-以下は renga v1.4.0（`Cargo.toml` の `version = "1.4.0"`、Rust 実装・全 43 ファイル 28,864 LOC）の実ソースを読んで確認したもの。パスは renga リポジトリのルート相対。
+以下は renga v1.4.0（`Cargo.toml` の `version = "1.4.0"`、Rust 実装・全 43 ファイル 28,864 LOC）の実ソースを読んで確認したもの。パスは renga リポジトリのルート相対。**この棚卸しは v1.4.0 時点のままで、renga 2.0 に対しては再調査していない**（2.0 の実体に合わせて更新したのは [§2.8.3](#283-operator-が-worker-の作業画面を直接覗ける可視性) と [§5.3](#53-可視性の保全--最重要要件) の可視性の記述だけである）。
 
 - **MCP peer サーバ 15 ツール**（`src/mcp_peer/mod.rs:444-737` のツールカタログ、同 :967-981 のディスパッチ）— `list_peers` / `send_message` / `set_summary` / `check_messages` / `list_panes` / `spawn_pane` / `spawn_claude_pane` / `spawn_codex_pane` / `close_pane` / `focus_pane` / `new_tab` / `inspect_pane` / `send_keys` / `set_pane_identity` / `poll_events`。**[§2.5](#25-layer-3--輸送層と端末-backend) の Surface 1-6 に相当する面は既に全部ある。**
 - **role 付き spawn** — ただし現状は**自由記述のラベル**であり、「UI と `list_panes` の出力に表示される」だけで権限や振る舞いを持たない（`src/mcp_peer/mod.rs:544-547` の `role` フィールド説明: "Optional free-form role label (e.g. 'worker', 'foreman', 'curator'). Shown in the UI and in list_panes output."）。
@@ -596,7 +598,7 @@ attention watcher は既に `state.db` / `pending_decisions.json` を読む独�
 | broker × tmux（POSIX 正準） | あり（`tmux attach -r -t <session>`） | 既存 session に PTY ブリッジを噛ませる。最も安い | **Phase 4 の第一対象** |
 | broker × WezTerm（Windows 正準） | tmux socket なし | `TerminalAdapter` の `get_text` / `type_text` を streaming 化するか、WezTerm 側の multiplexer 機能に乗る。**未検証** | Phase 4 の第二対象。実現性は要スパイク |
 | broker × herdr | tmux socket なし | 同上（herdr の adapter 面を streaming 化） | Phase 4 の第三対象 |
-| renga | 概念が非適用（単一画面タイリング） | **適用外**。renga 利用者は従来どおり画面を直接見る | 対象外と明示 |
+| renga（transport） | 概念が非適用（ペインは所属タブ内のタイルで detached session を持たない） | **適用外**。renga 利用者は従来どおり、org のペインが並ぶ org のタブを表示して直接見る（org 同一タブ規則の下で。[§2.8.3](#283-operator-が-worker-の作業画面を直接覗ける可視性)） | 対象外と明示 |
 
 **この差を放置すると「Windows では中が見えないアプリ」になる**。Phase 4 は tmux から着手してよいが、**「A は tmux 専用」で終わらせるなら、アプリの対応 backend を broker+tmux に明示的に絞る**（= Windows は Phase 4 の対象外と宣言する）判断が要る。どちらを取るかは Phase 4 着手前の設計判断であり、[§8](#8-未確認事項と次の検証) の未確認事項に挙げる。
 

--- a/docs/operations/dispatcher-view.md
+++ b/docs/operations/dispatcher-view.md
@@ -17,9 +17,13 @@
 |---|---|---|
 | broker の **tmux backend**（Linux / macOS / WSL） | 適用 | 本スクリプトの想定環境 |
 | broker の **Windows backend (wezterm)** | 非適用 | broker の Windows backend は tmux ではなく wezterm のため、本スクリプトは動かない。同等品は follow-up |
-| **renga** フレーム | 不要 | renga は単一画面タイリングで、各ペインが別 tmux session に分かれず「detached session へ attach し直す」概念が写像しないため不要 |
+| **renga** transport（`ORG_TRANSPORT=renga`） | 条件付きで不要 | renga のペインは所属タブ内のタイルで、各ペインが別 tmux session に分かれず「detached session へ attach し直す」概念が写像しないため、本ビューアは適用外。ただし本ビューアの目的である「常に視界に保つ」が自動で満たされるのは **org のタブを表示している間だけ**である。別タブで作業している間は org のペインが視界に入らないので、org のタブへ切り替えるか org サイドバー（§4.2 の cross-tab パネル）で確認する |
 
 「見る側の端末」が WezTerm / tmux のどちらでも本ビューアは動く。スコープ外なのは **broker backend 自体が wezterm のケース** のみ。
+
+> **表の renga 行は transport が renga のケース（`ORG_TRANSPORT=renga`）に限る。** 外側フレームが renga でも transport が broker の構成では detached tmux session が実在するため、本ビューアは**適用される**（不要ではない）。その構成で必要なのは §4 の `Ctrl+B` 衝突回避である。
+>
+> なお org のペインがすべて同一タブに置かれるのは renga の性質ではなく **org 側の配置規則**で、規範の正本は契約 [`docs/contracts/backend-interface-contract.md`](../contracts/backend-interface-contract.md) §4.2 の SINGLE-TAB MUST である（本ドキュメントは規範を再掲せず参照する）。
 
 ## 3. WezTerm 手順（推奨）
 

--- a/tools/org-dispatcher-view.sh
+++ b/tools/org-dispatcher-view.sh
@@ -30,8 +30,17 @@
 #     **wezterm**（tmux ではない）ので本スクリプトは適用外。wezterm 版の同等品は
 #     follow-up とする（本スクリプトでは実装しない）。
 #   - broker daemon の HTTP / MCP は一切叩かない（純 tmux で役割解決する）。
-#   - renga フレーム（単一画面タイリング）では「detached session へ attach し直す」
-#     概念が写像しないので適用外。renga では画面そのものを直接見ればよい。
+#   - renga transport（ORG_TRANSPORT=renga）では、ペインが所属タブ内のタイルで別々の
+#     detached tmux session に分かれず「detached session へ attach し直す」概念が
+#     写像しないので適用外。org は全ペインを同一タブへ置くので（これは renga の性質では
+#     なく org 側の配置規則で、規範の正本は契約
+#     docs/contracts/backend-interface-contract.md の §4.2 SINGLE-TAB MUST）、その org の
+#     タブを表示している間は画面をそのまま見ればよい。別のタブを表示している間は org の
+#     ペインが視界に入らないため、タブを切り替えるか renga の org サイドバー（全タブ横断で
+#     タブとペインを一覧するパネル）から該当ペインを選ぶ。
+#     この適用外は transport が renga の場合に限る: 外側フレームが renga でも
+#     ORG_TRANSPORT が broker の構成では detached tmux session が実在するため本スクリプトは
+#     適用される（その場合に必要なのは下記「注意」の Ctrl+B 衝突回避）。
 #
 # 注意:
 #   `tmux` は zsh + oh-my-zsh の tmux プラグインで alias 化けするため、本スクリプト内の


### PR DESCRIPTION
## 概要

Closes #858
Refs #859

renga 2.0.0 は複数タブ（workspace）を持つのに、org 側ユーザー向け説明 5 ファイル 11 箇所が「renga は単一画面タイリング」という backend 性質の断定のまま残っていた。これを「renga のペインは所属タブ内のタイル」+「org は全ペインを同一タブに置く運用規則」の 2 段記述へ書き換える。prose のみ・コード挙動変更なし。5 ファイル +49/-21。

## 変更点

1. backend 性質の断定を全廃し 2 段記述へ（11 箇所、Issue の固定台帳どおり）
2. 同一タブ MUST の規範は複製せず、契約 backend-interface-contract.md §4.2 の SINGLE-TAB MUST を唯一の SoT としてポインタ参照
3. 「attach 不要」の結論を `ORG_TRANSPORT=renga` に限定（外側フレーム renga + transport broker の構成では tmux attach が実在するため。従来の無条件表現は誤案内）
4. 「別タブ表示中は org のペインが見えない」という運用上の帰結と復帰導線を追加。dispatcher-view の適用範囲表は「不要」→「条件付きで不要」へ
5. packaging doc に版数境界を明記（§4.4 棚卸しは v1.4.0 時点のまま、今回更新は §2.8.3 / §5.3 のみ）

## 検証

- 旧断定（単一画面 / ライブウィンドウ等）の repo 全文検索で renga 関連の残存ゼロ
- `tools/audit_link_paths.py` 指摘総数 baseline 不変（新規リンク由来の指摘ゼロ）・新規アンカーの実在確認済み
- `bash -n` + `--help` 実端末スモーク（org-dispatcher-view.sh）
- Codex exec review round 1 で Blocker / Major / Minor ゼロ

## 申し送り

後続 #876（org-attach への Ctrl-b 注記）は本 PR の org-attach header 変更（+11 行）に rebase で追随する。