### PR TITLE
chore(claude): 実効しない Write(...) deny を落とし、runtime 0.1.42 へ pin を上げる

### DIFF
--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -191,11 +191,8 @@ python tools/org_setup_prune.py --user-common-sandbox  # → "no changes"
       "PowerShell(Out-File *)"
     ],
     "deny": [
-      "Write(*/workers/*/.claude/settings.local.json)",
       "Edit(*/workers/*/.claude/settings.local.json)",
-      "Write(*/workers/*/.worktrees/*/.claude/settings.local.json)",
       "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)",
-      "Write(*/.worktrees/*/.claude/settings.local.json)",
       "Edit(*/.worktrees/*/.claude/settings.local.json)"
     ]
   },

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -216,9 +216,11 @@ python tools/org_setup_prune.py --user-common-sandbox  # → "no changes"
 
 **mcp__renga-peers__\* の重複**: ユーザー共通 settings.json と重複するが、窓口は run 直後に renga-peers MCP を必ず使うため、窓口スコープでも明示的に列挙して source-of-truth として固定する（user settings の drift でも窓口が動くことを保証）。
 
-**`permissions.deny` (Issue #99 Phase 2 で追加)**: ワーカー設定ファイル（`workers/<project>/.claude/settings.local.json` および worktree パス `workers/<project>/.worktrees/<task>/.claude/settings.local.json`）への **Claude の `Write` / `Edit` ツール経由の直接編集**を窓口に対して禁止する。窓口は通常モード起動（`bypassPermissions` ではない）なので、この `permissions.deny` は静的パターンマッチで常に効く。
+**`permissions.deny` (Issue #99 Phase 2 で追加)**: ワーカー設定ファイル（`workers/<project>/.claude/settings.local.json` および worktree パス `workers/<project>/.worktrees/<task>/.claude/settings.local.json`、加えて live-repo worktree の `.worktrees/<task>/.claude/settings.local.json`）への **Claude の `Edit` ツール経由の直接編集**を窓口に対して禁止する。窓口は通常モード起動（`bypassPermissions` ではない）なので、この `permissions.deny` は静的パターンマッチで常に効く。
 
-ただしこの deny は Claude のファイル編集ツール（Write/Edit）系のゲートに限定される。窓口は引き続き `Bash(python:*)` / `Bash(python3:*)` / `PowerShell(Out-File *)` を allow しているため、Bash/PowerShell から `cat > settings.local.json` のように書き出すことは技術的に可能。本 deny は **「窓口が手作業で `Edit` ツールを開いて settings を書き換える」** という主要な誤付与経路を塞ぐためのもので、`claude-org-runtime settings generate` 以外の経路を完全に遮断するものではない。完全な generator-only 化（Bash 側の遮断を含む）は Phase 3 の課題（drift CI 拡張・escape hatch と併走）。
+**`Write(...)` を併記しない理由**: Claude Code の file permission check は `Edit(path)` のみを評価し、`Write(path)` の deny は実効しない。宣言すると 1 エントリにつき 1 行、起動のたびに `Permission deny rule (.claude/settings.local.json): Write(...) is not matched by file permission checks -- only Edit(path) rules are. Use Edit(...) instead` という警告が出るだけで、防御が死んでいるという誤読を招く。同一 glob の `Edit(...)` が防御を全て担っているため、runtime 0.1.42（suisya-systems/claude-org-runtime#178）と ja の同期で `Write(...)` 3 行を削除した。**ここに `Write(...)` を足し戻さないこと。**
+
+ただしこの deny は Claude のファイル編集ツール（`Edit`）のゲートに限定される。窓口は引き続き `Bash(python:*)` / `Bash(python3:*)` / `PowerShell(Out-File *)` を allow しているため、Bash/PowerShell から `cat > settings.local.json` のように書き出すことは技術的に可能。本 deny は **「窓口が手作業で `Edit` ツールを開いて settings を書き換える」** という主要な誤付与経路を塞ぐためのもので、`claude-org-runtime settings generate` 以外の経路を完全に遮断するものではない。完全な generator-only 化（Bash 側の遮断を含む）は Phase 3 の課題（drift CI 拡張・escape hatch と併走）。
 
 **renga bootstrap の重複**: 同じ理由でユーザー共通と重複するが、窓口が初回レイアウト起動やペイン制御で即時使うため明示列挙。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,34 @@
 
 ### Changed
 
+- 窓口の `required_deny` から実効しない `Write(...)` 3 行を削除し、起動時の警告 3 行を解消した
+  (suisya-systems/claude-org-runtime#178)。Claude Code の file permission check は `Edit(path)` のみを
+  評価するため `Write(path)` の deny は発火せず、宣言されている間は 1 エントリにつき 1 行
+  `Permission deny rule (.claude/settings.local.json): Write(...) is not matched by file permission
+  checks -- only Edit(path) rules are. Use Edit(...) instead` がセッション起動のたびに出ていた。
+  同一 glob の `Edit(...)` が防御を全て担っているため穴ではないが、警告を読んだ運用者が
+  「settings ファイルの防御が死んでいる」と誤読する事故が実際に起きたため落とした。
+  `tools/org_extension_schema.json` の `roles.secretary.required_deny` と
+  `.claude/skills/org-setup/references/permissions.md` から 3 行ずつ削除し、対になる `Edit(...)` 3 行は残置。
+  同ファイルは `tools/check_runtime_schema_drift.py` によりバイト一致を要求されるため、
+  **同 PR で runtime の下限 pin を 0.1.41 → 0.1.42 へ引き上げた**
+  (`pyproject.toml` / `requirements.txt` / `docker/Dockerfile` / `docker/compose.yaml` /
+  `docker/README.md` の image tag 例)。`RUNTIME_PIN_LOWER_INCLUSIVE` も `(0, 1, 42)` へ同時に引き上げている —
+  前回 (#854) と同じく schema 自体が変わるため、0.1.41 以下の環境では byte check が skip ではなく
+  **hard fail** になるからである。上限 `RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)` は不変。
+  docker 側の `RUNTIME_VERSION` を据え置くと `claude-org-runtime==${RUNTIME_VERSION}` の完全一致指定により
+  コンテナ内 runtime が ja 自身の floor を下回り、byte check が pin 窓外として黙って skip したうえで
+  今回潰した起動時警告がコンテナでだけ再発するため、5 箇所を 1 単位として引き上げている。
+  あわせて `Write` deny の存在を前提にしていた記述を実態へ揃えた
+  (`docs/contracts/role-pattern-sandbox-contract.md` §3.1.2 の 2 行と「Denied writes (prescriptive)」一覧・
+  §3.1.3 の attribution 表、`docs/worker-permissions-design.md` §3、
+  `.claude/skills/org-setup/references/permissions.md` の散文、`docs/verification.md` /
+  `docs/operations/attention-watch.md` の下限 pin 記述)。`docs/worker-permissions-design.md` の
+  Acceptance Criteria は Phase 2 時点の履歴なので書き換えず注記のみ追記した。
+  なお `role-pattern-sandbox-contract.md` §3.1.2 が live-repo worktree
+  (`<claude_org_path>/.worktrees/<task>/.claude/settings.local.json`) を「Layer 2 未カバー、Gap → Phase 1」と
+  記述していた点は本件と独立した既存の誤りで、`Edit(*/.worktrees/*/.claude/settings.local.json)` は
+  以前から `required_deny` に存在する。同 PR で「Gap 解消済み」へ訂正した。
 - `registry/projects.md` を operator-local な生成ファイルへ移行 (#811)。コミット対象は列スキーマ・
   仕様説明・一般サンプル行だけを持つテンプレート `registry/projects.example.md` になり、実体は
   `.gitignore` 対象。`/org-start` (Step 0) と `/org-setup` (Step 3.5) が

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ ARG ORG_UID=1000
 ARG ORG_GID=1000
 # runtime pin（設計 §7.7: 起動時 upgrade はせず、更新は image rebuild）。
 # 既定値は pyproject.toml の claude-org-runtime floor（下限 pin）と同期させること。
-ARG RUNTIME_VERSION=0.1.41
+ARG RUNTIME_VERSION=0.1.42
 # Claude Code ネイティブインストーラに渡すバージョン（stable | latest | x.y.z）
 ARG CLAUDE_CODE_VERSION=stable
 ARG INSTALL_HERDR=1

--- a/docker/README.md
+++ b/docker/README.md
@@ -80,7 +80,7 @@ socket mount はホスト root 相当の権限付与である。オーバーレ�
 docker buildx build -f docker/Dockerfile \
   --platform linux/amd64,linux/arm64 \
   --build-arg REPO_REF="$(git describe --always)" \
-  -t ghcr.io/suisya-systems/claude-org-ja:$(git describe --always)-r0.1.41 \
+  -t ghcr.io/suisya-systems/claude-org-ja:$(git describe --always)-r0.1.42 \
   --push .
 ```
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -14,7 +14,7 @@ services:
         # host bind mount を使う場合はホスト UID に合わせる（設計 §8）
         ORG_UID: "${ORG_UID:-1000}"
         ORG_GID: "${ORG_GID:-1000}"
-        RUNTIME_VERSION: "${RUNTIME_VERSION:-0.1.41}"
+        RUNTIME_VERSION: "${RUNTIME_VERSION:-0.1.42}"
         INSTALL_HERDR: "${INSTALL_HERDR:-1}"
         REPO_REF: "${REPO_REF:-dev}"
     # PID1 は image 内の tini（init: true と等価の機能を image 側で自己完結。設計 §5）

--- a/docs/contracts/role-pattern-sandbox-contract.md
+++ b/docs/contracts/role-pattern-sandbox-contract.md
@@ -229,18 +229,28 @@ worker briefs and `settings.local.json` files.
 | `<claude_org_path>/registry/**` | Direct | `registry/projects.md`, `registry/org-config.md`. |
 | `<claude_org_path>/dashboard/**` | Direct | Snapshot regeneration via [`dashboard/org_state_converter.py`](../../dashboard/org_state_converter.py). |
 | `<claude_org_path>/knowledge/skill-candidates.md` | Direct | Per [`docs/contracts/knowledge-curation-contract.md`](./knowledge-curation-contract.md) the secretary may write the skill-candidate queue. **`<claude_org_path>/knowledge/raw/**` and `<claude_org_path>/knowledge/curated/**` are NOT secretary-writeable** in the normal flow — see same contract §1.1 and §3.1; scrub of operator-private content is delegated, not edited in place. |
-| `<workers_dir>/<task>/CLAUDE.md` and `<task>/.claude/settings.local.json` | Generator-only | Worker brief + settings file placement during the org-delegate skill's worker-dir-prep step. **`Edit` / `Write` to `*/workers/*/.claude/settings.local.json` is denied at Layer 2** (`required_deny` in [`tools/org_extension_schema.json`](../../tools/org_extension_schema.json) `roles.secretary`); the canonical generator is `claude-org-runtime settings generate`. Manual JSON authoring is rejected by drift CI. |
+| `<workers_dir>/<task>/CLAUDE.md` and `<task>/.claude/settings.local.json` | Generator-only | Worker brief + settings file placement during the org-delegate skill's worker-dir-prep step. **`Edit` to `*/workers/*/.claude/settings.local.json` is denied at Layer 2** (`required_deny` in [`tools/org_extension_schema.json`](../../tools/org_extension_schema.json) `roles.secretary`); the canonical generator is `claude-org-runtime settings generate`. Manual JSON authoring is rejected by drift CI. A `Write(...)` twin is not declared because Claude Code evaluates file permission rules on `Edit(path)` only — see the "Denied writes (prescriptive)" list below. |
 | `<workers_dir>/<task>/.worktrees/.../.claude/settings.local.json` | Generator-only | Same constraint; required_deny rule covers the worktree path too. |
-| `<claude_org_path>/.worktrees/<task>/.claude/settings.local.json` | Generator-only (convention) | **NOT covered by the secretary's current Layer 2 `required_deny`** — those rules glob only `*/workers/*/.claude/settings.local.json` and `*/workers/*/.worktrees/*/.claude/settings.local.json`, neither of which matches the live repo's `.worktrees/` subtree. The generator-only discipline is enforced for this variant by *convention* (the org-delegate skill calls `claude-org-runtime settings generate`); there is no Layer 2 rule that would block a manual `Edit`/`Write` here today. **Gap → Phase 1**: extend `roles.secretary.required_deny` with a glob that matches `<claude_org_path>/.worktrees/*/.claude/settings.local.json` so the live_repo_worktree variant has the same hard guarantee. |
+| `<claude_org_path>/.worktrees/<task>/.claude/settings.local.json` | Generator-only | **Covered at Layer 2 — the Phase 1 gap is closed.** `roles.secretary.required_deny` carries `Edit(*/.worktrees/*/.claude/settings.local.json)` ([`tools/org_extension_schema.json`](../../tools/org_extension_schema.json)), whose glob matches the live repo's `.worktrees/` subtree, so the `live_repo_worktree` variant now has the same hard guarantee as the two `workers_dir` rows above. Earlier revisions of this row described the variant as convention-only, from a time when `required_deny` globbed `*/workers/*/...` exclusively. As with the other two rows the guarantee is `Edit`-scoped, and the Bash / PowerShell write path remains uncovered by Layer 2 (§3.1.3). |
 
 **Denied writes (prescriptive)**:
 
-- `Write(*/workers/*/.claude/settings.local.json)` — secretary must call
+- `Edit(*/workers/*/.claude/settings.local.json)` — secretary must call
   `claude-org-runtime settings generate` instead. Layer 2 `required_deny`
   enforces.
-- `Edit(*/workers/*/.claude/settings.local.json)` — same as above.
-- `Write(*/workers/*/.worktrees/*/.claude/settings.local.json)` and the
-  `Edit` twin — same.
+- `Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)` — same as
+  above.
+- `Edit(*/.worktrees/*/.claude/settings.local.json)` — same as above, for
+  the `live_repo_worktree` variant.
+- **`Write(...)` twins are deliberately NOT declared.** Claude Code matches
+  file permission rules on `Edit(path)` only, so a `Write(path)` deny never
+  fires — it merely emits a startup warning per entry ("is not matched by
+  file permission checks -- only Edit(path) rules are"), which reads as if
+  the guard were dead. The three `Write(...)` entries that used to sit
+  beside these were removed in claude-org-runtime 0.1.42
+  (suisya-systems/claude-org-runtime#178) and the paired ja sync. The
+  `Edit` rules above carry the whole Layer 2 guarantee; the Bash / PowerShell
+  write path was never covered by either tool rule (see §3.1.3).
 - `git push` (raw or via `eval`/`bash -c`) — Layer 4
   [`.hooks/block-git-push.sh`](../../.hooks/block-git-push.sh) is **NOT**
   installed on the secretary because the secretary is the role that *does*
@@ -253,7 +263,7 @@ worker briefs and `settings.local.json` files.
 
 | Surface | Layer 2 | Layer 3 | Layer 4 |
 |---|---|---|---|
-| `*/workers/*/.claude/settings.local.json` write | `required_deny` ✔ | n/a (Phase 1) | none |
+| `*/workers/*/.claude/settings.local.json` write | `required_deny` ✔ — **`Edit` tool only**. `Write(...)` twins are not declared because Claude Code evaluates file permission rules on `Edit(path)` alone, and the Bash / PowerShell write path (`Bash(python:*)`, `PowerShell(Out-File *)`) is outside every file permission rule, so `cat > settings.local.json` stays reachable. | n/a (Phase 1) | none |
 | `<claude_org_path>/.state/**` write | allowed via `Bash(python:*)` etc. | n/a | [`.hooks/block-no-verify.sh`](../../.hooks/block-no-verify.sh) (Bash) covers `git commit --no-verify` only |
 | `~/.aws/**` read | `Read(~/.aws/*)` ✔ (when added; not in default secretary template) | adaptive (see §1.3); not currently emitted for secretary | none |
 | Org-structure dir creation under workers | n/a (secretary is *not* a worker) | n/a | [`.hooks/block-workers-delete.sh`](../../.hooks/block-workers-delete.sh) (`Bash` matcher) for workers_dir delete only |

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -229,7 +229,7 @@ claude-org-runtime attention watch --state-dir .state --config .state/attention.
 - journal は末尾から window 分だけ遡って読む。この値を上げると走査範囲もそれに追随して広がるので、busy な daemon でも継続中の incident が視界外へ押し出されることはない
 - dedup key は owner ではなく **競合している instance pair** に対して張られる。片方のセッションを終了させた後に別の instance が入れ替わりで競合を始めた場合は別 incident として扱われ、直前の pair の cooldown に飲まれない
 
-**runtime 版の前提（この kind だけの注意）**: broker journal reader は runtime 0.1.40 で入った経路で、ja の下限 pin は現行 0.1.41 とこれを上回っている（`pyproject.toml` / `requirements.txt` の `claude-org-runtime` floor、`docker/Dockerfile` の `RUNTIME_VERSION`）。したがって pin を満たす環境では**この kind は実際に発火する**。手元の runtime に経路があるかを直接確かめたい場合は `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかを見る。**出ない場合は pin より古い runtime が入っている**（floor は下限であって、環境に実際に入っている版とは別物）。その状態ではテンプレートに `notify.duplicate_sidecar` / `templates.duplicate_sidecar` があっても no-op になるだけで、config load エラーにはならない — つまり「設定は正しいのに黙っている」形になるので、二重 sidecar を疑う状況で通知が来ないときは、まずこの `--help` で経路の有無を確かめる。
+**runtime 版の前提（この kind だけの注意）**: broker journal reader は runtime 0.1.40 で入った経路で、ja の下限 pin は現行 0.1.42 とこれを上回っている（`pyproject.toml` / `requirements.txt` の `claude-org-runtime` floor、`docker/Dockerfile` の `RUNTIME_VERSION`）。したがって pin を満たす環境では**この kind は実際に発火する**。手元の runtime に経路があるかを直接確かめたい場合は `claude-org-runtime attention scan --help` に `--broker-state-dir` が出るかを見る。**出ない場合は pin より古い runtime が入っている**（floor は下限であって、環境に実際に入っている版とは別物）。その状態ではテンプレートに `notify.duplicate_sidecar` / `templates.duplicate_sidecar` があっても no-op になるだけで、config load エラーにはならない — つまり「設定は正しいのに黙っている」形になるので、二重 sidecar を疑う状況で通知が来ないときは、まずこの `--help` で経路の有無を確かめる。
 
 ## 5. トラブルシューティング
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -628,7 +628,7 @@ claude-org-ja 本体は Issue #429 Task C（本 addendum と同 PR）で共有 `
 
 ### 11-a'. live capability 確認（`server_info`）
 
-> **allowlist 状況**: `mcp__renga-peers__server_info` は `user_common` / `secretary` の permission allowlist に入っており（[`tools/org_extension_schema.json`](../tools/org_extension_schema.json) の同名 role `required_allow`）、この 2 role では本手順を MCP ツールとして承認プロンプトなしで実行できる。同ファイルは claude-org-runtime の同梱 schema とバイト一致を要求されるため、このエントリは runtime 0.1.41 の同梱 schema 追加に追随したものである（下限 pin も 0.1.41）。**allowlist を持たない role（`dispatcher` / `worker` / `curator`）や、プロンプトを伴わない観測経路が要る場面では [`tools/check_renga_compat.py`](../tools/check_renga_compat.py)** を使う。こちらは `renga mcp-peer` を subprocess として起動するため allowlist の影響を受けない。
+> **allowlist 状況**: `mcp__renga-peers__server_info` は `user_common` / `secretary` の permission allowlist に入っており（[`tools/org_extension_schema.json`](../tools/org_extension_schema.json) の同名 role `required_allow`）、この 2 role では本手順を MCP ツールとして承認プロンプトなしで実行できる。同ファイルは claude-org-runtime の同梱 schema とバイト一致を要求されるため、このエントリは runtime 0.1.41 の同梱 schema 追加に追随したものである（下限 pin は現行 0.1.42 で、これを上回っている）。**allowlist を持たない role（`dispatcher` / `worker` / `curator`）や、プロンプトを伴わない観測経路が要る場面では [`tools/check_renga_compat.py`](../tools/check_renga_compat.py)** を使う。こちらは `renga mcp-peer` を subprocess として起動するため allowlist の影響を受けない。
 
 `server_info`（引数なし）を呼び、`structuredContent` を読む:
 1. `status` を最初に読む（判別子）。`connected` / `detached` / `unreachable` の 3 値

--- a/docs/worker-permissions-design.md
+++ b/docs/worker-permissions-design.md
@@ -57,10 +57,11 @@ python tools/generate_worker_settings.py \
 
 ### 3. Secretary PreToolUse hook（と静的 deny）
 
-`workers/*/.claude/settings.local.json`（および worktree 配下）への Claude の `Write` / `Edit` ツール経由の直接編集を **deny** する:
+`workers/*/.claude/settings.local.json`（および worktree 配下）への Claude の `Edit` ツール経由の直接編集を **deny** する:
 
 - 窓口の `.claude/settings.local.json` `permissions.deny` に追加
 - 主たる誤付与経路（窓口が `Edit` で手書き）を塞ぐのが目的
+- **`Write(...)` は宣言しない**。Claude Code の file permission check は `Edit(path)` のみを評価するため `Write(path)` の deny は実効せず、宣言すると起動のたびに「is not matched by file permission checks -- only Edit(path) rules are」という警告が 1 エントリにつき 1 行出る。防御が死んでいるという誤読を招くだけなので、runtime 0.1.42（suisya-systems/claude-org-runtime#178）と ja の同期で削除した
 - Bash/PowerShell からのファイル書き出し（`Bash(python:*)` 等）は別途 allow に残るため、Bash 経由の改変は技術的には可能。完全な generator-only 化は Phase 3 で `block-secretary-write-worker-settings.sh` 相当の hook と併せて行う想定
 
 ### 4. `org-delegate` Step 1.5 移行
@@ -113,7 +114,7 @@ python tools/generate_worker_settings.py \
 * [x] `tools/role_configs_schema.json` に `worker_roles` セクションを追加（Phase 1）
 * [x] `tools/generate_worker_settings.py` を実装（unit test 込み）（Phase 1）
 * [x] `org-delegate` Step 1.5 の手書き JSON 部分を generator 呼び出しに置換（Phase 2）
-* [x] 窓口設定に `Write(*/workers/*/.claude/settings.local.json)` deny ルールを追加（Phase 2）
+* [x] 窓口設定に `Write(*/workers/*/.claude/settings.local.json)` deny ルールを追加（Phase 2）（※ Write は実効しないため #178 / 0.1.42 で削除、Edit のみ有効）
 * [x] `tools/check_role_configs.py` が `--include-worker-settings` でワーカー `settings.local.json` を schema 検証（Phase 1）。ただし現状は `<BASE_DIR>/*/.claude/...` のみで、Pattern B worktree 配下は Phase 3 で追加予定
 * [x] README / 内部ドキュメントに 7 メリット / 7 デメリットを明示（本ドキュメント）
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.41,<0.2",
+    "claude-org-runtime>=0.1.42,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,23 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
+# Floor bumped to 0.1.42 for the removal of the inert `Write(...)` deny rules
+# from role_configs_schema.json's `roles.secretary.required_deny`: Claude Code
+# evaluates file permission rules on `Edit(path)` only, so the three
+# `Write(*/...settings.local.json)` twins never fired and only emitted a
+# "not matched by file permission checks" warning per entry at every session
+# start (suisya-systems/claude-org-runtime#178). ja drops the same three lines
+# from tools/org_extension_schema.json in this paired commit, so a
+# 0.1.41-or-older install would now *fail* the byte-identical check.
+# RUNTIME_PIN_LOWER_INCLUSIVE in tools/check_runtime_schema_drift.py IS raised
+# in step to (0, 1, 42) for that reason — same rule as the 0.1.41 bump below:
+# raise the window floor whenever the schema itself changed, so the mismatch
+# degrades to skip-with-warning instead of a hard failure until the environment
+# catches up. docker/Dockerfile's `RUNTIME_VERSION` ARG and the
+# docker/compose.yaml default are raised in step too (the Dockerfile installs
+# `claude-org-runtime==${RUNTIME_VERSION}` exactly, so leaving it behind would
+# ship a container below ja's own floor). The earlier 0.1.41 floor (below) is
+# subsumed.
 # Floor bumped to 0.1.41 for the renga 2.0.0 capability probe
 # `mcp__renga-peers__server_info`: 0.1.41 adds that entry to
 # role_configs_schema.json's `user_common` / `secretary` required_allow, and ja
@@ -142,7 +159,7 @@ core-harness>=0.3.2,<0.4
 # (transport surface descriptor claude_org_runtime.transport consumed by
 # tools/transport.py — Epic #6 next-stage D / ja#513) are subsumed by 0.1.28.
 # Keep in sync with pyproject.toml.
-claude-org-runtime>=0.1.41,<0.2
+claude-org-runtime>=0.1.42,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).

--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -62,7 +62,7 @@ from typing import Any, Callable
 # requirements.txt. Keep this constant in sync when widening the pin
 # (Phase 5e+ scope per CLAUDE.local.md). Stored as tuples for ordered
 # comparison; only major.minor.micro are honoured.
-RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 41)
+RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 42)
 RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -147,11 +147,8 @@
       ],
       "allowed_allow_regex": [],
       "required_deny": [
-        "Write(*/workers/*/.claude/settings.local.json)",
         "Edit(*/workers/*/.claude/settings.local.json)",
-        "Write(*/workers/*/.worktrees/*/.claude/settings.local.json)",
         "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)",
-        "Write(*/.worktrees/*/.claude/settings.local.json)",
         "Edit(*/.worktrees/*/.claude/settings.local.json)"
       ],
       "required_hooks": [


### PR DESCRIPTION
claude-org-runtime 0.1.42（[#179](https://github.com/suisya-systems/claude-org-runtime/pull/179) / Closes runtime#178）との paired sync。

## 何を直すか

Claude Code は worker ペイン起動時に次の警告を 3 行出していた。

```
Permission deny rule: Write(*/workers/*/.claude/settings.local.json) is not matched by
file permission checks — only Edit(path) rules are.
Use Edit(*/workers/*/.claude/settings.local.json) instead
```

同じ glob に `Edit(...)` が併記されているので **防御は効いており穴ではない**。`Write(...)` は照合されない不活性な記述で、起動のたびに警告が出て「防御が死んでいるのでは」という誤読を招く。実際にこの警告を見たディスパッチャーが判断を仰いできたのが起点である。

## 変更

**1. `Write(...)` deny 3 行の削除**（`tools/org_extension_schema.json` / `.claude/skills/org-setup/references/permissions.md`）。対の `Edit(...)` は残す。**enforcement は不変**。

**2. pin を 5 箇所まとめて 0.1.41 → 0.1.42**

schema は runtime の同梱物とバイト一致が要求されるため、ja だけでは land できない（片側だけ落とすと drift check または missing required deny のどちらかで CI が赤くなる）。0.1.42 が出たのでここで揃える。

| 箇所 | |
|---|---|
| `pyproject.toml` / `requirements.txt` | 依存の下限 |
| `tools/check_runtime_schema_drift.py` の `RUNTIME_PIN_LOWER_INCLUSIVE` | pin のミラー |
| `docker/Dockerfile` の `ARG RUNTIME_VERSION` / `docker/compose.yaml` | コンテナに焼く版 |

**docker 側を据え置くと silent degradation になる**: Dockerfile は `claude-org-runtime==${RUNTIME_VERSION}` と完全一致でインストールするため、コンテナ内 runtime が ja の floor を下回り、drift check は pin 窓外として**警告付き skip に落ちて黙る**。さらにコンテナ内の secretary settings に `Write(...)` が復活し、本 PR で潰した警告がコンテナでだけ再発する。

**3. 契約・docs を実態に合わせる**

- `docs/contracts/role-pattern-sandbox-contract.md` — 「Denied writes (prescriptive)」一覧から Write の項を落として Edit 3 本に統合、§3.1.3 の attribution 表を更新。「なぜ Write を宣言しないか」と足し戻し防止の文言を追加
- 同 §3.1.2 の live-repo worktree 行 — **本件と独立な既存の誤り**を訂正。「Gap → Phase 1 で glob を追加せよ」と書かれていたが、その glob（`Edit(*/.worktrees/*/...)`）は既に存在する。「Gap 解消済み」に書き換えた
- `docs/worker-permissions-design.md:116` — Phase 2 完了時点の Acceptance Criteria は**書き換えず注記を追記**（遡って改変すると当時の判断の記録が失われるため）
- `requirements.txt` の floor 理由コメント / `docs/verification.md` / `docs/operations/attention-watch.md` / `CHANGELOG.md`

## 検証

- `check_runtime_schema_drift.py` byte / `--semantic`（14 fixtures）/ 併用 → すべて OK
- `check_role_configs.py --include-worker-settings .` / `--docs-only` → OK
- `unittest discover -s tests` 1018 / `-s tools` 930 / `bash tests/run-all.sh` 898 → OK
- 残存する `0.1.41` の記述を全 grep し、6 箇所すべてが歴史的記述として正しいことを確認
- 0.1.41 → 0.1.42 の schema 差分が required_deny の 3 行削除のみであることを全キー走査で実測
- `codex exec review --base origin/main` → 指摘ゼロ（1 round で収束）