### PR TITLE
feat(claude): 背景タブ配置の worker brief を数値 pane id 宛の報告先で生成する

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -220,7 +220,7 @@ python tools/gen_delegate_payload.py apply \
 - `--commit-prefix "<prefix>"`: 省略時は project_slug の頭部から推論 (例: `claude-org-ja` → `feat(claude):`)
 - `--closes-issue N` / `--refs-issues N1 N2`: 「Closes #N」「Refs #N1 #N2」を brief に埋め込む
 - `--impl-target <path>` / `--impl-guidance "<text>"` / `--knowledge <path>`: optional な `[implementation]` / `[references]` セクション
-- `--placement same_tab|background_tab` (default `same_tab`) / `--report-target <id>`: worker を**背景タブに置く派遣**（spawn-flow 3-1d の例外経路）でのみ使う。peer 名は送信者と同じタブ内でしか解決しないため、背景タブの worker は既定の `to_id="secretary"` に届かず完了報告が沈黙で落ちる。`--placement background_tab` は `--report-target` に**窓口ペインの数値 pane id**（`list_peers` で確認）を要求し、brief の報告先と DELEGATE 本文の報告先行を同じ数値 id で生成する。数値でない値・`--report-target` 欠落は `apply` 前に fail loud で止まる。既定の同一タブ派遣ではどちらも渡さない（渡さなければ生成物は従来と 1 バイトも変わらない）
+- `--placement same_tab|background_tab` (default `same_tab`) / `--report-target <id>`: worker を**背景タブに置く派遣**（spawn-flow 3-1d の例外経路）でのみ使う。peer 名は送信者と同じタブ内でしか解決しないため、背景タブの worker は既定の `to_id="secretary"` に届かず完了報告が沈黙で落ちる。`--placement background_tab` は `--report-target` に**窓口ペインの数値 pane id**（`list_peers` で確認）を要求し、brief の報告先と DELEGATE 本文の報告先行を同じ数値 id で生成する。数値でない値・`--report-target` 欠落は `apply` 前に fail loud で止まる。既定の同一タブ派遣ではどちらも渡さない（渡さなければ生成物は従来と 1 バイトも変わらない）。**ディスパッチャーが 3-1d の条件を満たせず同一タブ経路に倒した場合、その brief は流用できない**（背景タブ前提の報告先・報告規律が焼き込まれている）。差し戻しを受けたら `--placement` 無しで `apply` をやり直して brief を再生成する
 - `--skip-settings`: `claude-org-runtime settings generate` をスキップ (CLI 未導入環境向け)
 - `--from-toml <path>`: 既存 `worker_brief.toml` を入力にする。CLI フラグは TOML を上書きする
 

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -220,6 +220,7 @@ python tools/gen_delegate_payload.py apply \
 - `--commit-prefix "<prefix>"`: 省略時は project_slug の頭部から推論 (例: `claude-org-ja` → `feat(claude):`)
 - `--closes-issue N` / `--refs-issues N1 N2`: 「Closes #N」「Refs #N1 #N2」を brief に埋め込む
 - `--impl-target <path>` / `--impl-guidance "<text>"` / `--knowledge <path>`: optional な `[implementation]` / `[references]` セクション
+- `--placement same_tab|background_tab` (default `same_tab`) / `--report-target <id>`: worker を**背景タブに置く派遣**（spawn-flow 3-1d の例外経路）でのみ使う。peer 名は送信者と同じタブ内でしか解決しないため、背景タブの worker は既定の `to_id="secretary"` に届かず完了報告が沈黙で落ちる。`--placement background_tab` は `--report-target` に**窓口ペインの数値 pane id**（`list_peers` で確認）を要求し、brief の報告先と DELEGATE 本文の報告先行を同じ数値 id で生成する。数値でない値・`--report-target` 欠落は `apply` 前に fail loud で止まる。既定の同一タブ派遣ではどちらも渡さない（渡さなければ生成物は従来と 1 バイトも変わらない）
 - `--skip-settings`: `claude-org-runtime settings generate` をスキップ (CLI 未導入環境向け)
 - `--from-toml <path>`: 既存 `worker_brief.toml` を入力にする。CLI フラグは TOML を上書きする
 

--- a/.claude/skills/org-delegate/SKILL.md.in
+++ b/.claude/skills/org-delegate/SKILL.md.in
@@ -214,7 +214,7 @@ python tools/gen_delegate_payload.py apply \
 - `--commit-prefix "<prefix>"`: 省略時は project_slug の頭部から推論 (例: `claude-org-ja` → `feat(claude):`)
 - `--closes-issue N` / `--refs-issues N1 N2`: 「Closes #N」「Refs #N1 #N2」を brief に埋め込む
 - `--impl-target <path>` / `--impl-guidance "<text>"` / `--knowledge <path>`: optional な `[implementation]` / `[references]` セクション
-- `--placement same_tab|background_tab` (default `same_tab`) / `--report-target <id>`: worker を**背景タブに置く派遣**（spawn-flow 3-1d の例外経路）でのみ使う。peer 名は送信者と同じタブ内でしか解決しないため、背景タブの worker は既定の `to_id="secretary"` に届かず完了報告が沈黙で落ちる。`--placement background_tab` は `--report-target` に**窓口ペインの数値 pane id**（`list_peers` で確認）を要求し、brief の報告先と DELEGATE 本文の報告先行を同じ数値 id で生成する。数値でない値・`--report-target` 欠落は `apply` 前に fail loud で止まる。既定の同一タブ派遣ではどちらも渡さない（渡さなければ生成物は従来と 1 バイトも変わらない）
+- `--placement same_tab|background_tab` (default `same_tab`) / `--report-target <id>`: worker を**背景タブに置く派遣**（spawn-flow 3-1d の例外経路）でのみ使う。peer 名は送信者と同じタブ内でしか解決しないため、背景タブの worker は既定の `to_id="secretary"` に届かず完了報告が沈黙で落ちる。`--placement background_tab` は `--report-target` に**窓口ペインの数値 pane id**（`list_peers` で確認）を要求し、brief の報告先と DELEGATE 本文の報告先行を同じ数値 id で生成する。数値でない値・`--report-target` 欠落は `apply` 前に fail loud で止まる。既定の同一タブ派遣ではどちらも渡さない（渡さなければ生成物は従来と 1 バイトも変わらない）。**ディスパッチャーが 3-1d の条件を満たせず同一タブ経路に倒した場合、その brief は流用できない**（背景タブ前提の報告先・報告規律が焼き込まれている）。差し戻しを受けたら `--placement` 無しで `apply` をやり直して brief を再生成する
 - `--skip-settings`: `claude-org-runtime settings generate` をスキップ (CLI 未導入環境向け)
 - `--from-toml <path>`: 既存 `worker_brief.toml` を入力にする。CLI フラグは TOML を上書きする
 

--- a/.claude/skills/org-delegate/SKILL.md.in
+++ b/.claude/skills/org-delegate/SKILL.md.in
@@ -214,6 +214,7 @@ python tools/gen_delegate_payload.py apply \
 - `--commit-prefix "<prefix>"`: 省略時は project_slug の頭部から推論 (例: `claude-org-ja` → `feat(claude):`)
 - `--closes-issue N` / `--refs-issues N1 N2`: 「Closes #N」「Refs #N1 #N2」を brief に埋め込む
 - `--impl-target <path>` / `--impl-guidance "<text>"` / `--knowledge <path>`: optional な `[implementation]` / `[references]` セクション
+- `--placement same_tab|background_tab` (default `same_tab`) / `--report-target <id>`: worker を**背景タブに置く派遣**（spawn-flow 3-1d の例外経路）でのみ使う。peer 名は送信者と同じタブ内でしか解決しないため、背景タブの worker は既定の `to_id="secretary"` に届かず完了報告が沈黙で落ちる。`--placement background_tab` は `--report-target` に**窓口ペインの数値 pane id**（`list_peers` で確認）を要求し、brief の報告先と DELEGATE 本文の報告先行を同じ数値 id で生成する。数値でない値・`--report-target` 欠落は `apply` 前に fail loud で止まる。既定の同一タブ派遣ではどちらも渡さない（渡さなければ生成物は従来と 1 バイトも変わらない）
 - `--skip-settings`: `claude-org-runtime settings generate` をスキップ (CLI 未導入環境向け)
 - `--from-toml <path>`: 既存 `worker_brief.toml` を入力にする。CLI フラグは TOML を上書きする
 

--- a/.claude/skills/org-delegate/references/instruction-template.md
+++ b/.claude/skills/org-delegate/references/instruction-template.md
@@ -187,7 +187,7 @@ doc-audit role + write 成果物がある委譲では、以下の文言を「制
 - `branch_strategy` (必須): ブランチ戦略。worktree 配備で main 既定にすると誤誘導するため必須
 - `verification_depth` (必須): `full` または `minimal`
 - `constraints` (任意): 制約。省略時は "(なし)"
