### PR TITLE
feat(claude): pr-watch に conflict 検知を追加し、CI 不発の PR を沈黙させない

### DIFF
--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -182,6 +182,7 @@ dedupe_key=<sha256>`); direct DB INSERTs are forbidden per
 |------------------------|-----------------------------------------------------------|-----------|------------|--------------|
 | `ci_completed`         | `pr`, `repo`, `status`, `duration_sec`, `head`, `fail_count`?, `pending_count`?, `total_checks`?, `retry_recommended`?, `retry_after_sec`?, `probe_attempts`? | secretary | secretary  | E4           |
 | `pr_watch_pane_started`| `pr`, `repo`, `pane_id`                                   | secretary | secretary  | —            |
+| `pr_conflict_detected` | `pr`, `repo`, `head`, `mergeable`, `merge_state_status`    | secretary | secretary  | —            |
 
 `status` ∈ `{passed, failed, incomplete, indeterminate, canceled}`.
 `head` (Issue #636)
@@ -224,6 +225,32 @@ Issue #685 additive payload keys (base keys above are unchanged):
 The probe is retried with exponential backoff (initial 5s, doubling to
 a 30s cap) inside `tools/pr_watch.py`, so a transient gh failure
 resolves to a definitive `passed`/`failed` before the budget is spent.
+
+`pr_conflict_detected` (Issue #946) is written by `tools/pr_watch.py`
+when its ci-watch poll observes `gh pr view --json mergeable` reporting
+`CONFLICTING` for the PR's current head. A conflicting head cannot be
+merged into base, so GitHub never builds the merge ref and **no
+`pull_request` workflow fires at all** — the PR sits at zero checks,
+which every check-arrival probe reads as "CI has not started yet". That
+is what left kura PR #248 silent on 2026-08-19 until a human noticed.
+`head` is the short sha the conflict was observed on (or `"unknown"`
+when `headRefOid` was unreadable), `mergeable` is always `CONFLICTING`,
+and `merge_state_status` carries GitHub's `mergeStateStatus` (typically
+`DIRTY`) for triage. A `PR_CONFLICT: PR #<n> (head=<sha>, ...)` peer
+message is pushed alongside it on the same best-effort
+`_notify_or_record` path as the other pr-watch signals, so a dropped
+push still surfaces as `notify_failed` with
+`failed_kind: "pr_conflict_detected"`.
+
+The event is **not terminal**: a conflict is cleared by a re-push, and
+the new head's CI is exactly what the watcher should go on to observe,
+so `tools/pr_watch.py` keeps polling and emits the usual `ci_completed`
+for the head that resolves it. It is emitted **at most once per head** —
+a conflict persists across every poll until someone pushes, and the head
+moving is precisely the event that makes it worth re-announcing.
+`mergeable: UNKNOWN` (GitHub computes mergeability asynchronously, so a
+freshly pushed head reports it for a few seconds) and an unreadable
+probe are both silent: neither records an event nor pushes a message.
 
 `pr_watch_pane_started` is a best-effort audit row written by the
 `/pr-watch-pane` skill (secretary) when it spawns a CI/merge-watch pane

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -280,7 +280,14 @@ reaches the watcher in three different shapes:
    full set of passed checks. The probe there is report-only — the
    `ci_completed` event, its status, and the `CI_COMPLETED` message are
    unchanged, and `PR_CONFLICT` simply rides alongside so the secretary
-   does not walk into a merge GitHub will refuse.
+   does not walk into a merge GitHub will refuse. It runs only against a
+   head the verdict actually describes (after the phase's head-stability
+   check, and pinned to that head), so a branch advancing mid-probe can
+   never spend the new head's one-shot announcement on a claim about the
+   old head. Because this can be the watcher's LAST observation (without
+   `--merge-watch` it exits straight after), an `UNKNOWN` answer here is
+   re-probed a couple of times; `MERGEABLE` and an unreadable answer
+   return at once, so a healthy watch pays nothing.
 
 Only a *confirmed* `CONFLICTING` changes the watcher's control flow, so
 neither an unreadable probe nor a gh outage can wedge the watch.

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -252,6 +252,30 @@ moving is precisely the event that makes it worth re-announcing.
 freshly pushed head reports it for a few seconds) and an unreadable
 probe are both silent: neither records an event nor pushes a message.
 
+The probe runs at three points in a ci-watch round, because a conflict
+reaches the watcher in three different shapes:
+
+1. **Zero visible checks** (the kura #248 shape). A confirmed conflict
+   here means the missing checks are explained rather than racing, so
+   the self-poll loop keeps polling instead of handing off to the
+   bounded resolver — which would otherwise spend its budget recording
+   a misleading `incomplete`.
+2. **During the resolver's retry budget.** Mergeability is computed
+   asynchronously, so a freshly pushed conflicting head often reads
+   `UNKNOWN` at the moment of the handoff and settles to `CONFLICTING`
+   seconds later. The resolver keeps probing and bails out the moment it
+   is confirmed, returning control to the self-poll loop.
+3. **At verdict time, even on a green verdict.** A terminal check
+   verdict does not imply the PR is mergeable: CI can finish green and
+   the base branch then move underneath it, leaving `CONFLICTING` with a
+   full set of passed checks. The probe there is report-only — the
+   `ci_completed` event, its status, and the `CI_COMPLETED` message are
+   unchanged, and `PR_CONFLICT` simply rides alongside so the secretary
+   does not walk into a merge GitHub will refuse.
+
+Only a *confirmed* `CONFLICTING` changes the watcher's control flow, so
+neither an unreadable probe nor a gh outage can wedge the watch.
+
 `pr_watch_pane_started` is a best-effort audit row written by the
 `/pr-watch-pane` skill (secretary) when it spawns a CI/merge-watch pane
 (`name="pr-watch-<PR>"`, `role="watcher"`) running `tools/pr-watch.sh`.

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -182,7 +182,7 @@ dedupe_key=<sha256>`); direct DB INSERTs are forbidden per
 |------------------------|-----------------------------------------------------------|-----------|------------|--------------|
 | `ci_completed`         | `pr`, `repo`, `status`, `duration_sec`, `head`, `fail_count`?, `pending_count`?, `total_checks`?, `retry_recommended`?, `retry_after_sec`?, `probe_attempts`? | secretary | secretary  | E4           |
 | `pr_watch_pane_started`| `pr`, `repo`, `pane_id`                                   | secretary | secretary  | —            |
-| `pr_conflict_detected` | `pr`, `repo`, `head`, `mergeable`, `merge_state_status`    | secretary | secretary  | —            |
+| `pr_conflict_detected` | `pr`, `repo`, `head`, `mergeable`, `merge_state_status`, `ci_settled` | secretary | secretary  | —            |
 
 `status` ∈ `{passed, failed, incomplete, indeterminate, canceled}`.
 `head` (Issue #636)
@@ -235,12 +235,21 @@ which every check-arrival probe reads as "CI has not started yet". That
 is what left kura PR #248 silent on 2026-08-19 until a human noticed.
 `head` is the short sha the conflict was observed on (or `"unknown"`
 when `headRefOid` was unreadable), `mergeable` is always `CONFLICTING`,
-and `merge_state_status` carries GitHub's `mergeStateStatus` (typically
-`DIRTY`) for triage. A `PR_CONFLICT: PR #<n> (head=<sha>, ...)` peer
-message is pushed alongside it on the same best-effort
-`_notify_or_record` path as the other pr-watch signals, so a dropped
-push still surfaces as `notify_failed` with
-`failed_kind: "pr_conflict_detected"`.
+`merge_state_status` carries GitHub's `mergeStateStatus` (typically
+`DIRTY`) for triage, and `ci_settled` says whether a CI verdict already
+existed when the conflict was seen (`false`: CI never fired and the
+watch continues; `true`: CI already reported and the conflict blocks the
+merge, not the run) — the `PR_CONFLICT` message carries the matching
+advice.
+
+A `PR_CONFLICT: PR #<n> (head=<sha>, ...)` peer message is pushed
+alongside the row on the same best-effort `_notify_or_record` path as
+the other pr-watch signals, so a dropped push surfaces as `notify_failed`
+with `failed_kind: "pr_conflict_detected"`. Unlike the other pr-watch
+signals the kind is ALSO in `tools/relay_scan.py`'s `TERMINAL_KINDS`
+despite being non-terminal: a pane with no transport configured at all
+records no `notify_failed` by design, which would otherwise leave this
+row as the only trace of the conflict with nothing to relay it.
 
 The event is **not terminal**: a conflict is cleared by a re-push, and
 the new head's CI is exactly what the watcher should go on to observe,

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -458,6 +458,11 @@ class _ConflictWatch:
         # ``"unknown"`` for a conflict observed while headRefOid was
         # unreadable (still deduped, so an unreadable head cannot spam).
         self._announced: "set[str]" = set()
+        # Result of the most recent :meth:`probe`. Lets a caller that did
+        # not make the probe itself (the resolver handoff in
+        # :func:`_run_ci_watch_phase`) react to a conflict another poll
+        # site just confirmed, without spending a second gh call.
+        self.last_conflicting = False
 
     @property
     def announced_heads(self) -> "set[str]":
@@ -480,13 +485,13 @@ class _ConflictWatch:
         try:
             view = _fetch_mergeable(self._pr, self._repo)
         except Exception:  # noqa: BLE001 — additive probe, never fatal
-            return False
-        if not isinstance(view, dict):
-            return False
-        mergeable = view.get("mergeable")
+            view = None
+        mergeable = view.get("mergeable") if isinstance(view, dict) else None
         if (not isinstance(mergeable, str)
                 or mergeable.strip().upper() != MERGEABLE_CONFLICTING):
+            self.last_conflicting = False
             return False
+        self.last_conflicting = True
         head = _short_head(view.get("headRefOid")) or "unknown"
         if head not in self._announced:
             # Marked BEFORE announcing, not after: if the announce path
