### PR TITLE
fix(claude): pr-watch-pane の self-close をペイン実体で分類し直し、renga を窓口イベント駆動 close 側へ載せ替える

### DIFF
--- a/.claude/skills/pr-watch-pane/SKILL.md
+++ b/.claude/skills/pr-watch-pane/SKILL.md
@@ -6,7 +6,9 @@ description: >
   pr-watch-<PR> で回す。窓口が PR 作成直後に `/pr-watch-pane <PR>` で起動すると、
   ja-root cwd・sandbox 外で監視が走り、/clear や窓口セッション寿命と無関係に継続する。
   pane name で冪等起動 (二重監視しない)、role=watcher で identity 登録、監視終了
-  (CI green / PR merged / timeout) でペイン自動 close。Bash tool の background は
+  (CI green / PR merged / timeout) で broker の tmux backend ならペイン自動 close
+  (herdr / wezterm / renga のペインは tmux ペインでないため自動 close されず、窓口が
+  監視終端でイベント駆動 close する)。Bash tool の background は
   session 寿命依存で長時間 watcher には不適なので本 skill が推奨経路。
   「CI 監視をペインで」「pr-watch をペインで回して」「PR <N> の CI を見張って」等で発動。
 effort: low
@@ -82,29 +84,45 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
   `tools/pr-watch.sh` を ja-root 基点で resolve する必要があるため、**cwd trap を skill
   側で吸収する**（Step 1 で `git rev-parse --show-toplevel` の絶対パスを spawn_pane の
   `cwd` に明示。窓口 cwd が何らかの理由で ja-root を外れていても正しく解決される）。
-- **自己 close の実装は tmux backend 前提**。Step 3 の `command` は `bash` 実行と、自己
-  close の `tmux kill-pane -t "$TMUX_PANE"`（**自ペインを `$TMUX_PANE` で明示指定して** kill。
-  socket は `$TMUX` 継承をそのまま使い `-L` で固定しない ＝ broker / renga / 非既定 socket
-  いずれの transport でも正しい server に当たる。Issue #647 提案 1 の「明示 target 指定」を
-  transport-neutral に実装した形）に依存する。
-- **自己 close は tmux backend の低遅延経路であり、backend 依存で効き方が変わる（herdr
-  ゾンビ残留の根治, Issue #751）**。broker は backend として tmux / herdr / wezterm を取りうる
-  （解決済み backend は `daemon.json` sidecar が持つ。renga opt-in は常に tmux。契約は
+- **自己 close の実装は「watcher ペインが tmux ペインであること」前提**。Step 3 の `command` は
+  `bash` 実行と、自己 close の `tmux kill-pane -t "$TMUX_PANE"`（**自ペインを `$TMUX_PANE` で明示
+  指定して** kill。socket は `$TMUX` 継承をそのまま使い `-L` で固定しない ＝ tmux 上に立つ
+  ペインであれば broker の既定 socket / 非既定 socket いずれでも正しい server に当たる。
+  Issue #647 提案 1 の「明示 target 指定」を実装した形）に依存する。**tmux ペインでない環境では
+  `$TMUX` / `$TMUX_PANE` がそもそも env に無く、`-t ""` へ展開されて `2>/dev/null || true` で
+  無言失敗する**（下記の分類を参照）。
+- **自己 close は tmux ペインの低遅延経路であり、watcher ペインの実体が tmux ペインかどうかで
+  効き方が変わる（herdr ゾンビ残留の根治, Issue #751 / renga 残留, Issue #911）**。broker は
+  backend として tmux / herdr / wezterm を取りうる（解決済み backend は `daemon.json` sidecar が
+  持つ。契約は
   [`docs/contracts/backend-interface-contract.md`](../../../docs/contracts/backend-interface-contract.md)
-  Surface 8）:
-  - **tmux backend**: Step 3 末尾の `tmux kill-pane -t "$TMUX_PANE"` が実ペインを即座に消す
-    ＝ **監視終端で watcher ペインが自動 close される低遅延経路**（従来挙動。温存する）。
-  - **herdr / wezterm backend（Windows native broker の別 GUI ウィンドウ・tmux 非経由を含む）**:
+  Surface 8）。**opt-in `renga` のペインは tmux ペインではない**ので、transport の綴りではなく
+  「ペインの実体」で次の 2 分類に読み替える:
+  - **自己 close が効く = broker の tmux backend**: Step 3 末尾の `tmux kill-pane -t "$TMUX_PANE"`
+    が実ペインを即座に消す ＝ **監視終端で watcher ペインが自動 close される低遅延経路**
+    （従来挙動。温存する）。
+  - **自己 close が効かない = broker の herdr / wezterm backend（Windows native broker の別 GUI
+    ウィンドウ・tmux 非経由を含む）、および opt-in `renga`**:
     watcher ペインは tmux ペインではないため `tmux kill-pane` が **no-op**（`|| true` で握り潰され
