### PR TITLE
feat(claude): PR CI 監視の規律を .claude/rules と PreToolUse フックの 2 段で機械化する

### DIFF
--- a/.claude/rules/pr-ci-watch.md
+++ b/.claude/rules/pr-ci-watch.md
@@ -1,0 +1,6 @@
+# PR の CI 監視は /pr-watch-pane のみ
+
+- PR の CI チェック / 監視の正規経路は `/pr-watch-pane <PR>` だけ（canonical 記録は events テーブルの `ci_completed` 行）。
+- `/pr-watch-pane` が `[split_refused]` 等で立てられないときは、代替監視に流れず**人間に報告して指示を仰ぐ**。自己判断での差し替えは禁止。
+- Monitor / Bash（背景・前景とも）での `gh pr checks` polling ループ、および `tools/pr-watch.sh` / `tools/pr-watch.ps1` / `tools/pr_watch.py` の直接起動による代替監視は禁止（PreToolUse フック [`.hooks/block-adhoc-pr-watch.sh`](../../.hooks/block-adhoc-pr-watch.sh) が機械的に deny する）。
+- 例外: 単発の `gh pr checks <PR>`（ループ・`--watch` なし）による現在状態の確認は監視ではないので可。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -82,6 +82,15 @@
             "command": "bash \"${CLAUDE_PROJECT_DIR}/.hooks/block-foreground-subagent.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Bash|Monitor",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.hooks/block-adhoc-pr-watch.sh\""
+          }
+        ]
       }
     ]
   },

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# PreToolUse Hook: PR CI 監視の ad-hoc 代替 (gh pr checks polling / pr-watch.* 直接起動) をブロックする
+# 方式: exit 2 + stderr メッセージ でブロック
+#
+# 背景 (2026-08-20 実害):
+#   PR #51 の CI 監視で正規経路 /pr-watch-pane が [split_refused] (ペイン枠不足) に
+#   なった際、窓口がスキルの規定 (「報告して中断」) に従わず、セッション寿命依存の
+#   Monitor (gh pr checks の polling ループ) へ自己判断で差し替えた。prose の規律
+#   (root CLAUDE.md「PR 後の CI 監視」節 / .claude/rules/pr-ci-watch.md) だけでは
+#   逸脱を防げなかったため、本フックで機械的に deny する。
+#
+# 検知方針:
+#   1. tool_name が "Bash" / "Monitor" でなければ passthrough (exit 0)。
+#   2. Monitor: command に `gh pr checks` を含んだ時点で deny (Monitor は定義上
+#      「監視」)。Bash: `gh pr checks` + polling 構造 (while / until / for / watch)
+#      または `--watch` フラグを伴うもののみ deny。単発の `gh pr checks <n>`
+#      (ループなし) は状態確認であり監視ではないので許可 (false positive を作らない)。
+#   3. command が tools/pr-watch.sh / tools/pr-watch.ps1 / tools/pr_watch.py を
+#      「コマンド位置」で直接起動するものを deny する。緊急経路はユーザー自身の
+#      `!` 手動実行であり、Claude のツール呼び出しは deny してよい。
+#      grep / cat 等の引数としてファイル名が現れるだけの読み取りは deny しない
+#      (コマンド位置 + 既知ラッパー (bash/nohup/setsid 等) のみを起動とみなす)。
+#
+# 正規経路: /pr-watch-pane <PR> (broker tmux セッション内の専用ペイン、
+# セッション寿命非依存、events テーブルへ ci_completed を記録)。
+# ペイン枠不足等で立てられないときは代替に流れず人間に報告して指示を仰ぐ。
+#
+# 入力: stdin から PreToolUse JSON ({tool_name, tool_input})
+# 出力: 拒否時 exit 2 + stderr。許可時 exit 0。
+#
+# 既知の制限:
+#   - jq が無い環境では fail-closed で対象ツール呼び出しを deny する
+#     (既存 block-foreground-subagent.sh と同じ安全側挙動)。
+#   - 空 stdin / 不正 JSON / 非 object payload も fail-closed で deny する。
+#   - 文字列連結等で難読化された起動 (V=tools/pr-watch; bash "$V.sh") は検出
+#     できない。本フックは「うっかり逸脱」を止める防波堤であり、意図的回避の
+#     完全防御ではない (その層は prose 規律とレビューが担う)。
+
+set -euo pipefail
+
+DENY_GUIDANCE="PR の CI 監視の正規経路は /pr-watch-pane <PR> のみです (.claude/rules/pr-ci-watch.md)。ペイン枠不足 ([split_refused]) 等で立てられない場合は、代替監視に流れず人間に報告して指示を仰いでください。"
+
+deny_with_reason() {
+  local reason="$1"
+  echo "ブロック: $reason $DENY_GUIDANCE" >&2
+  exit 2
+}
+
+# jq チェック (fail closed)
+if ! command -v jq &>/dev/null; then
+  echo "ブロック: jq がインストールされていません。セキュリティ Hook の実行に必要です。" >&2
+  exit 2
+fi
+
+INPUT=$(cat)
+
+# 空 payload の fail-closed ガード (block-foreground-subagent.sh と同じ根拠:
+# jq は「JSON 値ゼロ個」の入力を parse error にせず exit 0 を返すため、
+# 型ガードの手前で明示的に弾く)。
+if [[ -z "${INPUT//[[:space:]]/}" ]]; then
+  deny_with_reason "PreToolUse payload が空でした。安全側 (fail-closed) で拒否します。"
+fi
+
+# top-level が単一の JSON object であることを検証する (fail closed)。
+# `echo` でなく `printf '%s\n'`、`-s` slurp で単一値を要求する理由は
+# block-foreground-subagent.sh の同箇所コメントを参照。
+if ! printf '%s\n' "$INPUT" | jq -e -s 'length == 1 and (.[0] | type) == "object" and (.[0].tool_input == null or (.[0].tool_input | type) == "object")' >/dev/null 2>&1; then
+  deny_with_reason "PreToolUse payload を JSON object として解析できませんでした。安全側 (fail-closed) で拒否します。"
+fi
+
+TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+if [[ "$TOOL_NAME" != "Bash" && "$TOOL_NAME" != "Monitor" ]]; then
+  exit 0
+fi
+
+# 対象ツール確定。command 文字列を取り出す (欠落 / 非文字列は空扱い)。
+# Monitor は ws source (command なし) の形もあるため、command 欠落は許可に倒す
+# (本フックの関心は shell command による polling のみ)。
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command? // empty | if type == "string" then . else "" end' 2>/dev/null || echo "")
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# --- 判定 1: gh pr checks による ad-hoc CI 監視 ---
+# Monitor tool: command に `gh pr checks` を含んだ時点で deny する。Monitor は
+#   定義上「監視」であり、ループの有無によらず gh pr checks を Monitor に載せる
+#   ことがそのまま「正規経路外の CI 監視」になる (2026-08-20 の実害はこの形)。
+# Bash tool: `gh pr checks` に加えて polling 構造を伴う場合のみ deny する:
+#   - シェルのループ構文 (while / until / for) / watch コマンド
+#   - gh 自身の --watch フラグ (gh pr checks <n> --watch は張り付き監視)。
+#     短縮 -w は --web (ブラウザで開く) であり watch ではないので対象外
+#     (gh pr checks --help で実確認済み)。
+#   単発の `gh pr checks <n>` (ループなし) はどれにも該当せず許可される
+#   (false positive を作らない)。
+if printf '%s' "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+checks'; then
+  if [[ "$TOOL_NAME" == "Monitor" ]]; then
+    deny_with_reason "Monitor tool による gh pr checks の CI 監視は禁止です。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
+  fi
+  if printf '%s' "$COMMAND" | grep -qE '(^|[;&|({[:space:]])(while|until|for|watch)([[:space:]]|$)|[[:space:]]--watch([[:space:]=]|$)'; then
+    deny_with_reason "gh pr checks の polling ループ / --watch による ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
+  fi
+fi
+
+# --- 判定 2: tools/pr-watch.* の直接起動 ---
+# コマンド位置 (行頭 / ; & | ( ` $( の直後)、または既知のラッパー
+# (nohup / setsid / exec / env / command / time / bash / sh / zsh / pwsh /
+# powershell / python / python3 / uv run) を介した起動のみを対象にする。
+# `grep foo tools/pr-watch.sh` のような引数位置での出現は起動でないので許可。
+PR_WATCH_LAUNCH_RE='(^|[;&|(`]|\$\()[[:space:]]*((nohup|setsid|exec|env|command|time)[[:space:]]+)*((bash|sh|zsh|pwsh|powershell(\.exe)?|python3?|uv[[:space:]]+run)[[:space:]]+)?[^[:space:]]*(pr-watch\.(sh|ps1)|pr_watch\.py)([[:space:]]|$|["'"'"'])'
+if printf '%s' "$COMMAND" | grep -qE "$PR_WATCH_LAUNCH_RE"; then
+  deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
+fi
+
+exit 0

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -214,7 +214,7 @@ GH_PR_CHECKS_CMD='((^|[;&|({])[[:space:]]*|(^|[[:space:]])(if|then|elif|else|do|
 # --watch は「同一の gh pr checks 呼び出しに付いたフラグ」だけを対象にする:
 # checks の後、コマンド区切り文字を跨がずに --watch トークンへ到達する場合のみ。
 # `gh pr checks 51; other-tool --watch x` のような別コマンドの --watch は拾わない。
-GH_CHECKS_WATCH_RE="$GH_PR_CHECKS_CMD"'([[:space:]]+[^[:space:];&|()]+)*[[:space:]]+--watch([[:space:];&|=]|$)'
+GH_CHECKS_WATCH_RE="$GH_PR_CHECKS_CMD"'([[:space:]]+[^[:space:];&|()]+)*[[:space:]]+--watch([[:space:];&|=)]|$)'
 if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_PR_CHECKS_RE"; then
   if [[ "$TOOL_NAME" == "Monitor" ]] && printf '%s' "$COMMAND_POLL" | grep -qE "$GH_PR_CHECKS_CMD"; then
     deny_with_reason "Monitor tool による gh pr checks の CI 監視は禁止です。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
@@ -268,7 +268,7 @@ if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_PR_CHECKS_RE"; then
   # watch コマンド (path 付き /usr/bin/watch も対象) は done を使わないため別判定:
   # 同一コマンド区間内 (; & | を跨がない) で watch の引数に gh pr checks が
   # 現れる場合を deny する。
-  GH_WATCH_CMD_RE='(^|[;&|({[:space:]])([^[:space:]]*/)?watch[[:space:]][^;&|]*'"$GH_PR_CHECKS_PREFIX"
+  GH_WATCH_CMD_RE='((^|[;&|({])[[:space:]]*|(^|[[:space:]])(if|then|elif|else|do|while|until)[[:space:]]+)([^[:space:]]*/)?watch[[:space:]][^;&|]*'"$GH_PR_CHECKS_PREFIX"
   if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_WATCH_CMD_RE"; then
     deny_with_reason "watch コマンドによる gh pr checks の ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
@@ -314,7 +314,7 @@ PR_WATCH_LAUNCH_SEG_RE='^[[:space:]]*((if|then|elif|else|do|while|until)[[:space
 # `env LC_ALL=C grep -n x tools/pr-watch.sh` / `timeout 1s cat tools/pr-watch.sh`
 # のような「ラッパー越しの読み取り」も LAUNCH_SEG_RE に一致してしまう。同一区間内で
 # 既知の読み取りコマンドが pr-watch ファイルより前に現れる場合は読み取りとみなす。
-PR_WATCH_READER_SEG_RE='(^|[[:space:]])(grep|egrep|fgrep|rg|ag|cat|bat|head|tail|sed|awk|less|more|wc|diff|cmp|stat|file|md5sum|sha[0-9]*sum|cksum|shellcheck|shfmt|cut|sort|uniq|hexdump|xxd|strings|nl|od|ls|realpath|readlink|basename|dirname|du|touch|chmod|cp|mv|ln|git)[[:space:]].*(pr-watch\.(sh|ps1)|pr_watch(\.py)?)'
+PR_WATCH_READER_SEG_RE='(^|[[:space:]])(grep|egrep|fgrep|rg|ag|cat|bat|head|tail|sed|awk|less|more|wc|diff|cmp|stat|file|md5sum|sha[0-9]*sum|cksum|shellcheck|shfmt|cut|sort|uniq|hexdump|xxd|strings|nl|od|ls|realpath|readlink|basename|dirname|du|touch|chmod|cp|mv|ln|git|printf|echo)[[:space:]].*(pr-watch\.(sh|ps1)|pr_watch(\.py)?)'
 # 実行しないインタプリタモードの例外: 構文チェック (`bash -n` / `sh -n`) や
 # バイトコンパイル (`python3 -m py_compile`) はファイルを実行しないため許可する。
 # `-n` は `-nv` のような結合フラグ形も対象。

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -92,7 +92,12 @@ fi
 #     (gh pr checks --help で実確認済み)。
 #   単発の `gh pr checks <n>` (ループなし) はどれにも該当せず許可される
 #   (false positive を作らない)。
-if printf '%s' "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+checks'; then
+# `gh pr checks` の検出は `pr` と `checks` の間の親コマンドフラグ
+# (`gh pr --repo owner/repo checks` / `gh pr -R owner/repo checks` 等) を許容する:
+# 「`-` 始まりのフラグ + 任意でその引数トークン (非 `-` 始まり)」の繰り返しだけを
+# 挟めるようにし、`gh pr view ... checks` のような別サブコマンドは挟めない。
+GH_PR_CHECKS_RE='gh[[:space:]]+pr([[:space:]]+-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+checks([[:space:]]|$)'
+if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
   if [[ "$TOOL_NAME" == "Monitor" ]]; then
     deny_with_reason "Monitor tool による gh pr checks の CI 監視は禁止です。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
@@ -102,11 +107,18 @@ if printf '%s' "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+checks'; then
 fi
 
 # --- 判定 2: tools/pr-watch.* の直接起動 ---
-# コマンド位置 (行頭 / ; & | ( ` $( の直後)、または既知のラッパー
-# (nohup / setsid / exec / env / command / time / bash / sh / zsh / pwsh /
-# powershell / python / python3 / uv run) を介した起動のみを対象にする。
-# `grep foo tools/pr-watch.sh` のような引数位置での出現は起動でないので許可。
-PR_WATCH_LAUNCH_RE='(^|[;&|(`]|\$\()[[:space:]]*((nohup|setsid|exec|env|command|time)[[:space:]]+)*((bash|sh|zsh|pwsh|powershell(\.exe)?|python3?|uv[[:space:]]+run)[[:space:]]+)?[^[:space:]]*(pr-watch\.(sh|ps1)|pr_watch\.py)([[:space:]]|$|["'"'"'])'
+# コマンド位置 (行頭 / ; & | ( ` $( の直後) から pr-watch ファイルまでの間に
+# 挟めるトークンを「起動の前置」に限定して検出する:
+#   - 既知のラッパー / インタプリタ (nohup / setsid / exec / env / command / time /
+#     bash / sh / zsh / dash / ksh / pwsh / powershell / python[3.x] / py / uv / run)。
+#     絶対パス前置 (/usr/bin/bash 等) も許容。
+#   - それらのフラグ (-3 / -u / -c 等の `-` 始まりトークン)
+#   - 環境変数代入 (VAR=value)
+# `grep foo tools/pr-watch.sh` のような読み取りは、先頭トークン grep が上記の
+# いずれでもないため起動とみなされず許可される (false positive を作らない)。
+PR_WATCH_WRAPPER='([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)'
+PR_WATCH_PREFIX_TOKEN="(${PR_WATCH_WRAPPER}|-[^[:space:]]*|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*)"
+PR_WATCH_LAUNCH_RE='(^|[;&|(`]|\$\()[[:space:]]*('"$PR_WATCH_PREFIX_TOKEN"'[[:space:]]+)*[^[:space:]]*(pr-watch\.(sh|ps1)|pr_watch\.py)([[:space:]]|$|["'"'"'])'
 if printf '%s' "$COMMAND" | grep -qE "$PR_WATCH_LAUNCH_RE"; then
   deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
 fi

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -107,49 +107,73 @@ COMMAND=$(printf '%s' "$COMMAND" | tr '\n\r' ';;')
 # フラグ / 引数トークンにコマンド区切り文字 (; & | 括弧) を含めない
 # (`gh --version; pr checks ...` のような別コマンドへの越境 FP を防ぐ)。
 GH_FLAG_TOKENS='([[:space:]]+-[^[:space:];&|()]+([[:space:]]+[^-[:space:];&|()][^[:space:];&|()]*)?)*'
-GH_PR_CHECKS_RE='gh'"$GH_FLAG_TOKENS"'[[:space:]]+pr'"$GH_FLAG_TOKENS"'[[:space:]]+checks([[:space:]]|$)'
+GH_PR_CHECKS_PREFIX='gh'"$GH_FLAG_TOKENS"'[[:space:]]+pr'"$GH_FLAG_TOKENS"'[[:space:]]+checks'
+GH_PR_CHECKS_RE="$GH_PR_CHECKS_PREFIX"'([[:space:];&|)]|$)'
+# --watch は「同一の gh pr checks 呼び出しに付いたフラグ」だけを対象にする:
+# checks の後、コマンド区切り文字を跨がずに --watch トークンへ到達する場合のみ。
+# `gh pr checks 51; other-tool --watch x` のような別コマンドの --watch は拾わない。
+GH_CHECKS_WATCH_RE="$GH_PR_CHECKS_PREFIX"'([[:space:]]+[^[:space:];&|()]+)*[[:space:]]+--watch([[:space:];&|=]|$)'
 if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
   if [[ "$TOOL_NAME" == "Monitor" ]]; then
     deny_with_reason "Monitor tool による gh pr checks の CI 監視は禁止です。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
-  # ループ判定は「ループ構文が gh pr checks より前にある」(= 呼び出しがループ本体に
-  # 入って反復される) 場合のみ deny する。`gh pr checks ... | while read ...` のように
-  # 単発実行の結果をループで加工するだけの形は gh が 1 回しか走らないので許可する
-  # (単発例外の false positive を作らない)。watch は path 付き (/usr/bin/watch) も対象。
+  # 同一呼び出しの --watch フラグ (張り付き監視)。
+  if printf '%s' "$COMMAND" | grep -qE "$GH_CHECKS_WATCH_RE"; then
+    deny_with_reason "gh pr checks --watch による ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
+  fi
+  # ループ判定は「ループ構文が gh pr checks より前にあり、かつその間に loop を閉じる
+  # `done` が無い」(= 呼び出しがループ本体に入って反復される) 場合のみ deny する。
+  #   - `gh pr checks ... | while read ...` (単発結果のループ加工) は gh が 1 回しか
+  #     走らないので許可。
+  #   - `for f in a b; do echo "$f"; done; gh pr checks 51` (閉じたループの後の単発)
+  #     も許可: word `done` の境界で command を分割し、同一区間内で loop 構文 →
+  #     gh pr checks の順に並ぶ場合だけを反復とみなす。
+  # watch コマンドは path 付き (/usr/bin/watch) も対象。
   GH_LOOP_BEFORE_RE='(^|[;&|({[:space:]])(while|until|for|([^[:space:]]*/)?watch)[[:space:]].*'"$GH_PR_CHECKS_RE"
-  if printf '%s' "$COMMAND" | grep -qE "$GH_LOOP_BEFORE_RE|[[:space:]]--watch([[:space:]=]|$)"; then
-    deny_with_reason "gh pr checks の polling ループ / --watch による ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
+  if printf '%s' "$COMMAND" | sed -E 's/(^|[;[:space:]])done([;[:space:]]|$)/\1\n\2/g' | grep -qE "$GH_LOOP_BEFORE_RE"; then
+    deny_with_reason "gh pr checks の polling ループによる ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
 fi
 
 # --- 判定 2: tools/pr-watch.* の直接起動 ---