@@ -1034,6 +1039,7 @@ def _resolve_final_status(
     retry_interval_sec: "float | None" = None,
     backoff_factor: "float | None" = None,
     max_interval_sec: "float | None" = None,
+    conflict: "_ConflictWatch | None" = None,
 ) -> dict:
     """Drive `_fetch_checks` until a final CI verdict is observed.
 
@@ -1139,6 +1145,19 @@ def _resolve_final_status(
         # Either probe was unparseable (checks is None) or the verdict
         # is `incomplete`. Initialise the budget on the first observed
         # need to wait, then back off and try again.
+        #
+        # Issue #946: keep probing mergeability across the budget too.
+        # GitHub computes mergeability asynchronously, so a freshly
+        # pushed conflicting head commonly reads `UNKNOWN` on the single
+        # probe `_self_poll_watch` made before handing off here. Without
+        # this the conflict would settle DURING the budget and still go
+        # unreported, and the watch would end on a misleading
+        # `incomplete` — the exact silence Issue #946 exists to break.
+        # Bail out as soon as it is confirmed: the caller reads
+        # ``conflict.last_conflicting`` and returns to the self-poll
+        # loop, which keeps watching for the re-push.
+        if conflict is not None and conflict.probe():
+            break
         _set_deadline_once()
         if time.monotonic() >= deadline:
             break
@@ -1613,11 +1632,21 @@ def _run_ci_watch_phase(
             verdict = _resolve_final_status(
                 pr, repo, exit_code=8,
                 budget_sec=CI_WATCH_EMPTY_RACE_BUDGET_SEC,
+                conflict=conflict,
             )
             if verdict["pending_count"]:
                 # Real, still-pending checks exist -- not an empty-race
                 # artifact, and not fully decided even if a sibling
                 # check already failed. Resume unbounded polling.
+                verdict = None
+                continue
+            if conflict is not None and conflict.last_conflicting:
+                # Issue #946: mergeability settled to CONFLICTING during
+                # the resolver budget (it read UNKNOWN when the self-poll
+                # loop handed off). The zero-check state is explained, not
+                # undecided — recording this `incomplete` would be the
+                # misleading verdict, so go back to the self-poll loop and
+                # keep watching for the re-push that unblocks CI.
                 verdict = None
                 continue
             break
@@ -1655,6 +1684,18 @@ def _run_ci_watch_phase(
         pending_count = verdict["pending_count"]
         total_checks = verdict["total_checks"]
         probe_attempts = verdict["probe_attempts"]
+        # Issue #946 (Codex review, P1): a terminal check verdict does
+        # NOT imply the PR is mergeable. CI can finish green and the base
+        # branch then move underneath it, leaving `mergeable=CONFLICTING`
+        # with a full set of passed checks — a shape neither the
+        # zero-check branch of `_self_poll_watch` nor the resolver
+        # handoff above can ever see. Probe once here so the secretary
+        # gets `PR_CONFLICT` alongside the green `CI_COMPLETED` instead
+        # of walking into a merge that GitHub will refuse. Report-only:
+        # the verdict, its event, and its message are untouched.
+        if conflict is not None:
+            conflict.probe()
+
         head_after = _fetch_head_oid(pr, repo)
         if (head_before is not None and head_after is not None
                 and head_before != head_after):

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -385,6 +385,15 @@ def _fetch_head_oid(pr: int, repo: str) -> "str | None":
 # explicitly kept silent so the watcher never cries conflict at a PR
 # GitHub simply has not finished evaluating.
 MERGEABLE_CONFLICTING = "CONFLICTING"
+MERGEABLE_UNKNOWN = "UNKNOWN"
+
+# Verdict-time re-probes while GitHub still answers UNKNOWN, and the wait
+# between them. Small on purpose: mergeability is normally long settled
+# by the time CI finishes, so this is a narrow race-closer, not a poll
+# loop — and it costs a healthy (MERGEABLE) watch nothing, since only
+# UNKNOWN retries at all.
+CONFLICT_SETTLED_UNKNOWN_RETRIES = 2
+CONFLICT_SETTLED_UNKNOWN_DELAY_SEC = 5.0
 
 
 def _fetch_mergeable(pr: int, repo: str) -> "dict | None":
@@ -469,7 +478,10 @@ class _ConflictWatch:
         """Copy of the announced-head ledger (tests / diagnostics)."""
         return set(self._announced)
 
-    def probe(self, *, ci_settled: bool = False) -> bool:
+    def probe(self, *, ci_settled: bool = False,
+              expect_head: "str | None" = None,
+              unknown_retries: int = 0,
+              unknown_delay: float = 5.0) -> bool:
         """Probe mergeability once; announce a newly-seen conflicting head.
 
         ``ci_settled`` says which of the two conflict shapes the caller is
@@ -479,6 +491,25 @@ class _ConflictWatch:
         watch continues; ``True`` (the verdict-time probe) means a CI
         verdict already exists and the conflict blocks the *merge*, not
         the run.
+
+        ``expect_head`` (Codex review, P2) pins the observation to the
+        head the caller reasoned about. A branch that advances between
+        the caller's head read and this probe would otherwise let a
+        ``ci_settled=True`` announcement land on the NEW head — burning
+        that head's one-shot dedup slot on a claim about the old head's
+        verdict, so the new head's real conflict could never be
+        announced. On a mismatch we report nothing and consume nothing;
+        the caller's own head-change handling restarts the phase and the
+        next probe observes the new head cleanly.
+
+        ``unknown_retries`` re-probes while GitHub answers ``UNKNOWN``
+        (mergeability is computed asynchronously). Used by the
+        verdict-time probe, whose caller may exit immediately afterwards
+        and so has no later poll to settle on — the zero-check sites need
+        none, they are already looping. Only ``UNKNOWN`` retries: a
+        ``MERGEABLE`` answer (the overwhelmingly common green path) and
+        an unreadable probe both return at once, so this adds no latency
+        to a healthy watch.
 
         Returns ``True`` iff the PR is *confirmed* conflicting right now.
         ``UNKNOWN`` / ``MERGEABLE`` / an unreadable probe all return