-    silent）。self-close が効かず、**監視終了後もペインがゾンビとして残留する**（実測: 2026-07-22
-    に PR #154 / #749 / #750 の watcher 3 枚が herdr backend で残留し、`close_pane`(id 指定) で
-    掃除した）。この backend では自己 close に頼れないため、**監視終端で窓口がイベント駆動で
-    watcher ペインを close する経路が正路**になる
+    silent）。self-close が効かず、**監視終了後もペインがゾンビとして残留する**。実測は 2 系統:
+    2026-07-22 に PR #154 / #749 / #750 の watcher 3 枚が herdr backend で残留し `close_pane`(id 指定)
+    で掃除した件と、**2026-08-09 の PR #908 監視で renga のペインが残留し窓口が `close_pane` で
+    手動掃除した件**（renga ペインでは `printenv TMUX TMUX_PANE` がどちらも未設定を返す ＝
+    `kill-pane -t ""` に展開されて無言失敗する）。この分類では自己 close に頼れないため、
+    **監視終端で窓口がイベント駆動で watcher ペインを close する経路が正路**になる
     （[`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md) の post-merge
     cleanup / `PR_MERGE_WATCH_TIMEOUT` / CI 失敗確定の各終端で窓口が発火。掃除手順は下記 Step 5 の
     (a)/(b) split に従う ＝ live pane は list_panes 確認済みの数値 pane_id で close、stale binding
-    のみ broker 条件付き allowlist で name 指定）。`close_pane` は transport 抽象上 tmux / herdr 両対応で、tmux backend で既に
-    self-close 済みなら `[pane_not_found]` が返る（自己クローズ済みで正常）。Windows native の手動起動経路
+    のみ broker 条件付き allowlist で name 指定）。`close_pane` は transport 抽象上 tmux / herdr /
+    renga いずれでも呼べ、broker の tmux backend で既に
+    self-close 済みなら `[pane_not_found]` が返る（自己クローズ済みで正常）。
+    - **renga では窓口 close も無条件には撃てない**: Step 5 (a) の自タブ確立は **(i) backend が
+      Group B を自身の single-tab モデル内で解決する（＝ `org-broker`）/ (ii) `caller_scope` を
+      確立できている**のいずれかを要し（契約 T-§4.2「Fail-safe consequence for Group B」/ T-§cap）、
+      renga では (i) が成立しないため **(ii) を確立できない限り close を撃たず、watcher ペインが
+      残る旨を報告して人手掃除に委ねる**（相対セレクタへはフォールバックしない）。self-close の
+      無言失敗と違い、**残留が報告として可視化される**のがこの載せ替えの眼目である。
+    Windows native の手動起動経路
     （人間が `tools/pr-watch.ps1 <PR>` を `!` 経由で起動）も従来どおり遮断しない（既存経路は不変）。
 
 ## Step 1: 引数解決と cwd / repo の確定
@@ -231,19 +249,25 @@ mcp__org-broker__spawn_pane(
 - `command`: pr-watch を前景実行し、stdout/stderr を `.state/pr-watch-<PR>.log` に `tee -a`
   （tmux スクロールバッファにも出る二段）。先頭 `mkdir -p .state` で fresh clone でも tee の
   出力先を確保する。pr-watch 終了後に `tmux kill-pane -t "$TMUX_PANE"`
-  で **ペインを自己 close**（監視終了で自動 close。`|| true` で tmux 不在環境でも握り潰す）。
+  で **ペインを自己 close**（broker の tmux backend でのみ効く低遅延経路。`|| true` は tmux ペイン
+  でない環境 = herdr / wezterm / renga で失敗を握り潰すためのもので、**そこでは自動 close されず
+  窓口のイベント駆動 close が正路**になる。前掲「前提」節の 2 分類）。
   - **`$TMUX_PANE` は placeholder ではなく実行時 env**: `<PR>` / `<OWNER/REPO>` と違い
-    `$TMUX_PANE` は窓口が値に置換してはならない。spawn されたペインの shell に自動露出する
-    自ペイン id（例 `%16`）で、self-close 時に **その pane 自身**を明示 target 解決する。
+    `$TMUX_PANE` は窓口が値に置換してはならない。tmux ペインとして spawn された場合に shell へ
+    自動露出する自ペイン id（例 `%16`）で、self-close 時に **その pane 自身**を明示 target 解決する。
     旧形 `tmux kill-pane`（target 無指定）は現在ペインを暗黙推定するが、`-t "$TMUX_PANE"` で
     明示することで曖昧さを排す（Issue #647 提案 1 の「明示 target 指定」）。
+    - **tmux ペインでなければ未設定で無言失敗する（Issue #911）**: renga のペインでは
+      `printenv TMUX TMUX_PANE` がどちらも未設定を返すため、この行は `tmux kill-pane -t ""` に
+      展開され `2>/dev/null || true` で無言失敗する（herdr / wezterm も同様に tmux ペインでない）。
+      **この失敗はエラーとして表に出ないので、残留の検知を self-close の成否に依存させない。**
   - **socket は `$TMUX` 継承をそのまま使う（`-L` で固定しない）**: `tmux` を `-L` 無しで
     起動すると、ペインが属する tmux server の socket を `$TMUX` から自動解決する。broker では
-    それが `claude-org-broker` socket、opt-in renga や非既定 socket 構成では別 socket になる
-    が、いずれも `$TMUX` が正しい server を指すので kill が当たる。ここで `-L claude-org-broker`
-    と固定すると renga / 非既定 socket 下で **別 server に当たって self-close が無言で失敗**
-    するため、socket は固定せず transport-neutral に保つ。
-  - **self-close は tmux 層だけを掃除する**: `kill-pane` は broker socket 上の実 tmux ペイン
+    それが `claude-org-broker` socket、非既定 socket 構成では別 socket になるが、いずれも
+    `$TMUX` が正しい server を指すので kill が当たる。ここで `-L claude-org-broker`
+    と固定すると非既定 socket 下で **別 server に当たって self-close が無言で失敗**
+    するため、socket は固定しない（renga では `$TMUX` 自体が無いので、そもそもこの経路に乗らない）。
+  - **self-close は（効いた場合も）tmux 層だけを掃除する**: `kill-pane` は broker socket 上の実 tmux ペイン
     を消すので、直後から `list_panes` には現れなくなる。ただし broker daemon の pane 登録簿
     （name binding）は self-close では pop されず **stale に残りうる**（daemon は自 pane の外部
     kill を検知しないため）。stale binding が残ると同名 `pr-watch-<PR>` の再 spawn が
@@ -253,9 +277,10 @@ mcp__org-broker__spawn_pane(
     allowlist 経路**であり、無条件の name 指定ではない（3 条件と broker 以外での扱いは Step 5 の
     (b) が SoT）。
   - `--merge-watch`: CI green で `CI_COMPLETED` を出した後もマージまで poll し続け（最大
-    24h）、マージで `PR_MERGED`、timeout で `PR_MERGE_WATCH_TIMEOUT` を出してから自己 close
-    する。CI 確定だけで止めたい場合は呼び出し時に `--merge-watch` を外す（その場合は CI green
-    / failed 確定で自己 close）。
+    24h）、マージで `PR_MERGED`、timeout で `PR_MERGE_WATCH_TIMEOUT` を出してから自己 close を
+    試みる。CI 確定だけで止めたい場合は呼び出し時に `--merge-watch` を外す（その場合は CI green
+    / failed 確定で自己 close を試みる）。いずれも実際に閉じるのは broker の tmux backend のみで、
+    herdr / wezterm / renga では窓口のイベント駆動 close が掃除する。
   - pr-watch.sh の既存メッセージ形・event payload 形は **本 skill では一切変更しない**（不変条件）。
     既存の手動 `tools/pr-watch.sh` 起動経路（人間の `!` 経由など）も従来どおり動作する。
 
@@ -397,21 +422,24 @@ mcp__org-broker__spawn_pane(
    ```
    PR #<PR> の CI / マージ監視ペイン pr-watch-<PR> (id={N}) を起動しました。
    - ログ: .state/pr-watch-<PR>.log（tmux スクロールバッファにも出力）
-   - 監視終了（マージ / CI 失敗確定 / timeout のいずれか）で、tmux backend ではペインが
-     自動で閉じます。herdr / wezterm backend では自己 close が効かず残留するため、窓口が
-     監視終端でイベント駆動 close します（org-pull-request の各終端処理）。
+   - 監視終了（マージ / CI 失敗確定 / timeout のいずれか）で、broker の tmux backend では
+     ペインが自動で閉じます。herdr / wezterm backend と renga では自己 close が効かず残留する
+     ため、窓口が監視終端でイベント駆動 close します（org-pull-request の各終端処理）。
      確定した CI 判定は `.state/state.db` の `ci_completed` 行とログに残るので、
      ペインが閉じても判定は失われません（merge gate はそこを読む）。
    - tmux で直接見るには `/org-attach` のコマンドを使ってください。
    ```
 
-3. **監視終端クローズ / 手動 close（Issue #647 提案 3 / Issue #751）**: self-close の効き方は
-   backend 依存（前掲「前提」節）。**herdr / wezterm backend では self-close が no-op で watcher
+3. **監視終端クローズ / 手動 close（Issue #647 提案 3 / Issue #751 / Issue #911）**: self-close の
+   効き方は watcher ペインの実体が tmux ペインかどうかで決まる（前掲「前提」節の 2 分類）。
+   **herdr / wezterm backend と opt-in renga では self-close が no-op で watcher
    ペインが必ず残留する**ため、監視終端（PR_MERGED / PR_MERGE_WATCH_TIMEOUT / CI 失敗確定）で
    窓口がイベント駆動で watcher ペインを掃除するのが正路になる
-   （[`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md) の各終端処理で発火）。
-   tmux backend では self-close が tmux ペインを消すが broker 登録簿の name binding は残りうる
-   （前掲「self-close は tmux 層だけを掃除する」）。掃除は下記 (a)/(b) の split に従う。**窓口の
+   （[`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md) の各終端処理で発火。
+   renga では下記 (a) の自タブ確立が `caller_scope` 依存で、確立できなければ close を撃たず
+   残留を報告する ＝ 無言残留を可視な残留に変えるところまでが本経路の効果）。
+   broker の tmux backend では self-close が tmux ペインを消すが登録簿の name binding は残りうる
+   （前掲「self-close は（効いた場合も）tmux 層だけを掃除する」）。掃除は下記 (a)/(b) の split に従う。**窓口の
    イベント駆動 close（監視終端）では、下記に加えて「spawn 時に控えた pane_id + 監視対象 head に束縛し、
    終端イベントの head が追跡中 instance と一致するときだけ close する」freshness gate を必ず併用する**
    （終端イベントが遅延 / 重複配送されて同一 PR の watcher が既に再起動済みの場合、`name` で live pane を

--- a/.claude/skills/pr-watch-pane/SKILL.md.in
+++ b/.claude/skills/pr-watch-pane/SKILL.md.in
@@ -6,7 +6,9 @@ description: >
   pr-watch-<PR> で回す。窓口が PR 作成直後に `/pr-watch-pane <PR>` で起動すると、
   ja-root cwd・sandbox 外で監視が走り、/clear や窓口セッション寿命と無関係に継続する。
   pane name で冪等起動 (二重監視しない)、role=watcher で identity 登録、監視終了
-  (CI green / PR merged / timeout) でペイン自動 close。Bash tool の background は
+  (CI green / PR merged / timeout) で broker の tmux backend ならペイン自動 close
+  (herdr / wezterm / renga のペインは tmux ペインでないため自動 close されず、窓口が
+  監視終端でイベント駆動 close する)。Bash tool の background は
   session 寿命依存で長時間 watcher には不適なので本 skill が推奨経路。
   「CI 監視をペインで」「pr-watch をペインで回して」「PR <N> の CI を見張って」等で発動。
 effort: low
@@ -76,29 +78,45 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
   `tools/pr-watch.sh` を ja-root 基点で resolve する必要があるため、**cwd trap を skill
   側で吸収する**（Step 1 で `git rev-parse --show-toplevel` の絶対パスを spawn_pane の
   `cwd` に明示。窓口 cwd が何らかの理由で ja-root を外れていても正しく解決される）。
-- **自己 close の実装は tmux backend 前提**。Step 3 の `command` は `bash` 実行と、自己
-  close の `tmux kill-pane -t "$TMUX_PANE"`（**自ペインを `$TMUX_PANE` で明示指定して** kill。
-  socket は `$TMUX` 継承をそのまま使い `-L` で固定しない ＝ broker / renga / 非既定 socket
-  いずれの transport でも正しい server に当たる。Issue #647 提案 1 の「明示 target 指定」を
-  transport-neutral に実装した形）に依存する。
-- **自己 close は tmux backend の低遅延経路であり、backend 依存で効き方が変わる（herdr
-  ゾンビ残留の根治, Issue #751）**。broker は backend として tmux / herdr / wezterm を取りうる
-  （解決済み backend は `daemon.json` sidecar が持つ。renga opt-in は常に tmux。契約は
+- **自己 close の実装は「watcher ペインが tmux ペインであること」前提**。Step 3 の `command` は
+  `bash` 実行と、自己 close の `tmux kill-pane -t "$TMUX_PANE"`（**自ペインを `$TMUX_PANE` で明示
+  指定して** kill。socket は `$TMUX` 継承をそのまま使い `-L` で固定しない ＝ tmux 上に立つ
+  ペインであれば broker の既定 socket / 非既定 socket いずれでも正しい server に当たる。
+  Issue #647 提案 1 の「明示 target 指定」を実装した形）に依存する。**tmux ペインでない環境では
+  `$TMUX` / `$TMUX_PANE` がそもそも env に無く、`-t ""` へ展開されて `2>/dev/null || true` で
+  無言失敗する**（下記の分類を参照）。
+- **自己 close は tmux ペインの低遅延経路であり、watcher ペインの実体が tmux ペインかどうかで
+  効き方が変わる（herdr ゾンビ残留の根治, Issue #751 / renga 残留, Issue #911）**。broker は
+  backend として tmux / herdr / wezterm を取りうる（解決済み backend は `daemon.json` sidecar が
+  持つ。契約は
   [`docs/contracts/backend-interface-contract.md`](../../../docs/contracts/backend-interface-contract.md)
-  Surface 8）:
-  - **tmux backend**: Step 3 末尾の `tmux kill-pane -t "$TMUX_PANE"` が実ペインを即座に消す
-    ＝ **監視終端で watcher ペインが自動 close される低遅延経路**（従来挙動。温存する）。
-  - **herdr / wezterm backend（Windows native broker の別 GUI ウィンドウ・tmux 非経由を含む）**:
+  Surface 8）。**opt-in `renga` のペインは tmux ペインではない**ので、transport の綴りではなく
+  「ペインの実体」で次の 2 分類に読み替える:
+  - **自己 close が効く = broker の tmux backend**: Step 3 末尾の `tmux kill-pane -t "$TMUX_PANE"`
+    が実ペインを即座に消す ＝ **監視終端で watcher ペインが自動 close される低遅延経路**
+    （従来挙動。温存する）。
+  - **自己 close が効かない = broker の herdr / wezterm backend（Windows native broker の別 GUI
+    ウィンドウ・tmux 非経由を含む）、および opt-in `renga`**:
     watcher ペインは tmux ペインではないため `tmux kill-pane` が **no-op**（`|| true` で握り潰され
-    silent）。self-close が効かず、**監視終了後もペインがゾンビとして残留する**（実測: 2026-07-22
-    に PR #154 / #749 / #750 の watcher 3 枚が herdr backend で残留し、`close_pane`(id 指定) で
-    掃除した）。この backend では自己 close に頼れないため、**監視終端で窓口がイベント駆動で
-    watcher ペインを close する経路が正路**になる
+    silent）。self-close が効かず、**監視終了後もペインがゾンビとして残留する**。実測は 2 系統:
+    2026-07-22 に PR #154 / #749 / #750 の watcher 3 枚が herdr backend で残留し `close_pane`(id 指定)
+    で掃除した件と、**2026-08-09 の PR #908 監視で renga のペインが残留し窓口が `close_pane` で
+    手動掃除した件**（renga ペインでは `printenv TMUX TMUX_PANE` がどちらも未設定を返す ＝
+    `kill-pane -t ""` に展開されて無言失敗する）。この分類では自己 close に頼れないため、
+    **監視終端で窓口がイベント駆動で watcher ペインを close する経路が正路**になる
     （[`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md) の post-merge
     cleanup / `PR_MERGE_WATCH_TIMEOUT` / CI 失敗確定の各終端で窓口が発火。掃除手順は下記 Step 5 の
     (a)/(b) split に従う ＝ live pane は list_panes 確認済みの数値 pane_id で close、stale binding