-# コマンド位置 (行頭 / ; & | ( ` $( の直後) を起点に、次の 3 形を起動とみなす:
+# 次の 3 形を起動とみなす:
 #   a. 環境変数代入 (VAR=value) の連なりの直後に pr-watch ファイル
 #   b. 既知のラッパー / インタプリタが先頭トークンで、その後 (フラグ・引数を挟んで)
 #      pr-watch ファイル。ラッパーは絶対パス前置 (/usr/bin/bash 等) も許容し、
 #      timeout / source / stdbuf / sudo / xargs / py ランチャー / uv 等を含む。
-#      ラッパー確定後の中間トークンは任意 (timeout の `1h` 等) だが、コマンド区切り
-#      文字 (; & | ( )) を含むトークンは跨げない (別コマンドへの越境 FP を防ぐ)。
 #   c. pr-watch ファイルがコマンド位置に直接 (./tools/pr-watch.sh 51 等)
 # `grep foo tools/pr-watch.sh` のような読み取りは、先頭トークン grep がラッパー
 # 一覧に無いため起動とみなされず許可される (false positive を作らない)。
 # python の module 実行 (`python3 -m tools.pr_watch`) も拾うため、ファイル名は
 # 拡張子なしの pr_watch も対象にする。
-# コマンド位置の anchor は、記号境界 (行頭 ; & | ( ` { $( ) に加えてシェルの
-# 予約語境界 (then / do / else / elif) も含める。`if ...; then bash tools/pr-watch.sh; fi`
-# や `while ...; do bash tools/pr-watch.sh; done` の起動を素通りさせないため。
-PR_WATCH_ANCHOR='((^|[;&|(`{]|\$\()[[:space:]]*|(^|[[:space:]])(then|do|else|elif)[[:space:]]+)'
+# 判定はコマンド区切り文字 (; & | ( ) ` { }) で区間に分割し、区間単位で行う。
+# これにより起動判定と読み取り例外が別コマンドへ越境しない
+# (`cat tools/pr-watch.sh && bash tools/pr-watch.sh` の後半は読み取り例外に隠れず
+# deny され、`cat x; bash tools/pr-watch.sh` も後半区間だけで起動と判定される)。
 PR_WATCH_ASSIGN='[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*'
 PR_WATCH_WRAPPER='([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|timeout|stdbuf|source|sudo|doas|xargs|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)'
-PR_WATCH_MIDDLE_TOKEN='[^[:space:];&|()`]+'
 # ファイル名は basename 完全一致で照合する: 前置は `/` (パス) か `.` (python module
-# の package 区切り / 引用符) で終わる場合のみ許容し、`tools/test_pr_watch.py` の
+# の package 区切り) か引用符で終わる場合のみ許容し、`tools/test_pr_watch.py` の
 # ような別名 (前置が `_` 等で終わる) を拾わない。リポジトリ実在の
 # tools/test_pr_watch.py (watcher の unit test) を deny しないための制約。
 PR_WATCH_FILE='(["'"'"']?|[^[:space:]]*[/.'"'"'"])(pr-watch\.(sh|ps1)|pr_watch(\.py)?)([[:space:]]|$|["'"'"'])'
-PR_WATCH_LAUNCH_RE="$PR_WATCH_ANCHOR"'('"$PR_WATCH_ASSIGN"'[[:space:]]+)*('"$PR_WATCH_WRAPPER"'[[:space:]]+('"$PR_WATCH_MIDDLE_TOKEN"'[[:space:]]+)*)?'"$PR_WATCH_FILE"
-if printf '%s' "$COMMAND" | grep -qE "$PR_WATCH_LAUNCH_RE"; then
-  deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
-fi
+# 区間内の起動形: 区間先頭から、予約語 (if/then/elif/else/do/while/until) →
+# 環境変数代入 → ラッパー / インタプリタ (+ その引数トークン任意) の順に前置を
+# 許し、pr-watch ファイルへ到達するもの。先頭トークンがラッパー一覧に無い語
+# (grep / sed 等) の場合は前置が成立せず起動とみなされない。
+PR_WATCH_LAUNCH_SEG_RE='^[[:space:]]*((if|then|elif|else|do|while|until)[[:space:]]+)*('"$PR_WATCH_ASSIGN"'[[:space:]]+)*('"$PR_WATCH_WRAPPER"'[[:space:]]+([^[:space:]]+[[:space:]]+)*)?'"$PR_WATCH_FILE"
+# 読み取り専用コマンドの例外: ラッパーの中間トークンは任意の語を許すため、
+# `env LC_ALL=C grep -n x tools/pr-watch.sh` / `timeout 1s cat tools/pr-watch.sh`
+# のような「ラッパー越しの読み取り」も LAUNCH_SEG_RE に一致してしまう。同一区間内で
+# 既知の読み取りコマンドが pr-watch ファイルより前に現れる場合は読み取りとみなす。
+PR_WATCH_READER_SEG_RE='(^|[[:space:]])(grep|egrep|fgrep|rg|ag|cat|bat|head|tail|sed|awk|less|more|wc|diff|cmp|stat|file|md5sum|sha[0-9]*sum|cksum|shellcheck|shfmt|cut|sort|uniq|hexdump|xxd|strings|nl|od|ls|realpath|readlink|basename|dirname|du|touch|chmod|cp|mv|ln|git)[[:space:]].*(pr-watch\.(sh|ps1)|pr_watch(\.py)?)'
+while IFS= read -r SEGMENT; do
+  [[ -z "${SEGMENT//[[:space:]]/}" ]] && continue
+  if printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_LAUNCH_SEG_RE"; then
+    if ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_SEG_RE"; then
+      deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
+    fi
+  fi
+done < <(printf '%s\n' "$COMMAND" | tr ';&|(){}`' '\n')
 
 exit 0

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -101,24 +101,34 @@ if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
   if [[ "$TOOL_NAME" == "Monitor" ]]; then
     deny_with_reason "Monitor tool による gh pr checks の CI 監視は禁止です。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
-  if printf '%s' "$COMMAND" | grep -qE '(^|[;&|({[:space:]])(while|until|for|watch)([[:space:]]|$)|[[:space:]]--watch([[:space:]=]|$)'; then
+  # ループ判定は「ループ構文が gh pr checks より前にある」(= 呼び出しがループ本体に
+  # 入って反復される) 場合のみ deny する。`gh pr checks ... | while read ...` のように
+  # 単発実行の結果をループで加工するだけの形は gh が 1 回しか走らないので許可する
+  # (単発例外の false positive を作らない)。watch は path 付き (/usr/bin/watch) も対象。
+  GH_LOOP_BEFORE_RE='(^|[;&|({[:space:]])(while|until|for|([^[:space:]]*/)?watch)[[:space:]].*'"$GH_PR_CHECKS_RE"
+  if printf '%s' "$COMMAND" | grep -qE "$GH_LOOP_BEFORE_RE|[[:space:]]--watch([[:space:]=]|$)"; then
     deny_with_reason "gh pr checks の polling ループ / --watch による ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
 fi
 
 # --- 判定 2: tools/pr-watch.* の直接起動 ---
-# コマンド位置 (行頭 / ; & | ( ` $( の直後) から pr-watch ファイルまでの間に
-# 挟めるトークンを「起動の前置」に限定して検出する:
-#   - 既知のラッパー / インタプリタ (nohup / setsid / exec / env / command / time /
-#     bash / sh / zsh / dash / ksh / pwsh / powershell / python[3.x] / py / uv / run)。
-#     絶対パス前置 (/usr/bin/bash 等) も許容。
-#   - それらのフラグ (-3 / -u / -c 等の `-` 始まりトークン)
-#   - 環境変数代入 (VAR=value)
-# `grep foo tools/pr-watch.sh` のような読み取りは、先頭トークン grep が上記の
-# いずれでもないため起動とみなされず許可される (false positive を作らない)。
-PR_WATCH_WRAPPER='([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)'
-PR_WATCH_PREFIX_TOKEN="(${PR_WATCH_WRAPPER}|-[^[:space:]]*|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*)"
-PR_WATCH_LAUNCH_RE='(^|[;&|(`]|\$\()[[:space:]]*('"$PR_WATCH_PREFIX_TOKEN"'[[:space:]]+)*[^[:space:]]*(pr-watch\.(sh|ps1)|pr_watch\.py)([[:space:]]|$|["'"'"'])'
+# コマンド位置 (行頭 / ; & | ( ` $( の直後) を起点に、次の 3 形を起動とみなす:
+#   a. 環境変数代入 (VAR=value) の連なりの直後に pr-watch ファイル
+#   b. 既知のラッパー / インタプリタが先頭トークンで、その後 (フラグ・引数を挟んで)
+#      pr-watch ファイル。ラッパーは絶対パス前置 (/usr/bin/bash 等) も許容し、
+#      timeout / source / stdbuf / sudo / xargs / py ランチャー / uv 等を含む。
+#      ラッパー確定後の中間トークンは任意 (timeout の `1h` 等) だが、コマンド区切り
+#      文字 (; & | ( )) を含むトークンは跨げない (別コマンドへの越境 FP を防ぐ)。
+#   c. pr-watch ファイルがコマンド位置に直接 (./tools/pr-watch.sh 51 等)
+# `grep foo tools/pr-watch.sh` のような読み取りは、先頭トークン grep がラッパー
+# 一覧に無いため起動とみなされず許可される (false positive を作らない)。
+# python の module 実行 (`python3 -m tools.pr_watch`) も拾うため、ファイル名は
+# 拡張子なしの pr_watch も対象にする。
+PR_WATCH_ASSIGN='[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*'
+PR_WATCH_WRAPPER='([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|timeout|stdbuf|source|sudo|doas|xargs|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)'
+PR_WATCH_MIDDLE_TOKEN='[^[:space:];&|()`]+'
+PR_WATCH_FILE='[^[:space:]]*(pr-watch\.(sh|ps1)|pr_watch(\.py)?)([[:space:]]|$|["'"'"'])'
+PR_WATCH_LAUNCH_RE='(^|[;&|(`]|\$\()[[:space:]]*('"$PR_WATCH_ASSIGN"'[[:space:]]+)*('"$PR_WATCH_WRAPPER"'[[:space:]]+('"$PR_WATCH_MIDDLE_TOKEN"'[[:space:]]+)*)?'"$PR_WATCH_FILE"
 if printf '%s' "$COMMAND" | grep -qE "$PR_WATCH_LAUNCH_RE"; then
   deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
 fi

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -93,6 +93,29 @@ fi
 #   単発の `gh pr checks <n>` (ループなし) はどれにも該当せず許可される
 #   (false positive を作らない)。
 # --- command 文字列の正規化 (判定 1 / 2 共通の前処理) ---
+# (0) heredoc の本文を落とす。`cat > doc.md <<'EOF' ... EOF` の本文は shell にとって
+#     データであり、本文中に polling ループのテキストが書かれていても実行されない。
+#     本文行を残すと (2) の改行境界化でコマンド扱いになり false positive になる。
+#     heredoc 開始 (`<<` / `<<-` + 任意で引用された delimiter) を見つけたら、
+#     delimiter 単独行まで本文行を捨てる (1 行 1 heredoc の簡易対応)。
+COMMAND=$(printf '%s\n' "$COMMAND" | awk '
+  BEGIN { inhd = 0; delim = "" }
+  {
+    if (inhd) {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      if (line == delim) inhd = 0
+      next
+    }
+    print
+    if (match($0, /<<-?[[:space:]]*["'"'"']?[A-Za-z_][A-Za-z0-9_]*/)) {
+      d = substr($0, RSTART, RLENGTH)
+      sub(/^<<-?[[:space:]]*["'"'"']?/, "", d)
+      delim = d
+      inhd = 1
+    }
+  }
+')
 # (1) バックスラッシュ継続行 (`\` + 改行) は空白に潰す。シェルはこれを 1 つの
 #     コマンドとして実行するため、改行をコマンド境界にすると `gh pr \<NL> checks`
 #     の分割で検出を素通りする。
@@ -187,7 +210,9 @@ fi
 # これにより起動判定と読み取り例外が別コマンドへ越境しない
 # (`cat tools/pr-watch.sh && bash tools/pr-watch.sh` の後半は読み取り例外に隠れず
 # deny され、`cat x; bash tools/pr-watch.sh` も後半区間だけで起動と判定される)。
-PR_WATCH_ASSIGN='[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*'
+# 環境変数代入は引用された値 (`NOTE='CI watch'` のような空白入り) も 1 トークン
+# として許容する。
+PR_WATCH_ASSIGN='[A-Za-z_][A-Za-z0-9_]*=('"'"'[^'"'"']*'"'"'|"[^"]*"|[^[:space:]]*)'
 # POSIX の dot-source (`. tools/pr-watch.sh`) も source と同じ実行なので `\.` を
 # 単独トークンとしてラッパーに含める。
 PR_WATCH_WRAPPER='(([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|timeout|stdbuf|source|sudo|doas|xargs|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)|\.)'
@@ -195,7 +220,10 @@ PR_WATCH_WRAPPER='(([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|timeout|
 # の package 区切り) か引用符で終わる場合のみ許容し、`tools/test_pr_watch.py` の
 # ような別名 (前置が `_` 等で終わる) を拾わない。リポジトリ実在の
 # tools/test_pr_watch.py (watcher の unit test) を deny しないための制約。
-PR_WATCH_FILE='(["'"'"']?|[^[:space:]]*[/.'"'"'"])(pr-watch\.(sh|ps1)|pr_watch(\.py)?)([[:space:]]|$|["'"'"'])'
+# 前置は `/` `\` (Windows パス) `.` (python module 区切り) 引用符で終わる場合のみ。
+# 終端は空白 / 行末 / 引用符 / リダイレクト (`>` `<`) を認める
+# (`bash tools/pr-watch.sh>/tmp/log` のような密着リダイレクトも起動)。
+PR_WATCH_FILE='(["'"'"']?|[^[:space:]]*[/.\'"'"'"])(pr-watch\.(sh|ps1)|pr_watch(\.py)?)([[:space:]<>]|$|["'"'"'])'
 # 区間内の起動形: 区間先頭から、予約語 (if/then/elif/else/do/while/until) →
 # 環境変数代入 → ラッパー / インタプリタ (+ その引数トークン任意) の順に前置を
 # 許し、pr-watch ファイルへ到達するもの。先頭トークンがラッパー一覧に無い語

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -98,13 +98,18 @@ fi
 #     本文行を残すと (2) の改行境界化でコマンド扱いになり false positive になる。
 #     heredoc 開始 (`<<` / `<<-` + 任意で引用された delimiter) を見つけたら、
 #     delimiter 単独行まで本文行を捨てる (1 行 1 heredoc の簡易対応)。