@@ -490,17 +521,33 @@ class _ConflictWatch:
         Never raises: conflict detection is an additive diagnostic and
         must not be able to abort a watch that works today.
         """
-        try:
-            view = _fetch_mergeable(self._pr, self._repo)
-        except Exception:  # noqa: BLE001 — additive probe, never fatal
-            view = None
-        mergeable = view.get("mergeable") if isinstance(view, dict) else None
-        if (not isinstance(mergeable, str)
-                or mergeable.strip().upper() != MERGEABLE_CONFLICTING):
+        attempts_left = max(0, unknown_retries) + 1
+        while True:
+            try:
+                view = _fetch_mergeable(self._pr, self._repo)
+            except Exception:  # noqa: BLE001 — additive probe, never fatal
+                view = None
+            mergeable = (view.get("mergeable")
+                         if isinstance(view, dict) else None)
+            state = (mergeable.strip().upper()
+                     if isinstance(mergeable, str) else None)
+            attempts_left -= 1
+            if state != MERGEABLE_UNKNOWN or attempts_left <= 0:
+                break
+            time.sleep(unknown_delay)
+
+        if state != MERGEABLE_CONFLICTING:
+            self.last_conflicting = False
+            return False
+        full_head = view.get("headRefOid")
+        if (expect_head is not None and isinstance(full_head, str)
+                and full_head and full_head != expect_head):
+            # The branch moved out from under the caller's reasoning;
+            # attributing this conflict would mis-key the ledger.
             self.last_conflicting = False
             return False
         self.last_conflicting = True
-        head = _short_head(view.get("headRefOid")) or "unknown"
+        head = _short_head(full_head) or "unknown"
         if head not in self._announced:
             # Marked BEFORE announcing, not after: if the announce path
             # itself is broken (unwritable DB, dead transport) we want one
@@ -1703,18 +1750,6 @@ def _run_ci_watch_phase(
         pending_count = verdict["pending_count"]
         total_checks = verdict["total_checks"]
         probe_attempts = verdict["probe_attempts"]
-        # Issue #946 (Codex review, P1): a terminal check verdict does
-        # NOT imply the PR is mergeable. CI can finish green and the base
-        # branch then move underneath it, leaving `mergeable=CONFLICTING`
-        # with a full set of passed checks — a shape neither the
-        # zero-check branch of `_self_poll_watch` nor the resolver
-        # handoff above can ever see. Probe once here so the secretary
-        # gets `PR_CONFLICT` alongside the green `CI_COMPLETED` instead
-        # of walking into a merge that GitHub will refuse. Report-only:
-        # the verdict, its event, and its message are untouched.
-        if conflict is not None:
-            conflict.probe(ci_settled=True)
-
         head_after = _fetch_head_oid(pr, repo)
         if (head_before is not None and head_after is not None
                 and head_before != head_after):
@@ -1735,6 +1770,31 @@ def _run_ci_watch_phase(
         # Anchor on the pre-watch head; fall back to the post-resolution
         # read only if the pre-watch probe failed.
         head_oid = head_before if head_before is not None else head_after
+
+        # Issue #946 (Codex review, P1): a terminal check verdict does
+        # NOT imply the PR is mergeable. CI can finish green and the base
+        # branch then move underneath it, leaving `mergeable=CONFLICTING`
+        # with a full set of passed checks — a shape neither the
+        # zero-check branch of `_self_poll_watch` nor the resolver
+        # handoff above can ever see. Probe here so the secretary gets
+        # `PR_CONFLICT` alongside the green `CI_COMPLETED` instead of
+        # walking into a merge that GitHub will refuse. Report-only: the
+        # verdict, its event, and its message are untouched.
+        #
+        # Placed AFTER the head-stability check (Codex review, P2) so it
+        # can only ever run against a head this verdict actually
+        # describes; `expect_head` closes the remaining window between
+        # that check and this probe. `unknown_retries` covers the other
+        # side of the same race: without --merge-watch this is the LAST
+        # observation the watcher makes, so a mergeability that is still
+        # being computed has no later poll to settle on.
+        if conflict is not None:
+            conflict.probe(
+                ci_settled=True,
+                expect_head=head_oid,
+                unknown_retries=CONFLICT_SETTLED_UNKNOWN_RETRIES,
+                unknown_delay=CONFLICT_SETTLED_UNKNOWN_DELAY_SEC,
+            )
     head_short = _short_head(head_oid)
 
     # Issue #413: duration is measured from the start of the watch to

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -378,6 +378,169 @@ def _fetch_head_oid(pr: int, repo: str) -> "str | None":
     return oid if isinstance(oid, str) and oid else None
 
 
+# Issue #946: `gh pr view --json mergeable` values we act on. GitHub
+# computes mergeability asynchronously, so a freshly pushed head reports
+# ``UNKNOWN`` for a few seconds before settling into ``MERGEABLE`` /
+# ``CONFLICTING``. Only ``CONFLICTING`` is actionable; ``UNKNOWN`` is
+# explicitly kept silent so the watcher never cries conflict at a PR
+# GitHub simply has not finished evaluating.
+MERGEABLE_CONFLICTING = "CONFLICTING"
+
+
+def _fetch_mergeable(pr: int, repo: str) -> "dict | None":
+    """Return the PR's mergeability view, or ``None`` when unreadable.
+
+    Issue #946. Shape (all keys best-effort, any may be missing)::
+
+        {"mergeable": "CONFLICTING"|"MERGEABLE"|"UNKNOWN",
+         "mergeStateStatus": "DIRTY"|"BLOCKED"|...,
+         "headRefOid": "<full sha>"}
+
+    ``headRefOid`` rides along in the SAME probe as ``mergeable`` on
+    purpose: the conflict verdict and the head it describes must come
+    from one atomic read, or a force-push between two separate probes
+    would let us tag a conflict onto the wrong head (and so mis-key the
+    one-notification-per-head ledger).
+
+    Best-effort like :func:`_fetch_head_oid`: any gh / parse failure
+    degrades to ``None`` (read downstream as "mergeability unknown →
+    stay silent"), so a flaky probe never aborts the watch nor fakes a
+    conflict.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr), "--repo", repo,
+             "--json", "mergeable,mergeStateStatus,headRefOid"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",  # gh emits UTF-8; locale decode (cp932) corrupts/crashes (#537)
+            check=False,
+            timeout=GH_TIMEOUT_SEC,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    try:
+        # ``ValueError`` covers json.JSONDecodeError; ``TypeError`` covers a
+        # non-string stdout (e.g. a Mock in tests that don't stub this call).
+        data = json.loads(result.stdout or "")
+    except (TypeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+class _ConflictWatch:
+    """Detect a conflicting PR head during ci-watch (Issue #946).
+
+    The gap this closes (kura PR #248, 2026-08-19): when a PR's head goes
+    ``mergeable=CONFLICTING`` GitHub cannot build the merge ref, so **no
+    ``pull_request`` workflow fires at all** and the PR sits at zero
+    checks. Every CI probe pr_watch owns waits for checks to *arrive*, so
+    that state was indistinguishable from "CI hasn't started yet" and the
+    watcher stayed silent until its budget ran out. A human noticed first.
+
+    This object is the missing signal. It is deliberately *not* a
+    terminal condition: a conflict is resolved by a re-push, and the new
+    head's CI is exactly what the watcher should go on to observe — so
+    :meth:`probe` only reports, and the caller keeps watching.
+
+    One notification per head (the ledger below): a conflict persists
+    across every poll until someone pushes, and re-announcing it each
+    tick would bury the secretary. The head is the natural dedup key
+    because a re-push is precisely the event that makes the conflict
+    worth re-announcing.
+    """
+
+    def __init__(self, *, pr: int, repo: str, db_path: Path) -> None:
+        self._pr = pr
+        self._repo = repo
+        self._db_path = Path(db_path)
+        # Heads already announced. Short shas, plus the literal
+        # ``"unknown"`` for a conflict observed while headRefOid was
+        # unreadable (still deduped, so an unreadable head cannot spam).
+        self._announced: "set[str]" = set()
+
+    @property
+    def announced_heads(self) -> "set[str]":
+        """Copy of the announced-head ledger (tests / diagnostics)."""
+        return set(self._announced)
+
+    def probe(self) -> bool:
+        """Probe mergeability once; announce a newly-seen conflicting head.
+
+        Returns ``True`` iff the PR is *confirmed* conflicting right now.
+        ``UNKNOWN`` / ``MERGEABLE`` / an unreadable probe all return
+        ``False`` — the caller uses the return value to decide whether to
+        keep watching a zero-check PR, and only a confirmed conflict may
+        extend that watch (an unreadable probe must not be able to wedge
+        the loop).
+
+        Never raises: conflict detection is an additive diagnostic and
+        must not be able to abort a watch that works today.
+        """
+        try:
+            view = _fetch_mergeable(self._pr, self._repo)
+        except Exception:  # noqa: BLE001 — additive probe, never fatal
+            return False
+        if not isinstance(view, dict):
+            return False
+        mergeable = view.get("mergeable")
+        if (not isinstance(mergeable, str)
+                or mergeable.strip().upper() != MERGEABLE_CONFLICTING):
+            return False
+        head = _short_head(view.get("headRefOid")) or "unknown"
+        if head not in self._announced:
+            # Marked BEFORE announcing, not after: if the announce path
+            # itself is broken (unwritable DB, dead transport) we want one
+            # failed attempt per head, not one per poll forever.
+            self._announced.add(head)
+            self._announce(head, view.get("mergeStateStatus"))
+        return True
+
+    def _announce(self, head: str, merge_state_status: object) -> None:
+        """Record the canonical event, then push the peer message."""
+        state = (merge_state_status
+                 if isinstance(merge_state_status, str) and merge_state_status
+                 else "unknown")
+        # Refs #653 #658 order: canonical DB event FIRST, so this signal is
+        # never peer-only. A dropped push then still surfaces via the
+        # dispatcher's outbox relay (the `notify_failed` row
+        # `_notify_or_record` writes below names `pr_conflict_detected`).
+        try:
+            _record_event(
+                db_path=self._db_path,
+                kind="pr_conflict_detected",
+                payload={
+                    "pr": self._pr,
+                    "repo": self._repo,
+                    "head": head,
+                    "mergeable": MERGEABLE_CONFLICTING,
+                    "merge_state_status": state,
+                },
+            )
+        except Exception:  # noqa: BLE001
+            sys.stderr.write(
+                f"pr_watch: PR #{self._pr} conflict detected but the "
+                "pr_conflict_detected event could not be recorded\n"
+            )
+        try:
+            _notify_or_record(
+                f"PR_CONFLICT: PR #{self._pr} (head={head}, "
+                f"mergeStateStatus={state}, repo={self._repo}) - conflict "
+                "のため CI が発火しません。rebase / conflict 解消の上で "
+                "再 push してください（監視は継続します）",
+                db_path=self._db_path,
+                failed_kind="pr_conflict_detected",
+                pr=self._pr,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        sys.stdout.write(
+            f"pr_watch: PR #{self._pr} head={head} is CONFLICTING "
+            f"(mergeStateStatus={state}); CI cannot start until the "
+            "conflict is resolved - continuing to watch\n"
+        )
+
+
 def _record_ci_completed(*, db_path: Path, pr: int, repo: str,
                          status: str, duration: int,
                          head: "str | None" = None,
@@ -1009,7 +1172,9 @@ def _resolve_final_status(
     }
 
 
-def _self_poll_watch(pr: int, repo: str, interval: int) -> "dict | None":
+def _self_poll_watch(pr: int, repo: str, interval: int, *,
+                     conflict: "_ConflictWatch | None" = None,
+                     ) -> "dict | None":
     """Replace the blocking ``gh pr checks --watch`` subprocess (Issue #695).
 
     ``gh``'s own ``--watch`` loop does not treat the ``skipping`` bucket
@@ -1050,6 +1215,20 @@ def _self_poll_watch(pr: int, repo: str, interval: int) -> "dict | None":
       #413 / #685) reconciles it, exactly as it did for the
       post-``--watch`` race it was originally built for.
 
+      Issue #946 carves one exception out of that handoff: when
+      ``conflict`` is supplied and its probe *confirms* the head is
+      ``mergeable=CONFLICTING``, zero visible checks is not a race at
+      all — GitHub cannot build the merge ref, so no ``pull_request``
+      workflow will ever fire for this head and handing off to a bounded
+      resolver just spends the budget to record a misleading
+      ``incomplete``. Instead the conflict is announced once (see
+      :class:`_ConflictWatch`) and this loop keeps polling at
+      ``interval`` cadence, so the CI of the head that eventually
+      resolves the conflict is still observed. Only a *confirmed*
+      conflict extends the loop: ``UNKNOWN`` (GitHub still computing)
+      and an unreadable probe both fall through to the unchanged
+      handoff, so neither can wedge the watch.
+
     Returns a verdict dict shaped like :func:`_resolve_final_status`'s
     return value (``status`` / ``fail_count`` / ``pending_count`` /
     ``total_checks`` / ``probe_attempts``) once a decided verdict is
@@ -1086,6 +1265,14 @@ def _self_poll_watch(pr: int, repo: str, interval: int) -> "dict | None":
             # checks is None (unparseable probe) or [] (no check rows
             # visible yet) -- inconclusive; the bounded resolver is
             # better suited to this than unbounded polling here.
+            #
+            # Issue #946: unless the head is confirmed CONFLICTING, in
+            # which case zero checks is the *explanation*, not a race —
+            # keep watching for the re-push that will unblock CI rather
+            # than burning the resolver budget on an `incomplete`.
+            if conflict is not None and conflict.probe():
+                time.sleep(interval)
+                continue
             return None
         time.sleep(interval)
 
@@ -1328,6 +1515,7 @@ def _pr_exists(pr: int, repo: str) -> bool:
 
 def _run_ci_watch_phase(
     *, pr: int, repo: str, interval: int, db_path: Path,
+    conflict: "_ConflictWatch | None" = None,
 ) -> "tuple[str, int, str | None]":
     """Run one ci-watch round and record/emit its verdict (Issue #636).
 
@@ -1410,7 +1598,10 @@ def _run_ci_watch_phase(
         # Issue #719: skipped entirely when the startup evaluation above
         # already produced a terminal verdict (CI was done before spawn).
         while verdict is None:
-            verdict = _self_poll_watch(pr, repo, interval)
+            # Issue #946: `conflict` lets the self-poll loop tell a
+            # zero-check race apart from a zero-check *conflict*.
+            verdict = _self_poll_watch(pr, repo, interval,
+                                       conflict=conflict)
             if verdict is not None:
                 break
             # Issue #695 round 3 (Codex review, P2): use the wider
@@ -1696,10 +1887,17 @@ def _watch_loop(*, pr: int, repo: str, interval: int,
                 merge_watch: bool) -> int:
     """The ci-watch → merge-watch loop, extracted so :func:`main` can wrap
     it with pr_watch_aborted recording (Refs #653 #658)."""
+    # Issue #946: owned by the loop, not by a single ci-watch round, so
+    # the "one announcement per head" ledger survives the head_changed
+    # restarts below — a head that already announced its conflict must
+    # not re-announce it just because the phase was re-entered.
+    conflict = _ConflictWatch(pr=pr, repo=repo, db_path=JOURNAL_PATH)
+
     while True:
         status, exit_code, head_oid = _run_ci_watch_phase(
             pr=pr, repo=repo, interval=interval,
             db_path=JOURNAL_PATH,
+            conflict=conflict,
         )
 
         if status == "head_changed":

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -469,8 +469,16 @@ class _ConflictWatch:
         """Copy of the announced-head ledger (tests / diagnostics)."""
         return set(self._announced)
 
-    def probe(self) -> bool:
+    def probe(self, *, ci_settled: bool = False) -> bool:
         """Probe mergeability once; announce a newly-seen conflicting head.
+
+        ``ci_settled`` says which of the two conflict shapes the caller is
+        looking at, because the operator-facing advice differs and a
+        one-size message is wrong for one of them (Codex review, P2):
+        ``False`` (the zero-check poll sites) means CI never fired and the
+        watch continues; ``True`` (the verdict-time probe) means a CI
+        verdict already exists and the conflict blocks the *merge*, not
+        the run.
 
         Returns ``True`` iff the PR is *confirmed* conflicting right now.
         ``UNKNOWN`` / ``MERGEABLE`` / an unreadable probe all return
@@ -498,10 +506,12 @@ class _ConflictWatch:
             # itself is broken (unwritable DB, dead transport) we want one
             # failed attempt per head, not one per poll forever.
             self._announced.add(head)
-            self._announce(head, view.get("mergeStateStatus"))
+            self._announce(head, view.get("mergeStateStatus"),
+                           ci_settled=ci_settled)
         return True
 
-    def _announce(self, head: str, merge_state_status: object) -> None:
+    def _announce(self, head: str, merge_state_status: object, *,
+                  ci_settled: bool) -> None:
         """Record the canonical event, then push the peer message."""
         state = (merge_state_status
                  if isinstance(merge_state_status, str) and merge_state_status
@@ -520,6 +530,7 @@ class _ConflictWatch:
                     "head": head,
                     "mergeable": MERGEABLE_CONFLICTING,
                     "merge_state_status": state,
+                    "ci_settled": ci_settled,
                 },
             )
         except Exception:  # noqa: BLE001
@@ -527,12 +538,21 @@ class _ConflictWatch:
                 f"pr_watch: PR #{self._pr} conflict detected but the "
                 "pr_conflict_detected event could not be recorded\n"
             )
+        if ci_settled:
+            advice = ("CI 判定は出ていますが head が conflict のため "
+                      "このままではマージできません。rebase / conflict 解消の"
+                      "上で再 push してください")
+            log_advice = ("CI already reported, but the head cannot be "
+                          "merged until the conflict is resolved")
+        else:
+            advice = ("conflict のため CI が発火しません。rebase / conflict "
+                      "解消の上で再 push してください（監視は継続します）")
+            log_advice = ("CI cannot start until the conflict is resolved "
+                          "- continuing to watch")
         try:
             _notify_or_record(
                 f"PR_CONFLICT: PR #{self._pr} (head={head}, "
-                f"mergeStateStatus={state}, repo={self._repo}) - conflict "
-                "のため CI が発火しません。rebase / conflict 解消の上で "
-                "再 push してください（監視は継続します）",
+                f"mergeStateStatus={state}, repo={self._repo}) - {advice}",
                 db_path=self._db_path,
                 failed_kind="pr_conflict_detected",
                 pr=self._pr,
@@ -541,8 +561,7 @@ class _ConflictWatch:
             pass
         sys.stdout.write(
             f"pr_watch: PR #{self._pr} head={head} is CONFLICTING "
-            f"(mergeStateStatus={state}); CI cannot start until the "
-            "conflict is resolved - continuing to watch\n"
+            f"(mergeStateStatus={state}); {log_advice}\n"
         )
 
 
@@ -1694,7 +1713,7 @@ def _run_ci_watch_phase(
         # of walking into a merge that GitHub will refuse. Report-only:
         # the verdict, its event, and its message are untouched.
         if conflict is not None:
-            conflict.probe()
+            conflict.probe(ci_settled=True)
 
         head_after = _fetch_head_oid(pr, repo)
         if (head_before is not None and head_after is not None

--- a/tools/relay_scan.py
+++ b/tools/relay_scan.py
@@ -3,7 +3,9 @@
 
 CI-watch zero-miss (Refs #653 #658). ``events`` is the source of truth
 for terminal signals (ci_completed / pr_merged / merge timeout / no-run /
-head-unconfirmed / watcher abort / notify_failed). ``pr_watch`` writes
+head-unconfirmed / watcher abort / notify_failed) plus the one
+non-terminal signal that needs the same guarantee, ``pr_conflict_detected``
+(Issue #946). ``pr_watch`` writes
 those rows locally; the low-latency peer push from the pr-watch pane is
 best-effort and CAN silently no-op (the observed PR #73 failure: the pane
 had no ORG_TRANSPORT/broker env, so the push never reached the queue and
@@ -90,6 +92,17 @@ TERMINAL_KINDS = (
     "pr_merged_head_unconfirmed",
     "pr_watch_aborted",
     "notify_failed",
+    # Issue #946. The only non-terminal kind here, and deliberately so:
+    # a conflicting head means GitHub cannot build the merge ref, so no
+    # workflow fires and the PR sits at zero checks until a human
+    # rebases. It needs the same zero-miss guarantee as the terminal
+    # signals, and the `notify_failed` backstop does NOT cover it — a
+    # pane with no transport configured at all (the PR #73 env-injection
+    # failure) records no `notify_failed` by design, which would leave
+    # this canonical row as the only trace of the conflict and nothing
+    # to relay it. Delivery is still once-only: the ledger dedups by
+    # event id, and pr_watch emits at most one row per head.
+    "pr_conflict_detected",
 )
 
 # Default recipient for relays.
@@ -184,6 +197,15 @@ def compose_message(kind: str, payload: dict) -> str:
         return (
             f"PR_MERGED_HEAD_UNCONFIRMED: {pr_tag} (head={head}, "
             f"last CI-confirmed head={baseline}) [relay]"
+        )
+    if kind == "pr_conflict_detected":
+        state = payload.get("merge_state_status") or "unknown"
+        advice = ("CI 判定は出ていますが head が conflict のためマージ不可"
+                  if payload.get("ci_settled")
+                  else "conflict のため CI が発火しません")
+        return (
+            f"PR_CONFLICT: {pr_tag} (head={head}, mergeStateStatus={state})"
+            f" - {advice} [relay]"
         )
     if kind == "pr_watch_aborted":
         err = payload.get("error", "unknown error")

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -3819,5 +3819,196 @@ class ConflictAnnounceWordingTests(unittest.TestCase):
         self.assertIn("CI が発火しません", notify.call_args[0][0])
 
 
+class ConflictHeadAttributionTests(unittest.TestCase):
+    """Issue #946 (Codex review, P2): never attribute a conflict to a head
+    the caller was not reasoning about.
+
+    A branch that advances between the caller's head read and the probe
+    would otherwise let a `ci_settled=True` announcement land on the NEW
+    head — burning that head's one-shot dedup slot on a claim about the
+    OLD head's verdict, so the new head's real conflict (with no checks
+    at all) could never be announced.
+    """
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def test_head_mismatch_announces_nothing(self) -> None:
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_record_event") as rec, \
+             mock.patch.object(pr_watch, "_notify_or_record") as notify, \
+             mock.patch.object(
+                 pr_watch, "_fetch_mergeable",
+                 return_value={"mergeable": "CONFLICTING",
+                               "headRefOid": "b" * 40}):
+            self.assertFalse(watch.probe(ci_settled=True,
+                                         expect_head="a" * 40))
+        rec.assert_not_called()
+        notify.assert_not_called()
+        self.assertFalse(watch.last_conflicting)
+        # Crucially the ledger is untouched, so the new head can still
+        # announce its own conflict on the next round.
+        self.assertEqual(watch.announced_heads, set())
+
+    def test_matching_head_announces(self) -> None:
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_record_event") as rec, \
+             mock.patch.object(pr_watch, "_notify_or_record",
+                               return_value=True), \
+             mock.patch.object(
+                 pr_watch, "_fetch_mergeable",
+                 return_value={"mergeable": "CONFLICTING",
+                               "headRefOid": "a" * 40}):
+            self.assertTrue(watch.probe(ci_settled=True,
+                                        expect_head="a" * 40))
+        self.assertEqual(rec.call_count, 1)
+        self.assertEqual(watch.announced_heads, {"aaaaaaa"})
+
+    def test_unreadable_probe_head_does_not_block_the_announce(self) -> None:
+        # A missing headRefOid cannot be compared; report it under the
+        # "unknown" key rather than dropping the conflict entirely.
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_record_event") as rec, \
+             mock.patch.object(pr_watch, "_notify_or_record",
+                               return_value=True), \
+             mock.patch.object(pr_watch, "_fetch_mergeable",
+                               return_value={"mergeable": "CONFLICTING"}):
+            self.assertTrue(watch.probe(ci_settled=True,
+                                        expect_head="a" * 40))
+        self.assertEqual(rec.call_args.kwargs["payload"]["head"], "unknown")
+
+    def test_verdict_time_probe_runs_only_on_a_stable_head(self) -> None:
+        # head_before != head_after -> the phase restarts; probing here
+        # would attribute the verdict to a head it does not describe.
+        conflict = mock.Mock()
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "_fetch_head_oid",
+                                   side_effect=["a" * 40, "b" * 40]), \
+                 mock.patch.object(pr_watch, "_evaluate_startup_state",
+                                   return_value={"status": "passed",
+                                                 "fail_count": 0,
+                                                 "pending_count": 0,
+                                                 "total_checks": 1,
+                                                 "probe_attempts": 1}), \
+                 mock.patch.object(pr_watch, "_record_ci_completed") as rec, \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   return_value=True), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 1.0]):
+                status, _, _ = pr_watch._run_ci_watch_phase(
+                    pr=248, repo="octo/repo", interval=30, db_path=db,
+                    conflict=conflict)
+        self.assertEqual(status, "head_changed")
+        conflict.probe.assert_not_called()
+        rec.assert_not_called()
+
+    def test_verdict_time_probe_pins_the_verdict_head(self) -> None:
+        conflict = mock.Mock()
+        conflict.probe.return_value = False
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "_fetch_head_oid",
+                                   return_value="a" * 40), \
+                 mock.patch.object(pr_watch, "_evaluate_startup_state",
+                                   return_value={"status": "passed",
+                                                 "fail_count": 0,
+                                                 "pending_count": 0,
+                                                 "total_checks": 1,
+                                                 "probe_attempts": 1}), \
+                 mock.patch.object(pr_watch, "_record_ci_completed"), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   return_value=True), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 1.0]):
+                pr_watch._run_ci_watch_phase(
+                    pr=248, repo="octo/repo", interval=30, db_path=db,
+                    conflict=conflict)
+        kwargs = conflict.probe.call_args.kwargs
+        self.assertTrue(kwargs["ci_settled"])
+        self.assertEqual(kwargs["expect_head"], "a" * 40)
+        self.assertGreater(kwargs["unknown_retries"], 0)
+
+
+class ConflictUnknownRetryTests(unittest.TestCase):
+    """Issue #946 (Codex review, P2): the verdict-time probe may be the
+    LAST observation the watcher makes (no --merge-watch), so a
+    mergeability still being computed has no later poll to settle on."""
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def test_unknown_then_conflicting_is_announced(self) -> None:
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        views = [
+            {"mergeable": "UNKNOWN"},
+            {"mergeable": "UNKNOWN"},
+            {"mergeable": "CONFLICTING", "headRefOid": "a" * 40},
+        ]
+        with mock.patch.object(pr_watch, "_record_event") as rec, \
+             mock.patch.object(pr_watch, "_notify_or_record",
+                               return_value=True), \
+             mock.patch.object(pr_watch, "_fetch_mergeable",
+                               side_effect=views), \
+             mock.patch.object(pr_watch.time, "sleep",
+                               return_value=None) as sleep_mock:
+            self.assertTrue(watch.probe(ci_settled=True, unknown_retries=2,
+                                        unknown_delay=5.0))
+        self.assertEqual(rec.call_count, 1)
+        self.assertEqual(sleep_mock.call_count, 2)
+        sleep_mock.assert_called_with(5.0)
+
+    def test_still_unknown_after_the_budget_stays_silent(self) -> None:
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_record_event") as rec, \
+             mock.patch.object(pr_watch, "_notify_or_record") as notify, \
+             mock.patch.object(pr_watch, "_fetch_mergeable",
+                               return_value={"mergeable": "UNKNOWN"}), \
+             mock.patch.object(pr_watch.time, "sleep", return_value=None):
+            self.assertFalse(watch.probe(ci_settled=True, unknown_retries=2))
+        rec.assert_not_called()
+        notify.assert_not_called()
+
+    def test_mergeable_costs_a_healthy_watch_nothing(self) -> None:
+        # The overwhelmingly common green path: one probe, no sleeping.
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_fetch_mergeable",
+                               return_value={"mergeable": "MERGEABLE"}) as f, \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            self.assertFalse(watch.probe(ci_settled=True, unknown_retries=2))
+        self.assertEqual(f.call_count, 1)
+        sleep_mock.assert_not_called()
+
+    def test_unreadable_probe_does_not_retry(self) -> None:
+        # "Cannot read" is not "not yet decided"; retrying a broken gh
+        # would only add latency to the terminal path.
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_fetch_mergeable",
+                               return_value=None) as f, \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            self.assertFalse(watch.probe(ci_settled=True, unknown_retries=2))
+        self.assertEqual(f.call_count, 1)
+        sleep_mock.assert_not_called()
+
+    def test_zero_check_sites_do_not_retry(self) -> None:
+        # They are already looping at interval cadence; a retry here
+        # would just slow the loop down.
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_fetch_mergeable",
+                               return_value={"mergeable": "UNKNOWN"}) as f, \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            self.assertFalse(watch.probe())
+        self.assertEqual(f.call_count, 1)
+        sleep_mock.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -3103,5 +3103,384 @@ class ChecksJsonFallbackTests(unittest.TestCase):
             self.assertEqual(rec["fail_count"], 1)
 
 
+def _read_events(db_path: Path, kind: str) -> "list[dict]":
+    """Return every payload dict recorded under ``kind``, in insert order."""
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events WHERE kind = ? ORDER BY id",
+            (kind,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [json.loads(r["payload_json"] or "{}") for r in rows]
+
+
+class FetchMergeableTests(unittest.TestCase):
+    """Issue #946: the mergeability probe degrades, never raises."""
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def test_parses_the_view(self) -> None:
+        payload = {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY",
+                   "headRefOid": "a" * 40}
+        with mock.patch.object(
+            pr_watch.subprocess, "run",
+            return_value=mock.Mock(returncode=0, stdout=json.dumps(payload),
+                                   stderr=""),
+        ):
+            view = pr_watch._fetch_mergeable(248, "octo/repo")
+        self.assertEqual(view["mergeable"], "CONFLICTING")
+        self.assertEqual(view["mergeStateStatus"], "DIRTY")
+
+    def test_requests_head_in_the_same_probe(self) -> None:
+        # The conflict verdict and the head it describes must come from
+        # one atomic read (a force-push between two probes would mis-key
+        # the per-head dedup ledger).
+        seen = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            seen["cmd"] = cmd
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+
+        with mock.patch.object(pr_watch.subprocess, "run",
+                               side_effect=fake_run):
+            pr_watch._fetch_mergeable(1, "octo/repo")
+        self.assertIn("mergeable,mergeStateStatus,headRefOid", seen["cmd"])
+
+    def test_unparseable_stdout_is_none(self) -> None:
+        with mock.patch.object(
+            pr_watch.subprocess, "run",
+            return_value=mock.Mock(returncode=0, stdout="not json", stderr=""),
+        ):
+            self.assertIsNone(pr_watch._fetch_mergeable(1, "octo/repo"))
+
+    def test_non_object_json_is_none(self) -> None:
+        with mock.patch.object(
+            pr_watch.subprocess, "run",
+            return_value=mock.Mock(returncode=0, stdout="[]", stderr=""),
+        ):
+            self.assertIsNone(pr_watch._fetch_mergeable(1, "octo/repo"))
+
+    def test_gh_oserror_is_none(self) -> None:
+        with mock.patch.object(pr_watch.subprocess, "run",
+                               side_effect=OSError("boom")):
+            self.assertIsNone(pr_watch._fetch_mergeable(1, "octo/repo"))
+
+    def test_gh_timeout_is_none(self) -> None:
+        with mock.patch.object(
+            pr_watch.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=1),
+        ):
+            self.assertIsNone(pr_watch._fetch_mergeable(1, "octo/repo"))
+
+
+class ConflictWatchTests(unittest.TestCase):
+    """Issue #946: conflict detection, dedup, and UNKNOWN silence."""
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def _watch(self, db: Path) -> "pr_watch._ConflictWatch":
+        return pr_watch._ConflictWatch(pr=248, repo="octo/repo", db_path=db)
+
+    def test_conflicting_records_event_and_notifies(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            watch = self._watch(db)
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "CONFLICTING",
+                              "mergeStateStatus": "DIRTY",
+                              "headRefOid": "abcdef1234567890"},
+            ), mock.patch.object(pr_watch, "_notify_peer",
+                                 return_value=True) as notify:
+                self.assertTrue(watch.probe())
+            rows = _read_events(db, "pr_conflict_detected")
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["pr"], 248)
+            self.assertEqual(rows[0]["repo"], "octo/repo")
+            self.assertEqual(rows[0]["head"], "abcdef1")
+            self.assertEqual(rows[0]["mergeable"], "CONFLICTING")
+            self.assertEqual(rows[0]["merge_state_status"], "DIRTY")
+            msg = notify.call_args[0][0]
+            self.assertTrue(msg.startswith("PR_CONFLICT: PR #248 "))
+            self.assertIn("head=abcdef1", msg)
+
+    def test_same_head_notifies_once(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            watch = self._watch(db)
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "CONFLICTING",
+                              "mergeStateStatus": "DIRTY",
+                              "headRefOid": "abcdef1234567890"},
+            ), mock.patch.object(pr_watch, "_notify_peer",
+                                 return_value=True) as notify:
+                for _ in range(5):
+                    self.assertTrue(watch.probe())
+            self.assertEqual(len(_read_events(db, "pr_conflict_detected")), 1)
+            self.assertEqual(notify.call_count, 1)
+
+    def test_new_head_notifies_again(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            watch = self._watch(db)
+            views = [
+                {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY",
+                 "headRefOid": "a" * 40},
+                {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY",
+                 "headRefOid": "b" * 40},
+            ]
+            with mock.patch.object(pr_watch, "_fetch_mergeable",
+                                   side_effect=views), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   return_value=True) as notify:
+                self.assertTrue(watch.probe())
+                self.assertTrue(watch.probe())
+            rows = _read_events(db, "pr_conflict_detected")
+            self.assertEqual([r["head"] for r in rows], ["aaaaaaa", "bbbbbbb"])
+            self.assertEqual(notify.call_count, 2)
+
+    def test_unknown_is_silent(self) -> None:
+        # GitHub computes mergeability asynchronously; UNKNOWN means
+        # "not decided yet", never "conflict".
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            watch = self._watch(db)
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "UNKNOWN",
+                              "mergeStateStatus": "UNKNOWN",
+                              "headRefOid": "a" * 40},
+            ), mock.patch.object(pr_watch, "_notify_peer") as notify:
+                self.assertFalse(watch.probe())
+            self.assertEqual(_read_events(db, "pr_conflict_detected"), [])
+            notify.assert_not_called()
+
+    def test_mergeable_is_silent(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            watch = self._watch(db)
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "MERGEABLE",
+                              "mergeStateStatus": "CLEAN",
+                              "headRefOid": "a" * 40},
+            ), mock.patch.object(pr_watch, "_notify_peer") as notify:
+                self.assertFalse(watch.probe())
+            self.assertEqual(_read_events(db, "pr_conflict_detected"), [])
+            notify.assert_not_called()
+
+    def test_unreadable_probe_is_silent(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            watch = self._watch(db)
+            with mock.patch.object(pr_watch, "_fetch_mergeable",
+                                   return_value=None), \
+                 mock.patch.object(pr_watch, "_notify_peer") as notify:
+                self.assertFalse(watch.probe())
+            self.assertEqual(_read_events(db, "pr_conflict_detected"), [])
+            notify.assert_not_called()
+
+    def test_probe_never_raises(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            watch = self._watch(db)
+            with mock.patch.object(pr_watch, "_fetch_mergeable",
+                                   side_effect=RuntimeError("boom")):
+                self.assertFalse(watch.probe())
+
+    def test_unknown_head_still_deduped(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            watch = self._watch(db)
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "CONFLICTING"},
+            ), mock.patch.object(pr_watch, "_notify_peer",
+                                 return_value=True) as notify:
+                self.assertTrue(watch.probe())
+                self.assertTrue(watch.probe())
+            rows = _read_events(db, "pr_conflict_detected")
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["head"], "unknown")
+            self.assertEqual(rows[0]["merge_state_status"], "unknown")
+            self.assertEqual(notify.call_count, 1)
+
+    def test_broken_db_does_not_retry_forever(self) -> None:
+        # A broken announce path must cost one failed attempt per head,
+        # not one per poll.
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            watch = self._watch(db)
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "CONFLICTING",
+                              "headRefOid": "a" * 40},
+            ), mock.patch.object(pr_watch, "_record_event",
+                                 side_effect=OSError("db down")) as rec, \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   return_value=True):
+                for _ in range(4):
+                    self.assertTrue(watch.probe())
+            self.assertEqual(rec.call_count, 1)
+
+
+class SelfPollConflictTests(unittest.TestCase):
+    """Issue #946: a confirmed conflict keeps the ci-watch loop alive."""
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def test_conflicting_keeps_polling_until_checks_appear(self) -> None:
+        # The kura PR #248 shape: zero checks because the merge ref
+        # cannot be built. Handing off to the bounded resolver here would
+        # record a misleading `incomplete`; instead we keep watching, and
+        # the CI of the head that resolves the conflict is observed.
+        checks = [[], [], [{"name": "ci", "bucket": "pass"}]]
+        conflict = mock.Mock()
+        conflict.probe.return_value = True
+        with mock.patch.object(pr_watch, "_fetch_checks",
+                               side_effect=checks), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            verdict = pr_watch._self_poll_watch(
+                248, "octo/repo", 30, conflict=conflict)
+        self.assertEqual(verdict["status"], "passed")
+        self.assertEqual(conflict.probe.call_count, 2)
+        self.assertEqual(sleep_mock.call_count, 2)
+        sleep_mock.assert_called_with(30)
+
+    def test_non_conflicting_still_hands_off(self) -> None:
+        conflict = mock.Mock()
+        conflict.probe.return_value = False
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=[]), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            self.assertIsNone(pr_watch._self_poll_watch(
+                248, "octo/repo", 30, conflict=conflict))
+        sleep_mock.assert_not_called()
+
+    def test_unparseable_probe_with_conflict_still_hands_off(self) -> None:
+        # An unreadable checks probe on a conflicting PR: the conflict
+        # explains the missing checks, so keep watching.
+        conflict = mock.Mock()
+        conflict.probe.side_effect = [True, False]
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=None), \
+             mock.patch.object(pr_watch.time, "sleep", return_value=None):
+            self.assertIsNone(pr_watch._self_poll_watch(
+                248, "octo/repo", 30, conflict=conflict))
+        self.assertEqual(conflict.probe.call_count, 2)
+
+    def test_no_conflict_watch_supplied_is_unchanged(self) -> None:
+        # Pre-#946 callers (and the existing suite) must be untouched.
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=[]), \
+             mock.patch.object(pr_watch.time, "sleep") as sleep_mock:
+            self.assertIsNone(pr_watch._self_poll_watch(248, "octo/repo", 30))
+        sleep_mock.assert_not_called()
+
+    def test_pending_checks_do_not_trigger_the_probe(self) -> None:
+        # The probe costs a gh call; it only runs on the zero-check
+        # branch, which is the only shape a conflict can produce.
+        conflict = mock.Mock()
+        with mock.patch.object(
+            pr_watch, "_fetch_checks",
+            side_effect=[[{"name": "ci", "bucket": "pending"}],
+                         [{"name": "ci", "bucket": "pass"}]],
+        ), mock.patch.object(pr_watch.time, "sleep", return_value=None):
+            verdict = pr_watch._self_poll_watch(
+                248, "octo/repo", 30, conflict=conflict)
+        self.assertEqual(verdict["status"], "passed")
+        conflict.probe.assert_not_called()
+
+
+class ConflictEndToEndTests(unittest.TestCase):
+    """Issue #946: conflict -> re-push -> the new head's CI is tracked."""
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def test_conflict_then_resolution_records_both_events(self) -> None:
+        # Poll 1-2: zero checks + CONFLICTING (announce once, keep
+        # watching). Poll 3: the conflict was resolved by a re-push and
+        # the new head's checks are green -> the usual ci_completed.
+        checks_seq = [[], [], [{"name": "ci", "bucket": "pass"}]]
+        views = [
+            {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY",
+             "headRefOid": "a" * 40},
+            {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY",
+             "headRefOid": "a" * 40},
+        ]
+        checks_iter = iter(checks_seq)
+        views_iter = iter(views)
+
+        def fake_run(cmd, *args, **kwargs):
+            joined = ",".join(cmd)
+            if "view" in cmd and "mergeable" in joined:
+                return mock.Mock(returncode=0,
+                                 stdout=json.dumps(next(views_iter)),
+                                 stderr="")
+            if "view" in cmd and "headRefOid" in joined:
+                # Stable head across the phase so no head_changed restart.
+                return mock.Mock(returncode=0,
+                                 stdout=json.dumps({"headRefOid": "b" * 40}),
+                                 stderr="")
+            if "view" in cmd and "--json" in cmd and "number" in cmd:
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
+            if "checks" in cmd and "--json" in cmd:
+                payload = next(checks_iter)
+                return mock.Mock(returncode=_gh_exit_for_payload(payload),
+                                 stdout=json.dumps(payload), stderr="")
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   return_value=True) as notify, \
+                 mock.patch.object(pr_watch.shutil, "which",
+                                   return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run",
+                                   side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 12.0]):
+                rc = pr_watch.main([
+                    "--pr", "248", "--repo", "octo/repo", "--interval", "30",
+                ])
+            self.assertEqual(rc, 0)
+            conflicts = _read_events(journal, "pr_conflict_detected")
+            self.assertEqual(len(conflicts), 1)
+            self.assertEqual(conflicts[0]["head"], "aaaaaaa")
+            # Existing event shape unchanged.
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(rec["head"], "bbbbbbb")
+            kinds = [c[0][0].split(":")[0] for c in notify.call_args_list]
+            self.assertEqual(kinds, ["PR_CONFLICT", "CI_COMPLETED"])
+
+    def test_dedup_ledger_survives_head_changed_restart(self) -> None:
+        # The ledger lives on the watch loop, not on one ci-watch round,
+        # so a head_changed restart cannot re-announce the same head.
+        watch = pr_watch._ConflictWatch(
+            pr=1, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_record_event") as rec, \
+             mock.patch.object(pr_watch, "_notify_or_record",
+                               return_value=True):
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "CONFLICTING",
+                              "headRefOid": "c" * 40},
+            ):
+                watch.probe()
+                watch.probe()
+        self.assertEqual(rec.call_count, 1)
+        self.assertEqual(watch.announced_heads, {"ccccccc"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -3745,5 +3745,79 @@ class ConflictWithTerminalChecksTests(unittest.TestCase):
         conflict.probe.assert_not_called()
 
 
+class ConflictAnnounceWordingTests(unittest.TestCase):
+    """Issue #946 (Codex review, P2): the two conflict shapes need
+    different operator advice.
+
+    "conflict のため CI が発火しません（監視は継続します）" is simply false
+    when the probe fires after a terminal verdict — CI already reported
+    and, without --merge-watch, the watcher exits right after.
+    """
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def _probe(self, **kwargs) -> str:
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_record_event"), \
+             mock.patch.object(pr_watch, "_notify_or_record",
+                               return_value=True) as notify, \
+             mock.patch.object(
+                 pr_watch, "_fetch_mergeable",
+                 return_value={"mergeable": "CONFLICTING",
+                               "mergeStateStatus": "DIRTY",
+                               "headRefOid": "a" * 40}):
+            watch.probe(**kwargs)
+        return notify.call_args[0][0]
+
+    def test_ci_pending_wording(self) -> None:
+        msg = self._probe()
+        self.assertTrue(msg.startswith("PR_CONFLICT: PR #248 "))
+        self.assertIn("CI が発火しません", msg)
+        self.assertIn("監視は継続します", msg)
+
+    def test_ci_settled_wording(self) -> None:
+        msg = self._probe(ci_settled=True)
+        self.assertTrue(msg.startswith("PR_CONFLICT: PR #248 "))
+        self.assertIn("CI 判定は出ています", msg)
+        self.assertNotIn("CI が発火しません", msg)
+        self.assertNotIn("監視は継続します", msg)
+
+    def test_payload_records_which_shape(self) -> None:
+        for ci_settled in (False, True):
+            with self.subTest(ci_settled=ci_settled), TempDir() as tmp:
+                db = tmp / ".state" / "state.db"
+                watch = pr_watch._ConflictWatch(
+                    pr=248, repo="octo/repo", db_path=db)
+                with mock.patch.object(pr_watch, "_notify_peer",
+                                       return_value=True), \
+                     mock.patch.object(
+                         pr_watch, "_fetch_mergeable",
+                         return_value={"mergeable": "CONFLICTING",
+                                       "headRefOid": "a" * 40}):
+                    watch.probe(ci_settled=ci_settled)
+                rows = _read_events(db, "pr_conflict_detected")
+                self.assertEqual(rows[0]["ci_settled"], ci_settled)
+
+    def test_zero_check_poll_sites_use_the_pending_wording(self) -> None:
+        # The self-poll loop must not pass ci_settled through by accident.
+        watch = pr_watch._ConflictWatch(
+            pr=248, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_record_event"), \
+             mock.patch.object(pr_watch, "_notify_or_record",
+                               return_value=True) as notify, \
+             mock.patch.object(
+                 pr_watch, "_fetch_mergeable",
+                 return_value={"mergeable": "CONFLICTING",
+                               "headRefOid": "a" * 40}), \
+             mock.patch.object(pr_watch, "_fetch_checks",
+                               side_effect=[[], [{"name": "ci",
+                                                  "bucket": "pass"}]]), \
+             mock.patch.object(pr_watch.time, "sleep", return_value=None):
+            pr_watch._self_poll_watch(248, "octo/repo", 30, conflict=watch)
+        self.assertIn("CI が発火しません", notify.call_args[0][0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -2047,6 +2047,14 @@ class HeadPollLoopbackTests(unittest.TestCase):
             def fake_run(cmd, *args, **kwargs):
                 if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
                     jval = cmd[cmd.index("--json") + 1]
+                    if jval.startswith("mergeable"):
+                        # Issue #946 conflict probe. These fixtures all watch
+                        # clean PRs, so it answers MERGEABLE and must not
+                        # consume an entry of the sequences below.
+                        return mock.Mock(
+                            returncode=0,
+                            stdout=json.dumps({"mergeable": "MERGEABLE"}),
+                            stderr="")
                     if jval == "number":
                         return mock.Mock(returncode=0, stdout="{}", stderr="")
                     if jval == "headRefOid":
@@ -2133,6 +2141,14 @@ class HeadPollLoopbackTests(unittest.TestCase):
         def fake_run(cmd, *args, **kwargs):
             if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
                 jval = cmd[cmd.index("--json") + 1]
+                if jval.startswith("mergeable"):
+                    # Issue #946 conflict probe. These fixtures all watch
+                    # clean PRs, so it answers MERGEABLE and must not
+                    # consume an entry of the sequences below.
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps({"mergeable": "MERGEABLE"}),
+                        stderr="")
                 if jval == "number":
                     return mock.Mock(returncode=0, stdout="{}", stderr="")
                 if jval == "headRefOid":
@@ -2239,6 +2255,14 @@ class HeadPollLoopbackTests(unittest.TestCase):
             def fake_run(cmd, *args, **kwargs):
                 if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
                     jval = cmd[cmd.index("--json") + 1]
+                    if jval.startswith("mergeable"):
+                        # Issue #946 conflict probe. These fixtures all watch
+                        # clean PRs, so it answers MERGEABLE and must not
+                        # consume an entry of the sequences below.
+                        return mock.Mock(
+                            returncode=0,
+                            stdout=json.dumps({"mergeable": "MERGEABLE"}),
+                            stderr="")
                     if jval == "number":
                         return mock.Mock(returncode=0, stdout="{}", stderr="")
                     if jval == "headRefOid":
@@ -2332,6 +2356,14 @@ class HeadPollLoopbackTests(unittest.TestCase):
         def fake_run(cmd, *args, **kwargs):
             if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
                 jval = cmd[cmd.index("--json") + 1]
+                if jval.startswith("mergeable"):
+                    # Issue #946 conflict probe. These fixtures all watch
+                    # clean PRs, so it answers MERGEABLE and must not
+                    # consume an entry of the sequences below.
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps({"mergeable": "MERGEABLE"}),
+                        stderr="")
                 if jval == "number":
                     return mock.Mock(returncode=0, stdout="{}", stderr="")
                 if jval == "headRefOid":
@@ -2727,6 +2759,14 @@ class StartupStateEvalTests(unittest.TestCase):
         def fake_run(cmd, *args, **kwargs):
             if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
                 jval = cmd[cmd.index("--json") + 1]
+                if jval.startswith("mergeable"):
+                    # Issue #946 conflict probe. These fixtures all watch
+                    # clean PRs, so it answers MERGEABLE and must not
+                    # consume an entry of the sequences below.
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps({"mergeable": "MERGEABLE"}),
+                        stderr="")
                 if jval == "number":
                     return mock.Mock(returncode=0, stdout="{}", stderr="")
                 if jval == "headRefOid":