-- `report_target` (任意): 完了報告先 peer 名。省略時は `secretary`
+- `report_target` (任意): 完了報告先 peer 名。省略時は `secretary`。**背景タブ配置（spawn-flow 3-1d）の worker に対しては窓口ペインの数値 pane id を渡す** — peer 名は送信者と同じタブ内でしか解決せず、別タブの worker からは名前宛が届かないため（同じ数値 id が `gen_delegate_payload.py --placement background_tab --report-target <id>` で brief 側にも埋まっている）
 - `claude_md_filename` (任意): ワーカーが読む行動規範ファイル名。省略時は `CLAUDE.md`。claude-org 自己編集タスクでは `CLAUDE.local.md` を渡すこと（`references/claude-org-self-edit.md` 参照）
 
 未知の変数キーは input_invalid として弾く。`verification_depth` が `full` / `minimal` 以外でも input_invalid。

--- a/.claude/skills/org-delegate/references/instruction-template.md.in
+++ b/.claude/skills/org-delegate/references/instruction-template.md.in
@@ -181,7 +181,7 @@ doc-audit role + write 成果物がある委譲では、以下の文言を「制
 - `branch_strategy` (必須): ブランチ戦略。worktree 配備で main 既定にすると誤誘導するため必須
 - `verification_depth` (必須): `full` または `minimal`
 - `constraints` (任意): 制約。省略時は "(なし)"
-- `report_target` (任意): 完了報告先 peer 名。省略時は `secretary`
+- `report_target` (任意): 完了報告先 peer 名。省略時は `secretary`。**背景タブ配置（spawn-flow 3-1d）の worker に対しては窓口ペインの数値 pane id を渡す** — peer 名は送信者と同じタブ内でしか解決せず、別タブの worker からは名前宛が届かないため（同じ数値 id が `gen_delegate_payload.py --placement background_tab --report-target <id>` で brief 側にも埋まっている）
 - `claude_md_filename` (任意): ワーカーが読む行動規範ファイル名。省略時は `CLAUDE.md`。claude-org 自己編集タスクでは `CLAUDE.local.md` を渡すこと（`references/claude-org-self-edit.md` 参照）
 
 未知の変数キーは input_invalid として弾く。`verification_depth` が `full` / `minimal` 以外でも input_invalid。

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -230,7 +230,7 @@ done: {commit SHA 短縮形} {変更ファイル名}
 ワーカーを**窓口と別のタブ**に置く派遣（spawn-flow 3-1d の例外経路）では、上記テンプレートの `to_id="{report_target}"` を**窓口ペインの数値 pane id**（例 `to_id="1"`）で生成し、「作業完了時」の直前に以下の節を追記する。peer 名は送信者と同じタブ内でしか解決しないため、名前宛の報告は `[pane_not_found]`（broker: `[peer_not_found]`）で落ち、ワーカーは送ったつもりで待機し窓口からは stall にしか見えない:
 
 > ## 報告先（背景タブ配置）
-> あなたは窓口とは別のタブに配置されている。peer 名（`secretary` / `dispatcher`）は送信者と同じタブ内でしか解決しないため、名前宛の送信は必ず失敗する。報告・進捗・判断仰ぎはすべて数値 pane id `to_id="{report_target}"`（窓口）宛に送ること。届かないときは `list_peers`（タブを跨いで列挙される）で `role=secretary` の数値 id を取り直す（`list_panes` は自分のタブしか映さない）。
+> あなたは窓口とは別のタブに配置されている。peer 名（`secretary` / `dispatcher`）は送信者と同じタブ内でしか解決しないため、名前宛の送信は必ず失敗する。報告・進捗・判断仰ぎはすべて数値 pane id `to_id="{report_target}"`（窓口）宛に送ること。届かないときだけ `list_peers`（タブを跨いで列挙される）で取り直すが、`role=secretary` だけで選んではならない（列挙は他の org のタブも映すため、role 一致だけでは別 org の窓口へ完了報告を漏らす）。`name` / `role` / `cwd` の 3 属性が自分の org と一致する行に限って宛先にし、確定できないうちは何も送らずペインを保持したまま停止する。`list_panes` は自分のタブしか映さないので確認には使えない。
 
 生成経路（`tools/gen_delegate_payload.py` / `tools/gen_worker_brief.py`）では `--placement background_tab --report-target <数値 pane id>` を渡すとこの分岐がそのまま出る。**同一タブ配置（既定）では何も渡さない** — 渡さなければ brief は従来どおり `to_id="secretary"` で生成される。
 

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -225,6 +225,17 @@ done: {commit SHA 短縮形} {変更ファイル名}
 
 ---
 
+## 条件付き追記: 背景タブに配置するワーカー
+
+ワーカーを**窓口と別のタブ**に置く派遣（spawn-flow 3-1d の例外経路）では、上記テンプレートの `to_id="{report_target}"` を**窓口ペインの数値 pane id**（例 `to_id="1"`）で生成し、「作業完了時」の直前に以下の節を追記する。peer 名は送信者と同じタブ内でしか解決しないため、名前宛の報告は `[pane_not_found]`（broker: `[peer_not_found]`）で落ち、ワーカーは送ったつもりで待機し窓口からは stall にしか見えない:
+
+> ## 報告先（背景タブ配置）
+> あなたは窓口とは別のタブに配置されている。peer 名（`secretary` / `dispatcher`）は送信者と同じタブ内でしか解決しないため、名前宛の送信は必ず失敗する。報告・進捗・判断仰ぎはすべて数値 pane id `to_id="{report_target}"`（窓口）宛に送ること。届かないときは `list_peers`（タブを跨いで列挙される）で `role=secretary` の数値 id を取り直す（`list_panes` は自分のタブしか映さない）。
+
+生成経路（`tools/gen_delegate_payload.py` / `tools/gen_worker_brief.py`）では `--placement background_tab --report-target <数値 pane id>` を渡すとこの分岐がそのまま出る。**同一タブ配置（既定）では何も渡さない** — 渡さなければ brief は従来どおり `to_id="secretary"` で生成される。
+
+---
+
 ## 条件付き追記: 監視ロール待ち合わせ設計を含むタスク
 
 委譲タスクが監視ロール（dispatcher / curator 等の /loop 常駐・定期 polling ロール）への待ち合わせ・spawn 連携・lifecycle を変更する場合、生成する CLAUDE.md（claude-org 自己編集タスクでは CLAUDE.local.md）の「現在のタスク」セクション直後に、以下の節を**そのまま**追記する（**ファイル変更が 1 件でも省略しない**。[`.claude/skills/org-delegate/references/instruction-template.md`](instruction-template.md) の brief 必須文言と同内容）:
@@ -248,3 +259,4 @@ done: {commit SHA 短縮形} {変更ファイル名}
 | `{claude_org_path}` | claude-org リポジトリの絶対パス | /home/user/work/claude-org |
 | `{worker_dir}` | ワーカー作業ディレクトリの絶対パス | /home/user/work/workers/data-analysis |
 | `{YYYY-MM-DD}` | 実行日 | 2026-04-05 |
+| `{report_target}` | 完了報告の宛先。既定（同一タブ配置）は `secretary`。背景タブ配置では窓口ペインの数値 pane id | secretary / 1 |

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -230,7 +230,7 @@ done: {commit SHA 短縮形} {変更ファイル名}
 ワーカーを**窓口と別のタブ**に置く派遣（spawn-flow 3-1d の例外経路）では、上記テンプレートの `to_id="{report_target}"` を**窓口ペインの数値 pane id**（例 `to_id="1"`）で生成し、「作業完了時」の直前に以下の節を追記する。peer 名は送信者と同じタブ内でしか解決しないため、名前宛の報告は `[pane_not_found]`（broker: `[peer_not_found]`）で落ち、ワーカーは送ったつもりで待機し窓口からは stall にしか見えない:
 
 > ## 報告先（背景タブ配置）
-> あなたは窓口とは別のタブに配置されている。peer 名（`secretary` / `dispatcher`）は送信者と同じタブ内でしか解決しないため、名前宛の送信は必ず失敗する。報告・進捗・判断仰ぎはすべて数値 pane id `to_id="{report_target}"`（窓口）宛に送ること。届かないときだけ `list_peers`（タブを跨いで列挙される）で取り直すが、`role=secretary` だけで選んではならない（列挙は他の org のタブも映すため、role 一致だけでは別 org の窓口へ完了報告を漏らす）。`name` / `role` / `cwd` の 3 属性が自分の org と一致する行に限って宛先にし、確定できないうちは何も送らずペインを保持したまま停止する。`list_panes` は自分のタブしか映さないので確認には使えない。
+> あなたは窓口とは別のタブに配置されている。peer 名（`secretary` / `dispatcher`）は送信者と同じタブ内でしか解決しないため、名前宛の送信は必ず失敗する。報告・進捗・判断仰ぎはすべて数値 pane id `to_id="{report_target}"`（窓口）宛に送ること。**送信前に毎回 identity を照合する**（失敗時だけではない）: 数値 pane id は backend session に閉じた識別子で daemon restart 後は振り直され、stale な id は別の生きたペインに「成功」で届きエラーコードも出ない（契約 T-§4.2-id の session provenance）。`list_peers` で当該 id の行を引き、`name` / `role` / `cwd` の 3 属性が自分の org の窓口と一致してから送ること。一致しない / 行が無いときは `role=secretary` だけで別の行を選ばない（他 org のタブも列挙されるため完了報告を別 org へ漏らす）。確定できないうちは何も送らずペインを保持したまま停止する。`list_panes` は自分のタブしか映さないので確認には使えない。
 
 生成経路（`tools/gen_delegate_payload.py` / `tools/gen_worker_brief.py`）では `--placement background_tab --report-target <数値 pane id>` を渡すとこの分岐がそのまま出る。**同一タブ配置（既定）では何も渡さない** — 渡さなければ brief は従来どおり `to_id="secretary"` で生成される。
 