+#     ただし heredoc がシェルインタプリタ (bash / sh 等) の stdin になっている場合、
+#     本文はデータでなく実行されるコードなので落とさず残す (残した本文は (2) 以降で
+#     コードとして走査される)。
 COMMAND=$(printf '%s\n' "$COMMAND" | awk '
-  BEGIN { inhd = 0; delim = "" }
+  BEGIN { inhd = 0; drop = 0; delim = "" }
   {
     if (inhd) {
       line = $0
       sub(/^[[:space:]]*/, "", line)
-      if (line == delim) inhd = 0
+      if (line == delim) { inhd = 0; next }
+      if (drop) next
+      print
       next
     }
     print
@@ -113,6 +118,8 @@ COMMAND=$(printf '%s\n' "$COMMAND" | awk '
       sub(/^<<-?[[:space:]]*["'"'"']?/, "", d)
       delim = d
       inhd = 1
+      # heredoc の届き先がシェルインタプリタ (bash <<EOF 等) なら本文はコード: 残す
+      drop = (match($0, /(^|[;&|(`[:space:]])([^[:space:]]*\/)?(bash|sh|zsh|dash|ksh|eval)([[:space:]][^<]*)?<</) == 0)
     }
   }
 ')
@@ -124,6 +131,15 @@ COMMAND=${COMMAND//$'\\\n'/ }
 #     gh 呼び出しが別行に割れると検出を素通りする。改行はシェルのコマンド境界なので
 #     `;` への置換は意味を保つ (空白だと「行頭 = コマンド位置」の情報が落ちる)。
 COMMAND=$(printf '%s' "$COMMAND" | tr '\n\r' ';;')
+# (2.5) シェルインタプリタへ渡す引用済みスクリプト (`bash -c '...'` / `eval '...'`)
+#     は引用符を外す。この引用内はデータでなく実行されるコードであり、(3) で区切り
+#     文字を潰すと `bash -c 'while ...; do gh pr checks ...; done'` が素通りする。
+#     `-c` は `-lc` のような結合フラグ形も対象。
+COMMAND=$(printf '%s' "$COMMAND" | sed -E \
+  -e "s/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+'([^']*)'/\3 -c \6/g" \
+  -e 's/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+"([^"]*)"/\3 -c \6/g' \
+  -e "s/(^|[;&|({[:space:]])eval[[:space:]]+'([^']*)'/\1eval \2/g" \
+  -e 's/(^|[;&|({[:space:]])eval[[:space:]]+"([^"]*)"/\1eval \2/g')
 # (3) 引用符の中のコマンド区切り文字 (; & | 括弧 ` ) を空白に潰す。引用内は shell
 #     にとってデータであり、`echo 'x; bash tools/pr-watch.sh 51'` の `;` を境界扱い
 #     すると echo のデータが起動に見える false positive になる。引用符自体と
@@ -171,19 +187,30 @@ if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
   if printf '%s' "$COMMAND" | grep -qE "$GH_CHECKS_WATCH_RE"; then
     deny_with_reason "gh pr checks --watch による ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
-  # ループ判定は「ループ構文 (while/until/for) が gh pr checks より前にあり、かつ
-  # gh pr checks の後にループを閉じる word `done` が続く」(= 呼び出しがループ本体の
-  # 中にある) 場合のみ deny する。ループ本体内の呼び出しは必ず後方の done より前に
-  # あるため、ネスト (`while ...; do for ...; done; gh pr checks; done`) でも外側
-  # ループの done が後方条件を満たして検出される。
+  # ループ判定は「gh pr checks の呼び出し位置が未閉のループスコープ内にある」場合のみ
+  # deny する。各出現位置について、その手前のテキストでループ開始語
+  # (while/until/for/select) と閉じ語 (done) を数え、開始が閉じより多ければその
+  # 呼び出しはループの条件部または本体にあり反復される。
   #   - `gh pr checks ... | while read ...; do ...; done` (単発結果のループ加工) は
-  #     loop 構文が gh より後ろなので許可 (gh は 1 回しか走らない)。
+  #     手前にループ開始が無いので許可 (gh は 1 回しか走らない)。
   #   - `for f in a b; do ...; done; gh pr checks 51` (閉じたループの後の単発) は
-  #     gh の後ろに done が無いので許可。
-  GH_LOOP_BEFORE_RE='(^|[;&|({[:space:]])(while|until|for)[[:space:]].*'"$GH_PR_CHECKS_RE"
-  GH_DONE_AFTER_RE="$GH_PR_CHECKS_PREFIX"'([[:space:];&|)]).*[;[:space:]]done([;[:space:]]|$)'
-  if printf '%s' "$COMMAND" | grep -qE "$GH_LOOP_BEFORE_RE" \
-    && printf '%s' "$COMMAND" | grep -qE "$GH_DONE_AFTER_RE"; then
+  #     開始 1 / 閉じ 1 で釣り合うので許可。兄弟ループが後続しても影響しない。
+  #   - ネスト (`while ...; do for ...; done; gh pr checks; done`) は開始 2 / 閉じ 1
+  #     で未閉スコープ内と判定される。
+  GH_IN_LOOP=$(printf '%s' "$COMMAND" | awk -v ghre="$GH_PR_CHECKS_PREFIX" '
+    {
+      s = $0
+      off = 0
+      while (match(substr(s, off + 1), ghre) > 0) {
+        pos = off + RSTART
+        prefix = substr(s, 1, pos - 1)
+        t = prefix; opens  = gsub(/(^|[;&|({[:space:]])(while|until|for|select)[[:space:]]/, " ", t)
+        t = prefix; closes = gsub(/(^|[;&|([:space:]])done([;&|)[:space:]]|$)/, " ", t)
+        if (opens > closes) { print "in_loop"; exit }
+        off = pos
+      }
+    }')
+  if [[ "$GH_IN_LOOP" == "in_loop" ]]; then
     deny_with_reason "gh pr checks の polling ループによる ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
   # watch コマンド (path 付き /usr/bin/watch も対象) は done を使わないため別判定:
@@ -234,10 +261,15 @@ PR_WATCH_LAUNCH_SEG_RE='^[[:space:]]*((if|then|elif|else|do|while|until)[[:space
 # のような「ラッパー越しの読み取り」も LAUNCH_SEG_RE に一致してしまう。同一区間内で
 # 既知の読み取りコマンドが pr-watch ファイルより前に現れる場合は読み取りとみなす。
 PR_WATCH_READER_SEG_RE='(^|[[:space:]])(grep|egrep|fgrep|rg|ag|cat|bat|head|tail|sed|awk|less|more|wc|diff|cmp|stat|file|md5sum|sha[0-9]*sum|cksum|shellcheck|shfmt|cut|sort|uniq|hexdump|xxd|strings|nl|od|ls|realpath|readlink|basename|dirname|du|touch|chmod|cp|mv|ln|git)[[:space:]].*(pr-watch\.(sh|ps1)|pr_watch(\.py)?)'
+# 実行しないインタプリタモードの例外: 構文チェック (`bash -n` / `sh -n`) や
+# バイトコンパイル (`python3 -m py_compile`) はファイルを実行しないため許可する。
+# `-n` は `-nv` のような結合フラグ形も対象。
+PR_WATCH_NOEXEC_SEG_RE='(^|[[:space:]/])((bash|sh|zsh|dash|ksh)[[:space:]]+-[A-Za-z]*n[A-Za-z]*[[:space:]]|python[0-9.]*[[:space:]]+-m[[:space:]]+py_compile[[:space:]])'
 while IFS= read -r SEGMENT; do
   [[ -z "${SEGMENT//[[:space:]]/}" ]] && continue
   if printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_LAUNCH_SEG_RE"; then
-    if ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_SEG_RE"; then
+    if ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_SEG_RE" \
+      && ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_NOEXEC_SEG_RE"; then
       deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
     fi
   fi

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -92,11 +92,22 @@ fi
 #     (gh pr checks --help で実確認済み)。
 #   単発の `gh pr checks <n>` (ループなし) はどれにも該当せず許可される
 #   (false positive を作らない)。
-# `gh pr checks` の検出は `pr` と `checks` の間の親コマンドフラグ
-# (`gh pr --repo owner/repo checks` / `gh pr -R owner/repo checks` 等) を許容する:
+# 複数行 command は改行を `;` に潰してから判定する。grep は行単位で評価するため、
+# そのままだと `while true; do\n  gh pr checks 51\n  sleep 30\ndone` のような
+# 複数行ループで loop 構文と gh 呼び出しが別行に割れて検出を素通りする。
+# 改行はシェルのコマンド境界なので `;` への置換は意味を保つ (空白への置換だと
+# 「行頭 = コマンド位置」の情報が落ちて判定 2 の anchor を取りこぼす)。
+COMMAND=$(printf '%s' "$COMMAND" | tr '\n\r' ';;')
+
+# `gh pr checks` の検出はフラグの挿入位置 2 箇所を許容する:
+#   - `gh` と `pr` の間の global フラグ (`gh -R owner/repo pr checks` 等)
+#   - `pr` と `checks` の間の親コマンドフラグ (`gh pr --repo owner/repo checks` 等)
 # 「`-` 始まりのフラグ + 任意でその引数トークン (非 `-` 始まり)」の繰り返しだけを
 # 挟めるようにし、`gh pr view ... checks` のような別サブコマンドは挟めない。
-GH_PR_CHECKS_RE='gh[[:space:]]+pr([[:space:]]+-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+checks([[:space:]]|$)'
+# フラグ / 引数トークンにコマンド区切り文字 (; & | 括弧) を含めない
+# (`gh --version; pr checks ...` のような別コマンドへの越境 FP を防ぐ)。
+GH_FLAG_TOKENS='([[:space:]]+-[^[:space:];&|()]+([[:space:]]+[^-[:space:];&|()][^[:space:];&|()]*)?)*'
+GH_PR_CHECKS_RE='gh'"$GH_FLAG_TOKENS"'[[:space:]]+pr'"$GH_FLAG_TOKENS"'[[:space:]]+checks([[:space:]]|$)'
 if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
   if [[ "$TOOL_NAME" == "Monitor" ]]; then
     deny_with_reason "Monitor tool による gh pr checks の CI 監視は禁止です。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
@@ -124,11 +135,19 @@ fi
 # 一覧に無いため起動とみなされず許可される (false positive を作らない)。
 # python の module 実行 (`python3 -m tools.pr_watch`) も拾うため、ファイル名は
 # 拡張子なしの pr_watch も対象にする。
+# コマンド位置の anchor は、記号境界 (行頭 ; & | ( ` { $( ) に加えてシェルの
+# 予約語境界 (then / do / else / elif) も含める。`if ...; then bash tools/pr-watch.sh; fi`
+# や `while ...; do bash tools/pr-watch.sh; done` の起動を素通りさせないため。
+PR_WATCH_ANCHOR='((^|[;&|(`{]|\$\()[[:space:]]*|(^|[[:space:]])(then|do|else|elif)[[:space:]]+)'
 PR_WATCH_ASSIGN='[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*'
 PR_WATCH_WRAPPER='([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|timeout|stdbuf|source|sudo|doas|xargs|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)'
 PR_WATCH_MIDDLE_TOKEN='[^[:space:];&|()`]+'
-PR_WATCH_FILE='[^[:space:]]*(pr-watch\.(sh|ps1)|pr_watch(\.py)?)([[:space:]]|$|["'"'"'])'
-PR_WATCH_LAUNCH_RE='(^|[;&|(`]|\$\()[[:space:]]*('"$PR_WATCH_ASSIGN"'[[:space:]]+)*('"$PR_WATCH_WRAPPER"'[[:space:]]+('"$PR_WATCH_MIDDLE_TOKEN"'[[:space:]]+)*)?'"$PR_WATCH_FILE"
+# ファイル名は basename 完全一致で照合する: 前置は `/` (パス) か `.` (python module
+# の package 区切り / 引用符) で終わる場合のみ許容し、`tools/test_pr_watch.py` の
+# ような別名 (前置が `_` 等で終わる) を拾わない。リポジトリ実在の
+# tools/test_pr_watch.py (watcher の unit test) を deny しないための制約。
+PR_WATCH_FILE='(["'"'"']?|[^[:space:]]*[/.'"'"'"])(pr-watch\.(sh|ps1)|pr_watch(\.py)?)([[:space:]]|$|["'"'"'])'
+PR_WATCH_LAUNCH_RE="$PR_WATCH_ANCHOR"'('"$PR_WATCH_ASSIGN"'[[:space:]]+)*('"$PR_WATCH_WRAPPER"'[[:space:]]+('"$PR_WATCH_MIDDLE_TOKEN"'[[:space:]]+)*)?'"$PR_WATCH_FILE"
 if printf '%s' "$COMMAND" | grep -qE "$PR_WATCH_LAUNCH_RE"; then
   deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
 fi

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -120,8 +120,9 @@ COMMAND=$(printf '%s\n' "$COMMAND" | awk '
       inhd = 1
       # heredoc の届き先がシェルインタプリタなら本文はコード: 残す。
       # 前置形 (bash <<EOF) と pipe 消費形 (cat <<EOF | bash) の両方を見る。
+      # pipe 消費形はラッパー越し (cat <<EOF | env bash 等) も認める。
       drop = (match($0, /(^|[;&|(`[:space:]])([^[:space:]]*\/)?(bash|sh|zsh|dash|ksh|eval)([[:space:]][^<]*)?<</) == 0 \
-              && match($0, /\|[[:space:]]*([^[:space:]]*\/)?(bash|sh|zsh|dash|ksh)([[:space:]]|$)/) == 0)
+              && match($0, /\|[[:space:]]*(([^[:space:]]*\/)?(env|nohup|setsid|command|time|timeout|stdbuf|sudo|doas|xargs)[[:space:]]+([^|;&]*[[:space:]])?)?([^[:space:]]*\/)?(bash|sh|zsh|dash|ksh)([[:space:]]|$)/) == 0)
     }
   }
 ')
@@ -138,10 +139,10 @@ COMMAND=$(printf '%s' "$COMMAND" | tr '\n\r' ';;')
 #     文字を潰すと `bash -c 'while ...; do gh pr checks ...; done'` が素通りする。
 #     `-c` は `-lc` のような結合フラグ形も対象。
 COMMAND=$(printf '%s' "$COMMAND" | sed -E \
-  -e "s/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+'([^']*)'/\3 -c \6/g" \
-  -e 's/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+"([^"]*)"/\3 -c \6/g' \
-  -e "s/(^|[;&|({[:space:]])eval[[:space:]]+'([^']*)'/\1eval \2/g" \
-  -e 's/(^|[;&|({[:space:]])eval[[:space:]]+"([^"]*)"/\1eval \2/g' \
+  -e "s/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+'([^']*)'/\3 -c ;\6/g" \
+  -e 's/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+"([^"]*)"/\3 -c ;\6/g' \
+  -e "s/(^|[;&|({[:space:]])eval[[:space:]]+'([^']*)'/\1eval ;\2/g" \
+  -e 's/(^|[;&|({[:space:]])eval[[:space:]]+"([^"]*)"/\1eval ;\2/g' \
   -e "s/(^|[;&|({[:space:]])(([^[:space:]\/]*\/)*)?watch((([[:space:]]+-[^[:space:]]+)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*)[[:space:]]+'([^']*)'/\1watch\4 \8/g" \
   -e 's/(^|[;&|({[:space:]])(([^[:space:]\/]*\/)*)?watch((([[:space:]]+-[^[:space:]]+)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*)[[:space:]]+"([^"]*)"/\1watch\4 \8/g')
 # (3) 引用符の中のコマンド区切り文字 (; & | 括弧 ` ) を空白に潰す。引用内は shell
@@ -205,12 +206,17 @@ COMMAND_POLL=$(printf '%s' "$COMMAND" | awk '{
 GH_FLAG_TOKENS='([[:space:]]+-[^[:space:];&|()]+([[:space:]]+[^-[:space:];&|()][^[:space:];&|()]*)?)*'
 GH_PR_CHECKS_PREFIX='gh'"$GH_FLAG_TOKENS"'[[:space:]]+pr'"$GH_FLAG_TOKENS"'[[:space:]]+checks'
 GH_PR_CHECKS_RE="$GH_PR_CHECKS_PREFIX"'([[:space:];&|)]|$)'
+# コマンド位置の gh: 区切り記号 / 予約語境界の直後 (環境変数代入・パス前置は許容)。
+# `echo gh pr checks 51` のような引数テキスト (gh が別コマンドの引数) を polling と
+# 誤認しないための左境界。watch の引数位置 (`watch -n 30 gh pr checks`) は
+# GH_WATCH_CMD_RE 側で別途照合するのでここには含めない。
+GH_PR_CHECKS_CMD='((^|[;&|({])[[:space:]]*|(^|[[:space:]])(if|then|elif|else|do|while|until)[[:space:]]+)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*([^[:space:]]*/)?'"$GH_PR_CHECKS_PREFIX"
 # --watch は「同一の gh pr checks 呼び出しに付いたフラグ」だけを対象にする:
 # checks の後、コマンド区切り文字を跨がずに --watch トークンへ到達する場合のみ。
 # `gh pr checks 51; other-tool --watch x` のような別コマンドの --watch は拾わない。
-GH_CHECKS_WATCH_RE="$GH_PR_CHECKS_PREFIX"'([[:space:]]+[^[:space:];&|()]+)*[[:space:]]+--watch([[:space:];&|=]|$)'
+GH_CHECKS_WATCH_RE="$GH_PR_CHECKS_CMD"'([[:space:]]+[^[:space:];&|()]+)*[[:space:]]+--watch([[:space:];&|=]|$)'
 if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_PR_CHECKS_RE"; then
-  if [[ "$TOOL_NAME" == "Monitor" ]]; then
+  if [[ "$TOOL_NAME" == "Monitor" ]] && printf '%s' "$COMMAND_POLL" | grep -qE "$GH_PR_CHECKS_CMD"; then
     deny_with_reason "Monitor tool による gh pr checks の CI 監視は禁止です。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
   # 同一呼び出しの --watch フラグ (張り付き監視)。
@@ -229,12 +235,18 @@ if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_PR_CHECKS_RE"; then
   #     で未閉スコープ内と判定される。
   # ループ開始語の直後は空白のほか `;` (改行由来: `until\n gh ...`) と `(`
   # (算術 for: `for((;;))`) も境界として認める。
-  GH_IN_LOOP=$(printf '%s' "$COMMAND_POLL" | awk -v ghre="$GH_PR_CHECKS_PREFIX" '
+  # awk には CMD 形 (境界込み) と PREFIX 形 (gh 本体) の両方を渡す。CMD 形の一致は
+  # 予約語境界 (until 等) を一致範囲に含むため、そのまま prefix を切るとループ開始語
+  # が prefix から消えて計数を誤る。CMD 一致範囲の中で PREFIX の開始位置を取り直し、
+  # その手前までを prefix とする。
+  GH_IN_LOOP=$(printf '%s' "$COMMAND_POLL" | awk -v ghre="$GH_PR_CHECKS_CMD" -v ghpre="$GH_PR_CHECKS_PREFIX" '
     {
       s = $0
       off = 0
       while (match(substr(s, off + 1), ghre) > 0) {
         pos = off + RSTART
+        rest = substr(s, pos)
+        if (match(rest, ghpre) > 0) pos = pos + RSTART - 1
         prefix = substr(s, 1, pos - 1)
         t = prefix; opens  = gsub(/(^|[;&|({[:space:]])(while|until|for|select)([[:space:](;]|$)/, " ", t)
         t = prefix; closes = gsub(/(^|[;&|([:space:]])done([;&|)[:space:]]|$)/, " ", t)
@@ -290,7 +302,9 @@ PR_WATCH_WRAPPER='(([^[:space:]]*/)?(nohup|setsid|exec|env|command|eval|time|tim
 # 前置は `/` `\` (Windows パス) `.` (python module 区切り) 引用符で終わる場合のみ。
 # 終端は空白 / 行末 / 引用符 / リダイレクト (`>` `<`) を認める
 # (`bash tools/pr-watch.sh>/tmp/log` のような密着リダイレクトも起動)。
-PR_WATCH_FILE='(["'"'"']?|[^[:space:]]*[/.\'"'"'"])(pr-watch\.(sh|ps1)|pr_watch(\.py)?)([[:space:]<>]|$|["'"'"'])'
+# 前置に `=` を含めない: `SCRIPT=tools/pr-watch.sh` のような変数代入の値は
+# 実行されないデータであり、起動として誤検出しない。
+PR_WATCH_FILE='(["'"'"']?|[^[:space:]=]*[/.\'"'"'"])(pr-watch\.(sh|ps1)|pr_watch(\.py)?)([[:space:]<>]|$|["'"'"'])'
 # 区間内の起動形: 区間先頭から、予約語 (if/then/elif/else/do/while/until) →
 # 環境変数代入 → ラッパー / インタプリタ (+ その引数トークン任意) の順に前置を
 # 許し、pr-watch ファイルへ到達するもの。先頭トークンがラッパー一覧に無い語

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -92,12 +92,39 @@ fi
 #     (gh pr checks --help で実確認済み)。
 #   単発の `gh pr checks <n>` (ループなし) はどれにも該当せず許可される
 #   (false positive を作らない)。
-# 複数行 command は改行を `;` に潰してから判定する。grep は行単位で評価するため、
-# そのままだと `while true; do\n  gh pr checks 51\n  sleep 30\ndone` のような
-# 複数行ループで loop 構文と gh 呼び出しが別行に割れて検出を素通りする。
-# 改行はシェルのコマンド境界なので `;` への置換は意味を保つ (空白への置換だと
-# 「行頭 = コマンド位置」の情報が落ちて判定 2 の anchor を取りこぼす)。
+# --- command 文字列の正規化 (判定 1 / 2 共通の前処理) ---
+# (1) バックスラッシュ継続行 (`\` + 改行) は空白に潰す。シェルはこれを 1 つの
+#     コマンドとして実行するため、改行をコマンド境界にすると `gh pr \<NL> checks`
+#     の分割で検出を素通りする。
+COMMAND=${COMMAND//$'\\\n'/ }
+# (2) 残る改行を `;` に潰す。grep は行単位で評価するため、複数行ループで loop 構文と
+#     gh 呼び出しが別行に割れると検出を素通りする。改行はシェルのコマンド境界なので
+#     `;` への置換は意味を保つ (空白だと「行頭 = コマンド位置」の情報が落ちる)。
 COMMAND=$(printf '%s' "$COMMAND" | tr '\n\r' ';;')
+# (3) 引用符の中のコマンド区切り文字 (; & | 括弧 ` ) を空白に潰す。引用内は shell
+#     にとってデータであり、`echo 'x; bash tools/pr-watch.sh 51'` の `;` を境界扱い
+#     すると echo のデータが起動に見える false positive になる。引用符自体と
+#     その他の文字は保持する (bash -c '...' 内の起動は引き続き検出できる)。
+COMMAND=$(printf '%s' "$COMMAND" | awk '{
+  out = ""; sq = 0; dq = 0
+  n = length($0)
+  for (i = 1; i <= n; i++) {
+    c = substr($0, i, 1)
+    if (sq) {
+      if (c == "\x27") sq = 0
+      else if (index(";&|(){}`", c)) c = " "
+    } else if (dq) {
+      if (c == "\\") { out = out c; i++; c = (i <= n) ? substr($0, i, 1) : ""; out = out c; continue }
+      if (c == "\"") dq = 0
+      else if (index(";&|(){}`", c)) c = " "
+    } else {
+      if (c == "\x27") sq = 1
+      else if (c == "\"") dq = 1
+    }
+    out = out c
+  }
+  print out
+}')
 
 # `gh pr checks` の検出はフラグの挿入位置 2 箇所を許容する:
 #   - `gh` と `pr` の間の global フラグ (`gh -R owner/repo pr checks` 等)
@@ -121,17 +148,27 @@ if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
   if printf '%s' "$COMMAND" | grep -qE "$GH_CHECKS_WATCH_RE"; then
     deny_with_reason "gh pr checks --watch による ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
-  # ループ判定は「ループ構文が gh pr checks より前にあり、かつその間に loop を閉じる
-  # `done` が無い」(= 呼び出しがループ本体に入って反復される) 場合のみ deny する。
-  #   - `gh pr checks ... | while read ...` (単発結果のループ加工) は gh が 1 回しか
-  #     走らないので許可。
-  #   - `for f in a b; do echo "$f"; done; gh pr checks 51` (閉じたループの後の単発)
-  #     も許可: word `done` の境界で command を分割し、同一区間内で loop 構文 →
-  #     gh pr checks の順に並ぶ場合だけを反復とみなす。
-  # watch コマンドは path 付き (/usr/bin/watch) も対象。
-  GH_LOOP_BEFORE_RE='(^|[;&|({[:space:]])(while|until|for|([^[:space:]]*/)?watch)[[:space:]].*'"$GH_PR_CHECKS_RE"
-  if printf '%s' "$COMMAND" | sed -E 's/(^|[;[:space:]])done([;[:space:]]|$)/\1\n\2/g' | grep -qE "$GH_LOOP_BEFORE_RE"; then
+  # ループ判定は「ループ構文 (while/until/for) が gh pr checks より前にあり、かつ
+  # gh pr checks の後にループを閉じる word `done` が続く」(= 呼び出しがループ本体の
+  # 中にある) 場合のみ deny する。ループ本体内の呼び出しは必ず後方の done より前に
+  # あるため、ネスト (`while ...; do for ...; done; gh pr checks; done`) でも外側
+  # ループの done が後方条件を満たして検出される。
+  #   - `gh pr checks ... | while read ...; do ...; done` (単発結果のループ加工) は
+  #     loop 構文が gh より後ろなので許可 (gh は 1 回しか走らない)。
+  #   - `for f in a b; do ...; done; gh pr checks 51` (閉じたループの後の単発) は
+  #     gh の後ろに done が無いので許可。
+  GH_LOOP_BEFORE_RE='(^|[;&|({[:space:]])(while|until|for)[[:space:]].*'"$GH_PR_CHECKS_RE"
+  GH_DONE_AFTER_RE="$GH_PR_CHECKS_PREFIX"'([[:space:];&|)]).*[;[:space:]]done([;[:space:]]|$)'
+  if printf '%s' "$COMMAND" | grep -qE "$GH_LOOP_BEFORE_RE" \
+    && printf '%s' "$COMMAND" | grep -qE "$GH_DONE_AFTER_RE"; then
     deny_with_reason "gh pr checks の polling ループによる ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
+  fi
+  # watch コマンド (path 付き /usr/bin/watch も対象) は done を使わないため別判定:
+  # 同一コマンド区間内 (; & | を跨がない) で watch の引数に gh pr checks が
+  # 現れる場合を deny する。
+  GH_WATCH_CMD_RE='(^|[;&|({[:space:]])([^[:space:]]*/)?watch[[:space:]][^;&|]*'"$GH_PR_CHECKS_PREFIX"
+  if printf '%s' "$COMMAND" | grep -qE "$GH_WATCH_CMD_RE"; then
+    deny_with_reason "watch コマンドによる gh pr checks の ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
 fi
 
@@ -151,7 +188,9 @@ fi
 # (`cat tools/pr-watch.sh && bash tools/pr-watch.sh` の後半は読み取り例外に隠れず
 # deny され、`cat x; bash tools/pr-watch.sh` も後半区間だけで起動と判定される)。
 PR_WATCH_ASSIGN='[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*'
-PR_WATCH_WRAPPER='([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|timeout|stdbuf|source|sudo|doas|xargs|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)'
+# POSIX の dot-source (`. tools/pr-watch.sh`) も source と同じ実行なので `\.` を
+# 単独トークンとしてラッパーに含める。
+PR_WATCH_WRAPPER='(([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|timeout|stdbuf|source|sudo|doas|xargs|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)|\.)'
 # ファイル名は basename 完全一致で照合する: 前置は `/` (パス) か `.` (python module
 # の package 区切り) か引用符で終わる場合のみ許容し、`tools/test_pr_watch.py` の
 # ような別名 (前置が `_` 等で終わる) を拾わない。リポジトリ実在の

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -141,27 +141,55 @@ COMMAND=$(printf '%s' "$COMMAND" | sed -E \
   -e "s/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+'([^']*)'/\3 -c \6/g" \
   -e 's/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+"([^"]*)"/\3 -c \6/g' \
   -e "s/(^|[;&|({[:space:]])eval[[:space:]]+'([^']*)'/\1eval \2/g" \
-  -e 's/(^|[;&|({[:space:]])eval[[:space:]]+"([^"]*)"/\1eval \2/g')
+  -e 's/(^|[;&|({[:space:]])eval[[:space:]]+"([^"]*)"/\1eval \2/g' \
+  -e "s/(^|[;&|({[:space:]])(([^[:space:]\/]*\/)*)?watch((([[:space:]]+-[^[:space:]]+)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*)[[:space:]]+'([^']*)'/\1watch\4 \8/g" \
+  -e 's/(^|[;&|({[:space:]])(([^[:space:]\/]*\/)*)?watch((([[:space:]]+-[^[:space:]]+)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*)[[:space:]]+"([^"]*)"/\1watch\4 \8/g')
 # (3) 引用符の中のコマンド区切り文字 (; & | 括弧 ` ) を空白に潰す。引用内は shell
 #     にとってデータであり、`echo 'x; bash tools/pr-watch.sh 51'` の `;` を境界扱い
 #     すると echo のデータが起動に見える false positive になる。引用符自体と
 #     その他の文字は保持する (bash -c '...' 内の起動は引き続き検出できる)。
+#     例外: 二重引用内の `$( ... )` (コマンド置換) は shell が実行するコードなので
+#     潰さずそのまま残す (`echo "$(bash tools/pr-watch.sh 51)"` は起動)。
 COMMAND=$(printf '%s' "$COMMAND" | awk '{
-  out = ""; sq = 0; dq = 0
+  out = ""; sq = 0; dq = 0; cs = 0
   n = length($0)
   for (i = 1; i <= n; i++) {
     c = substr($0, i, 1)
     if (sq) {
       if (c == "\x27") sq = 0
       else if (index(";&|(){}`", c)) c = " "
+    } else if (dq && cs > 0) {
+      # 二重引用内のコマンド置換: コードとして保持し、括弧の深さだけ追跡する
+      if (c == "(") cs++
+      else if (c == ")") cs--
     } else if (dq) {
       if (c == "\\") { out = out c; i++; c = (i <= n) ? substr($0, i, 1) : ""; out = out c; continue }
       if (c == "\"") dq = 0
+      else if (c == "$" && substr($0, i + 1, 1) == "(") { cs = 1; out = out c; i++; c = "(" }
       else if (index(";&|(){}`", c)) c = " "
     } else {
       if (c == "\x27") sq = 1
       else if (c == "\"") dq = 1
     }
+    out = out c
+  }
+  print out
+}')
+# (4) 判定 1 (polling 検出) 用に、単一引用内をすべて空白にマスクした変体を作る。
+#     この時点で残っている単一引用内は純データ (実行される bash -c / eval / watch の
+#     引用は (2.5) で既に外れている) であり、`printf '%s' 'docs: while ...; do gh pr
+#     checks ...; done'` のような文書テキストを polling と誤認しないため。
+#     判定 2 は引用込みの COMMAND を使う (引用されたパス引数 `pwsh '.\tools\...'` を
+#     見る必要があるため)。
+COMMAND_POLL=$(printf '%s' "$COMMAND" | awk '{
+  out = ""; sq = 0
+  n = length($0)
+  for (i = 1; i <= n; i++) {
+    c = substr($0, i, 1)
+    if (sq) {
+      if (c == "\x27") sq = 0
+      else c = " "
+    } else if (c == "\x27") sq = 1
     out = out c
   }
   print out
@@ -181,12 +209,12 @@ GH_PR_CHECKS_RE="$GH_PR_CHECKS_PREFIX"'([[:space:];&|)]|$)'
 # checks の後、コマンド区切り文字を跨がずに --watch トークンへ到達する場合のみ。
 # `gh pr checks 51; other-tool --watch x` のような別コマンドの --watch は拾わない。
 GH_CHECKS_WATCH_RE="$GH_PR_CHECKS_PREFIX"'([[:space:]]+[^[:space:];&|()]+)*[[:space:]]+--watch([[:space:];&|=]|$)'
-if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
+if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_PR_CHECKS_RE"; then
   if [[ "$TOOL_NAME" == "Monitor" ]]; then
     deny_with_reason "Monitor tool による gh pr checks の CI 監視は禁止です。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
   # 同一呼び出しの --watch フラグ (張り付き監視)。
-  if printf '%s' "$COMMAND" | grep -qE "$GH_CHECKS_WATCH_RE"; then
+  if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_CHECKS_WATCH_RE"; then
     deny_with_reason "gh pr checks --watch による ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
   # ループ判定は「gh pr checks の呼び出し位置が未閉のループスコープ内にある」場合のみ
@@ -201,7 +229,7 @@ if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
   #     で未閉スコープ内と判定される。
   # ループ開始語の直後は空白のほか `;` (改行由来: `until\n gh ...`) と `(`
   # (算術 for: `for((;;))`) も境界として認める。
-  GH_IN_LOOP=$(printf '%s' "$COMMAND" | awk -v ghre="$GH_PR_CHECKS_PREFIX" '
+  GH_IN_LOOP=$(printf '%s' "$COMMAND_POLL" | awk -v ghre="$GH_PR_CHECKS_PREFIX" '
     {
       s = $0
       off = 0
@@ -221,15 +249,15 @@ if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
   # のように関数へ包むと、gh の出現位置自体はループ外になり上の計数を逃れる。
   # 関数呼び出しの追跡は静的にはできないため、「関数定義 + ループ構文 + gh pr checks」
   # が 1 つの command に同居する形は反復とみなして保守的に deny する。
-  if printf '%s' "$COMMAND" | grep -qE '[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(\)' \
-    && printf '%s' "$COMMAND" | grep -qE '(^|[;&|({[:space:]])(while|until|for|select)([[:space:](;]|$)'; then
+  if printf '%s' "$COMMAND_POLL" | grep -qE '[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(\)' \
+    && printf '%s' "$COMMAND_POLL" | grep -qE '(^|[;&|({[:space:]])(while|until|for|select)([[:space:](;]|$)'; then
     deny_with_reason "関数定義とループ構文を伴う gh pr checks は、関数経由の polling とみなして保守的に拒否します (${TOOL_NAME} tool)。単発確認は関数・ループに包まず gh pr checks <PR> を直接 1 回だけ実行してください。"
   fi
   # watch コマンド (path 付き /usr/bin/watch も対象) は done を使わないため別判定:
   # 同一コマンド区間内 (; & | を跨がない) で watch の引数に gh pr checks が
   # 現れる場合を deny する。
   GH_WATCH_CMD_RE='(^|[;&|({[:space:]])([^[:space:]]*/)?watch[[:space:]][^;&|]*'"$GH_PR_CHECKS_PREFIX"
-  if printf '%s' "$COMMAND" | grep -qE "$GH_WATCH_CMD_RE"; then
+  if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_WATCH_CMD_RE"; then
     deny_with_reason "watch コマンドによる gh pr checks の ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
   fi
 fi
@@ -254,7 +282,7 @@ fi
 PR_WATCH_ASSIGN='[A-Za-z_][A-Za-z0-9_]*=('"'"'[^'"'"']*'"'"'|"[^"]*"|[^[:space:]]*)'
 # POSIX の dot-source (`. tools/pr-watch.sh`) も source と同じ実行なので `\.` を
 # 単独トークンとしてラッパーに含める。
-PR_WATCH_WRAPPER='(([^[:space:]]*/)?(nohup|setsid|exec|env|command|time|timeout|stdbuf|source|sudo|doas|xargs|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)|\.)'
+PR_WATCH_WRAPPER='(([^[:space:]]*/)?(nohup|setsid|exec|env|command|eval|time|timeout|stdbuf|source|sudo|doas|xargs|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)|\.)'
 # ファイル名は basename 完全一致で照合する: 前置は `/` (パス) か `.` (python module
 # の package 区切り) か引用符で終わる場合のみ許容し、`tools/test_pr_watch.py` の
 # ような別名 (前置が `_` 等で終わる) を拾わない。リポジトリ実在の
@@ -277,22 +305,19 @@ PR_WATCH_READER_SEG_RE='(^|[[:space:]])(grep|egrep|fgrep|rg|ag|cat|bat|head|tail
 # バイトコンパイル (`python3 -m py_compile`) はファイルを実行しないため許可する。
 # `-n` は `-nv` のような結合フラグ形も対象。
 PR_WATCH_NOEXEC_SEG_RE='(^|[[:space:]/])((bash|sh|zsh|dash|ksh)[[:space:]]+-[A-Za-z]*n[A-Za-z]*[[:space:]]|python[0-9.]*[[:space:]]+-m[[:space:]]+py_compile[[:space:]])'
-# 読み取り例外の無効化: 読み取り語と pr-watch ファイルの間にシェルインタプリタ名が
-# 挟まる場合 (`sudo -u git bash tools/pr-watch.sh` — `git` はユーザー名であって
-# 読み取りコマンドではない) は、実効コマンドが shell = 起動なので例外を適用しない。
-PR_WATCH_READER_VOID_RE='(^|[[:space:]])(grep|egrep|fgrep|rg|ag|cat|bat|head|tail|sed|awk|less|more|wc|diff|cmp|stat|file|md5sum|sha[0-9]*sum|cksum|shellcheck|shfmt|cut|sort|uniq|hexdump|xxd|strings|nl|od|ls|realpath|readlink|basename|dirname|du|touch|chmod|cp|mv|ln|git)[[:space:]]+([^[:space:]]+[[:space:]]+)*([^[:space:]]*/)?(bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py)[[:space:]].*(pr-watch\.(sh|ps1)|pr_watch(\.py)?)'
+# sudo / doas の値付きフラグ (`sudo -u git ...` の `git` はユーザー名) は、reader
+# 例外の判定前に区間から取り除く。除去しないと `git` が読み取りコマンド語と誤認され、
+# `sudo -u git bash tools/pr-watch.sh` が読み取り扱いで素通りする。除去後の区間
+# (`bash tools/pr-watch.sh ...`) は通常の起動判定に掛かる。grep のパターン引数が
+# たまたま `bash` である読み取り (`grep -n bash tools/pr-watch.sh`) は sudo/doas が
+# 無いので影響を受けず、reader 例外がそのまま効く。
+PR_WATCH_SUDO_STRIP_RE='(^|[[:space:]])(sudo|doas)(([[:space:]]+-[^[:space:]]+)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+'
 while IFS= read -r SEGMENT; do
   [[ -z "${SEGMENT//[[:space:]]/}" ]] && continue
+  SEGMENT=$(printf '%s' "$SEGMENT" | sed -E "s/$PR_WATCH_SUDO_STRIP_RE/\1/g")
   if printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_LAUNCH_SEG_RE"; then
-    READER_EXEMPT=0
-    if printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_SEG_RE" \
-      && ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_VOID_RE"; then
-      READER_EXEMPT=1
-    fi
-    if printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_NOEXEC_SEG_RE"; then
-      READER_EXEMPT=1
-    fi
-    if [[ "$READER_EXEMPT" -eq 0 ]]; then
+    if ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_SEG_RE" \
+      && ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_NOEXEC_SEG_RE"; then
       deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
     fi
   fi

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -1,340 +1,54 @@
 #!/usr/bin/env bash
-# PreToolUse Hook: PR CI 監視の ad-hoc 代替 (gh pr checks polling / pr-watch.* 直接起動) をブロックする
-# 方式: exit 2 + stderr メッセージ でブロック
+# PreToolUse Hook: ad-hoc PR CI 監視の定型逸脱を止める best-effort の安全網
 #
-# 背景 (2026-08-20 実害):
-#   PR #51 の CI 監視で正規経路 /pr-watch-pane が [split_refused] (ペイン枠不足) に
-#   なった際、窓口がスキルの規定 (「報告して中断」) に従わず、セッション寿命依存の
-#   Monitor (gh pr checks の polling ループ) へ自己判断で差し替えた。prose の規律
-#   (root CLAUDE.md「PR 後の CI 監視」節 / .claude/rules/pr-ci-watch.md) だけでは
-#   逸脱を防げなかったため、本フックで機械的に deny する。
+# 設計方針 (確定):
+#   - best-effort: Claude 自身の定型的な逸脱 (Monitor / Bash での gh pr checks
+#     polling ループ、tools/pr-watch.* 直接起動) だけを止める。敵対者対策ではない。
+#   - bash の完全パースは非目標。false negative (すり抜け) は許容する。
+#   - すり抜けは一次規律 .claude/rules/pr-ci-watch.md と人間レビューが受ける。
 #
-# 検知方針:
-#   1. tool_name が "Bash" / "Monitor" でなければ passthrough (exit 0)。
-#   2. Monitor: command に `gh pr checks` を含んだ時点で deny (Monitor は定義上
-#      「監視」)。Bash: `gh pr checks` + polling 構造 (while / until / for / watch)
-#      または `--watch` フラグを伴うもののみ deny。単発の `gh pr checks <n>`
-#      (ループなし) は状態確認であり監視ではないので許可 (false positive を作らない)。
-#   3. command が tools/pr-watch.sh / tools/pr-watch.ps1 / tools/pr_watch.py を
-#      「コマンド位置」で直接起動するものを deny する。緊急経路はユーザー自身の
-#      `!` 手動実行であり、Claude のツール呼び出しは deny してよい。
-#      grep / cat 等の引数としてファイル名が現れるだけの読み取りは deny しない
-#      (コマンド位置 + 既知ラッパー (bash/nohup/setsid 等) のみを起動とみなす)。
+# したがって判定不能 (jq 欠落 / JSON 破損 / command 欠落) は許可側に倒す
+# (安全網であってゲートではない。fail-closed の enforcement フックとは方針が異なる)。
 #
-# 正規経路: /pr-watch-pane <PR> (broker tmux セッション内の専用ペイン、
-# セッション寿命非依存、events テーブルへ ci_completed を記録)。
-# ペイン枠不足等で立てられないときは代替に流れず人間に報告して指示を仰ぐ。
+# 正規経路は /pr-watch-pane <PR>。pr-watch-pane skill 経由の監視 spawn は
+# MCP ツール (mcp__renga-peers__spawn_pane 等) で行われ、本フックの matcher
+# (Bash|Monitor) を通らないため誤 deny しない。
 #
 # 入力: stdin から PreToolUse JSON ({tool_name, tool_input})
 # 出力: 拒否時 exit 2 + stderr。許可時 exit 0。
-#
-# 既知の制限:
-#   - jq が無い環境では fail-closed で対象ツール呼び出しを deny する
-#     (既存 block-foreground-subagent.sh と同じ安全側挙動)。
-#   - 空 stdin / 不正 JSON / 非 object payload も fail-closed で deny する。
-#   - 文字列連結等で難読化された起動 (V=tools/pr-watch; bash "$V.sh") は検出
-#     できない。本フックは「うっかり逸脱」を止める防波堤であり、意図的回避の
-#     完全防御ではない (その層は prose 規律とレビューが担う)。
 
-set -euo pipefail
+set -uo pipefail
 
-DENY_GUIDANCE="PR の CI 監視の正規経路は /pr-watch-pane <PR> のみです (.claude/rules/pr-ci-watch.md)。ペイン枠不足 ([split_refused]) 等で立てられない場合は、代替監視に流れず人間に報告して指示を仰いでください。"
+# 判定材料が揃わなければ全て許可側 (best-effort 安全網)
+command -v jq >/dev/null 2>&1 || exit 0
+INPUT=$(cat 2>/dev/null) || exit 0
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+[[ "$TOOL_NAME" == "Bash" || "$TOOL_NAME" == "Monitor" ]] || exit 0
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[[ -n "$COMMAND" ]] || exit 0
 
-deny_with_reason() {
-  local reason="$1"
-  echo "ブロック: $reason $DENY_GUIDANCE" >&2
+deny() {
+  {
+    echo "BLOCKED: $1"
+    echo "PR の CI 監視の正規経路は /pr-watch-pane <PR> のみです (.claude/rules/pr-ci-watch.md)。"
+    echo "ペイン枠不足等で /pr-watch-pane が立てられないときは、代替監視に流れず人間に報告して指示を仰いでください。"
+  } >&2
   exit 2
 }
 
-# jq チェック (fail closed)
-if ! command -v jq &>/dev/null; then
-  echo "ブロック: jq がインストールされていません。セキュリティ Hook の実行に必要です。" >&2
-  exit 2
+# 1) tools/pr-watch.* の直接起動: Bash 背景タスクは spawn したシェルのみ追跡され、
+#    自己デタッチした監視本体は孤児化して /clear やセッション終了で黙死する
+if printf '%s' "$COMMAND" | grep -qE 'tools/(pr-watch\.(sh|ps1)|pr_watch\.py)'; then
+  deny "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。"
 fi
 
-INPUT=$(cat)
-
-# 空 payload の fail-closed ガード (block-foreground-subagent.sh と同じ根拠:
-# jq は「JSON 値ゼロ個」の入力を parse error にせず exit 0 を返すため、
-# 型ガードの手前で明示的に弾く)。
-if [[ -z "${INPUT//[[:space:]]/}" ]]; then
-  deny_with_reason "PreToolUse payload が空でした。安全側 (fail-closed) で拒否します。"
-fi
-
-# top-level が単一の JSON object であることを検証する (fail closed)。
-# `echo` でなく `printf '%s\n'`、`-s` slurp で単一値を要求する理由は
-# block-foreground-subagent.sh の同箇所コメントを参照。
-if ! printf '%s\n' "$INPUT" | jq -e -s 'length == 1 and (.[0] | type) == "object" and (.[0].tool_input == null or (.[0].tool_input | type) == "object")' >/dev/null 2>&1; then
-  deny_with_reason "PreToolUse payload を JSON object として解析できませんでした。安全側 (fail-closed) で拒否します。"
-fi
-
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
-if [[ "$TOOL_NAME" != "Bash" && "$TOOL_NAME" != "Monitor" ]]; then
-  exit 0
-fi
-
-# 対象ツール確定。command 文字列を取り出す (欠落 / 非文字列は空扱い)。
-# Monitor は ws source (command なし) の形もあるため、command 欠落は許可に倒す
-# (本フックの関心は shell command による polling のみ)。
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command? // empty | if type == "string" then . else "" end' 2>/dev/null || echo "")
-if [[ -z "$COMMAND" ]]; then
-  exit 0
-fi
-
-# --- 判定 1: gh pr checks による ad-hoc CI 監視 ---
-# Monitor tool: command に `gh pr checks` を含んだ時点で deny する。Monitor は
-#   定義上「監視」であり、ループの有無によらず gh pr checks を Monitor に載せる
-#   ことがそのまま「正規経路外の CI 監視」になる (2026-08-20 の実害はこの形)。
-# Bash tool: `gh pr checks` に加えて polling 構造を伴う場合のみ deny する:
-#   - シェルのループ構文 (while / until / for) / watch コマンド
-#   - gh 自身の --watch フラグ (gh pr checks <n> --watch は張り付き監視)。
-#     短縮 -w は --web (ブラウザで開く) であり watch ではないので対象外
-#     (gh pr checks --help で実確認済み)。
-#   単発の `gh pr checks <n>` (ループなし) はどれにも該当せず許可される
-#   (false positive を作らない)。
-# --- command 文字列の正規化 (判定 1 / 2 共通の前処理) ---
-# (0) heredoc の本文を落とす。`cat > doc.md <<'EOF' ... EOF` の本文は shell にとって
-#     データであり、本文中に polling ループのテキストが書かれていても実行されない。
-#     本文行を残すと (2) の改行境界化でコマンド扱いになり false positive になる。
-#     heredoc 開始 (`<<` / `<<-` + 任意で引用された delimiter) を見つけたら、
-#     delimiter 単独行まで本文行を捨てる (1 行 1 heredoc の簡易対応)。
-#     ただし heredoc がシェルインタプリタ (bash / sh 等) の stdin になっている場合、
-#     本文はデータでなく実行されるコードなので落とさず残す (残した本文は (2) 以降で
-#     コードとして走査される)。
-COMMAND=$(printf '%s\n' "$COMMAND" | awk '
-  BEGIN { inhd = 0; drop = 0; delim = "" }
-  {
-    if (inhd) {
-      line = $0
-      sub(/^[[:space:]]*/, "", line)
-      if (line == delim) { inhd = 0; next }
-      if (drop) next
-      print
-      next
-    }
-    print
-    if (match($0, /<<-?[[:space:]]*["'"'"']?[A-Za-z_][A-Za-z0-9_]*/)) {
-      d = substr($0, RSTART, RLENGTH)
-      sub(/^<<-?[[:space:]]*["'"'"']?/, "", d)
-      delim = d
-      inhd = 1
-      # heredoc の届き先がシェルインタプリタなら本文はコード: 残す。
-      # 前置形 (bash <<EOF) と pipe 消費形 (cat <<EOF | bash) の両方を見る。
-      # pipe 消費形はラッパー越し (cat <<EOF | env bash 等) も認める。
-      drop = (match($0, /(^|[;&|(`[:space:]])([^[:space:]]*\/)?(bash|sh|zsh|dash|ksh|eval)([[:space:]][^<]*)?<</) == 0 \
-              && match($0, /\|[[:space:]]*(([^[:space:]]*\/)?(env|nohup|setsid|command|time|timeout|stdbuf|sudo|doas|xargs)[[:space:]]+([^|;&]*[[:space:]])?)?([^[:space:]]*\/)?(bash|sh|zsh|dash|ksh)([[:space:]]|$)/) == 0)
-    }
-  }
-')
-# (1) バックスラッシュ継続行 (`\` + 改行) は空白に潰す。シェルはこれを 1 つの
-#     コマンドとして実行するため、改行をコマンド境界にすると `gh pr \<NL> checks`
-#     の分割で検出を素通りする。
-COMMAND=${COMMAND//$'\\\n'/ }
-# (2) 残る改行を `;` に潰す。grep は行単位で評価するため、複数行ループで loop 構文と
-#     gh 呼び出しが別行に割れると検出を素通りする。改行はシェルのコマンド境界なので
-#     `;` への置換は意味を保つ (空白だと「行頭 = コマンド位置」の情報が落ちる)。
-COMMAND=$(printf '%s' "$COMMAND" | tr '\n\r' ';;')
-# (2.5) シェルインタプリタへ渡す引用済みスクリプト (`bash -c '...'` / `eval '...'`)
-#     は引用符を外す。この引用内はデータでなく実行されるコードであり、(3) で区切り
-#     文字を潰すと `bash -c 'while ...; do gh pr checks ...; done'` が素通りする。
-#     `-c` は `-lc` のような結合フラグ形も対象。
-COMMAND=$(printf '%s' "$COMMAND" | sed -E \
-  -e "s/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+'([^']*)'/\3 -c ;\6/g" \
-  -e 's/(([^[:space:]\/]*\/)*)?(bash|sh|zsh|dash|ksh)(([[:space:]]+-[^[:space:]]+)*)[[:space:]]+-[A-Za-z]*c[[:space:]]+"([^"]*)"/\3 -c ;\6/g' \
-  -e "s/(^|[;&|({[:space:]])eval[[:space:]]+'([^']*)'/\1eval ;\2/g" \
-  -e 's/(^|[;&|({[:space:]])eval[[:space:]]+"([^"]*)"/\1eval ;\2/g' \
-  -e "s/(^|[;&|({[:space:]])(([^[:space:]\/]*\/)*)?watch((([[:space:]]+-[^[:space:]]+)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*)[[:space:]]+'([^']*)'/\1watch\4 \8/g" \
-  -e 's/(^|[;&|({[:space:]])(([^[:space:]\/]*\/)*)?watch((([[:space:]]+-[^[:space:]]+)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*)[[:space:]]+"([^"]*)"/\1watch\4 \8/g')
-# (3) 引用符の中のコマンド区切り文字 (; & | 括弧 ` ) を空白に潰す。引用内は shell
-#     にとってデータであり、`echo 'x; bash tools/pr-watch.sh 51'` の `;` を境界扱い
-#     すると echo のデータが起動に見える false positive になる。引用符自体と
-#     その他の文字は保持する (bash -c '...' 内の起動は引き続き検出できる)。
-#     例外: 二重引用内の `$( ... )` (コマンド置換) は shell が実行するコードなので
-#     潰さずそのまま残す (`echo "$(bash tools/pr-watch.sh 51)"` は起動)。
-COMMAND=$(printf '%s' "$COMMAND" | awk '{
-  out = ""; sq = 0; dq = 0; cs = 0
-  n = length($0)
-  for (i = 1; i <= n; i++) {
-    c = substr($0, i, 1)
-    if (sq) {
-      if (c == "\x27") sq = 0
-      else if (index(";&|(){}`", c)) c = " "
-    } else if (dq && cs > 0) {
-      # 二重引用内のコマンド置換: コードとして保持し、括弧の深さだけ追跡する
-      if (c == "(") cs++
-      else if (c == ")") cs--
-    } else if (dq) {
-      if (c == "\\") { out = out c; i++; c = (i <= n) ? substr($0, i, 1) : ""; out = out c; continue }
-      if (c == "\"") dq = 0
-      else if (c == "$" && substr($0, i + 1, 1) == "(") { cs = 1; out = out c; i++; c = "(" }
-      else if (index(";&|(){}`", c)) c = " "
-    } else {
-      if (c == "\x27") sq = 1
-      else if (c == "\"") dq = 1
-    }
-    out = out c
-  }
-  print out
-}')
-# (4) 判定 1 (polling 検出) 用に、単一引用内をすべて空白にマスクした変体を作る。
-#     この時点で残っている単一引用内は純データ (実行される bash -c / eval / watch の
-#     引用は (2.5) で既に外れている) であり、`printf '%s' 'docs: while ...; do gh pr
-#     checks ...; done'` のような文書テキストを polling と誤認しないため。
-#     判定 2 は引用込みの COMMAND を使う (引用されたパス引数 `pwsh '.\tools\...'` を
-#     見る必要があるため)。
-COMMAND_POLL=$(printf '%s' "$COMMAND" | awk '{
-  out = ""; sq = 0
-  n = length($0)
-  for (i = 1; i <= n; i++) {
-    c = substr($0, i, 1)
-    if (sq) {
-      if (c == "\x27") sq = 0
-      else c = " "
-    } else if (c == "\x27") sq = 1
-    out = out c
-  }
-  print out
-}')
-
-# `gh pr checks` の検出はフラグの挿入位置 2 箇所を許容する:
-#   - `gh` と `pr` の間の global フラグ (`gh -R owner/repo pr checks` 等)
-#   - `pr` と `checks` の間の親コマンドフラグ (`gh pr --repo owner/repo checks` 等)
-# 「`-` 始まりのフラグ + 任意でその引数トークン (非 `-` 始まり)」の繰り返しだけを
-# 挟めるようにし、`gh pr view ... checks` のような別サブコマンドは挟めない。
-# フラグ / 引数トークンにコマンド区切り文字 (; & | 括弧) を含めない
-# (`gh --version; pr checks ...` のような別コマンドへの越境 FP を防ぐ)。
-GH_FLAG_TOKENS='([[:space:]]+-[^[:space:];&|()]+([[:space:]]+[^-[:space:];&|()][^[:space:];&|()]*)?)*'
-GH_PR_CHECKS_PREFIX='gh'"$GH_FLAG_TOKENS"'[[:space:]]+pr'"$GH_FLAG_TOKENS"'[[:space:]]+checks'
-GH_PR_CHECKS_RE="$GH_PR_CHECKS_PREFIX"'([[:space:];&|)]|$)'
-# コマンド位置の gh: 区切り記号 / 予約語境界の直後 (環境変数代入・パス前置は許容)。
-# `echo gh pr checks 51` のような引数テキスト (gh が別コマンドの引数) を polling と
-# 誤認しないための左境界。watch の引数位置 (`watch -n 30 gh pr checks`) は
-# GH_WATCH_CMD_RE 側で別途照合するのでここには含めない。
-GH_PR_CHECKS_CMD='((^|[;&|({])[[:space:]]*|(^|[[:space:]])(if|then|elif|else|do|while|until)[[:space:]]+)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*([^[:space:]]*/)?'"$GH_PR_CHECKS_PREFIX"
-# --watch は「同一の gh pr checks 呼び出しに付いたフラグ」だけを対象にする:
-# checks の後、コマンド区切り文字を跨がずに --watch トークンへ到達する場合のみ。
-# `gh pr checks 51; other-tool --watch x` のような別コマンドの --watch は拾わない。
-GH_CHECKS_WATCH_RE="$GH_PR_CHECKS_CMD"'([[:space:]]+[^[:space:];&|()]+)*[[:space:]]+--watch([[:space:];&|=)]|$)'
-if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_PR_CHECKS_RE"; then
-  if [[ "$TOOL_NAME" == "Monitor" ]] && printf '%s' "$COMMAND_POLL" | grep -qE "$GH_PR_CHECKS_CMD"; then
-    deny_with_reason "Monitor tool による gh pr checks の CI 監視は禁止です。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
-  fi
-  # 同一呼び出しの --watch フラグ (張り付き監視)。
-  if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_CHECKS_WATCH_RE"; then
-    deny_with_reason "gh pr checks --watch による ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
-  fi
-  # ループ判定は「gh pr checks の呼び出し位置が未閉のループスコープ内にある」場合のみ
-  # deny する。各出現位置について、その手前のテキストでループ開始語
-  # (while/until/for/select) と閉じ語 (done) を数え、開始が閉じより多ければその
-  # 呼び出しはループの条件部または本体にあり反復される。
-  #   - `gh pr checks ... | while read ...; do ...; done` (単発結果のループ加工) は
-  #     手前にループ開始が無いので許可 (gh は 1 回しか走らない)。
-  #   - `for f in a b; do ...; done; gh pr checks 51` (閉じたループの後の単発) は
-  #     開始 1 / 閉じ 1 で釣り合うので許可。兄弟ループが後続しても影響しない。
-  #   - ネスト (`while ...; do for ...; done; gh pr checks; done`) は開始 2 / 閉じ 1
-  #     で未閉スコープ内と判定される。
-  # ループ開始語の直後は空白のほか `;` (改行由来: `until\n gh ...`) と `(`
-  # (算術 for: `for((;;))`) も境界として認める。
-  # awk には CMD 形 (境界込み) と PREFIX 形 (gh 本体) の両方を渡す。CMD 形の一致は
-  # 予約語境界 (until 等) を一致範囲に含むため、そのまま prefix を切るとループ開始語
-  # が prefix から消えて計数を誤る。CMD 一致範囲の中で PREFIX の開始位置を取り直し、
-  # その手前までを prefix とする。
-  GH_IN_LOOP=$(printf '%s' "$COMMAND_POLL" | awk -v ghre="$GH_PR_CHECKS_CMD" -v ghpre="$GH_PR_CHECKS_PREFIX" '
-    {
-      s = $0
-      off = 0
-      while (match(substr(s, off + 1), ghre) > 0) {
-        pos = off + RSTART
-        rest = substr(s, pos)
-        if (match(rest, ghpre) > 0) pos = pos + RSTART - 1
-        prefix = substr(s, 1, pos - 1)
-        t = prefix; opens  = gsub(/(^|[;&|({[:space:]])(while|until|for|select)([[:space:](;]|$)/, " ", t)
-        t = prefix; closes = gsub(/(^|[;&|([:space:]])done([;&|)[:space:]]|$)/, " ", t)
-        if (opens > closes) { print "in_loop"; exit }
-        off = pos
-      }
-    }')
-  if [[ "$GH_IN_LOOP" == "in_loop" ]]; then
-    deny_with_reason "gh pr checks の polling ループによる ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
-  fi
-  # 関数間接呼び出しの保守的 deny: `poll() { gh pr checks 51; }; while true; do poll; done`
-  # のように関数へ包むと、gh の出現位置自体はループ外になり上の計数を逃れる。
-  # 関数呼び出しの追跡は静的にはできないため、「関数定義 + ループ構文 + gh pr checks」
-  # が 1 つの command に同居する形は反復とみなして保守的に deny する。
-  if printf '%s' "$COMMAND_POLL" | grep -qE '[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(\)' \
-    && printf '%s' "$COMMAND_POLL" | grep -qE '(^|[;&|({[:space:]])(while|until|for|select)([[:space:](;]|$)'; then
-    deny_with_reason "関数定義とループ構文を伴う gh pr checks は、関数経由の polling とみなして保守的に拒否します (${TOOL_NAME} tool)。単発確認は関数・ループに包まず gh pr checks <PR> を直接 1 回だけ実行してください。"
-  fi
-  # watch コマンド (path 付き /usr/bin/watch も対象) は done を使わないため別判定:
-  # 同一コマンド区間内 (; & | を跨がない) で watch の引数に gh pr checks が
-  # 現れる場合を deny する。
-  GH_WATCH_CMD_RE='((^|[;&|({])[[:space:]]*|(^|[[:space:]])(if|then|elif|else|do|while|until)[[:space:]]+)([^[:space:]]*/)?watch[[:space:]][^;&|]*'"$GH_PR_CHECKS_PREFIX"
-  if printf '%s' "$COMMAND_POLL" | grep -qE "$GH_WATCH_CMD_RE"; then
-    deny_with_reason "watch コマンドによる gh pr checks の ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
+# 2) gh pr checks + ループ語彙 (while / until / for / watch / --watch) の併用
+#    = polling ループ / 張り付き監視。単発の gh pr checks <PR> は状態確認であって
+#    監視ではないので許可する (false positive を避ける)
+if printf '%s' "$COMMAND" | grep -q 'gh pr checks'; then
+  if printf '%s' "$COMMAND" | grep -qE '(^|[;&|({[:space:]])(while|until|for|watch)[[:space:](]|--watch([[:space:]=;&|)]|$)'; then
+    deny "gh pr checks の polling ループ / --watch による ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。"
   fi
 fi
-
-# --- 判定 2: tools/pr-watch.* の直接起動 ---
-# 次の 3 形を起動とみなす:
-#   a. 環境変数代入 (VAR=value) の連なりの直後に pr-watch ファイル
-#   b. 既知のラッパー / インタプリタが先頭トークンで、その後 (フラグ・引数を挟んで)
-#      pr-watch ファイル。ラッパーは絶対パス前置 (/usr/bin/bash 等) も許容し、
-#      timeout / source / stdbuf / sudo / xargs / py ランチャー / uv 等を含む。
-#   c. pr-watch ファイルがコマンド位置に直接 (./tools/pr-watch.sh 51 等)
-# `grep foo tools/pr-watch.sh` のような読み取りは、先頭トークン grep がラッパー
-# 一覧に無いため起動とみなされず許可される (false positive を作らない)。
-# python の module 実行 (`python3 -m tools.pr_watch`) も拾うため、ファイル名は
-# 拡張子なしの pr_watch も対象にする。
-# 判定はコマンド区切り文字 (; & | ( ) ` { }) で区間に分割し、区間単位で行う。
-# これにより起動判定と読み取り例外が別コマンドへ越境しない
-# (`cat tools/pr-watch.sh && bash tools/pr-watch.sh` の後半は読み取り例外に隠れず
-# deny され、`cat x; bash tools/pr-watch.sh` も後半区間だけで起動と判定される)。
-# 環境変数代入は引用された値 (`NOTE='CI watch'` のような空白入り) も 1 トークン
-# として許容する。
-PR_WATCH_ASSIGN='[A-Za-z_][A-Za-z0-9_]*=('"'"'[^'"'"']*'"'"'|"[^"]*"|[^[:space:]]*)'
-# POSIX の dot-source (`. tools/pr-watch.sh`) も source と同じ実行なので `\.` を
-# 単独トークンとしてラッパーに含める。
-PR_WATCH_WRAPPER='(([^[:space:]]*/)?(nohup|setsid|exec|env|command|eval|time|timeout|stdbuf|source|sudo|doas|xargs|bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py|uv|run)|\.)'
-# ファイル名は basename 完全一致で照合する: 前置は `/` (パス) か `.` (python module
-# の package 区切り) か引用符で終わる場合のみ許容し、`tools/test_pr_watch.py` の
-# ような別名 (前置が `_` 等で終わる) を拾わない。リポジトリ実在の
-# tools/test_pr_watch.py (watcher の unit test) を deny しないための制約。
-# 前置は `/` `\` (Windows パス) `.` (python module 区切り) 引用符で終わる場合のみ。
-# 終端は空白 / 行末 / 引用符 / リダイレクト (`>` `<`) を認める
-# (`bash tools/pr-watch.sh>/tmp/log` のような密着リダイレクトも起動)。
-# 前置に `=` を含めない: `SCRIPT=tools/pr-watch.sh` のような変数代入の値は
-# 実行されないデータであり、起動として誤検出しない。
-PR_WATCH_FILE='(["'"'"']?|[^[:space:]=]*[/.\'"'"'"])(pr-watch\.(sh|ps1)|pr_watch(\.py)?)([[:space:]<>]|$|["'"'"'])'
-# 区間内の起動形: 区間先頭から、予約語 (if/then/elif/else/do/while/until) →
-# 環境変数代入 → ラッパー / インタプリタ (+ その引数トークン任意) の順に前置を
-# 許し、pr-watch ファイルへ到達するもの。先頭トークンがラッパー一覧に無い語
-# (grep / sed 等) の場合は前置が成立せず起動とみなされない。
-PR_WATCH_LAUNCH_SEG_RE='^[[:space:]]*((if|then|elif|else|do|while|until)[[:space:]]+)*('"$PR_WATCH_ASSIGN"'[[:space:]]+)*('"$PR_WATCH_WRAPPER"'[[:space:]]+([^[:space:]]+[[:space:]]+)*)?'"$PR_WATCH_FILE"
-# 読み取り専用コマンドの例外: ラッパーの中間トークンは任意の語を許すため、
-# `env LC_ALL=C grep -n x tools/pr-watch.sh` / `timeout 1s cat tools/pr-watch.sh`
-# のような「ラッパー越しの読み取り」も LAUNCH_SEG_RE に一致してしまう。同一区間内で
-# 既知の読み取りコマンドが pr-watch ファイルより前に現れる場合は読み取りとみなす。
-PR_WATCH_READER_SEG_RE='(^|[[:space:]])(grep|egrep|fgrep|rg|ag|cat|bat|head|tail|sed|awk|less|more|wc|diff|cmp|stat|file|md5sum|sha[0-9]*sum|cksum|shellcheck|shfmt|cut|sort|uniq|hexdump|xxd|strings|nl|od|ls|realpath|readlink|basename|dirname|du|touch|chmod|cp|mv|ln|git|printf|echo)[[:space:]].*(pr-watch\.(sh|ps1)|pr_watch(\.py)?)'
-# 実行しないインタプリタモードの例外: 構文チェック (`bash -n` / `sh -n`) や
-# バイトコンパイル (`python3 -m py_compile`) はファイルを実行しないため許可する。
-# `-n` は `-nv` のような結合フラグ形も対象。
-PR_WATCH_NOEXEC_SEG_RE='(^|[[:space:]/])((bash|sh|zsh|dash|ksh)[[:space:]]+-[A-Za-z]*n[A-Za-z]*[[:space:]]|python[0-9.]*[[:space:]]+-m[[:space:]]+py_compile[[:space:]])'
-# sudo / doas の値付きフラグ (`sudo -u git ...` の `git` はユーザー名) は、reader
-# 例外の判定前に区間から取り除く。除去しないと `git` が読み取りコマンド語と誤認され、
-# `sudo -u git bash tools/pr-watch.sh` が読み取り扱いで素通りする。除去後の区間
-# (`bash tools/pr-watch.sh ...`) は通常の起動判定に掛かる。grep のパターン引数が
-# たまたま `bash` である読み取り (`grep -n bash tools/pr-watch.sh`) は sudo/doas が
-# 無いので影響を受けず、reader 例外がそのまま効く。
-PR_WATCH_SUDO_STRIP_RE='(^|[[:space:]])(sudo|doas)(([[:space:]]+-[^[:space:]]+)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+'
-while IFS= read -r SEGMENT; do
-  [[ -z "${SEGMENT//[[:space:]]/}" ]] && continue
-  SEGMENT=$(printf '%s' "$SEGMENT" | sed -E "s/$PR_WATCH_SUDO_STRIP_RE/\1/g")
-  if printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_LAUNCH_SEG_RE"; then
-    if ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_SEG_RE" \
-      && ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_NOEXEC_SEG_RE"; then
-      deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
-    fi
-  fi
-done < <(printf '%s\n' "$COMMAND" | tr ';&|(){}`' '\n')
 
 exit 0

--- a/.hooks/block-adhoc-pr-watch.sh
+++ b/.hooks/block-adhoc-pr-watch.sh
@@ -118,8 +118,10 @@ COMMAND=$(printf '%s\n' "$COMMAND" | awk '
       sub(/^<<-?[[:space:]]*["'"'"']?/, "", d)
       delim = d
       inhd = 1
-      # heredoc の届き先がシェルインタプリタ (bash <<EOF 等) なら本文はコード: 残す
-      drop = (match($0, /(^|[;&|(`[:space:]])([^[:space:]]*\/)?(bash|sh|zsh|dash|ksh|eval)([[:space:]][^<]*)?<</) == 0)
+      # heredoc の届き先がシェルインタプリタなら本文はコード: 残す。
+      # 前置形 (bash <<EOF) と pipe 消費形 (cat <<EOF | bash) の両方を見る。
+      drop = (match($0, /(^|[;&|(`[:space:]])([^[:space:]]*\/)?(bash|sh|zsh|dash|ksh|eval)([[:space:]][^<]*)?<</) == 0 \
+              && match($0, /\|[[:space:]]*([^[:space:]]*\/)?(bash|sh|zsh|dash|ksh)([[:space:]]|$)/) == 0)
     }
   }
 ')
@@ -197,6 +199,8 @@ if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
   #     開始 1 / 閉じ 1 で釣り合うので許可。兄弟ループが後続しても影響しない。
   #   - ネスト (`while ...; do for ...; done; gh pr checks; done`) は開始 2 / 閉じ 1
   #     で未閉スコープ内と判定される。
+  # ループ開始語の直後は空白のほか `;` (改行由来: `until\n gh ...`) と `(`
+  # (算術 for: `for((;;))`) も境界として認める。
   GH_IN_LOOP=$(printf '%s' "$COMMAND" | awk -v ghre="$GH_PR_CHECKS_PREFIX" '
     {
       s = $0
@@ -204,7 +208,7 @@ if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
       while (match(substr(s, off + 1), ghre) > 0) {
         pos = off + RSTART
         prefix = substr(s, 1, pos - 1)
-        t = prefix; opens  = gsub(/(^|[;&|({[:space:]])(while|until|for|select)[[:space:]]/, " ", t)
+        t = prefix; opens  = gsub(/(^|[;&|({[:space:]])(while|until|for|select)([[:space:](;]|$)/, " ", t)
         t = prefix; closes = gsub(/(^|[;&|([:space:]])done([;&|)[:space:]]|$)/, " ", t)
         if (opens > closes) { print "in_loop"; exit }
         off = pos
@@ -212,6 +216,14 @@ if printf '%s' "$COMMAND" | grep -qE "$GH_PR_CHECKS_RE"; then
     }')
   if [[ "$GH_IN_LOOP" == "in_loop" ]]; then
     deny_with_reason "gh pr checks の polling ループによる ad-hoc CI 監視は禁止です (${TOOL_NAME} tool)。セッション寿命依存の監視は /clear やセッション終了で黙死します。"
+  fi
+  # 関数間接呼び出しの保守的 deny: `poll() { gh pr checks 51; }; while true; do poll; done`
+  # のように関数へ包むと、gh の出現位置自体はループ外になり上の計数を逃れる。
+  # 関数呼び出しの追跡は静的にはできないため、「関数定義 + ループ構文 + gh pr checks」
+  # が 1 つの command に同居する形は反復とみなして保守的に deny する。
+  if printf '%s' "$COMMAND" | grep -qE '[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(\)' \
+    && printf '%s' "$COMMAND" | grep -qE '(^|[;&|({[:space:]])(while|until|for|select)([[:space:](;]|$)'; then
+    deny_with_reason "関数定義とループ構文を伴う gh pr checks は、関数経由の polling とみなして保守的に拒否します (${TOOL_NAME} tool)。単発確認は関数・ループに包まず gh pr checks <PR> を直接 1 回だけ実行してください。"
   fi
   # watch コマンド (path 付き /usr/bin/watch も対象) は done を使わないため別判定:
   # 同一コマンド区間内 (; & | を跨がない) で watch の引数に gh pr checks が
@@ -265,11 +277,22 @@ PR_WATCH_READER_SEG_RE='(^|[[:space:]])(grep|egrep|fgrep|rg|ag|cat|bat|head|tail
 # バイトコンパイル (`python3 -m py_compile`) はファイルを実行しないため許可する。
 # `-n` は `-nv` のような結合フラグ形も対象。
 PR_WATCH_NOEXEC_SEG_RE='(^|[[:space:]/])((bash|sh|zsh|dash|ksh)[[:space:]]+-[A-Za-z]*n[A-Za-z]*[[:space:]]|python[0-9.]*[[:space:]]+-m[[:space:]]+py_compile[[:space:]])'
+# 読み取り例外の無効化: 読み取り語と pr-watch ファイルの間にシェルインタプリタ名が
+# 挟まる場合 (`sudo -u git bash tools/pr-watch.sh` — `git` はユーザー名であって
+# 読み取りコマンドではない) は、実効コマンドが shell = 起動なので例外を適用しない。
+PR_WATCH_READER_VOID_RE='(^|[[:space:]])(grep|egrep|fgrep|rg|ag|cat|bat|head|tail|sed|awk|less|more|wc|diff|cmp|stat|file|md5sum|sha[0-9]*sum|cksum|shellcheck|shfmt|cut|sort|uniq|hexdump|xxd|strings|nl|od|ls|realpath|readlink|basename|dirname|du|touch|chmod|cp|mv|ln|git)[[:space:]]+([^[:space:]]+[[:space:]]+)*([^[:space:]]*/)?(bash|sh|zsh|dash|ksh|pwsh|powershell(\.exe)?|python[0-9.]*|py)[[:space:]].*(pr-watch\.(sh|ps1)|pr_watch(\.py)?)'
 while IFS= read -r SEGMENT; do
   [[ -z "${SEGMENT//[[:space:]]/}" ]] && continue
   if printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_LAUNCH_SEG_RE"; then
-    if ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_SEG_RE" \
-      && ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_NOEXEC_SEG_RE"; then
+    READER_EXEMPT=0
+    if printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_SEG_RE" \
+      && ! printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_READER_VOID_RE"; then
+      READER_EXEMPT=1
+    fi
+    if printf '%s' "$SEGMENT" | grep -qE "$PR_WATCH_NOEXEC_SEG_RE"; then
+      READER_EXEMPT=1
+    fi
+    if [[ "$READER_EXEMPT" -eq 0 ]]; then
       deny_with_reason "tools/pr-watch.* の直接起動は禁止です (${TOOL_NAME} tool)。Claude Code の背景タスクは spawn したシェルのみ追跡し、監視本体が孤児化します。緊急経路はユーザー自身の ! 手動実行のみです。"
     fi
   fi

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -510,6 +510,26 @@ json=$(make_payload "Bash" 'while read -r x; do echo gh pr checks 51; done')
 ec=$(run_hook "$json" "$stderr")
 assert_exit 0 "$ec" "Bash: echo of gh pr checks text inside loop is allowed (argument position)"
 
+# --- Cases (Codex round 11 指摘: subshell 終端 / watch のコマンド位置 / 非実行コマンド引数) ---
+
+# 7ba. Bash + subshell 内の gh pr checks --watch -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" '(gh pr checks 51 --watch)')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: (gh pr checks --watch) in subshell is blocked"
+
+# 7bb. Bash + echo の引数に watch gh pr checks のテキスト -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'echo watch gh pr checks 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: echo of 'watch gh pr checks' text is allowed (argument position)"
+
+# 7bc. Bash + env printf の引数に pr-watch.sh のパス -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "env printf '%s\\n' tools/pr-watch.sh")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: env printf with pr-watch.sh path argument is allowed"
+
 # --- Fail-closed Cases ---
 
 # 15. 空 stdin -> block

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -486,6 +486,30 @@ json=$(make_payload "Bash" "printf '%s\\n' 'docs: while true; do gh pr checks 51
 ec=$(run_hook "$json" "$stderr")
 assert_exit 0 "$ec" "Bash: single-quoted polling-loop text passed to printf is allowed (data)"
 
+# --- Block Cases (Codex round 10 指摘: ラッパー越し pipe heredoc) ---
+
+# 7ax. Bash + heredoc を env bash に pipe (本文はコード) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "cat <<'EOF' | env bash
+while true; do gh pr checks 51; sleep 30; done
+EOF")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: heredoc piped to env bash (executable body) is blocked"
+
+# --- Allow Cases (Codex round 10 指摘: 代入値 / 引数テキストの gh) ---
+
+# 7ay. Bash + 変数代入の値が pr-watch.sh (実行しない) -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'SCRIPT=tools/pr-watch.sh echo assigned')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: assignment value tools/pr-watch.sh without execution is allowed"
+
+# 7az. Bash + ループ内で echo の引数に gh pr checks のテキスト -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'while read -r x; do echo gh pr checks 51; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: echo of gh pr checks text inside loop is allowed (argument position)"
+
 # --- Fail-closed Cases ---
 
 # 15. 空 stdin -> block

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Tests for block-adhoc-pr-watch.sh
+# Validates: exit code (0=allow/passthrough, 2=block) and stderr messages.
+#
+# 確認観点 (2026-08-20 の PR #51 実害への機械ガード):
+#   - Monitor + gh pr checks (ループの有無問わず)   -> block (Monitor は定義上「監視」)
+#   - Bash + while/until/for + gh pr checks         -> block (polling ループ)
+#   - Bash + gh pr checks --watch                   -> block (張り付き監視)
+#   - Bash/Monitor + tools/pr-watch.* の直接起動     -> block (孤児化する ad-hoc 監視)
+#   - Bash + 単発 gh pr checks <n>                  -> allow (状態確認は監視でない)
+#   - Bash + gh pr checks | grep -w (=--web でない) -> allow (-w を watch と誤認しない)
+#   - Bash + grep/cat の引数に pr-watch.sh          -> allow (読み取りは起動でない)
+#   - 非対象ツール / command 欠落 (Monitor ws)       -> passthrough
+#   - 不正 JSON / 空 stdin                          -> block (fail-closed)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/.hooks/block-adhoc-pr-watch.sh"
+
+PASS=0; FAIL=0; TEST_NUM=0
+TMPFILES=()
+cleanup() { rm -f "${TMPFILES[@]}"; }
+trap cleanup EXIT
+
+assert_exit() {
+  local expected="$1" actual="$2" desc="$3"
+  ((TEST_NUM++))
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "ok $TEST_NUM - $desc"
+    ((PASS++))
+  else
+    echo "not ok $TEST_NUM - $desc (expected exit $expected, got $actual)"
+    ((FAIL++))
+  fi
+}
+
+assert_stderr_contains() {
+  local pattern="$1" file="$2" desc="$3"
+  ((TEST_NUM++))
+  if grep -qF "$pattern" "$file" 2>/dev/null; then
+    echo "ok $TEST_NUM - $desc"
+    ((PASS++))
+  else
+    echo "not ok $TEST_NUM - $desc (stderr did not contain '$pattern')"
+    ((FAIL++))
+  fi
+}
+
+run_hook() {
+  local json="$1" stderr_file="$2"
+  local exit_code=0
+  printf '%s' "$json" | bash "$HOOK" 2>"$stderr_file" || exit_code=$?
+  echo "$exit_code"
+}
+
+# jq で command を安全に JSON エンコードして payload を作る (ループ構文等の
+# クォート事故を避ける)
+make_payload() {
+  local tool="$1" cmd="$2"
+  jq -cn --arg tool "$tool" --arg cmd "$cmd" '{tool_name: $tool, tool_input: {command: $cmd}}'
+}
+
+# --- Block Cases ---
+
+# 1. Monitor + while + gh pr checks polling ループ (実害と同形) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Monitor" 'while true; do gh pr checks 51 --json name,bucket; sleep 30; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Monitor: while + gh pr checks polling loop is blocked"
+assert_stderr_contains "/pr-watch-pane" "$stderr" "deny stderr names the canonical path /pr-watch-pane"
+assert_stderr_contains "人間に報告して指示を仰いでください" "$stderr" "deny stderr instructs to consult the human"
+
+# 2. Monitor + gh pr checks (ループなしでも Monitor は監視) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Monitor" 'gh pr checks 51 --json name,bucket')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Monitor: gh pr checks without loop is still blocked (Monitor is watching by definition)"
+
+# 3. Bash + until ループ + gh pr checks -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'until gh pr checks 51 | grep -q pass; do sleep 60; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: until + gh pr checks polling loop is blocked"
+
+# 4. Bash + gh pr checks --watch -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'gh pr checks 51 --watch')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: gh pr checks --watch is blocked"
+
+# 5. Bash + tools/pr-watch.sh 直接起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'setsid bash tools/pr-watch.sh 51 < /dev/null > /dev/null 2>&1 &')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: setsid bash tools/pr-watch.sh direct launch is blocked"
+assert_stderr_contains "tools/pr-watch.* の直接起動は禁止" "$stderr" "deny stderr names the pr-watch direct-launch ban"
+
+# 6. Bash + 絶対パスの pr_watch.py 起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'python3 /home/user/repo/tools/pr_watch.py --pr 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: python3 .../tools/pr_watch.py launch is blocked"
+
+# 7. Monitor + pr-watch.sh 起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Monitor" './tools/pr-watch.sh 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Monitor: ./tools/pr-watch.sh launch is blocked"
+
+# --- Allow Cases ---
+
+# 8. Bash + 単発 gh pr checks (ループなし) -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'gh pr checks 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: one-shot gh pr checks is allowed"
+
+# 9. Bash + 単発 gh pr checks --repo 付き + jq 加工 -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'gh pr checks 51 --repo owner/repo --json name,bucket | jq -r ".[].bucket"')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: one-shot gh pr checks with --repo/--json pipeline is allowed"
+
+# 10. Bash + grep -w (=word-regexp) は --watch でない -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'gh pr checks 51 | grep -w pass')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: gh pr checks piped to grep -w is allowed (-w is not --watch)"
+
+# 11. Bash + pr-watch.sh を引数位置で読むだけ (grep) -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'grep -n ci_completed tools/pr-watch.sh')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: reading tools/pr-watch.sh as a grep argument is allowed"
+
+# 12. Bash + gh pr checks を含まない while ループ -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'while read -r line; do echo "$line"; done < input.txt')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: unrelated while loop without gh pr checks is allowed"
+
+# 13. 非対象ツール (Edit) は passthrough -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Edit","tool_input":{"file_path":"/tmp/x","old_string":"while gh pr checks","new_string":"y"}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "non-target tool (Edit) passes through"
+
+# 14. Monitor + ws source (command 欠落) -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Monitor","tool_input":{"ws":{"url":"wss://example.com/stream"},"description":"x"}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Monitor ws source without command is allowed"
+
+# --- Fail-closed Cases ---
+
+# 15. 空 stdin -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook "" "$stderr")
+assert_exit 2 "$ec" "empty stdin is blocked (fail-closed)"
+
+# 16. 不正 JSON -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook 'not json {' "$stderr")
+assert_exit 2 "$ec" "invalid JSON is blocked (fail-closed)"
+
+# 17. tool_input が object でない -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook '{"tool_name":"Bash","tool_input":"gh pr checks"}' "$stderr")
+assert_exit 2 "$ec" "non-object tool_input is blocked (fail-closed)"
+
+# --- Summary ---
+echo "# $PASS passed, $FAIL failed out of $TEST_NUM tests"
+[[ $FAIL -eq 0 ]]

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -227,6 +227,35 @@ json=$(make_payload "Bash" 'cat tools/pr-watch.sh && bash tools/pr-watch.sh 51')
 ec=$(run_hook "$json" "$stderr")
 assert_exit 2 "$ec" "Bash: cat then launch compound is still blocked (reader exemption does not leak)"
 
+# --- Block Cases (Codex round 5 指摘: ネストループ / 継続行 / dot-source) ---
+
+# 7aa. Bash + ネストしたループ (内側 done の後に gh pr checks、外側 done で反復) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'while true; do for x in a; do :; done; gh pr checks 51; sleep 30; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: nested loop with gh pr checks after inner done is blocked"
+
+# 7ab. Bash + バックスラッシュ継続行入りの polling ループ -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'while true; do gh pr \
+checks 51; sleep 30; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: polling loop with backslash-newline continuation is blocked"
+
+# 7ac. Bash + POSIX dot-source での pr-watch.sh 実行 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" '. tools/pr-watch.sh 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: POSIX dot-source of tools/pr-watch.sh is blocked"
+
+# --- Allow Cases (Codex round 5 指摘: 引用内の区切り文字はデータ) ---
+
+# 7ad. Bash + 引用文字列の中に `; bash tools/pr-watch.sh` を含む echo -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "echo 'x; bash tools/pr-watch.sh 51'")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: quoted separator inside echo data is not treated as a launch"
+
 # --- Allow Cases (Codex round 4 指摘: 閉じたループ後の単発 / 無関係 --watch / ラッパー越し読み取り) ---
 
 # 7w. Bash + 閉じたループの後の単発 gh pr checks -> allow

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -248,6 +248,36 @@ json=$(make_payload "Bash" '. tools/pr-watch.sh 51')
 ec=$(run_hook "$json" "$stderr")
 assert_exit 2 "$ec" "Bash: POSIX dot-source of tools/pr-watch.sh is blocked"
 
+# --- Block Cases (Codex round 6 指摘: 密着リダイレクト / 引用付き代入 / Windows パス) ---
+
+# 7ae. Bash + ファイル名直後の密着リダイレクト -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'bash tools/pr-watch.sh>/tmp/watch.log 51 &')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: pr-watch.sh launch with attached redirection is blocked"
+
+# 7af. Bash + 空白入り引用値の環境変数代入前置 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "NOTE='CI watch' bash tools/pr-watch.sh 51")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: quoted env assignment prefix launch is blocked"
+
+# 7ag. Bash + Windows パス区切りの pr-watch.ps1 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "pwsh '.\\tools\\pr-watch.ps1' 51")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: pwsh with backslash-separated pr-watch.ps1 path is blocked"
+
+# --- Allow Cases (Codex round 6 指摘: heredoc 本文はデータ) ---
+
+# 7ah. Bash + heredoc 本文に polling ループのテキストを書くドキュメント生成 -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "cat > doc.md <<'EOF'
+while true; do gh pr checks 51; sleep 30; done
+EOF")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: heredoc body containing polling-loop text is allowed (data, not code)"
+
 # --- Allow Cases (Codex round 5 指摘: 引用内の区切り文字はデータ) ---
 
 # 7ad. Bash + 引用文字列の中に `; bash tools/pr-watch.sh` を含む echo -> allow

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -146,7 +146,39 @@ json=$(make_payload "Bash" 'python3 -u tools/pr_watch.py --pr 51')
 ec=$(run_hook "$json" "$stderr")
 assert_exit 2 "$ec" "Bash: python3 -u tools/pr_watch.py launch is blocked"
 
+# --- Block Cases (Codex round 2 指摘: path 付き watch / 未網羅ラッパー / module 実行) ---
+
+# 7h. Bash + /usr/bin/watch -n 30 gh pr checks -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" '/usr/bin/watch -n 30 gh pr checks 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: path-qualified /usr/bin/watch + gh pr checks is blocked"
+
+# 7i. Bash + timeout ラッパー経由の pr-watch.sh -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'timeout 1h bash tools/pr-watch.sh 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: timeout 1h bash tools/pr-watch.sh launch is blocked"
+
+# 7j. Bash + source での取り込み実行 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'source tools/pr-watch.sh 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: source tools/pr-watch.sh is blocked"
+
+# 7k. Bash + python module 実行 (python3 -m tools.pr_watch) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'python3 -m tools.pr_watch --pr 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: python3 -m tools.pr_watch module launch is blocked"
+
 # --- Allow Cases ---
+
+# 7l. Bash + 単発 gh pr checks の結果を while read で加工 (gh は 1 回実行) -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'gh pr checks 51 --json name,bucket | while read -r row; do echo "$row"; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: one-shot gh pr checks piped into while-read processing is allowed"
 
 # 8. Bash + 単発 gh pr checks (ループなし) -> allow
 stderr=$(mktemp); TMPFILES+=("$stderr")

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -452,6 +452,40 @@ json=$(make_payload "Bash" 'while true; do gh pr view 51 --json title; echo chec
 ec=$(run_hook "$json" "$stderr")
 assert_exit 0 "$ec" "Bash: gh pr view loop with unrelated 'checks' word is allowed"
 
+# --- Block Cases (Codex round 9 指摘: 二重引用内 cmdsubst / eval / watch 引用引数) ---
+
+# 7as. Bash + 二重引用内のコマンド置換での起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'echo "$(bash tools/pr-watch.sh 51)"')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: launch inside double-quoted command substitution is blocked"
+
+# 7at. Bash + eval の引用スクリプトでの起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "eval 'bash tools/pr-watch.sh 51'")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: eval-quoted launch of pr-watch.sh is blocked"
+
+# 7au. Bash + watch の引用引数の gh pr checks -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "watch -n 30 'gh pr checks 51'")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: watch with quoted gh pr checks argument is blocked"
+
+# --- Allow Cases (Codex round 9 指摘: grep パターンの bash / 単一引用データ) ---
+
+# 7av. Bash + grep のパターン引数がたまたま bash である読み取り -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'env LC_ALL=C grep -n bash tools/pr-watch.sh')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: grep with pattern 'bash' reading pr-watch.sh is allowed"
+
+# 7aw. Bash + 単一引用データに polling ループのテキストを含む printf -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "printf '%s\\n' 'docs: while true; do gh pr checks 51; done'")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: single-quoted polling-loop text passed to printf is allowed (data)"
+
 # --- Fail-closed Cases ---
 
 # 15. 空 stdin -> block

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -172,7 +172,54 @@ json=$(make_payload "Bash" 'python3 -m tools.pr_watch --pr 51')
 ec=$(run_hook "$json" "$stderr")
 assert_exit 2 "$ec" "Bash: python3 -m tools.pr_watch module launch is blocked"
 
+# --- Block Cases (Codex round 3 指摘: 複数行 / 予約語境界 / gh global フラグ) ---
+
+# 7m. Bash + 複数行の while ループ (loop 構文と gh が別行) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'while true; do
+  gh pr checks 51
+  sleep 30
+done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: multiline while + gh pr checks polling loop is blocked"
+
+# 7n. Bash + if/then 内の pr-watch.sh 起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'if true; then bash tools/pr-watch.sh 51; fi')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: pr-watch.sh launch after 'then' is blocked"
+
+# 7o. Bash + while/do 内の pr-watch.sh 起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'while true; do bash tools/pr-watch.sh 51; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: pr-watch.sh launch after 'do' is blocked"
+
+# 7p. Bash + gh global フラグ (-R) が pr の前に来る形 + --watch -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'gh -R owner/repo pr checks 51 --watch')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: gh -R owner/repo pr checks --watch is blocked"
+
+# 7q. Monitor + gh -R owner/repo pr checks -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Monitor" 'gh -R owner/repo pr checks 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Monitor: gh -R owner/repo pr checks is blocked"
+
 # --- Allow Cases ---
+
+# 7r. Bash + watcher の unit test 実行 (tools/test_pr_watch.py) -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'python3 tools/test_pr_watch.py')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: python3 tools/test_pr_watch.py (unit test) is allowed"
+
+# 7s. Bash + unittest module 形の unit test -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'python3 -m unittest tools.test_pr_watch')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: python3 -m unittest tools.test_pr_watch is allowed"
 
 # 7l. Bash + 単発 gh pr checks の結果を while read で加工 (gh は 1 回実行) -> allow
 stderr=$(mktemp); TMPFILES+=("$stderr")

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -268,6 +268,48 @@ json=$(make_payload "Bash" "pwsh '.\\tools\\pr-watch.ps1' 51")
 ec=$(run_hook "$json" "$stderr")
 assert_exit 2 "$ec" "Bash: pwsh with backslash-separated pr-watch.ps1 path is blocked"
 
+# --- Block Cases (Codex round 7 指摘: interpreter heredoc / bash -c 引用スクリプト) ---
+
+# 7ai. Bash + シェルへの heredoc stdin (本文はコード) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "bash <<'EOF'
+while true; do gh pr checks 51; sleep 30; done
+EOF")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: heredoc piped into bash (executable body) is blocked"
+
+# 7aj. Bash + bash -c の引用スクリプト内の polling ループ -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "bash -c 'while true; do gh pr checks 51; sleep 30; done'")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: bash -c quoted polling loop is blocked"
+
+# 7ak. Bash + bash -c の引用スクリプト内の --watch -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "bash -c 'gh pr checks 51 --watch'")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: bash -c quoted gh pr checks --watch is blocked"
+
+# --- Allow Cases (Codex round 7 指摘: 兄弟ループ / 非実行インタプリタモード) ---
+
+# 7al. Bash + 兄弟ループに挟まれた単発 gh pr checks -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'for x in a; do :; done; gh pr checks 51; for y in b; do :; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: one-shot gh pr checks between sibling loops is allowed"
+
+# 7am. Bash + bash -n の構文チェック -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'bash -n tools/pr-watch.sh')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: bash -n syntax check of pr-watch.sh is allowed"
+
+# 7an. Bash + py_compile のバイトコンパイル -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'python3 -m py_compile tools/pr_watch.py')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: python3 -m py_compile of pr_watch.py is allowed"
+
 # --- Allow Cases (Codex round 6 指摘: heredoc 本文はデータ) ---
 
 # 7ah. Bash + heredoc 本文に polling ループのテキストを書くドキュメント生成 -> allow

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -290,6 +290,36 @@ json=$(make_payload "Bash" "bash -c 'gh pr checks 51 --watch'")
 ec=$(run_hook "$json" "$stderr")
 assert_exit 2 "$ec" "Bash: bash -c quoted gh pr checks --watch is blocked"
 
+# --- Block Cases (Codex round 8 指摘: 関数間接 / 改行区切り予約語 / pipe heredoc / sudo -u) ---
+
+# 7ao. Bash + 関数に包んだ gh pr checks をループから呼ぶ -> block (保守的)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'poll_ci() { gh pr checks 51; }; while true; do poll_ci; sleep 30; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: function-wrapped gh pr checks called from loop is blocked"
+
+# 7ap. Bash + 予約語が独立行のループ -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'until
+gh pr checks 51 | grep -q pass
+do sleep 30; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: loop with reserved word on its own line is blocked"
+
+# 7aq. Bash + cat heredoc を bash に pipe (本文はコード) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" "cat <<'EOF' | bash
+while true; do gh pr checks 51; sleep 30; done
+EOF")
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: heredoc piped to bash (executable body) is blocked"
+
+# 7ar. Bash + sudo -u git (reader 語がユーザー名) 経由の起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'sudo -u git bash tools/pr-watch.sh 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: sudo -u git bash tools/pr-watch.sh is blocked (git is a username, not a reader)"
+
 # --- Allow Cases (Codex round 7 指摘: 兄弟ループ / 非実行インタプリタモード) ---
 
 # 7al. Bash + 兄弟ループに挟まれた単発 gh pr checks -> allow

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -108,6 +108,44 @@ json=$(make_payload "Monitor" './tools/pr-watch.sh 51')
 ec=$(run_hook "$json" "$stderr")
 assert_exit 2 "$ec" "Monitor: ./tools/pr-watch.sh launch is blocked"
 
+# --- Block Cases (Codex round 1 指摘: gh 親コマンドフラグ / インタプリタ形の取りこぼし) ---
+
+# 7b. Bash + while + gh pr --repo owner/repo checks (pr と checks の間にフラグ) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'while true; do gh pr --repo owner/repo checks 51; sleep 30; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: while + gh pr --repo owner/repo checks is blocked"
+
+# 7c. Monitor + gh pr -R owner/repo checks -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Monitor" 'gh pr -R owner/repo checks 51 --json name,bucket')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Monitor: gh pr -R owner/repo checks is blocked"
+
+# 7d. Bash + py -3 tools/pr_watch.py (Windows launcher 形) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'py -3 tools/pr_watch.py --pr 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: py -3 tools/pr_watch.py launch is blocked"
+
+# 7e. Bash + 絶対パスのインタプリタ -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" '/usr/bin/bash tools/pr-watch.sh 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: /usr/bin/bash tools/pr-watch.sh launch is blocked"
+
+# 7f. Bash + 環境変数代入前置 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'env ORG_TRANSPORT=broker bash tools/pr-watch.sh 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: env VAR=... bash tools/pr-watch.sh launch is blocked"
+
+# 7g. Bash + python3 -u tools/pr_watch.py (インタプリタフラグ付き) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'python3 -u tools/pr_watch.py --pr 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: python3 -u tools/pr_watch.py launch is blocked"
+
 # --- Allow Cases ---
 
 # 8. Bash + 単発 gh pr checks (ループなし) -> allow
@@ -151,6 +189,12 @@ stderr=$(mktemp); TMPFILES+=("$stderr")
 json='{"tool_name":"Monitor","tool_input":{"ws":{"url":"wss://example.com/stream"},"description":"x"}}'
 ec=$(run_hook "$json" "$stderr")
 assert_exit 0 "$ec" "Monitor ws source without command is allowed"
+
+# 14b. Bash + gh pr view (checks でない別サブコマンド + 文中の checks 語) -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'while true; do gh pr view 51 --json title; echo checks done; sleep 5; done')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: gh pr view loop with unrelated 'checks' word is allowed"
 
 # --- Fail-closed Cases ---
 

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -207,6 +207,52 @@ json=$(make_payload "Monitor" 'gh -R owner/repo pr checks 51')
 ec=$(run_hook "$json" "$stderr")
 assert_exit 2 "$ec" "Monitor: gh -R owner/repo pr checks is blocked"
 
+# --- Block Cases (Codex round 4 指摘: 条件位置 / case 腕 / 読み取り例外の越境) ---
+
+# 7t. Bash + if 条件位置での pr-watch.sh 起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'if bash tools/pr-watch.sh 51; then echo ok; fi')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: pr-watch.sh launch as if-condition is blocked"
+
+# 7u. Bash + case 腕 (`)` の直後) での pr-watch.sh 起動 -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'case $x in y) bash tools/pr-watch.sh 51;; esac')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: pr-watch.sh launch in case arm is blocked"
+
+# 7v. Bash + 読み取りと起動の複合 (読み取り例外が起動区間へ越境しない) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'cat tools/pr-watch.sh && bash tools/pr-watch.sh 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Bash: cat then launch compound is still blocked (reader exemption does not leak)"
+
+# --- Allow Cases (Codex round 4 指摘: 閉じたループ後の単発 / 無関係 --watch / ラッパー越し読み取り) ---
+
+# 7w. Bash + 閉じたループの後の単発 gh pr checks -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'for f in a b; do echo "$f"; done; gh pr checks 51')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: one-shot gh pr checks after a closed loop is allowed"
+
+# 7x. Bash + 単発 gh pr checks の後に別コマンドの --watch -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'gh pr checks 51; other-tool --watch x')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: unrelated other-tool --watch after one-shot gh pr checks is allowed"
+
+# 7y. Bash + env 越しの grep 読み取り -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'env LC_ALL=C grep -n ci_completed tools/pr-watch.sh')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: env-wrapped grep read of pr-watch.sh is allowed"
+
+# 7z. Bash + timeout 越しの cat 読み取り -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json=$(make_payload "Bash" 'timeout 1s cat tools/pr-watch.sh')
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash: timeout-wrapped cat read of pr-watch.sh is allowed"
+
 # --- Allow Cases ---
 
 # 7r. Bash + watcher の unit test 実行 (tools/test_pr_watch.py) -> allow

--- a/tests/test-block-adhoc-pr-watch.sh
+++ b/tests/test-block-adhoc-pr-watch.sh
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
-# Tests for block-adhoc-pr-watch.sh
-# Validates: exit code (0=allow/passthrough, 2=block) and stderr messages.
+# Tests for block-adhoc-pr-watch.sh (best-effort 安全網の簡素版)
+# Validates: exit code (0=allow/passthrough, 2=block) and deny stderr の誘導文言。
 #
-# 確認観点 (2026-08-20 の PR #51 実害への機械ガード):
-#   - Monitor + gh pr checks (ループの有無問わず)   -> block (Monitor は定義上「監視」)
-#   - Bash + while/until/for + gh pr checks         -> block (polling ループ)
-#   - Bash + gh pr checks --watch                   -> block (張り付き監視)
-#   - Bash/Monitor + tools/pr-watch.* の直接起動     -> block (孤児化する ad-hoc 監視)
+# 確認観点:
+#   - Monitor + while + gh pr checks polling ループ  -> block
+#   - Bash + until ループ + gh pr checks            -> block
+#   - Bash + tools/pr-watch.sh の直接起動           -> block
 #   - Bash + 単発 gh pr checks <n>                  -> allow (状態確認は監視でない)
-#   - Bash + gh pr checks | grep -w (=--web でない) -> allow (-w を watch と誤認しない)
-#   - Bash + grep/cat の引数に pr-watch.sh          -> allow (読み取りは起動でない)
-#   - 非対象ツール / command 欠落 (Monitor ws)       -> passthrough
-#   - 不正 JSON / 空 stdin                          -> block (fail-closed)
+#   - Bash + gh pr view                             -> allow (無関係な gh サブコマンド)
+#   - Bash + 無関係コマンド                          -> allow
+#   - 壊れた JSON                                   -> allow (best-effort: 判定不能は許可側)
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -71,481 +69,43 @@ assert_exit 2 "$ec" "Monitor: while + gh pr checks polling loop is blocked"
 assert_stderr_contains "/pr-watch-pane" "$stderr" "deny stderr names the canonical path /pr-watch-pane"
 assert_stderr_contains "人間に報告して指示を仰いでください" "$stderr" "deny stderr instructs to consult the human"
 
-# 2. Monitor + gh pr checks (ループなしでも Monitor は監視) -> block
+# 2. Bash + until ループ + gh pr checks -> block
 stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Monitor" 'gh pr checks 51 --json name,bucket')
+json=$(make_payload "Bash" 'until gh pr checks 51 --json bucket | jq -e "all(.bucket == \"pass\")"; do sleep 60; done')
 ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Monitor: gh pr checks without loop is still blocked (Monitor is watching by definition)"
+assert_exit 2 "$ec" "Bash: until loop + gh pr checks is blocked"
 
-# 3. Bash + until ループ + gh pr checks -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'until gh pr checks 51 | grep -q pass; do sleep 60; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: until + gh pr checks polling loop is blocked"
-
-# 4. Bash + gh pr checks --watch -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'gh pr checks 51 --watch')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: gh pr checks --watch is blocked"
-
-# 5. Bash + tools/pr-watch.sh 直接起動 -> block
+# 3. Bash + tools/pr-watch.sh の直接起動 -> block
 stderr=$(mktemp); TMPFILES+=("$stderr")
 json=$(make_payload "Bash" 'setsid bash tools/pr-watch.sh 51 < /dev/null > /dev/null 2>&1 &')
 ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: setsid bash tools/pr-watch.sh direct launch is blocked"
-assert_stderr_contains "tools/pr-watch.* の直接起動は禁止" "$stderr" "deny stderr names the pr-watch direct-launch ban"
-
-# 6. Bash + 絶対パスの pr_watch.py 起動 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'python3 /home/user/repo/tools/pr_watch.py --pr 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: python3 .../tools/pr_watch.py launch is blocked"
-
-# 7. Monitor + pr-watch.sh 起動 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Monitor" './tools/pr-watch.sh 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Monitor: ./tools/pr-watch.sh launch is blocked"
-
-# --- Block Cases (Codex round 1 指摘: gh 親コマンドフラグ / インタプリタ形の取りこぼし) ---
-
-# 7b. Bash + while + gh pr --repo owner/repo checks (pr と checks の間にフラグ) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'while true; do gh pr --repo owner/repo checks 51; sleep 30; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: while + gh pr --repo owner/repo checks is blocked"
-
-# 7c. Monitor + gh pr -R owner/repo checks -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Monitor" 'gh pr -R owner/repo checks 51 --json name,bucket')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Monitor: gh pr -R owner/repo checks is blocked"
-
-# 7d. Bash + py -3 tools/pr_watch.py (Windows launcher 形) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'py -3 tools/pr_watch.py --pr 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: py -3 tools/pr_watch.py launch is blocked"
-
-# 7e. Bash + 絶対パスのインタプリタ -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" '/usr/bin/bash tools/pr-watch.sh 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: /usr/bin/bash tools/pr-watch.sh launch is blocked"
-
-# 7f. Bash + 環境変数代入前置 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'env ORG_TRANSPORT=broker bash tools/pr-watch.sh 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: env VAR=... bash tools/pr-watch.sh launch is blocked"
-
-# 7g. Bash + python3 -u tools/pr_watch.py (インタプリタフラグ付き) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'python3 -u tools/pr_watch.py --pr 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: python3 -u tools/pr_watch.py launch is blocked"
-
-# --- Block Cases (Codex round 2 指摘: path 付き watch / 未網羅ラッパー / module 実行) ---
-
-# 7h. Bash + /usr/bin/watch -n 30 gh pr checks -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" '/usr/bin/watch -n 30 gh pr checks 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: path-qualified /usr/bin/watch + gh pr checks is blocked"
-
-# 7i. Bash + timeout ラッパー経由の pr-watch.sh -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'timeout 1h bash tools/pr-watch.sh 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: timeout 1h bash tools/pr-watch.sh launch is blocked"
-
-# 7j. Bash + source での取り込み実行 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'source tools/pr-watch.sh 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: source tools/pr-watch.sh is blocked"
-
-# 7k. Bash + python module 実行 (python3 -m tools.pr_watch) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'python3 -m tools.pr_watch --pr 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: python3 -m tools.pr_watch module launch is blocked"
-
-# --- Block Cases (Codex round 3 指摘: 複数行 / 予約語境界 / gh global フラグ) ---
-
-# 7m. Bash + 複数行の while ループ (loop 構文と gh が別行) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'while true; do
-  gh pr checks 51
-  sleep 30
-done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: multiline while + gh pr checks polling loop is blocked"
-
-# 7n. Bash + if/then 内の pr-watch.sh 起動 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'if true; then bash tools/pr-watch.sh 51; fi')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: pr-watch.sh launch after 'then' is blocked"
-
-# 7o. Bash + while/do 内の pr-watch.sh 起動 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'while true; do bash tools/pr-watch.sh 51; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: pr-watch.sh launch after 'do' is blocked"
-
-# 7p. Bash + gh global フラグ (-R) が pr の前に来る形 + --watch -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'gh -R owner/repo pr checks 51 --watch')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: gh -R owner/repo pr checks --watch is blocked"
-
-# 7q. Monitor + gh -R owner/repo pr checks -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Monitor" 'gh -R owner/repo pr checks 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Monitor: gh -R owner/repo pr checks is blocked"
-
-# --- Block Cases (Codex round 4 指摘: 条件位置 / case 腕 / 読み取り例外の越境) ---
-
-# 7t. Bash + if 条件位置での pr-watch.sh 起動 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'if bash tools/pr-watch.sh 51; then echo ok; fi')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: pr-watch.sh launch as if-condition is blocked"
-
-# 7u. Bash + case 腕 (`)` の直後) での pr-watch.sh 起動 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'case $x in y) bash tools/pr-watch.sh 51;; esac')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: pr-watch.sh launch in case arm is blocked"
-
-# 7v. Bash + 読み取りと起動の複合 (読み取り例外が起動区間へ越境しない) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'cat tools/pr-watch.sh && bash tools/pr-watch.sh 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: cat then launch compound is still blocked (reader exemption does not leak)"
-
-# --- Block Cases (Codex round 5 指摘: ネストループ / 継続行 / dot-source) ---
-
-# 7aa. Bash + ネストしたループ (内側 done の後に gh pr checks、外側 done で反復) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'while true; do for x in a; do :; done; gh pr checks 51; sleep 30; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: nested loop with gh pr checks after inner done is blocked"
-
-# 7ab. Bash + バックスラッシュ継続行入りの polling ループ -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'while true; do gh pr \
-checks 51; sleep 30; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: polling loop with backslash-newline continuation is blocked"
-
-# 7ac. Bash + POSIX dot-source での pr-watch.sh 実行 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" '. tools/pr-watch.sh 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: POSIX dot-source of tools/pr-watch.sh is blocked"
-
-# --- Block Cases (Codex round 6 指摘: 密着リダイレクト / 引用付き代入 / Windows パス) ---
-
-# 7ae. Bash + ファイル名直後の密着リダイレクト -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'bash tools/pr-watch.sh>/tmp/watch.log 51 &')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: pr-watch.sh launch with attached redirection is blocked"
-
-# 7af. Bash + 空白入り引用値の環境変数代入前置 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "NOTE='CI watch' bash tools/pr-watch.sh 51")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: quoted env assignment prefix launch is blocked"
-
-# 7ag. Bash + Windows パス区切りの pr-watch.ps1 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "pwsh '.\\tools\\pr-watch.ps1' 51")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: pwsh with backslash-separated pr-watch.ps1 path is blocked"
-
-# --- Block Cases (Codex round 7 指摘: interpreter heredoc / bash -c 引用スクリプト) ---
-
-# 7ai. Bash + シェルへの heredoc stdin (本文はコード) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "bash <<'EOF'
-while true; do gh pr checks 51; sleep 30; done
-EOF")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: heredoc piped into bash (executable body) is blocked"
-
-# 7aj. Bash + bash -c の引用スクリプト内の polling ループ -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "bash -c 'while true; do gh pr checks 51; sleep 30; done'")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: bash -c quoted polling loop is blocked"
-
-# 7ak. Bash + bash -c の引用スクリプト内の --watch -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "bash -c 'gh pr checks 51 --watch'")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: bash -c quoted gh pr checks --watch is blocked"
-
-# --- Block Cases (Codex round 8 指摘: 関数間接 / 改行区切り予約語 / pipe heredoc / sudo -u) ---
-
-# 7ao. Bash + 関数に包んだ gh pr checks をループから呼ぶ -> block (保守的)
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'poll_ci() { gh pr checks 51; }; while true; do poll_ci; sleep 30; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: function-wrapped gh pr checks called from loop is blocked"
-
-# 7ap. Bash + 予約語が独立行のループ -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'until
-gh pr checks 51 | grep -q pass
-do sleep 30; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: loop with reserved word on its own line is blocked"
-
-# 7aq. Bash + cat heredoc を bash に pipe (本文はコード) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "cat <<'EOF' | bash
-while true; do gh pr checks 51; sleep 30; done
-EOF")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: heredoc piped to bash (executable body) is blocked"
-
-# 7ar. Bash + sudo -u git (reader 語がユーザー名) 経由の起動 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'sudo -u git bash tools/pr-watch.sh 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: sudo -u git bash tools/pr-watch.sh is blocked (git is a username, not a reader)"
-
-# --- Allow Cases (Codex round 7 指摘: 兄弟ループ / 非実行インタプリタモード) ---
-
-# 7al. Bash + 兄弟ループに挟まれた単発 gh pr checks -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'for x in a; do :; done; gh pr checks 51; for y in b; do :; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: one-shot gh pr checks between sibling loops is allowed"
-
-# 7am. Bash + bash -n の構文チェック -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'bash -n tools/pr-watch.sh')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: bash -n syntax check of pr-watch.sh is allowed"
-
-# 7an. Bash + py_compile のバイトコンパイル -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'python3 -m py_compile tools/pr_watch.py')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: python3 -m py_compile of pr_watch.py is allowed"
-
-# --- Allow Cases (Codex round 6 指摘: heredoc 本文はデータ) ---
-
-# 7ah. Bash + heredoc 本文に polling ループのテキストを書くドキュメント生成 -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "cat > doc.md <<'EOF'
-while true; do gh pr checks 51; sleep 30; done
-EOF")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: heredoc body containing polling-loop text is allowed (data, not code)"
-
-# --- Allow Cases (Codex round 5 指摘: 引用内の区切り文字はデータ) ---
-
-# 7ad. Bash + 引用文字列の中に `; bash tools/pr-watch.sh` を含む echo -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "echo 'x; bash tools/pr-watch.sh 51'")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: quoted separator inside echo data is not treated as a launch"
-
-# --- Allow Cases (Codex round 4 指摘: 閉じたループ後の単発 / 無関係 --watch / ラッパー越し読み取り) ---
-
-# 7w. Bash + 閉じたループの後の単発 gh pr checks -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'for f in a b; do echo "$f"; done; gh pr checks 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: one-shot gh pr checks after a closed loop is allowed"
-
-# 7x. Bash + 単発 gh pr checks の後に別コマンドの --watch -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'gh pr checks 51; other-tool --watch x')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: unrelated other-tool --watch after one-shot gh pr checks is allowed"
-
-# 7y. Bash + env 越しの grep 読み取り -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'env LC_ALL=C grep -n ci_completed tools/pr-watch.sh')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: env-wrapped grep read of pr-watch.sh is allowed"
-
-# 7z. Bash + timeout 越しの cat 読み取り -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'timeout 1s cat tools/pr-watch.sh')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: timeout-wrapped cat read of pr-watch.sh is allowed"
+assert_exit 2 "$ec" "Bash: direct launch of tools/pr-watch.sh is blocked"
+assert_stderr_contains "/pr-watch-pane" "$stderr" "pr-watch.sh deny stderr names /pr-watch-pane"
 
 # --- Allow Cases ---
 
-# 7r. Bash + watcher の unit test 実行 (tools/test_pr_watch.py) -> allow
+# 4. Bash + 単発 gh pr checks <n> (状態確認) -> allow
 stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'python3 tools/test_pr_watch.py')
+json=$(make_payload "Bash" 'gh pr checks 51 --json name,bucket')
 ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: python3 tools/test_pr_watch.py (unit test) is allowed"
+assert_exit 0 "$ec" "Bash: single-shot gh pr checks is allowed (status check, not watching)"
 
-# 7s. Bash + unittest module 形の unit test -> allow
+# 5. Bash + gh pr view -> allow
 stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'python3 -m unittest tools.test_pr_watch')
+json=$(make_payload "Bash" 'gh pr view 51 --json state,title')
 ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: python3 -m unittest tools.test_pr_watch is allowed"
+assert_exit 0 "$ec" "Bash: gh pr view is allowed"
 
-# 7l. Bash + 単発 gh pr checks の結果を while read で加工 (gh は 1 回実行) -> allow
+# 6. Bash + 無関係コマンド -> allow
 stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'gh pr checks 51 --json name,bucket | while read -r row; do echo "$row"; done')
+json=$(make_payload "Bash" 'git status && python3 -m pytest tests/')
 ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: one-shot gh pr checks piped into while-read processing is allowed"
+assert_exit 0 "$ec" "Bash: unrelated command is allowed"
 
-# 8. Bash + 単発 gh pr checks (ループなし) -> allow
+# 7. 壊れた JSON -> allow (best-effort 安全網: 判定不能は許可側に倒す)
 stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'gh pr checks 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: one-shot gh pr checks is allowed"
-
-# 9. Bash + 単発 gh pr checks --repo 付き + jq 加工 -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'gh pr checks 51 --repo owner/repo --json name,bucket | jq -r ".[].bucket"')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: one-shot gh pr checks with --repo/--json pipeline is allowed"
-
-# 10. Bash + grep -w (=word-regexp) は --watch でない -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'gh pr checks 51 | grep -w pass')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: gh pr checks piped to grep -w is allowed (-w is not --watch)"
-
-# 11. Bash + pr-watch.sh を引数位置で読むだけ (grep) -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'grep -n ci_completed tools/pr-watch.sh')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: reading tools/pr-watch.sh as a grep argument is allowed"
-
-# 12. Bash + gh pr checks を含まない while ループ -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'while read -r line; do echo "$line"; done < input.txt')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: unrelated while loop without gh pr checks is allowed"
-
-# 13. 非対象ツール (Edit) は passthrough -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json='{"tool_name":"Edit","tool_input":{"file_path":"/tmp/x","old_string":"while gh pr checks","new_string":"y"}}'
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "non-target tool (Edit) passes through"
-
-# 14. Monitor + ws source (command 欠落) -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json='{"tool_name":"Monitor","tool_input":{"ws":{"url":"wss://example.com/stream"},"description":"x"}}'
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Monitor ws source without command is allowed"
-
-# 14b. Bash + gh pr view (checks でない別サブコマンド + 文中の checks 語) -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'while true; do gh pr view 51 --json title; echo checks done; sleep 5; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: gh pr view loop with unrelated 'checks' word is allowed"
-
-# --- Block Cases (Codex round 9 指摘: 二重引用内 cmdsubst / eval / watch 引用引数) ---
-
-# 7as. Bash + 二重引用内のコマンド置換での起動 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'echo "$(bash tools/pr-watch.sh 51)"')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: launch inside double-quoted command substitution is blocked"
-
-# 7at. Bash + eval の引用スクリプトでの起動 -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "eval 'bash tools/pr-watch.sh 51'")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: eval-quoted launch of pr-watch.sh is blocked"
-
-# 7au. Bash + watch の引用引数の gh pr checks -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "watch -n 30 'gh pr checks 51'")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: watch with quoted gh pr checks argument is blocked"
-
-# --- Allow Cases (Codex round 9 指摘: grep パターンの bash / 単一引用データ) ---
-
-# 7av. Bash + grep のパターン引数がたまたま bash である読み取り -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'env LC_ALL=C grep -n bash tools/pr-watch.sh')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: grep with pattern 'bash' reading pr-watch.sh is allowed"
-
-# 7aw. Bash + 単一引用データに polling ループのテキストを含む printf -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "printf '%s\\n' 'docs: while true; do gh pr checks 51; done'")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: single-quoted polling-loop text passed to printf is allowed (data)"
-
-# --- Block Cases (Codex round 10 指摘: ラッパー越し pipe heredoc) ---
-
-# 7ax. Bash + heredoc を env bash に pipe (本文はコード) -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "cat <<'EOF' | env bash
-while true; do gh pr checks 51; sleep 30; done
-EOF")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: heredoc piped to env bash (executable body) is blocked"
-
-# --- Allow Cases (Codex round 10 指摘: 代入値 / 引数テキストの gh) ---
-
-# 7ay. Bash + 変数代入の値が pr-watch.sh (実行しない) -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'SCRIPT=tools/pr-watch.sh echo assigned')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: assignment value tools/pr-watch.sh without execution is allowed"
-
-# 7az. Bash + ループ内で echo の引数に gh pr checks のテキスト -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'while read -r x; do echo gh pr checks 51; done')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: echo of gh pr checks text inside loop is allowed (argument position)"
-
-# --- Cases (Codex round 11 指摘: subshell 終端 / watch のコマンド位置 / 非実行コマンド引数) ---
-
-# 7ba. Bash + subshell 内の gh pr checks --watch -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" '(gh pr checks 51 --watch)')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 2 "$ec" "Bash: (gh pr checks --watch) in subshell is blocked"
-
-# 7bb. Bash + echo の引数に watch gh pr checks のテキスト -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" 'echo watch gh pr checks 51')
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: echo of 'watch gh pr checks' text is allowed (argument position)"
-
-# 7bc. Bash + env printf の引数に pr-watch.sh のパス -> allow
-stderr=$(mktemp); TMPFILES+=("$stderr")
-json=$(make_payload "Bash" "env printf '%s\\n' tools/pr-watch.sh")
-ec=$(run_hook "$json" "$stderr")
-assert_exit 0 "$ec" "Bash: env printf with pr-watch.sh path argument is allowed"
-
-# --- Fail-closed Cases ---
-
-# 15. 空 stdin -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-ec=$(run_hook "" "$stderr")
-assert_exit 2 "$ec" "empty stdin is blocked (fail-closed)"
-
-# 16. 不正 JSON -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-ec=$(run_hook 'not json {' "$stderr")
-assert_exit 2 "$ec" "invalid JSON is blocked (fail-closed)"
-
-# 17. tool_input が object でない -> block
-stderr=$(mktemp); TMPFILES+=("$stderr")
-ec=$(run_hook '{"tool_name":"Bash","tool_input":"gh pr checks"}' "$stderr")
-assert_exit 2 "$ec" "non-object tool_input is blocked (fail-closed)"
+ec=$(run_hook '{"tool_name": "Bash", broken' "$stderr")
+assert_exit 0 "$ec" "broken JSON is allowed (best-effort safety net, not a gate)"
 
 # --- Summary ---
 echo "# $PASS passed, $FAIL failed out of $TEST_NUM tests"

--- a/tests/test-hooks-payload-fail-closed.sh
+++ b/tests/test-hooks-payload-fail-closed.sh
@@ -51,7 +51,11 @@ PARSE_MARKER="JSON object として解析できませんでした"
 # 検査対象外。ファイル名と理由を 1 行ずつ明示する。
 # - fixture-always-block.sh: hook 配線の手動確認用 fixture であり常時 exit 2。
 #   stdin を /tmp/hook-test.log へ追記する副作用があるためテストからは呼ばない。
-EXEMPT=("fixture-always-block.sh")
+# - block-adhoc-pr-watch.sh: enforcement ゲートではなく best-effort の安全網
+#   (一次規律は .claude/rules/pr-ci-watch.md)。false positive を避けるため
+#   判定不能な payload は意図的に許可側 (fail-open) に倒す設計。
+#   専用テスト tests/test-block-adhoc-pr-watch.sh 側で挙動を検査する。
+EXEMPT=("fixture-always-block.sh" "block-adhoc-pr-watch.sh")
 
 PASS=0; FAIL=0; TEST_NUM=0
 


### PR DESCRIPTION
## 概要

2026-08-20、窓口が PR #51 の CI 監視で /pr-watch-pane の [split_refused] に遭った際、スキル規定（報告して中断）に従わずセッション寿命依存の Monitor polling へ自己判断で差し替えた逸脱の再発防止。prose の規律（root CLAUDE.md / pr-watch-pane SKILL.md）は存在したが埋もれて効かなかったため、(1) 常時ロードの短い rule と (2) PreToolUse の機械ガードの 2 段にする。

- **`.claude/rules/pr-ci-watch.md`**（6 行）: 正規経路は /pr-watch-pane のみ / 立てられないときは人間に報告 / Monitor・Bash での gh pr checks polling ループと tools/pr-watch.* 直接起動は禁止 / 単発 gh pr checks は可
- **`.hooks/block-adhoc-pr-watch.sh`**（54 行）: Bash / Monitor の command に対する保守的パターン 2 つのみで deny する **best-effort 安全網**。bash 完全パースは非目標と冒頭に明記し、判定不能は許可側（fail-open。同 suite の fail-closed 強制からは理由コメント付きで EXEMPT）
- 配線は `.claude/settings.json` の Bash|Monitor matcher

## 経緯（レビュー履歴の説明）

コミット履歴の round 2〜11 は、初版実装が Codex レビューで bash パースの抜け道指摘の無限収束ループに入った痕跡。最終コミット 6f08060 で 340 行 → 54 行に簡素化し「敵対者対策ではなく自己規律の安全網」という設計に確定した（抜け道の網羅は放棄が正しい）。

## 検証

- フックテスト 7 ケース 10 assertion 全 pass（deny 3 / allow 4、壊れた JSON の fail-open 含む）
- `tests/run-all.sh`: **912/912 pass**
- codex exec review（簡素化後 1 回）: P1 1 件（テスト summary 形式）のみ → 修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)