-    のみ broker 条件付き allowlist で name 指定）。`close_pane` は transport 抽象上 tmux / herdr 両対応で、tmux backend で既に
-    self-close 済みなら `[pane_not_found]` が返る（自己クローズ済みで正常）。Windows native の手動起動経路
+    のみ broker 条件付き allowlist で name 指定）。`close_pane` は transport 抽象上 tmux / herdr /
+    renga いずれでも呼べ、broker の tmux backend で既に
+    self-close 済みなら `[pane_not_found]` が返る（自己クローズ済みで正常）。
+    - **renga では窓口 close も無条件には撃てない**: Step 5 (a) の自タブ確立は **(i) backend が
+      Group B を自身の single-tab モデル内で解決する（＝ `org-broker`）/ (ii) `caller_scope` を
+      確立できている**のいずれかを要し（契約 T-§4.2「Fail-safe consequence for Group B」/ T-§cap）、
+      renga では (i) が成立しないため **(ii) を確立できない限り close を撃たず、watcher ペインが
+      残る旨を報告して人手掃除に委ねる**（相対セレクタへはフォールバックしない）。self-close の
+      無言失敗と違い、**残留が報告として可視化される**のがこの載せ替えの眼目である。
+    Windows native の手動起動経路
     （人間が `tools/pr-watch.ps1 <PR>` を `!` 経由で起動）も従来どおり遮断しない（既存経路は不変）。
 
 ## Step 1: 引数解決と cwd / repo の確定