--- a/tests/fixtures/delegate_payload/delegate_payload_pattern_a_background_tab.golden.md
+++ b/tests/fixtures/delegate_payload/delegate_payload_pattern_a_background_tab.golden.md
@@ -1,0 +1,14 @@
+DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- snap-a-background: add a sparkline
+  - ワーカーディレクトリ: <SANDBOX>/workers/clock-app（CLAUDE.md・設定配置済み）
+  - ディレクトリパターン: A: プロジェクトディレクトリ
+  - プロジェクト: clone or reuse: -
+  - ブランチ (planned): feat/snap-a-background
+  - Permission Mode: auto
+  - 検証深度: full
+  - 指示内容: 詳細は `<SANDBOX>/workers/clock-app/CLAUDE.md` を参照。要約: add a sparkline
+
+配置 (placement): background_tab（spawn-flow 3-1d。6 条件を満たさなくなったら既定の同一タブ経路に倒すこと）
+窓口の報告先: `to_id="1"`（数値 pane id。背景タブの worker からは pane 名 `secretary` が解決しないため、brief も同じ数値 id で生成済み）

--- a/tests/fixtures/delegate_payload/delegate_payload_pattern_a_background_tab.golden.md
+++ b/tests/fixtures/delegate_payload/delegate_payload_pattern_a_background_tab.golden.md
@@ -10,5 +10,6 @@ DELEGATE: 以下のワーカーを派遣してください。
   - 検証深度: full
   - 指示内容: 詳細は `<SANDBOX>/workers/clock-app/CLAUDE.md` を参照。要約: add a sparkline
 
-配置 (placement): background_tab（spawn-flow 3-1d。6 条件を満たさなくなったら既定の同一タブ経路に倒すこと）
+配置 (placement): background_tab（spawn-flow 3-1d）
 窓口の報告先: `to_id="1"`（数値 pane id。背景タブの worker からは pane 名 `secretary` が解決しないため、brief も同じ数値 id で生成済み）
+**6 条件のいずれかを満たさず同一タブ経路に倒す場合、この brief をそのまま使ってはならない**（背景タブ前提の報告先・報告規律が書かれている）。派遣を進めず窓口へ差し戻し、`--placement` 無しで brief を再生成させること

