### PR TITLE
docs(claude): journal-events の新イベント追加手順に TERMINAL_KINDS 登録ステップを足す

### DIFF
--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -323,6 +323,13 @@ that pane.
 4. Use the helper to write:
    - bash: `bash tools/journal_append.sh <event> k=v k2=v2`
    - python: `py -3 tools/journal_append.py <event> k=v --json '{"nested": {...}}'`
+5. If the dispatcher relay must deliver the event to the secretary (a
+   terminal signal, or any kind that needs the same zero-miss
+   guarantee), register the kind in `TERMINAL_KINDS` in
+   `tools/relay_scan.py`. Kinds missing from that tuple are never
+   relayed — the relay scan skips them and the row sits in state.db as
+   the only trace (Issue #946: `pr_conflict_detected` needed exactly
+   this registration to reach the secretary).
 
 Do **not** hand-craft direct DB inserts (`sqlite3 .state/state.db
 "INSERT INTO events ..."`) or the legacy `printf '%s\n' '{...}' >>


### PR DESCRIPTION
## 概要

キュレーター提案（Issue #946 の実害起点）の反映。relay 配送対象のイベントは `tools/relay_scan.py` の `TERMINAL_KINDS`（relay_scan.py:87-106）へ登録しないと dispatcher relay が配送しないが、docs/journal-events.md の「Adding a new event type」手順にこのステップが無かった。step 5 として追記する（7 行追加のみ）。

## 検証

- `python3 tools/audit_link_paths.py`: journal-events.md への指摘ゼロ
- codex exec review --base origin/main: Blocker/Major ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)