@@ -225,19 +243,25 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
 - `command`: pr-watch を前景実行し、stdout/stderr を `.state/pr-watch-<PR>.log` に `tee -a`
   （tmux スクロールバッファにも出る二段）。先頭 `mkdir -p .state` で fresh clone でも tee の
   出力先を確保する。pr-watch 終了後に `tmux kill-pane -t "$TMUX_PANE"`
-  で **ペインを自己 close**（監視終了で自動 close。`|| true` で tmux 不在環境でも握り潰す）。
+  で **ペインを自己 close**（broker の tmux backend でのみ効く低遅延経路。`|| true` は tmux ペイン
+  でない環境 = herdr / wezterm / renga で失敗を握り潰すためのもので、**そこでは自動 close されず
+  窓口のイベント駆動 close が正路**になる。前掲「前提」節の 2 分類）。
   - **`$TMUX_PANE` は placeholder ではなく実行時 env**: `<PR>` / `<OWNER/REPO>` と違い
-    `$TMUX_PANE` は窓口が値に置換してはならない。spawn されたペインの shell に自動露出する
-    自ペイン id（例 `%16`）で、self-close 時に **その pane 自身**を明示 target 解決する。
+    `$TMUX_PANE` は窓口が値に置換してはならない。tmux ペインとして spawn された場合に shell へ
+    自動露出する自ペイン id（例 `%16`）で、self-close 時に **その pane 自身**を明示 target 解決する。
     旧形 `tmux kill-pane`（target 無指定）は現在ペインを暗黙推定するが、`-t "$TMUX_PANE"` で
     明示することで曖昧さを排す（Issue #647 提案 1 の「明示 target 指定」）。