@@ -2952,6 +2992,14 @@ class ChecksJsonFallbackTests(unittest.TestCase):
                 )
             if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
                 jval = cmd[cmd.index("--json") + 1]
+                if jval.startswith("mergeable"):
+                    # Issue #946 conflict probe. These fixtures all watch
+                    # clean PRs, so it answers MERGEABLE and must not
+                    # consume an entry of the sequences below.
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps({"mergeable": "MERGEABLE"}),
+                        stderr="")
                 if jval in ("number", "headRefOid"):
                     return mock.Mock(returncode=0, stdout="{}", stderr="")
                 if jval == "statusCheckRollup":
@@ -3480,6 +3528,221 @@ class ConflictEndToEndTests(unittest.TestCase):
                 watch.probe()
         self.assertEqual(rec.call_count, 1)
         self.assertEqual(watch.announced_heads, {"ccccccc"})
+
+
+class ConflictSettlingDuringBudgetTests(unittest.TestCase):
+    """Issue #946 (Codex review, P1): mergeability settles asynchronously.
+
+    A freshly pushed conflicting head commonly reads ``UNKNOWN`` on the
+    single probe the self-poll loop makes before handing off to the
+    bounded resolver. If the resolver never probed again, the conflict
+    would settle inside its budget and STILL go unreported — the watch
+    ending on a misleading ``incomplete``, which is exactly the silence
+    Issue #946 exists to break.
+    """
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def test_resolver_probes_across_the_budget(self) -> None:
+        conflict = mock.Mock()
+        conflict.probe.side_effect = [False, False, True]
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=[]), \
+             mock.patch.object(pr_watch.time, "sleep",
+                               return_value=None) as sleep_mock, \
+             mock.patch.object(pr_watch.time, "monotonic",
+                               side_effect=[0.0] + [1.0] * 20):
+            verdict = pr_watch._resolve_final_status(
+                248, "octo/repo", exit_code=8, budget_sec=300,
+                conflict=conflict)
+        # Bailed out on the confirmed conflict rather than spending the
+        # rest of the budget.
+        self.assertEqual(conflict.probe.call_count, 3)
+        self.assertEqual(sleep_mock.call_count, 2)
+        self.assertEqual(verdict["status"], "incomplete")
+
+    def test_resolver_without_conflict_watch_is_unchanged(self) -> None:
+        with mock.patch.object(pr_watch, "_fetch_checks", return_value=[]), \
+             mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+             mock.patch.object(pr_watch.time, "monotonic",
+                               side_effect=[0.0, 0.0, 999.0]):
+            verdict = pr_watch._resolve_final_status(
+                248, "octo/repo", exit_code=8, budget_sec=300)
+        self.assertEqual(verdict["status"], "incomplete")
+
+    def test_phase_returns_to_self_poll_instead_of_incomplete(self) -> None:
+        # UNKNOWN at handoff -> CONFLICTING during the budget: the phase
+        # must NOT record `incomplete`; it goes back to the self-poll
+        # loop, which keeps watching for the re-push.
+        conflict = mock.Mock()
+        conflict.probe.return_value = True
+        conflict.last_conflicting = True
+        resolver_verdict = {
+            "status": "incomplete", "fail_count": 0, "pending_count": 0,
+            "total_checks": 0, "probe_attempts": 3,
+        }
+        poll_results = [None, {"status": "passed", "fail_count": 0,
+                               "pending_count": 0, "total_checks": 1,
+                               "probe_attempts": 1}]
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "_fetch_head_oid",
+                                   return_value="a" * 40), \
+                 mock.patch.object(pr_watch, "_evaluate_startup_state",
+                                   return_value=None), \
+                 mock.patch.object(pr_watch, "_self_poll_watch",
+                                   side_effect=poll_results) as poll, \
+                 mock.patch.object(pr_watch, "_resolve_final_status",
+                                   return_value=resolver_verdict) as resolve, \
+                 mock.patch.object(pr_watch, "_record_ci_completed") as rec, \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   return_value=True), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 4.0]):
+                status, exit_code, _ = pr_watch._run_ci_watch_phase(
+                    pr=248, repo="octo/repo", interval=30, db_path=db,
+                    conflict=conflict)
+        self.assertEqual(status, "passed")
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(poll.call_count, 2)
+        self.assertEqual(resolve.call_count, 1)
+        self.assertEqual(rec.call_args.kwargs["status"], "passed")
+
+    def test_conflict_watch_tracks_last_probe_result(self) -> None:
+        watch = pr_watch._ConflictWatch(
+            pr=1, repo="octo/repo", db_path=Path("unused"))
+        self.assertFalse(watch.last_conflicting)
+        with mock.patch.object(pr_watch, "_record_event"), \
+             mock.patch.object(pr_watch, "_notify_or_record",
+                               return_value=True):
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "UNKNOWN"},
+            ):
+                watch.probe()
+            self.assertFalse(watch.last_conflicting)
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "CONFLICTING",
+                              "headRefOid": "d" * 40},
+            ):
+                watch.probe()
+            self.assertTrue(watch.last_conflicting)
+            # Cleared again once the re-push resolves it.
+            with mock.patch.object(
+                pr_watch, "_fetch_mergeable",
+                return_value={"mergeable": "MERGEABLE"},
+            ):
+                watch.probe()
+            self.assertFalse(watch.last_conflicting)
+
+    def test_probe_failure_clears_last_conflicting(self) -> None:
+        # An unreadable probe must not leave a stale True behind — that
+        # would let a gh outage wedge the watch in the conflict branch.
+        watch = pr_watch._ConflictWatch(
+            pr=1, repo="octo/repo", db_path=Path("unused"))
+        with mock.patch.object(pr_watch, "_record_event"), \
+             mock.patch.object(pr_watch, "_notify_or_record",
+                               return_value=True), \
+             mock.patch.object(
+                 pr_watch, "_fetch_mergeable",
+                 return_value={"mergeable": "CONFLICTING",
+                               "headRefOid": "e" * 40}):
+            watch.probe()
+        self.assertTrue(watch.last_conflicting)
+        with mock.patch.object(pr_watch, "_fetch_mergeable",
+                               side_effect=RuntimeError("gh down")):
+            self.assertFalse(watch.probe())
+        self.assertFalse(watch.last_conflicting)
+
+
+class ConflictWithTerminalChecksTests(unittest.TestCase):
+    """Issue #946 (Codex review, P1): green CI does not imply mergeable.
+
+    CI can finish green and the base branch then move underneath it,
+    leaving `mergeable=CONFLICTING` with a full set of passed checks — a
+    shape neither the zero-check branch nor the resolver handoff can
+    see. Without a probe at verdict time the secretary is handed a clean
+    `CI_COMPLETED: passed` and walks into a merge GitHub will refuse.
+    """
+
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
+    def test_passed_verdict_still_announces_the_conflict(self) -> None:
+        conflicting_view = {"mergeable": "CONFLICTING",
+                            "mergeStateStatus": "DIRTY",
+                            "headRefOid": "a" * 40}
+
+        def fake_run(cmd, *args, **kwargs):
+            joined = ",".join(cmd)
+            if "view" in cmd and "mergeable" in joined:
+                return mock.Mock(returncode=0,
+                                 stdout=json.dumps(conflicting_view),
+                                 stderr="")
+            if "view" in cmd and "headRefOid" in joined:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps({"headRefOid": "a" * 40}), stderr="")
+            if "view" in cmd and "--json" in cmd and "number" in cmd:
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
+            if "checks" in cmd and "--json" in cmd:
+                payload = [{"name": "ci", "state": "COMPLETED",
+                            "bucket": "pass"}]
+                return mock.Mock(returncode=0, stdout=json.dumps(payload),
+                                 stderr="")
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   return_value=True) as notify, \
+                 mock.patch.object(pr_watch.shutil, "which",
+                                   return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run",
+                                   side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep",
+                                   return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 3.0]):
+                rc = pr_watch.main([
+                    "--pr", "248", "--repo", "octo/repo", "--interval", "30",
+                ])
+            # The CI verdict itself is untouched — this is additive.
+            self.assertEqual(rc, 0)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+            conflicts = _read_events(journal, "pr_conflict_detected")
+            self.assertEqual(len(conflicts), 1)
+            self.assertEqual(conflicts[0]["head"], "aaaaaaa")
+            prefixes = [c[0][0].split(":")[0] for c in notify.call_args_list]
+            self.assertEqual(sorted(prefixes),
+                             ["CI_COMPLETED", "PR_CONFLICT"])
+
+    def test_canceled_verdict_skips_the_probe(self) -> None:
+        # Cancellation aborts the watch; a second subprocess there would
+        # only surface an ugly traceback on the user's next Ctrl-C.
+        conflict = mock.Mock()
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "_fetch_head_oid",
+                                   return_value=None), \
+                 mock.patch.object(pr_watch, "_evaluate_startup_state",
+                                   return_value=None), \
+                 mock.patch.object(pr_watch, "_self_poll_watch",
+                                   side_effect=KeyboardInterrupt), \
+                 mock.patch.object(pr_watch, "_record_ci_completed"), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   return_value=True), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 1.0]):
+                status, exit_code, _ = pr_watch._run_ci_watch_phase(
+                    pr=248, repo="octo/repo", interval=30, db_path=db,
+                    conflict=conflict)
+        self.assertEqual(status, "canceled")
+        self.assertEqual(exit_code, 2)
+        conflict.probe.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tools/test_relay_scan.py
+++ b/tools/test_relay_scan.py
@@ -51,6 +51,22 @@ class TestComposeMessage(unittest.TestCase):
             "PR_WATCH_ABORTED",
             relay_scan.compose_message("pr_watch_aborted",
                                        {"pr": 5, "error": "boom"}))
