### PR TITLE
fix(claude): org-attach / org-start の素の Ctrl-b 案内に renga サイドバー衝突の読み替え注記を足す

### DIFF
--- a/.claude/skills/org-attach/SKILL.md
+++ b/.claude/skills/org-attach/SKILL.md
@@ -181,8 +181,18 @@ join できた各ペインについて、role + name(task_id) ラベル付きで
   → `/usr/bin/tmux -L claude-org-broker attach -t <session>`
 - **デタッチ**: attach 中に `Ctrl-b d` を押すと、ペインを動かしたまま自分だけ抜ける
   （ペインは生き続ける ― close ではない）
+  - **`Ctrl-b` は tmux prefix の既定値**: prefix を変更している場合は設定した prefix に読み替える。
+    さらに、**attach する端末が renga の場合はこの打鍵が届かない** — renga の org サイドバーは既定で
+    有効なあいだ `Ctrl+B`（tmux prefix `Ctrl-b` と同じ物理入力）を消費して PTY へ渡さないため、
+    detach できず抜けられなくなる。attach する前に
+    [`docs/operations/dispatcher-view.md`](../../../docs/operations/dispatcher-view.md) の
+    「外側フレームが renga の場合」の回避策（renga 設定 `[ui] org_sidebar = "off"`、または tmux prefix
+    の変更）を適用すること。
 
-出力末尾に「`tmux` は zsh で alias 化けするため、必ず実体パス `/usr/bin/tmux` を使うこと」を 1 行添える。
+出力末尾に「`tmux` は zsh で alias 化けするため、必ず実体パス `/usr/bin/tmux` を使うこと」と、上記
+`Ctrl-b` の読み替え（tmux prefix の既定値であること・renga の画面から attach する場合は先に
+[`docs/operations/dispatcher-view.md`](../../../docs/operations/dispatcher-view.md)「外側フレームが renga の
+場合」の回避策が要ること）を添える。
 
 ## 出力フォーマット（worked example）
 
@@ -225,6 +235,11 @@ logical pane 除外 → `%N` を持つ dispatcher / worker のみ join → 生�
 - まず読取専用（-r）で入るのを推奨。自分で打ちたい時だけ -r を外す。
 - 抜けるとき: Ctrl-b d（デタッチ。ペインは動いたまま自分だけ抜ける）。
 - 別セッションへ切替: Ctrl-b s（attach 中にセッション一覧から選ぶ。現状は per-session attach）。
+- 上記 Ctrl-b は tmux prefix の既定値。変更していれば設定した prefix に読み替える。
+  renga の画面から attach する場合は、org サイドバー（既定で有効）が Ctrl+B（tmux prefix Ctrl-b と
+  同じ物理入力）を消費して PTY へ渡さないため上の打鍵が届かない（detach できず抜けられなくなる）。
+  先に docs/operations/dispatcher-view.md「外側フレームが renga の場合」の回避策
+  （renga 設定 [ui] org_sidebar = "off"、または tmux prefix の変更）を適用すること。
 - tmux は zsh で alias 化けするため、必ず実体パス /usr/bin/tmux を使うこと。
 ```
 

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -429,6 +429,8 @@ dispatcher は初回 DELEGATE 完了報告で「/loop 3m で監視します」�
 > ```
 >
 > read-only で十分だが、attach 中に **`Ctrl-b s`** で同 socket 上の他のセッション（= worker / curator のペイン）に切り替えて覗ける。終了は `Ctrl-b d` で detach してからプロンプトで `Ctrl-C`。renga フレームでは tmux session モデルが写像しないので案内しない（renga なら画面そのものを見ればよい）。詳細は [`tools/org-dispatcher-view.sh`](../../../tools/org-dispatcher-view.sh) の `--help`。
+>
+> **打鍵の読み替え**: 上記 `Ctrl-b` は tmux prefix の既定値なので、prefix を変更している場合は設定した prefix に読み替える。さらに、**この broker フレームのビューアを renga の画面の中で起動する場合はこの打鍵が届かない** — renga の org サイドバーは既定で有効なあいだ `Ctrl+B`（tmux prefix `Ctrl-b` と同じ物理入力）を消費して PTY へ渡さないため、`Ctrl-b s` での切替も `Ctrl-b d` での detach もできなくなる（抜けられなくなるので起動前に対処する）。回避策（renga 設定 `[ui] org_sidebar = "off"`、または内側 tmux prefix の変更）は [`docs/operations/dispatcher-view.md`](../../../docs/operations/dispatcher-view.md)「外側フレームが renga の場合」を参照。
 
 **前回の状態がある場合**:
 ```


### PR DESCRIPTION
## 概要

Closes #876
Refs #857 #859

renga 2.0 org サイドバー（既定 coexist）が `Ctrl+B` を消費し内側 tmux へ prefix が届かない件の読み替え注記を、#857 のスコープ外として持ち越されていた 2 ファイルに追加する。文書のみ・コード変更なし（2 ファイル +19/-2）。

## 変更点

1. **org-attach Step 4 のデタッチ案内**: `Ctrl-b d` は tmux prefix の既定値であること、attach する端末が renga だと org サイドバーが `Ctrl+B`（同じ物理入力）を消費して detach できなくなること、回避策は `docs/operations/dispatcher-view.md`「外側フレームが renga の場合」であることの 3 点
2. **スキルが実際に印字する出力ブロック**（worked example）にも同注記 — attach 直前に人間が読む面に出す。Step 4 の生成指示も出力例と一致するよう拡張
3. **org-start の dispatcher-view sidebar に 1 行**: 既存文は transport=renga の場合しか書いておらず、「transport=broker かつ外側フレームが renga」（ビューア適用対象なのに打鍵が届かない）の空白経路を明示して §4 へ誘導

## 設計

- #857 が確立した先例（症状 1 文 + 原因 1 句 + §4 ポインタ）に横並び。原因の一次ソース（renga 実装の行番号）は dispatcher-view.md §4 に委譲し SoT を 1 箇所に保つ
- サイドバー幅の減算式は書かない（二重減算禁止、#857 と同じ制約）
- 表記規約: renga UI キー = `Ctrl+B` / tmux prefix = `Ctrl-b`

## 検証

- Codex exec review round 1 で Blocker / Major / Minor ゼロ
- リンク audit 指摘増減なし・両ファイルとも手保守（manifest 記載なし・再 render 不要）を実測確認