+    - **tmux ペインでなければ未設定で無言失敗する（Issue #911）**: renga のペインでは
+      `printenv TMUX TMUX_PANE` がどちらも未設定を返すため、この行は `tmux kill-pane -t ""` に
+      展開され `2>/dev/null || true` で無言失敗する（herdr / wezterm も同様に tmux ペインでない）。
+      **この失敗はエラーとして表に出ないので、残留の検知を self-close の成否に依存させない。**
   - **socket は `$TMUX` 継承をそのまま使う（`-L` で固定しない）**: `tmux` を `-L` 無しで
     起動すると、ペインが属する tmux server の socket を `$TMUX` から自動解決する。broker では
-    それが `claude-org-broker` socket、opt-in renga や非既定 socket 構成では別 socket になる
-    が、いずれも `$TMUX` が正しい server を指すので kill が当たる。ここで `-L claude-org-broker`
-    と固定すると renga / 非既定 socket 下で **別 server に当たって self-close が無言で失敗**
-    するため、socket は固定せず transport-neutral に保つ。
-  - **self-close は tmux 層だけを掃除する**: `kill-pane` は broker socket 上の実 tmux ペイン
+    それが `claude-org-broker` socket、非既定 socket 構成では別 socket になるが、いずれも
+    `$TMUX` が正しい server を指すので kill が当たる。ここで `-L claude-org-broker`
+    と固定すると非既定 socket 下で **別 server に当たって self-close が無言で失敗**
+    するため、socket は固定しない（renga では `$TMUX` 自体が無いので、そもそもこの経路に乗らない）。
+  - **self-close は（効いた場合も）tmux 層だけを掃除する**: `kill-pane` は broker socket 上の実 tmux ペイン
     を消すので、直後から `list_panes` には現れなくなる。ただし broker daemon の pane 登録簿
     （name binding）は self-close では pop されず **stale に残りうる**（daemon は自 pane の外部
     kill を検知しないため）。stale binding が残ると同名 `pr-watch-<PR>` の再 spawn が