+        # Issue #946: relayed so a pane with NO transport configured
+        # (which records no notify_failed by design) still surfaces the
+        # conflict; the wording follows the two conflict shapes.
+        self.assertEqual(
+            relay_scan.compose_message(
+                "pr_conflict_detected",
+                {"pr": 248, "head": "abc1234", "merge_state_status": "DIRTY"}),
+            "PR_CONFLICT: PR #248 (head=abc1234, mergeStateStatus=DIRTY) - "
+            "conflict のため CI が発火しません [relay]")
+        self.assertIn(
+            "CI 判定は出ています",
+            relay_scan.compose_message(
+                "pr_conflict_detected",
+                {"pr": 248, "head": "abc1234", "merge_state_status": "DIRTY",
+                 "ci_settled": True}))
+        self.assertIn("pr_conflict_detected", relay_scan.TERMINAL_KINDS)
         self.assertIn(
             "NOTIFY_FAILED",
             relay_scan.compose_message(


### PR DESCRIPTION
Closes #946

## 概要

conflict (mergeable=CONFLICTING) の PR は GitHub が merge ref を作れず pull_request 系 CI が発火しないため、checks の到着を待つ pr-watch は沈黙する（実害: 2026-08-19 kura PR #248。人間が先に気付いた）。conflict を検知して `pr_conflict_detected` イベント + `PR_CONFLICT` 通知で窓口に知らせ、監視は継続する。

- **3 箇所で検知**: (a) check 0 本の poll（#248 の形）、(b) resolver retry 予算中（push 直後の UNKNOWN 取りこぼし対策）、(c) verdict 確定時（green 後に base が動いて conflict になる形）
- **conflict は終端にしない**: ループを継続し、解消後の新 head の CI を従来どおり追跡（従来は誤解を招く `incomplete` で監視終了していた）
- **1 head 1 回 / UNKNOWN 静穏**: head を dedup キーに、announce 前に台帳記載。UNKNOWN / probe 読み取り失敗は記録も通知もせず制御フローも変えない（壊れた probe が監視を wedge しない）
- **relay 経路対応**: `pr_conflict_detected` を relay_scan の対象に追加（transport 未構成 pane では canonical 行が唯一の痕跡になるため。TERMINAL_KINDS 唯一の非終端 kind として理由コメント付き）
- **既存イベント形・メッセージ形は不変**（ci_completed / CI_COMPLETED は無変更、PR_CONFLICT は横に並ぶだけ）

## 残課題（別 Issue）

- #948: org-pull-request スキル側に PR_CONFLICT 分岐を追加（green + conflict 同時検知で merge 承認へ進まない）— codex R3 P1 のキャリーアウト、.claude self-edit のため別派遣
- #947: CI failed 後の再監視 gap（head 変化検知）— 本実装の `_ConflictWatch` は probe 分岐を閉じておらず、そのまま拡張可能

## Test plan

- `pytest tools/ tests/`: 2041 passed, 6 skipped（新規 40 件強: 3 検知経路 / dedup / UNKNOWN 静穏 / relay）
- codex review (base origin/main) 3 ラウンド: 同一指摘の再出ゼロで収束、R3 P1 は #948 へ切り出し

🤖 Generated with [Claude Code](https://claude.com/claude-code)