--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -598,6 +598,166 @@ class TestSettingsGenerateCmd(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Issue #909 — placement decides the report target
+# ---------------------------------------------------------------------------
+
+
+class TestIssue909Placement(unittest.TestCase):
+    """A background-tab dispatch must hand the worker a reachable address.
+
+    Peer names resolve only inside the sender's tab, so a worker placed in
+    a background tab (spawn-flow 3-1d) cannot reach ``to_id="secretary"``
+    at all — the completion report drops silently and the Secretary sees a
+    stall. The same-tab default must stay byte-identical.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _plan(self, **extra):
+        return gdp.build_delegate_plan(
+            task_id="place-task",
+            project_slug="clock-app",
+            description="do the thing",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            **extra,
+        )
+
+    def test_default_body_and_plan_fields_unchanged(self):
+        plan = self._plan()
+        self.assertEqual(plan.placement, "same_tab")
+        self.assertEqual(plan.report_target, "secretary")
+        self.assertIn("窓口ペイン名: `secretary`", plan.delegate_body)
+        self.assertNotIn("placement", plan.delegate_body)
+        # An explicit same_tab must render the identical body.
+        self.assertEqual(self._plan(placement="same_tab").delegate_body,
+                         plan.delegate_body)
+
+    def test_background_tab_body_carries_numeric_pane_id(self):
+        plan = self._plan(placement="background_tab", report_target="1")
+        self.assertEqual(plan.placement, "background_tab")
+        self.assertEqual(plan.report_target, "1")
+        self.assertIn('窓口の報告先: `to_id="1"`', plan.delegate_body)
+        self.assertIn("background_tab", plan.delegate_body)
+        # The unreachable name line must be gone, not merely supplemented.
+        self.assertNotIn("窓口ペイン名: `secretary`", plan.delegate_body)
+
+    def test_background_tab_flows_into_the_rendered_brief(self):
+        plan = self._plan(placement="background_tab", report_target="1")
+        brief = gwb.render(plan.config)
+        self.assertIn('send_message(to_id="1"', brief)
+        self.assertNotIn('send_message(to_id="secretary"', brief)
+
+    def test_summary_dict_discloses_both_fields(self):
+        summary = self._plan(
+            placement="background_tab", report_target="1"
+        ).to_summary_dict()
+        self.assertEqual(summary["placement"], "background_tab")
+        self.assertEqual(summary["report_target"], "1")
+
+    def test_background_tab_without_numeric_target_is_rejected(self):
+        with self.assertRaises(gwb.ConfigError):
+            self._plan(placement="background_tab")
+        with self.assertRaises(gwb.ConfigError):
+            self._plan(placement="background_tab", report_target="secretary")
+
+    def test_cli_rejects_background_tab_without_target_before_writing(self):
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        runs_before = len(self.sb.list_runs())
+        buf = StringIO()
+        with self.assertRaises(SystemExit) as ctx, redirect_stdout(buf):
+            gdp.main([
+                "apply",
+                "--task-id", "place-cli",
+                "--project-slug", "clock-app",
+                "--description", "do the thing",
+                "--claude-org-root", str(self.sb.claude_org_root),
+                "--state-db-path", str(self.sb.db_path),
+                "--skip-settings",
+                "--placement", "background_tab",
+            ])
+        msg = str(ctx.exception)
+        self.assertTrue(msg.startswith("error: "), msg)
+        self.assertIn("report.target is required", msg)
+        self.assertEqual(len(self.sb.list_runs()), runs_before)
+        self.assertFalse((self.sb.workers / "clock-app" / "CLAUDE.md").exists())
+
+    def test_cli_apply_writes_a_reachable_brief(self):
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main([
+                "apply",
+                "--task-id", "place-cli-ok",
+                "--project-slug", "clock-app",
+                "--description", "do the thing",
+                "--claude-org-root", str(self.sb.claude_org_root),
+                "--state-db-path", str(self.sb.db_path),
+                "--skip-settings",
+                "--placement", "background_tab",
+                "--report-target", "1",
+            ])
+        self.assertEqual(rc, 0)
+        self.assertIn("placement: background_tab", buf.getvalue())
+        brief = self.sb.workers / "clock-app" / "CLAUDE.md"
+        self.assertIn('send_message(to_id="1"', brief.read_text(encoding="utf-8"))
+        send_plan = json.loads(
+            brief.with_name("send_plan.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(send_plan["summary"]["report_target"], "1")
+        self.assertIn('窓口の報告先: `to_id="1"`', send_plan["message"])
+
+    def test_from_toml_round_trips_the_report_table(self):
+        toml = Path(self._td.name) / "input.toml"
+        toml.write_text(
+            "[task]\n"
+            'id = "round-trip-909"\n'
+            'description = "round-trip via TOML"\n'
+            'verification_depth = "full"\n'
+            'branch = "round-trip-909"\n'
+            'commit_prefix = "feat(clock):"\n'
+            "\n[worker]\n"
+            'dir = "X:/dummy"\n'
+            'pattern = "A"\n'
+            'role = "default"\n'
+            "self_edit = false\n"
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            'description = "Web 時計"\n'
+            "\n[paths]\n"
+            'claude_org = "."\n'
+            "\n[report]\n"
+            'placement = "background_tab"\n'
+            'target = "1"\n',
+            encoding="utf-8",
+        )
+        kwargs = gdp._gather_plan_kwargs(
+            argparse.Namespace(
+                from_toml=toml,
+                task_id=None, project_slug=None, target=[], description=None,
+                mode=None, branch_override=None, commit_prefix=None,
+                verification_depth=None, issue_url=None, closes_issue=None,
+                refs_issues=None, project_name_override=None,
+                project_description_override=None, impl_target=[],
+                impl_guidance=None, knowledge=[], parallel_notes=None,
+                registry_path=None, state_db_path=None, claude_org_root=None,
+                workers_dir=None,
+            )
+        )
+        self.assertEqual(kwargs["placement"], "background_tab")
+        self.assertEqual(kwargs["report_target"], "1")
+
+
+# ---------------------------------------------------------------------------
 # CLI smoke tests (preview + apply paths)
 # ---------------------------------------------------------------------------
 
@@ -802,6 +962,19 @@ class TestGoldenSnapshots(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self._check("pattern_a_default_full", plan.delegate_body)
+
+    def test_golden_pattern_a_background_tab(self):
+        """Issue #909: the background-tab body's report line, pinned."""
+        plan = gdp.build_delegate_plan(
+            task_id="snap-a-background",
+            project_slug="clock-app",
+            description="add a sparkline",
+            placement="background_tab",
+            report_target="1",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self._check("pattern_a_background_tab", plan.delegate_body)
 
     def test_golden_pattern_b_self_edit_full(self):
         # claude-org-ja with concurrent active run forces Pattern B

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -201,6 +201,14 @@ class DelegatePlan:
     # a value means the worktree is cut from ``origin/<base_branch>`` and that
     # same branch is the default ``gh pr create --base`` for the PR flow.
     base_branch: Optional[str] = None
+    # Issue #909: where the dispatcher will place the worker pane, and the
+    # address the brief tells the worker to report to. ``same_tab`` /
+    # ``secretary`` is the default dispatch and renders both the brief and
+    # the DELEGATE body byte-identically to pre-#909; ``background_tab``
+    # (spawn-flow 3-1d) carries the Secretary's numeric pane id because peer
+    # names only resolve inside the sender's tab.
+    placement: str = gwb.DEFAULT_PLACEMENT
+    report_target: str = gwb.DEFAULT_REPORT_TARGET
     # Where ``base_branch`` came from: ``"cli"`` (--base-ref), ``"registry"``
     # (the project's base_branch column), or ``"origin_head"`` (unconfigured).
     # Carried so the apply-time failure message can name the input the operator
@@ -228,6 +236,11 @@ class DelegatePlan:
             # ``base_ref`` value is exactly what ``git worktree add`` will use.
             "base_branch": self.base_branch,
             "base_branch_source": self.base_branch_source,
+            # Issue #909: disclose where the worker is planned to sit and the
+            # address its brief reports to, so Secretary can check the pair
+            # off ``preview --json`` before dispatching to a background tab.
+            "placement": self.placement,
+            "report_target": self.report_target,
             "base_ref": (
                 f"origin/{self.base_branch}"
                 if self.base_branch is not None
@@ -547,6 +560,8 @@ def _format_delegate_body(
     brief_filename: str,
     base_branch: Optional[str] = None,
     base_branch_source: str = "origin_head",
+    placement: str = gwb.DEFAULT_PLACEMENT,
+    report_target: str = gwb.DEFAULT_REPORT_TARGET,
 ) -> str:
     """Format the DELEGATE message body per org-delegate Step 2 template.
 
@@ -555,6 +570,11 @@ def _format_delegate_body(
     both see the non-default PR base without re-reading the registry. The
     line is omitted entirely when nothing is configured, keeping the body
     byte-identical to the pre-#808 output for every existing project.
+
+    Issue #909: a ``background_tab`` dispatch replaces the trailing
+    ``窓口ペイン名`` line with the Secretary's numeric pane id, because the
+    pane name it otherwise advertises is unreachable from another tab. The
+    default (``same_tab``) keeps that line exactly as before.
     """
     instr_summary = _summarize_description(description)
     branch_line = (
@@ -575,6 +595,17 @@ def _format_delegate_body(
             f"\n  - ベース: origin/{base_branch}"
             f"（{source_label}。PR も `--base {base_branch}` を既定とする）"
         )
+    if placement == "background_tab":
+        report_line = (
+            f"配置 (placement): background_tab（spawn-flow 3-1d。"
+            f"6 条件を満たさなくなったら既定の同一タブ経路に倒すこと）\n"
+            f'窓口の報告先: `to_id="{report_target}"`（数値 pane id。'
+            f"背景タブの worker からは pane 名 `secretary` が解決しないため、"
+            f"brief も同じ数値 id で生成済み）"
+        )
+    else:
+        report_line = "窓口ペイン名: `secretary`（renga layout で登録済み）"
+
     body = f"""DELEGATE: 以下のワーカーを派遣してください。
 
 タスク一覧:
@@ -587,7 +618,7 @@ def _format_delegate_body(
   - 検証深度: {verification_depth}
   - 指示内容: 詳細は `{brief_full_path}` を参照。要約: {instr_summary or '(none)'}
 
-窓口ペイン名: `secretary`（renga layout で登録済み）"""
+{report_line}"""
     return body
 
 
@@ -615,6 +646,8 @@ def build_delegate_plan(
     implementation_guidance: Optional[str] = None,
     references_knowledge: Optional[list[str]] = None,
     parallel_notes: Optional[str] = None,
+    placement: Optional[str] = None,
+    report_target: Optional[str] = None,
     registry_path: Optional[Path] = None,
     state_db_path: Optional[Path] = None,
     claude_org_root: Path,
@@ -643,12 +676,21 @@ def build_delegate_plan(
         implementation_guidance=implementation_guidance,
         references_knowledge=references_knowledge,
         parallel_notes=parallel_notes,
+        placement=placement,
+        report_target=report_target,
         registry_path=registry_path,
         state_db_path=state_db_path,
         claude_org_root=claude_org_root,
         workers_dir=workers_dir,
         layout_overrides=layout_overrides,
     )
+
+    # Read the effective values back off the config the brief renders from,
+    # so the DELEGATE body and the brief can never disagree about where the
+    # worker reports (Issue #909). ``build_config_from_task`` has already
+    # validated the pair.
+    effective_placement = gwb._report_placement(config)
+    effective_report_target = gwb._report_target(config)
 
     self_edit = bool(config["worker"]["self_edit"])
 
@@ -849,6 +891,8 @@ def build_delegate_plan(
         brief_filename=brief_filename,
         base_branch=base_branch,
         base_branch_source=base_branch_source,
+        placement=effective_placement,
+        report_target=effective_report_target,
     )
 
     artifacts = [
@@ -924,6 +968,8 @@ def build_delegate_plan(
         project_path=project_path,
         base_branch=base_branch,
         base_branch_source=base_branch_source,
+        placement=effective_placement,
+        report_target=effective_report_target,
     )
 
 
@@ -1474,6 +1520,8 @@ def _finalize_pending_clone_brief(plan: DelegatePlan) -> DelegatePlan:
         brief_filename="CLAUDE.local.md",
         base_branch=plan.base_branch,
         base_branch_source=plan.base_branch_source,
+        placement=plan.placement,
+        report_target=plan.report_target,
     )
     return replace(
         plan,
@@ -2030,6 +2078,9 @@ def _add_task_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--impl-guidance", default=None)
     p.add_argument("--knowledge", action="append", default=[])
     p.add_argument("--parallel-notes", default=None)
+    # Issue #909: placement / report target. Shared with
+    # ``gen_worker_brief.py from-task`` so both input surfaces stay at parity.
+    gwb._add_report_args(p)
     p.add_argument("--registry-path", type=Path, default=None)
     p.add_argument("--state-db-path", type=Path, default=None)
     p.add_argument("--claude-org-root", type=Path, default=None)
@@ -2148,6 +2199,9 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
     impl = cfg.get("implementation", {})
     refs = cfg.get("references", {})
     parallel = cfg.get("parallel", {})
+    report = cfg.get("report", {})
+    if not isinstance(report, dict):
+        raise SystemExit(f"error: {path}: [report] must be a TOML table")
     role = (worker.get("role") or "").strip()
     mode_from_toml = "audit" if role == "doc-audit" else "edit"
 
@@ -2205,6 +2259,11 @@ def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
         "implementation_guidance": impl.get("guidance"),
         "references_knowledge": refs.get("knowledge"),
         "parallel_notes": parallel.get("notes"),
+        # Issue #909: keep the TOML input form at parity with the CLI flags,
+        # so a ``--write-toml`` audit trail round-trips a background-tab
+        # dispatch instead of silently flattening it back to same_tab.
+        "placement": report.get("placement"),
+        "report_target": report.get("target"),
         "mode": mode_from_toml,
         "layout_overrides": layout_overrides or None,
     }
@@ -2263,6 +2322,10 @@ def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
         "implementation_guidance": args.impl_guidance,
         "references_knowledge": args.knowledge or None,
         "parallel_notes": args.parallel_notes,
+        # ``getattr`` for the same reason ``--pattern`` uses it: callers
+        # synthesize partial Namespaces (Issue #909).
+        "placement": getattr(args, "placement", None),
+        "report_target": getattr(args, "report_target", None),
         "registry_path": args.registry_path,
         "workers_dir": args.workers_dir,
     }
@@ -2291,9 +2354,12 @@ def _cmd_preview(args: argparse.Namespace) -> int:
             state_db_path=state_db_path if state_db_path.exists() else None,
             **kwargs,
         )
-    except rwl.ResolveError as e:
+    except (rwl.ResolveError, gwb.ConfigError) as e:
         # ``ResolveError`` is the layout resolver's *input-rejection* channel
         # (bad task_id / project_slug / mode), i.e. operator error, not a bug.
+        # ``ConfigError`` is the same channel for the brief config — Issue
+        # #909's ``--placement background_tab`` without a numeric
+        # ``--report-target`` lands here.
         # Surface it in the same one-line ``error: ...`` shape the argument
         # checks in ``_gather_plan_kwargs`` already use, instead of letting a
         # Python traceback out of the CLI: this path is how a human first meets
@@ -2359,7 +2425,7 @@ def _cmd_apply(args: argparse.Namespace) -> int:
             state_db_path=state_db_path if state_db_path.exists() else None,
             **kwargs,
         )
-    except rwl.ResolveError as e:
+    except (rwl.ResolveError, gwb.ConfigError) as e:
         # Same contract as ``_cmd_preview``: reject bad input with one line and
         # no traceback. Raised before ``apply_delegate_plan`` runs, so nothing
         # has been reserved / written when this fires.
@@ -2379,6 +2445,13 @@ def _cmd_apply(args: argparse.Namespace) -> int:
         print(
             f"base: origin/{plan.base_branch} "
             f"(source={plan.base_branch_source}; PR base default)"
+        )
+    # Issue #909: only announced for the background-tab exception, so the
+    # default same-tab dispatch keeps its existing output.
+    if plan.placement != gwb.DEFAULT_PLACEMENT:
+        print(
+            f"placement: {plan.placement} "
+            f"(brief reports to to_id=\"{plan.report_target}\")"
         )
     print(f"brief: {result.brief_path}")
     if result.settings_path is not None:

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -596,12 +596,20 @@ def _format_delegate_body(
             f"（{source_label}。PR も `--base {base_branch}` を既定とする）"
         )
     if placement == "background_tab":
+        # The brief is rendered here, before the dispatcher evaluates the
+        # 3-1d gates — so a fail-closed fallback to the same-tab path would
+        # leave the worker holding a brief that describes the other
+        # placement. The dispatcher cannot silently reuse it: say so in the
+        # body rather than letting the two artifacts drift apart.
         report_line = (
-            f"配置 (placement): background_tab（spawn-flow 3-1d。"
-            f"6 条件を満たさなくなったら既定の同一タブ経路に倒すこと）\n"
+            f"配置 (placement): background_tab（spawn-flow 3-1d）\n"
             f'窓口の報告先: `to_id="{report_target}"`（数値 pane id。'
             f"背景タブの worker からは pane 名 `secretary` が解決しないため、"
-            f"brief も同じ数値 id で生成済み）"
+            f"brief も同じ数値 id で生成済み）\n"
+            f"**6 条件のいずれかを満たさず同一タブ経路に倒す場合、この brief を"
+            f"そのまま使ってはならない**（背景タブ前提の報告先・報告規律が"
+            f"書かれている）。派遣を進めず窓口へ差し戻し、`--placement` 無しで "
+            f"brief を再生成させること"
         )
     else:
         report_line = "窓口ペイン名: `secretary`（renga layout で登録済み）"

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -49,6 +49,18 @@ VALID_PATTERNS = {"A", "B", "C"}
 VALID_ROLES = {"default", "claude-org-self-edit", "doc-audit"}
 VALID_DEPTHS = {"full", "minimal"}
 
+# Issue #909: where the worker's pane sits relative to the Secretary's tab.
+# ``same_tab`` is the default dispatch path (spawn-flow 3-1a..3-5) and keeps
+# the rendered brief byte-identical to the pre-#909 output; ``background_tab``
+# is the narrow spawn-flow 3-1d exception, where peer *names* do not resolve
+# (they only resolve inside the sender's tab), so the brief must carry the
+# Secretary's numeric pane id instead.
+VALID_PLACEMENTS = {"same_tab", "background_tab"}
+DEFAULT_PLACEMENT = "same_tab"
+DEFAULT_REPORT_TARGET = "secretary"
+# Numeric pane id: the only address form that reaches across tabs.
+_NUMERIC_PANE_ID_RE = re.compile(r"^[0-9]+$")
+
 REQUIRED_STRING_KEYS = {
     "task": ("id", "description", "verification_depth", "branch", "commit_prefix"),
     "worker": ("dir", "pattern", "role"),
@@ -156,6 +168,59 @@ def validate(config: dict[str, Any]) -> None:
         if "notes" in parallel and not isinstance(parallel["notes"], str):
             raise ConfigError("parallel.notes must be a string")
 
+    validate_report(config.get("report"))
+
+
+def validate_report(report: Any) -> None:
+    """Validate the optional ``[report]`` table (Issue #909).
+
+    Absent table == the same-tab default, which renders exactly the
+    pre-#909 brief. ``placement = "background_tab"`` REQUIRES a numeric
+    ``target`` because a background-tab worker cannot resolve peer names
+    at all (renga: names only resolve inside the sender's tab), so
+    accepting a name there would regenerate the very silent-drop this
+    field exists to close.
+    """
+    if report is None:
+        return
+    if not isinstance(report, dict):
+        raise ConfigError("[report] must be a TOML table")
+
+    placement = report.get("placement", DEFAULT_PLACEMENT)
+    if not isinstance(placement, str) or placement not in VALID_PLACEMENTS:
+        raise ConfigError(
+            f"report.placement must be one of {sorted(VALID_PLACEMENTS)}, "
+            f"got {placement!r}"
+        )
+
+    target = report.get("target")
+    if target is not None and (not isinstance(target, str) or not target):
+        raise ConfigError("report.target must be a non-empty string")
+
+    if placement == "background_tab":
+        if target is None:
+            raise ConfigError(
+                "report.target is required when report.placement = "
+                "'background_tab' (the Secretary's numeric pane id; peer "
+                "names only resolve inside the sender's tab)"
+            )
+        if not _NUMERIC_PANE_ID_RE.match(target):
+            raise ConfigError(
+                "report.target must be a numeric pane id when "
+                f"report.placement = 'background_tab', got {target!r} "
+                "(a name is not reachable from another tab)"
+            )
+
+
+def _report_placement(config: dict[str, Any]) -> str:
+    report = config.get("report") or {}
+    return report.get("placement") or DEFAULT_PLACEMENT
+
+
+def _report_target(config: dict[str, Any]) -> str:
+    report = config.get("report") or {}
+    return report.get("target") or DEFAULT_REPORT_TARGET
+
 
 def _closes_or_refs(task: dict[str, Any]) -> str:
     closes = task.get("closes_issue")
@@ -250,6 +315,9 @@ def _select_blocks(config: dict[str, Any]) -> dict[str, bool]:
         and bool(config["references"].get("knowledge")),
         "codex_full": depth == "full",
         "codex_minimal": depth == "minimal",
+        # Issue #909: cross-tab addressing prose, emitted only for the
+        # spawn-flow 3-1d background-tab exception.
+        "background_tab_report": _report_placement(config) == "background_tab",
     }
     return blocks
 
@@ -284,6 +352,10 @@ def _build_substitutions(config: dict[str, Any]) -> dict[str, str]:
 
     return {
         "transport_send_message": _transport.send_message_call(),
+        # Issue #909: ``secretary`` unless the worker is placed in a
+        # background tab, where only a numeric pane id is reachable. The
+        # default value renders the same-tab brief byte-identically.
+        "report_target": _report_target(config),
         "worker_dir": worker["dir"],
         "worker_pattern": worker["pattern"],
         "worker_role": worker["role"],
@@ -396,6 +468,8 @@ def build_config_from_task(
     implementation_guidance: Optional[str] = None,
     references_knowledge: Optional[list[str]] = None,
     parallel_notes: Optional[str] = None,
+    placement: Optional[str] = None,
+    report_target: Optional[str] = None,
     registry_path: Optional[Path] = None,
     state_db_path: Optional[Path] = None,
     claude_org_root: Path,
@@ -525,7 +599,39 @@ def build_config_from_task(
     if parallel_notes:
         config["parallel"] = {"notes": parallel_notes}
 
+    # Issue #909: the [report] table is written only when the dispatch
+    # actually departs from the same-tab default, so every existing
+    # dispatch keeps a [report]-free config (and a byte-identical brief /
+    # --write-toml audit trail). Validated eagerly here — rather than only
+    # at render() — so a background_tab dispatch missing its numeric pane
+    # id fails at plan time instead of writing an unreachable brief.
+    report = _build_report_section(placement, report_target)
+    if report is not None:
+        validate_report(report)
+        config["report"] = report
+
     return config, layout
+
+
+def _build_report_section(
+    placement: Optional[str], report_target: Optional[str]
+) -> Optional[dict[str, str]]:
+    """Assemble the ``[report]`` table, or None for the plain default.
+
+    None (= omit the table entirely) is returned when the caller asked for
+    nothing beyond the same-tab / ``secretary`` default, which is what keeps
+    the default dispatch's rendered brief byte-identical to pre-#909.
+    """
+    effective_placement = placement or DEFAULT_PLACEMENT
+    if effective_placement == DEFAULT_PLACEMENT and report_target in (
+        None,
+        DEFAULT_REPORT_TARGET,
+    ):
+        return None
+    report: dict[str, str] = {"placement": effective_placement}
+    if report_target is not None:
+        report["target"] = report_target
+    return report
 
 
 def _dump_toml(config: dict[str, Any]) -> str:
@@ -562,6 +668,34 @@ def _dump_toml(config: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _add_report_args(p: argparse.ArgumentParser) -> None:
+    """Add the Issue #909 report-target flags (shared with gen_delegate_payload).
+
+    Help text stays ASCII-only so ``--help`` does not crash a cp932
+    Windows console (repo convention).
+    """
+    p.add_argument(
+        "--placement",
+        choices=sorted(VALID_PLACEMENTS),
+        default=None,
+        help=(
+            "Where the dispatcher will put the worker pane. Default "
+            "'same_tab' renders the brief unchanged. 'background_tab' "
+            "(spawn-flow 3-1d) requires --report-target because peer names "
+            "only resolve inside the sender's tab."
+        ),
+    )
+    p.add_argument(
+        "--report-target",
+        default=None,
+        help=(
+            "Address the worker reports to. Default 'secretary' (pane "
+            "name). With --placement background_tab this must be the "
+            "Secretary pane's numeric id, e.g. '1'."
+        ),
+    )
+
+
 def _build_from_task_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="gen_worker_brief.py from-task",
@@ -595,6 +729,7 @@ def _build_from_task_parser() -> argparse.ArgumentParser:
     p.add_argument("--knowledge", action="append", default=[],
                    help="Add an entry to [references].knowledge (repeatable).")
     p.add_argument("--parallel-notes", default=None)
+    _add_report_args(p)
     p.add_argument("--registry-path", type=Path, default=None)
     p.add_argument("--state-db-path", type=Path, default=None)
     p.add_argument("--claude-org-root", type=Path, default=None)
@@ -654,6 +789,8 @@ def _main_from_task(argv: list[str]) -> int:
             implementation_guidance=args.impl_guidance,
             references_knowledge=args.knowledge,
             parallel_notes=args.parallel_notes,
+            placement=args.placement,
+            report_target=args.report_target,
             registry_path=args.registry_path,
             state_db_path=state_db_path,
             claude_org_root=claude_org_root,

--- a/tools/gen_worker_brief.py
+++ b/tools/gen_worker_brief.py
@@ -197,6 +197,20 @@ def validate_report(report: Any) -> None:
     if target is not None and (not isinstance(target, str) or not target):
         raise ConfigError("report.target must be a non-empty string")
 
+    if placement == DEFAULT_PLACEMENT:
+        # Codex Round 1 P2: a custom target under the same-tab default would
+        # render the brief against that target while the DELEGATE body still
+        # advertises ``窓口ペイン名: secretary`` — two artifacts of the same
+        # dispatch disagreeing about where the worker reports. The field
+        # exists for the background-tab branch only, so reject the
+        # combination instead of silently producing the split.
+        if target is not None and target != DEFAULT_REPORT_TARGET:
+            raise ConfigError(
+                f"report.target={target!r} requires report.placement = "
+                "'background_tab'; the same-tab dispatch always reports to "
+                f"{DEFAULT_REPORT_TARGET!r}"
+            )
+
     if placement == "background_tab":
         if target is None:
             raise ConfigError(

--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -110,8 +110,9 @@ done: {commit SHA 短縮形} {変更ファイル名}
 
 あなたは窓口とは**別のタブ**に配置されている。peer 名（`secretary` / `dispatcher`）は**送信者と同じタブの中でしか解決しない**ため、名前宛の送信は `[pane_not_found]`（broker: `[peer_not_found]`）で必ず失敗する。完了・進捗・判断仰ぎのすべてを、下記「作業完了時」も含めて数値 pane id `to_id="${report_target}"`（窓口）宛に送ること。
 
-- 数値 id 宛でも届かないときだけ `list_peers`（タブを跨いで列挙される）で取り直す。**`role=secretary` だけで選んではならない** — 列挙は他の org のタブも映すため、role 一致だけでは別 org の窓口に完了報告を漏らす。`name` / `role` / `cwd` の 3 属性が自分の org のものと一致する行に限って宛先にすること（下記「作業完了時」の 2 rule と復旧手順の正本 `${claude_org_path}/.claude/skills/org-delegate/references/renga-error-codes.md` がそのまま適用される。同節冒頭の capability gate も同じく適用対象）。
-- 名前宛へ切り替えるのは解決策にならない（別タブでは原理的に解決しない）。3 属性一致で確定できないうちは**何も送らず、ペインを保持したまま停止する**。
+- **送信の前に毎回 identity を照合する**（失敗したときだけではない）。数値 pane id は backend session に閉じた識別子で、daemon restart を跨ぐと先頭から振り直される。stale な id は**別の生きたペインに「成功」で届き、エラーコードは何も出ない**（契約 T-§4.2-id の session provenance）。送る前に `list_peers` で `id=${report_target}` の行を引き、`name` / `role` / `cwd` の 3 属性が自分の org の窓口と一致することを確認してから送ること。
+- 一致しない / その行が無いときは、**`role=secretary` だけで別の行を選んではならない** — 列挙は他の org のタブも映すため、role 一致だけでは別 org の窓口に完了報告を漏らす。3 属性一致で確定できないうちは**何も送らず、ペインを保持したまま停止する**（下記「作業完了時」の 2 rule と復旧手順の正本 `${claude_org_path}/.claude/skills/org-delegate/references/renga-error-codes.md` がそのまま適用される。同節冒頭の capability gate も同じく適用対象）。
+- 名前宛へ切り替えるのは解決策にならない（別タブでは原理的に解決しない）。
 - 下記の escalate 先 `dispatcher` も同じ理由で名前では解決しない。使うときは `list_peers` の数値 id を、同じ 3 属性一致の確認を通してから宛先にする。
 - `list_panes` は自分のタブしか映さない（自ペイン 1 行だけが返る）ので、窓口・ディスパッチャーの確認には使えない。
 

--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -110,8 +110,9 @@ done: {commit SHA 短縮形} {変更ファイル名}
 
 あなたは窓口とは**別のタブ**に配置されている。peer 名（`secretary` / `dispatcher`）は**送信者と同じタブの中でしか解決しない**ため、名前宛の送信は `[pane_not_found]`（broker: `[peer_not_found]`）で必ず失敗する。完了・進捗・判断仰ぎのすべてを、下記「作業完了時」も含めて数値 pane id `to_id="${report_target}"`（窓口）宛に送ること。
 
-- 数値 id 宛でも届かないときは `list_peers`（タブを跨いで列挙される）で `role=secretary` の行の数値 id を取り直してから送る。名前宛へ切り替えるのは解決策にならない。
-- 下記の escalate 先 `dispatcher` も同じ理由で名前では解決しない。使うときは `list_peers` の `role=dispatcher` の数値 id を宛先にする。
+- 数値 id 宛でも届かないときだけ `list_peers`（タブを跨いで列挙される）で取り直す。**`role=secretary` だけで選んではならない** — 列挙は他の org のタブも映すため、role 一致だけでは別 org の窓口に完了報告を漏らす。`name` / `role` / `cwd` の 3 属性が自分の org のものと一致する行に限って宛先にすること（下記「作業完了時」の 2 rule と復旧手順の正本 `${claude_org_path}/.claude/skills/org-delegate/references/renga-error-codes.md` がそのまま適用される。同節冒頭の capability gate も同じく適用対象）。
+- 名前宛へ切り替えるのは解決策にならない（別タブでは原理的に解決しない）。3 属性一致で確定できないうちは**何も送らず、ペインを保持したまま停止する**。
+- 下記の escalate 先 `dispatcher` も同じ理由で名前では解決しない。使うときは `list_peers` の数値 id を、同じ 3 属性一致の確認を通してから宛先にする。
 - `list_panes` は自分のタブしか映さない（自ペイン 1 行だけが返る）ので、窓口・ディスパッチャーの確認には使えない。
 
 <!--END:background_tab_report-->

--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -105,9 +105,19 @@ done: {commit SHA 短縮形} {変更ファイル名}
 - 振り返り記録（`knowledge/raw/`）も minimal では不要
 
 <!--END:codex_minimal-->
+<!--BEGIN:background_tab_report-->
+## 報告先（背景タブ配置）
+
+あなたは窓口とは**別のタブ**に配置されている。peer 名（`secretary` / `dispatcher`）は**送信者と同じタブの中でしか解決しない**ため、名前宛の送信は `[pane_not_found]`（broker: `[peer_not_found]`）で必ず失敗する。完了・進捗・判断仰ぎのすべてを、下記「作業完了時」も含めて数値 pane id `to_id="${report_target}"`（窓口）宛に送ること。
+
+- 数値 id 宛でも届かないときは `list_peers`（タブを跨いで列挙される）で `role=secretary` の行の数値 id を取り直してから送る。名前宛へ切り替えるのは解決策にならない。
+- 下記の escalate 先 `dispatcher` も同じ理由で名前では解決しない。使うときは `list_peers` の `role=dispatcher` の数値 id を宛先にする。
+- `list_panes` は自分のタブしか映さない（自ペイン 1 行だけが返る）ので、窓口・ディスパッチャーの確認には使えない。
+
+<!--END:background_tab_report-->
 ## 作業完了時
 
-1. **完了報告**: `${transport_send_message}(to_id="secretary", message="...")` で窓口に報告する。**ディスパッチャーではなく窓口に送ること**。宛先解決に失敗しても（renga: `[pane_not_found]` / broker: `[peer_not_found]`）**窓口が消えたとは解釈しない**。復旧手順の正本は `${claude_org_path}/.claude/skills/org-delegate/references/renga-error-codes.md` の「`pane_not_found` の messaging 分岐」節（同節の冒頭が capability gate へのポインタを持つ）。そこを読む前も読んだ後も、次の 2 つは必ず守る:
+1. **完了報告**: `${transport_send_message}(to_id="${report_target}", message="...")` で窓口に報告する。**ディスパッチャーではなく窓口に送ること**。宛先解決に失敗しても（renga: `[pane_not_found]` / broker: `[peer_not_found]`）**窓口が消えたとは解釈しない**。復旧手順の正本は `${claude_org_path}/.claude/skills/org-delegate/references/renga-error-codes.md` の「`pane_not_found` の messaging 分岐」節（同節の冒頭が capability gate へのポインタを持つ）。そこを読む前も読んだ後も、次の 2 つは必ず守る:
    - **宛先が自分と同じ org だと確認できるまで一切再送しない**（誤送信は別 org へ完了報告を漏らす）。数値 id・`same_tab: true` 候補を含め、確認できていない宛先へは送らない。
    - **宛先を確定できない / 再送も失敗したときは `to_id="dispatcher"` へ 1 回だけ escalate する**（ループにしない）。**この escalate も同じ確認の対象**で、dispatcher も同一 org だと確認できないときは**何も送らず、ペインを保持したまま停止する** — 報告内容はペインに残し、ディスパッチャーの監視 / 人間の回収に委ねる。
 2. **PR 作成後はペインを保持してレビュー指摘待機**: 「閉じてよい」「マージ済み」など窓口からの明示クローズ指示が来るまで待機状態を維持する。

--- a/tools/templates/worker_brief_self_edit.md
+++ b/tools/templates/worker_brief_self_edit.md
@@ -81,7 +81,7 @@ codex exec review --base ${task_base_ref} -m gpt-5.6-sol -c model_reasoning_effo
 <!--END:codex_minimal-->
 <!--BEGIN:background_tab_report-->
 ## 報告先（背景タブ配置）
-窓口とは別タブに居るため、peer 名（`secretary` / `dispatcher`）は解決しない（名前は送信者と同じタブ内でのみ解決する。名前宛は `[pane_not_found]` / broker: `[peer_not_found]`）。報告・進捗・判断仰ぎは数値 pane id `to_id="${report_target}"`（窓口）宛に送る。届かないときは `list_peers`（タブ跨ぎで列挙）で `role=secretary` の数値 id を取り直す（`list_panes` は自タブ 1 行のみで使えない）。
+窓口とは別タブに居るため、peer 名（`secretary` / `dispatcher`）は解決しない（名前は送信者と同じタブ内でのみ解決する。名前宛は `[pane_not_found]` / broker: `[peer_not_found]`）。報告・進捗・判断仰ぎは数値 pane id `to_id="${report_target}"`（窓口）宛に送る。届かないときだけ `list_peers`（タブ跨ぎで列挙）で取り直すが、**`role=secretary` だけで選んではならない** — 列挙は他の org のタブも映すため、role 一致だけでは別 org の窓口へ完了報告を漏らす。`name` / `role` / `cwd` の 3 属性が自分の org と一致する行に限って宛先にし、確定できないうちは**何も送らずペインを保持したまま停止する**（復旧手順の正本は `${claude_org_path}/.claude/skills/org-delegate/references/renga-error-codes.md`。同節冒頭の capability gate も適用対象）。`list_panes` は自タブ 1 行のみで確認には使えない。
 
 <!--END:background_tab_report-->
 ## 完了時

--- a/tools/templates/worker_brief_self_edit.md
+++ b/tools/templates/worker_brief_self_edit.md
@@ -79,8 +79,13 @@ codex exec review --base ${task_base_ref} -m gpt-5.6-sol -c model_reasoning_effo
 検証深度 minimal。minimal 用 1 行報告フォーマットを使用（`done: {SHA} {files}`）。Codex セルフレビュー・追加テスト・拡張された動作確認は一切禁止。
 
 <!--END:codex_minimal-->
+<!--BEGIN:background_tab_report-->
+## 報告先（背景タブ配置）
+窓口とは別タブに居るため、peer 名（`secretary` / `dispatcher`）は解決しない（名前は送信者と同じタブ内でのみ解決する。名前宛は `[pane_not_found]` / broker: `[peer_not_found]`）。報告・進捗・判断仰ぎは数値 pane id `to_id="${report_target}"`（窓口）宛に送る。届かないときは `list_peers`（タブ跨ぎで列挙）で `role=secretary` の数値 id を取り直す（`list_panes` は自タブ 1 行のみで使えない）。
+
+<!--END:background_tab_report-->
 ## 完了時
-1. `${transport_send_message}(to_id="secretary", ...)` で完了内容・変更ファイル・commit SHA・動作確認結果・残作業を報告
+1. `${transport_send_message}(to_id="${report_target}", ...)` で完了内容・変更ファイル・commit SHA・動作確認結果・残作業を報告
 2. PR 作成後ペイン保持
 3. 振り返り記録: 任意（非自明な学びがあれば `${claude_org_path}/knowledge/raw/{YYYY-MM-DD}-{topic}.md`）
 

--- a/tools/templates/worker_brief_self_edit.md
+++ b/tools/templates/worker_brief_self_edit.md
@@ -81,7 +81,7 @@ codex exec review --base ${task_base_ref} -m gpt-5.6-sol -c model_reasoning_effo
 <!--END:codex_minimal-->
 <!--BEGIN:background_tab_report-->
 ## 報告先（背景タブ配置）
-窓口とは別タブに居るため、peer 名（`secretary` / `dispatcher`）は解決しない（名前は送信者と同じタブ内でのみ解決する。名前宛は `[pane_not_found]` / broker: `[peer_not_found]`）。報告・進捗・判断仰ぎは数値 pane id `to_id="${report_target}"`（窓口）宛に送る。届かないときだけ `list_peers`（タブ跨ぎで列挙）で取り直すが、**`role=secretary` だけで選んではならない** — 列挙は他の org のタブも映すため、role 一致だけでは別 org の窓口へ完了報告を漏らす。`name` / `role` / `cwd` の 3 属性が自分の org と一致する行に限って宛先にし、確定できないうちは**何も送らずペインを保持したまま停止する**（復旧手順の正本は `${claude_org_path}/.claude/skills/org-delegate/references/renga-error-codes.md`。同節冒頭の capability gate も適用対象）。`list_panes` は自タブ 1 行のみで確認には使えない。
+窓口とは別タブに居るため、peer 名（`secretary` / `dispatcher`）は解決しない（名前は送信者と同じタブ内でのみ解決する。名前宛は `[pane_not_found]` / broker: `[peer_not_found]`）。報告・進捗・判断仰ぎは数値 pane id `to_id="${report_target}"`（窓口）宛に送る。**送信前に毎回 identity を照合する**（失敗時だけではない）: 数値 pane id は backend session に閉じた識別子で daemon restart 後は振り直され、stale な id は**別の生きたペインに「成功」で届きエラーコードも出ない**（契約 T-§4.2-id の session provenance）。`list_peers` で `id=${report_target}` の行を引き、`name` / `role` / `cwd` の 3 属性が自分の org の窓口と一致してから送ること。一致しない / 行が無いときは **`role=secretary` だけで別の行を選ばない**（他 org のタブも列挙されるため完了報告を別 org へ漏らす）。確定できないうちは**何も送らずペインを保持したまま停止する**（復旧手順の正本は `${claude_org_path}/.claude/skills/org-delegate/references/renga-error-codes.md`。同節冒頭の capability gate も適用対象）。`list_panes` は自タブ 1 行のみで確認には使えない。
 
 <!--END:background_tab_report-->
 ## 完了時

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -818,6 +818,21 @@ class Issue909ReportTargetPlacement(unittest.TestCase):
             )
         self.assertIn("numeric pane id", str(ctx.exception))
 
+    def test_same_tab_rejects_a_custom_target(self):
+        """Codex Round 1 P2: a custom target under same_tab would render the
+        brief against it while the DELEGATE body still names ``secretary``."""
+        with self.assertRaises(gwb.ConfigError) as ctx:
+            self._render(
+                self_edit=False,
+                report={"placement": "same_tab", "target": "dispatcher"},
+            )
+        self.assertIn("requires report.placement", str(ctx.exception))
+        # The explicit default pair stays legal (it renders identically).
+        self._render(
+            self_edit=False,
+            report={"placement": "same_tab", "target": "secretary"},
+        )
+
     def test_unknown_placement_is_rejected(self):
         with self.assertRaises(gwb.ConfigError):
             self._render(self_edit=False, report={"placement": "other_tab"})

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -598,6 +598,54 @@ class FromTaskSubcommand(unittest.TestCase):
         self.assertTrue(msg.startswith("error: "), f"expected 'error: ' prefix, got {msg!r}")
         self.assertNotIn("Traceback", msg)
 
+    # -- Issue #909: placement-driven report target ------------------------
+
+    def test_from_task_default_keeps_name_target(self):
+        text = self._run().read_text(encoding="utf-8")
+        self.assertIn('send_message(to_id="secretary"', text)
+
+    def test_from_task_background_tab_writes_numeric_target(self):
+        text = self._run(
+            "--placement", "background_tab", "--report-target", "1"
+        ).read_text(encoding="utf-8")
+        self.assertIn('send_message(to_id="1"', text)
+        self.assertIn("報告先（背景タブ配置）", text)
+
+    def test_from_task_background_tab_without_target_fails(self):
+        out = Path(self._td.name) / "CLAUDE.md"
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = gwb.main([
+                "from-task",
+                "--task-id", "demo-from-task",
+                "--project-slug", "clock-app",
+                "--description", "demo description for clock app",
+                "--claude-org-root", str(self.claude_org_root),
+                "--out", str(out),
+                "--placement", "background_tab",
+            ])
+        self.assertEqual(rc, 2)
+        self.assertIn("report.target is required", stderr.getvalue())
+        self.assertFalse(out.exists(), "no brief may be written on rejection")
+
+    def test_from_task_background_tab_round_trips_through_toml(self):
+        toml_path = Path(self._td.name) / "audit.toml"
+        self._run(
+            "--placement", "background_tab",
+            "--report-target", "1",
+            "--write-toml", str(toml_path),
+        )
+        cfg = gwb.load_config(toml_path)
+        self.assertEqual(
+            cfg["report"], {"placement": "background_tab", "target": "1"}
+        )
+        self.assertIn('send_message(to_id="1"', gwb.render(cfg))
+
+    def test_from_task_default_writes_no_report_table(self):
+        toml_path = Path(self._td.name) / "audit-default.toml"
+        self._run("--write-toml", str(toml_path))
+        self.assertNotIn("[report]", toml_path.read_text(encoding="utf-8"))
+
 
 class FromTaskPythonSrcLayout(unittest.TestCase):
     """Issue #676 end-to-end: the from-task path detects a Python
@@ -706,6 +754,85 @@ class FromTaskPythonSrcLayout(unittest.TestCase):
         # And the dumped TOML renders back to a brief with the rule.
         cfg = gwb.load_config(toml_path)
         self.assertIn(self.RULE_HEADER, gwb.render(cfg))
+
+
+class Issue909ReportTargetPlacement(unittest.TestCase):
+    """Placement decides the brief's report address (Issue #909).
+
+    Background-tab workers cannot resolve peer *names* at all (renga
+    resolves names inside the sender's tab only), so their brief must carry
+    the Secretary's numeric pane id. The same-tab default must keep
+    rendering the pre-#909 brief byte for byte.
+    """
+
+    def _render(self, *, self_edit: bool, report: dict | None = None) -> str:
+        cfg = _base_config(self_edit=self_edit)
+        if report is not None:
+            cfg["report"] = report
+        return gwb.render(cfg)
+
+    def test_default_is_secretary_by_name(self):
+        for self_edit in (False, True):
+            with self.subTest(self_edit=self_edit):
+                out = self._render(self_edit=self_edit)
+                self.assertIn('send_message(to_id="secretary"', out)
+                self.assertNotIn("報告先（背景タブ配置）", out)
+
+    def test_explicit_same_tab_is_byte_identical_to_default(self):
+        for self_edit in (False, True):
+            with self.subTest(self_edit=self_edit):
+                self.assertEqual(
+                    self._render(self_edit=self_edit),
+                    self._render(
+                        self_edit=self_edit, report={"placement": "same_tab"}
+                    ),
+                )
+
+    def test_background_tab_reports_to_numeric_pane_id(self):
+        for self_edit in (False, True):
+            with self.subTest(self_edit=self_edit):
+                out = self._render(
+                    self_edit=self_edit,
+                    report={"placement": "background_tab", "target": "7"},
+                )
+                self.assertIn('send_message(to_id="7"', out)
+                # The name form must be gone from the send call entirely —
+                # leaving it anywhere the worker could copy re-creates the
+                # silent [pane_not_found] drop this branch exists to close.
+                self.assertNotIn('send_message(to_id="secretary"', out)
+                self.assertIn("報告先（背景タブ配置）", out)
+                self.assertIn("list_peers", out)
+                self.assertNotIn("<!--BEGIN:", out)
+                self.assertNotIn("${", out)
+
+    def test_background_tab_requires_a_target(self):
+        with self.assertRaises(gwb.ConfigError) as ctx:
+            self._render(self_edit=False, report={"placement": "background_tab"})
+        self.assertIn("report.target is required", str(ctx.exception))
+
+    def test_background_tab_rejects_a_name_target(self):
+        with self.assertRaises(gwb.ConfigError) as ctx:
+            self._render(
+                self_edit=False,
+                report={"placement": "background_tab", "target": "secretary"},
+            )
+        self.assertIn("numeric pane id", str(ctx.exception))
+
+    def test_unknown_placement_is_rejected(self):
+        with self.assertRaises(gwb.ConfigError):
+            self._render(self_edit=False, report={"placement": "other_tab"})
+
+    def test_report_table_type_is_checked(self):
+        with self.assertRaises(gwb.ConfigError):
+            self._render(self_edit=False, report="background_tab")  # type: ignore[arg-type]
+
+    def test_build_report_section_omits_table_for_defaults(self):
+        self.assertIsNone(gwb._build_report_section(None, None))
+        self.assertIsNone(gwb._build_report_section("same_tab", "secretary"))
+        self.assertEqual(
+            gwb._build_report_section("background_tab", "3"),
+            {"placement": "background_tab", "target": "3"},
+        )
 
 
 class LegacyCLIPreserved(unittest.TestCase):


### PR DESCRIPTION
## 何を直したか

背景タブに配置した worker では、brief に書かれている正準の報告先 `send_message(to_id="secretary")` が `[pane_not_found]` で失敗する。名前はタブ内でしか解決しないため。**補正が無ければ完了報告が沈黙で落ち、窓口からは stall にしか見えない。**

2026-08-09 の placement dogfood（#907）で実測した欠陥で、実際に窓口の口頭補正で 2 回救っている。

## 変更の要点

1. brief config に `[report] placement` / `[report] target` を追加し、テンプレートの報告先を `${report_target}` 化。**既定（同一タブ）はテーブル自体を書かないので、brief・DELEGATE 本文・`--write-toml` の監査証跡すべて従来と 1 バイトも変わらない**（明示 `same_tab` との byte 等価もテストで pin）
2. `background_tab` では報告先を窓口の**数値 pane id** で埋め、名前・欠落は apply/render の前に **fail loud で拒否**（名前を許すと本 fix が塞ぐ沈黙をそのまま再生産するため）
3. 背景タブ brief に条件付き節を追加し、**送信前に毎回** `list_peers` で当該 id の `name` / `role` / `cwd` 3 属性一致を確認させる。stale な数値 id は別の生きたペインへ「成功」で届きエラーが出ない（契約 T-§4.2-id の session provenance）ため、照合を失敗時の復旧手順に留めると誤配が素通りする
4. DELEGATE 本文は背景タブ配置のとき報告先行を数値 id に差し替え、**3-1d の条件を満たせず同一タブに倒す場合はこの brief を流用せず窓口へ差し戻す**旨を明記（brief は 3-1d 評価より前に render されるため）
5. CLI に `--placement {same_tab,background_tab}` / `--report-target` を `gen_delegate_payload.py`（preview / apply）と `gen_worker_brief.py from-task` へ同形で追加

## 設計判断

- **採用**: placement フラグ + 明示 `--report-target`。窓口の pane id は state.db にも registry にも無く、生成器は pure（MCP 呼び出し不可）なので自動導出できない。placement だけを受けて id を推測するのは事故源になるため、数値 id を必須入力にして欠落は fail loud
- **却下**: `--report-target` 単独（placement を持たない）— 値だけでは「別タブに居る」文脈が brief に落ちず、cross-tab 固有の規律を出し分けられない
- **却下**: 同一タブでも常に数値 id で書く統一案 — 数値 id は session 依存で daemon restart 後に別ペインを指すため、名前で足りる同一タブをわざわざ脆くする

## 検証

- `python -m unittest discover -s tests` = 1008 tests OK / `-s tools` = 924 tests OK
- `gen_skill_prose --check` drift ゼロ / `--help` の cp932 encodable を実測
- Codex `codex exec review --base origin/main -m gpt-5.6-sol` 3 round、**P1 全解消**（各 round で別個の新規指摘が 1 round ずつ解消される健全型の収束）

## スコープ

brief 生成側のみ。背景タブ配置そのものの運用可否・契約 T-§4.2-place の充足記録は #910 のスコープ。既定経路が byte 等価なので #910 と独立にマージできる。

Closes #909
Refs #907 #906