@@ -247,9 +271,10 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
     allowlist 経路**であり、無条件の name 指定ではない（3 条件と broker 以外での扱いは Step 5 の
     (b) が SoT）。
   - `--merge-watch`: CI green で `CI_COMPLETED` を出した後もマージまで poll し続け（最大
-    24h）、マージで `PR_MERGED`、timeout で `PR_MERGE_WATCH_TIMEOUT` を出してから自己 close
-    する。CI 確定だけで止めたい場合は呼び出し時に `--merge-watch` を外す（その場合は CI green
-    / failed 確定で自己 close）。
+    24h）、マージで `PR_MERGED`、timeout で `PR_MERGE_WATCH_TIMEOUT` を出してから自己 close を
+    試みる。CI 確定だけで止めたい場合は呼び出し時に `--merge-watch` を外す（その場合は CI green
+    / failed 確定で自己 close を試みる）。いずれも実際に閉じるのは broker の tmux backend のみで、
+    herdr / wezterm / renga では窓口のイベント駆動 close が掃除する。
   - pr-watch.sh の既存メッセージ形・event payload 形は **本 skill では一切変更しない**（不変条件）。
     既存の手動 `tools/pr-watch.sh` 起動経路（人間の `!` 経由など）も従来どおり動作する。
 
@@ -391,21 +416,24 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
    ```
    PR #<PR> の CI / マージ監視ペイン pr-watch-<PR> (id={N}) を起動しました。
    - ログ: .state/pr-watch-<PR>.log（tmux スクロールバッファにも出力）
-   - 監視終了（マージ / CI 失敗確定 / timeout のいずれか）で、tmux backend ではペインが
-     自動で閉じます。herdr / wezterm backend では自己 close が効かず残留するため、窓口が
-     監視終端でイベント駆動 close します（org-pull-request の各終端処理）。
+   - 監視終了（マージ / CI 失敗確定 / timeout のいずれか）で、broker の tmux backend では
+     ペインが自動で閉じます。herdr / wezterm backend と renga では自己 close が効かず残留する
+     ため、窓口が監視終端でイベント駆動 close します（org-pull-request の各終端処理）。
      確定した CI 判定は `.state/state.db` の `ci_completed` 行とログに残るので、
      ペインが閉じても判定は失われません（merge gate はそこを読む）。
    - tmux で直接見るには `/org-attach` のコマンドを使ってください。
    ```
 
-3. **監視終端クローズ / 手動 close（Issue #647 提案 3 / Issue #751）**: self-close の効き方は
-   backend 依存（前掲「前提」節）。**herdr / wezterm backend では self-close が no-op で watcher
+3. **監視終端クローズ / 手動 close（Issue #647 提案 3 / Issue #751 / Issue #911）**: self-close の
+   効き方は watcher ペインの実体が tmux ペインかどうかで決まる（前掲「前提」節の 2 分類）。
+   **herdr / wezterm backend と opt-in renga では self-close が no-op で watcher
    ペインが必ず残留する**ため、監視終端（PR_MERGED / PR_MERGE_WATCH_TIMEOUT / CI 失敗確定）で
    窓口がイベント駆動で watcher ペインを掃除するのが正路になる
-   （[`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md) の各終端処理で発火）。
-   tmux backend では self-close が tmux ペインを消すが broker 登録簿の name binding は残りうる
-   （前掲「self-close は tmux 層だけを掃除する」）。掃除は下記 (a)/(b) の split に従う。**窓口の
+   （[`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md) の各終端処理で発火。
+   renga では下記 (a) の自タブ確立が `caller_scope` 依存で、確立できなければ close を撃たず
+   残留を報告する ＝ 無言残留を可視な残留に変えるところまでが本経路の効果）。
+   broker の tmux backend では self-close が tmux ペインを消すが登録簿の name binding は残りうる
+   （前掲「self-close は（効いた場合も）tmux 層だけを掃除する」）。掃除は下記 (a)/(b) の split に従う。**窓口の
    イベント駆動 close（監視終端）では、下記に加えて「spawn 時に控えた pane_id + 監視対象 head に束縛し、
    終端イベントの head が追跡中 instance と一致するときだけ close する」freshness gate を必ず併用する**
    （終端イベントが遅延 / 重複配送されて同一 PR の watcher が既に再起動済みの場合、`name` で live pane を


### PR DESCRIPTION
## 何を直したか

`/pr-watch-pane` で立てた CI 監視ペインが、renga 運用では監視終了後も**必ず残留する**。self-close の実装が `tmux kill-pane -t "$TMUX_PANE"` である一方、renga のペインは tmux ペインではなく `TMUX` / `TMUX_PANE` がどちらも未設定なので、`-t ""` に展開されて `2>/dev/null || true` で無言失敗するため。

SKILL.md の「前提」節が **「renga opt-in は常に tmux」** と書いていたのが誤りの根で、renga だけが「self-close が効く backend」側に分類されていた。

## 変更の要点

1. **分類軸を backend 名から「ペインの実体」へ**: 「自己 close が効く = broker の tmux backend」/「効かない = herdr・wezterm・renga」の 2 分類に書き換えた。綴り（`ORG_TRANSPORT` の値）で分類すると backend が増えるたびに同じ誤分類が再発するため
2. **renga を窓口イベント駆動 close の対象に載せた**: 監視終端節・ユーザー報告文・frontmatter description を同じ分類へ整合。**新しい導線は作らず**、既に org-pull-request 側にある herdr / wezterm 向け経路へ合流させただけ
3. **renga では窓口 close も無条件には撃てない点を明記**: Step 5 (a) の自タブ確立は「backend が single-tab で解決（= broker）」か「`caller_scope` 確立」のどちらかを要し、renga は前者が成立しない。確立できなければ close を撃たず**残留を報告**する。つまり本 PR の実効は **「無言残留 → 可視な残留」まで**であり、掃除そのものの自動化ではない（過大な効果を約束しない書き方にしてある）
4. **`$TMUX_PANE` / socket 注記の誤記述を修正**: 旧文の「renga や非既定 socket でも `$TMUX` が正しい server を指すので kill が当たる」は、renga では `$TMUX` 自体が無いので偽

`SKILL.md` は `SKILL.md.in` からの生成物（`tools/skill_src/manifest.json`）。source 側を編集し、生成物との一致を drift check で確認済み。**レビューは `.in` を見れば十分**。

## 検証

- `pytest tests/` → 997 passed, 2 skipped, 186 subtests passed
- `gen_skill_prose.py --check` → exit 0（drift なし）
- `audit_link_paths.py` → 新規の壊れリンクなし
- Codex `codex exec review --base origin/main -m gpt-5.6-sol` 1 round → **Blocker / Major ゼロ**

## 本 PR は 2 枚目の placement dogfood の成果物でもある

この変更は**背景タブに配置した worker が実施した**（契約 T-§4.2-place の placement dogfood 例外条項、人間監督下の bounded run）。dogfood 観測は Refs の issue に集約済みで、うち 1 件は容量会計が背景タブを数え落とすことの実測。

## スコープ外（別 Issue 候補）

Codex P2 として挙がったが、修正には `org-pull-request/SKILL.md` の終端処理を触る必要があるため本 PR では扱わない:

1. `--merge-watch` なしで CI green 終端した watcher が close 対象に入っていない
2. `PR_WATCH_ABORTED`（watcher の想定外例外終了）が close 対象に入っていない

Closes #911
Refs #907
