### PR TITLE
fix(claude): sandbox の .env.* deny から .env.example テンプレートを除外する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -98,6 +98,10 @@
     "enabled": true,
     "failIfUnavailable": false,
     "filesystem": {
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         ".env",
         ".env.*",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,27 @@
 
 ### Fixed
 
+- sandbox の `.env.*` deny がコミット済みテンプレート `.env.example` まで巻き込んでいた問題を、
+  Layer 3 の `allowRead` carve-out で解消 (#959 摩擦 1)。
+  [`tools/org_extension_schema.json`](tools/org_extension_schema.json) の全 11 個の
+  `sandbox.filesystem` body (`roles.{secretary,dispatcher,curator}` +
+  `worker_roles.{default,claude-org-self-edit,doc-audit}` の各 pattern) と
+  [`.claude/settings.json`](.claude/settings.json) に
+  `allowRead: [".env.example", ".env.*.example"]` を追加した。
+  `denyRead` は否定パターンを持たない (Claude Code 2.1.245 実機で `!.env.example` は deny のまま) ため、
+  公式の [`sandbox.filesystem.allowRead`](https://code.claude.com/docs/en/sandboxing)
+  (「re-allow specific paths within a denied region」/「When read rules overlap, the more specific path wins」)
+  を使っている。同 2.1.245 の実機検証で `.env` / `.env.local` / `.env.production` /
+  `.env.development.local` / `.env.staging` は deny のまま・`.env.example` /
+  `.env.live.example` / `.env.production.example` が読め・`.env` を指す `.env.evil.example`
+  symlink は deny のままであることを確認した (generator が実際に render した
+  worker `settings.local.json` — 絶対 path の `denyRead` と相対 `allowRead` の組み合わせ — でも同結果)。
+  Layer 2 (`permissions.deny` の `Read(.env.*)` と `layer2Fallback` 文字列) は**広いまま据え置き**である:
+  Layer 2 は deny が allow に優先し (同実機で確認)、narrow 化には秘密ファイル名の列挙が要って網羅できないため。
+  報告された摩擦 (pytest が `.env.example` を読む) は Bash 経由 = Layer 3 の事象なので、これで解消する。
+  背景と不変条件は
+  [`docs/contracts/role-pattern-sandbox-contract.md`](docs/contracts/role-pattern-sandbox-contract.md) §1.5 に新設した。
+
 - ディスパッチャーの監視判定が「観測不能」を「対象の異常」と解釈して誤検知を出していた問題を、
   3 箇所の個別修正ではなく 1 つの原則として根治 (#869)。
   [`.dispatcher/references/worker-monitoring.md`](.dispatcher/references/worker-monitoring.md) の

--- a/docs/contracts/role-pattern-sandbox-contract.md
+++ b/docs/contracts/role-pattern-sandbox-contract.md
@@ -159,6 +159,41 @@ enumerate:
   tools write to disk) but Phase 0 keeps them out of the row tables to avoid
   duplicating the role-contract `permissions.allow` enumeration.
 
+### 1.5 `.env` template carve-out (Layer 3 only)
+
+Every `denyRead` cell in this contract that reads `.env.*` is to be read with
+one exception, uniform across all roles and all patterns:
+
+> Layer 3 `allowRead`: `.env.example`, `.env.*.example` — committed template
+> files are re-opened inside the `.env.*` denied region.
+
+The `.env.*` glob matches committed `.env.example` / `.env.live.example`
+templates, which carry no secrets. Denying them produced real friction (a
+2026-08-25 worker report of `test_local_env` failing on `.env.example` with
+`PermissionError` inside the sandbox), and friction of that kind is one of the
+measured drivers of `dangerouslyDisableSandbox` bypasses (`claude-org-ja#959`:
+59% of worker `Bash` calls ran with the sandbox off). The carve-out is
+expressed with Claude Code's [`sandbox.filesystem.allowRead`](https://code.claude.com/docs/en/sandboxing)
+key ("re-allow specific paths within a denied region"; "When read rules
+overlap, the more specific path wins"), because `denyRead` has no negation
+syntax — a `!.env.example` entry was verified on Claude Code 2.1.245 to leave
+the file denied.
+
+Two properties of the carve-out matter for this contract:
+
+- **Layer 3 only.** The Layer 2 mirrors (`permissions.deny` `Read(.env.*)` and
+  the `layer2Fallback` strings in [`tools/org_extension_schema.json`](../../tools/org_extension_schema.json))
+  stay broad. Layer 2 resolves deny over allow — verified on 2.1.245: a
+  `permissions.allow` `Read(.env.example)` does not lift a `Read(.env.*)`
+  deny — so narrowing Layer 2 would mean enumerating secret filenames, which
+  cannot be made exhaustive. The `Read` tool therefore still refuses
+  templates; `Bash`, which is where the reported friction occurs and which
+  Layer 2 does not gate on paths at all, now succeeds under the sandbox.
+- **Symlinks do not widen it.** A `.env.evil.example` symlink pointing at
+  `.env` stays denied (verified on 2.1.245): the sandbox refuses to restore an
+  `allowRead` entry whose symlink escapes the expected location, so a
+  template-shaped name cannot be used to smuggle a secret out.
+
 ---
 
 ## 2. Pattern reference (recap)

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
@@ -156,6 +156,10 @@
       "additionalDirectories": [
         "/home/u/co/knowledge"
       ],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/co/.curator/.env",
         "/home/u/co/.curator/.env.*",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
@@ -69,6 +69,10 @@
       "additionalDirectories": [
         "/home/u/co"
       ],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/co/**/credentials*",
         "/home/u/co/**/*.pem",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
@@ -66,6 +66,10 @@
     "enabled": true,
     "filesystem": {
       "additionalDirectories": [],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/co/.env",
         "/home/u/co/.env.*",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_A.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_A.json
@@ -73,6 +73,10 @@
       "additionalDirectories": [
         "/home/u/co/knowledge/raw"
       ],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/workers/proj/.env",
         "/home/u/workers/proj/.env.*",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_B.json
@@ -96,6 +96,10 @@
         "/home/u/workers/proj/.git/packed-refs",
         "/home/u/co/knowledge/raw"
       ],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/workers/proj/.worktrees/T123/.env",
         "/home/u/workers/proj/.worktrees/T123/.env.*",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_C.json
@@ -73,6 +73,10 @@
       "additionalDirectories": [
         "/home/u/co/knowledge/raw"
       ],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/workers/T123/.env",
         "/home/u/workers/T123/.env.*",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_A.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_A.json
@@ -73,6 +73,10 @@
       "additionalDirectories": [
         "/home/u/work/wd/.claude/plans"
       ],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/work/wd/.env",
         "/home/u/work/wd/.env.*",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_B.json
@@ -96,6 +96,10 @@
         "/home/u/workers/proj/.git/refs/heads/feat/audit",
         "/home/u/workers/proj/.git/packed-refs"
       ],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/workers/proj/.worktrees/T123/.env",
         "/home/u/workers/proj/.worktrees/T123/.env.*",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_C.json
@@ -73,6 +73,10 @@
       "additionalDirectories": [
         "/home/u/workers/T123/.claude/plans"
       ],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/workers/T123/.env",
         "/home/u/workers/T123/.env.*",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_B.json
@@ -91,6 +91,10 @@
         "/home/u/co/.git/refs/heads/feat/self-edit",
         "/home/u/co/.git/packed-refs"
       ],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/co/.worktrees/T123/.env",
         "/home/u/co/.worktrees/T123/.env.*",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_C.json
@@ -67,6 +67,10 @@
     "enabled": true,
     "filesystem": {
       "additionalDirectories": [],
+      "allowRead": [
+        ".env.example",
+        ".env.*.example"
+      ],
       "denyRead": [
         "/home/u/co/.env",
         "/home/u/co/.env.*",

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -27,6 +27,7 @@
     "block-dispatcher-out-of-scope.sh"
   ],
   "$comment_roles_sandbox": "Phase 1 schema surface: each entry under `roles.<role>` may also include an optional `sandbox` object using the same shape and structured-anchor entry form documented under `worker_roles.$comment_sandbox` / `worker_roles.$comment_sandbox_anchor`. This lets secretary / dispatcher / curator declare Layer 3 sandbox intent alongside the existing Layer 2 `required_allow` / `required_deny` audit constraints. Roles without `sandbox` are treated as sandbox-disabled (backward compatible). Phase 1 PR3 (Refs claude-org-ja#378 #376) lands concrete bodies for `roles.secretary` / `roles.dispatcher` / `roles.curator`; each role's per-`sandbox` `$comment_sandbox` field documents the contract sections it is driven from and which prescriptions are deferred (e.g. curator knowledge/raw move-only is operation-semantic and not mechanizable here). `worker_roles.*` concrete bodies are NOT landed in PR3 — they need a `sandbox_by_pattern` schema decision (deferred to PR4). See `docs/contracts/role-pattern-sandbox-contract.md` for the contract that all bodies must satisfy.",
+  "$comment_sandbox_allow_read": "Refs claude-org-ja#959 (friction 1): every `sandbox.filesystem` body in this schema carries `allowRead: [\".env.example\", \".env.*.example\"]` alongside the credential `denyRead` set. WHY: the `.env.*` deny glob also matches committed template files (`.env.example`, `.env.live.example`), which hold no secrets. The 2026-08-25 kura report (`test_local_env` failing on `.env.example` with PermissionError inside the sandbox) is a direct instance, and such friction is one of the documented reasons workers reach for `dangerouslyDisableSandbox` (#959 measured 59% of worker Bash calls bypassing the sandbox). Claude Code has no negation syntax inside `denyRead` — a `!.env.example` entry was verified on a real 2.1.245 session to leave the file denied — so the carve-out is expressed with the documented `filesystem.allowRead` key (https://code.claude.com/docs/en/sandboxing: \"re-allow specific paths within a denied region using `sandbox.filesystem.allowRead`\" / \"When read rules overlap, the more specific path wins\"). Verified on Claude Code 2.1.245 (Linux/WSL2 bwrap) with this exact pair: `.env` / `.env.local` / `.env.production` / `.env.development.local` / `.env.staging` stay denied, `.env.example` / `.env.live.example` / `.env.production.example` become readable, and a `.env.evil.example` symlink pointing at `.env` stays DENIED (the sandbox refuses to restore an allowRead entry whose symlink escapes the expected location), so the carve-out cannot be abused to smuggle a secret through a template-shaped name. SHAPE: `allowRead` entries are plain relative strings, NOT the structured-anchor form used by `denyRead` / `denyWrite` — the runtime generator normalizes only those two layer keys and forwards any other `filesystem` key verbatim, so a structured object here would land in the rendered settings.local.json as an object Claude Code cannot parse. A relative sandbox path resolves against the project root for project settings (https://code.claude.com/docs/en/sandboxing), which for a rendered worker file is worker_dir — the same anchor the neighbouring `denyRead` entries declare explicitly. NO Layer-2 counterpart: the `layer2Fallback` strings and the `permissions.deny` mirrors keep the broad `Read(.env.*)` form, because Layer 2 resolves deny-over-allow (verified on 2.1.245: `Read(.env.*)` in `permissions.deny` blocks the Read tool on `.env.example` even with a matching `permissions.allow` entry). Narrowing Layer 2 would require enumerating secret filenames, which cannot be made exhaustive, so the mirror deliberately stays on the safe side: the Read tool still refuses templates, while Bash — the path the reported friction actually takes — is governed by Layer 3 and now succeeds.",
   "roles": {
     "repo_shared": {
       "description": "Repo-shared settings (.claude/settings.json) — tracked in git; hosts repo-wide safety hooks (block-no-verify, block-dangerous-git).",
@@ -166,6 +167,7 @@
         "enabled": true,
         "filesystem": {
           "additionalDirectories": [],
+          "allowRead": [".env.example", ".env.*.example"],
           "denyRead": [
             {
               "anchor": "worker_dir",
@@ -264,6 +266,7 @@
           "additionalDirectories": [
             "{claude_org_path}"
           ],
+          "allowRead": [".env.example", ".env.*.example"],
           "denyRead": [
             {
               "anchor": "home",
@@ -359,6 +362,7 @@
           "additionalDirectories": [
             "{claude_org_path}/knowledge"
           ],
+          "allowRead": [".env.example", ".env.*.example"],
           "denyRead": [
             {
               "anchor": "worker_dir",
@@ -541,6 +545,7 @@
             "additionalDirectories": [
               "{claude_org_path}/knowledge/raw"
             ],
+            "allowRead": [".env.example", ".env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
@@ -563,6 +568,7 @@
               "{base_clone}/.git/packed-refs",
               "{claude_org_path}/knowledge/raw"
             ],
+            "allowRead": [".env.example", ".env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
@@ -581,6 +587,7 @@
             "additionalDirectories": [
               "{claude_org_path}/knowledge/raw"
             ],
+            "allowRead": [".env.example", ".env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
@@ -735,6 +742,7 @@
               "{base_clone}/.git/refs/heads/{branch_ref}",
               "{base_clone}/.git/packed-refs"
             ],
+            "allowRead": [".env.example", ".env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
@@ -751,6 +759,7 @@
           "enabled": true,
           "filesystem": {
             "additionalDirectories": [],
+            "allowRead": [".env.example", ".env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
@@ -894,6 +903,7 @@
             "additionalDirectories": [
               "{worker_dir}/.claude/plans"
             ],
+            "allowRead": [".env.example", ".env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
@@ -919,6 +929,7 @@
               "{base_clone}/.git/refs/heads/{branch_ref}",
               "{base_clone}/.git/packed-refs"
             ],
+            "allowRead": [".env.example", ".env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
@@ -944,6 +955,7 @@
             "additionalDirectories": [
               "{worker_dir}/.claude/plans"
             ],
+            "allowRead": [".env.example", ".env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},


### PR DESCRIPTION
sandbox の `denyRead` パターン `.env.*` が `.env.example` にも当たり、コミット済みのテンプレート（秘密を含まない見本）まで読めなくなっていた。

実害: 2026-08-25、kura の worker が「sandbox 内では `test_local_env` 2 件が `.env.example` への PermissionError で落ちる」と報告。この摩擦が worker に sandbox を外させる理由の 1 つになっている（#959 の実測: worker の Bash 呼び出しの 58-59% が sandbox を外している）。

## 変更内容

`denyRead` の `.env.*` はそのまま残し、Claude Code 公式の `sandbox.filesystem.allowRead`（「re-allow specific paths within a denied region」/「When read rules overlap, the more specific path wins」— https://code.claude.com/docs/en/sandboxing ）で **2 件だけ carve out** した。

適用先は全 role で一貫させ、取り残しゼロ:
- `tools/org_extension_schema.json` の `sandbox.filesystem` body 全 11 個（`roles.{secretary,dispatcher,curator}` + `worker_roles.{default,claude-org-self-edit,doc-audit}` の各 pattern A/B/C）
- 窓口自身の `.claude/settings.json`
- `docs/contracts/role-pattern-sandbox-contract.md` §1.5 を新設し、全 role / 全 pattern 共通の carve-out として不変条件を明文化

## 設計判断

- **否定パターンが使えないことを実機で確認してから `allowRead` に倒した。** `denyRead` に `"!.env.example"` を足しても `.env.example` は deny のままだった。
- **却下した代替案 = 秘密ファイル名の列挙**（`.env.local` / `.env.production` …）。網羅できず、列挙漏れがそのまま秘密の露出になる。
- **`allowRead` は structured-anchor 形ではなく素の相対文字列。** runtime の generator は `denyRead` / `denyWrite` しか正規化せず、その他の `filesystem` key は verbatim 転送する。object を書くと settings.local.json にそのまま出て Claude Code が解釈できない。相対 path は project settings では project root（= worker_dir）に解決されるため、隣の `denyRead` が `anchor: worker_dir` で表している位置と一致する。
- **Layer 2（`permissions.deny` の `Read(.env.*)` と `layer2Fallback`）は広いまま据え置いた。** Layer 2 は deny が allow に優先する（実機確認: `permissions.deny` に `Read(.env.*)` があると `permissions.allow` に `Read(.env.example)` を足しても Read ツールは拒否される）。narrow 化には秘密ファイル名の列挙が必要で網羅できないため、安全側に倒した。報告された摩擦（pytest が `.env.example` を読む）は Bash 経由 = Layer 3 の事象なので、これで解消する。**残る影響は「Read ツールでは今も `.env.example` が読めない」の 1 点**（Bash では読める）。

## 実機検証（Claude Code 2.1.245, Linux/WSL2 bwrap）

sandbox ON の `cat` で確認:

- **deny のまま**: `.env` / `.env.local` / `.env.production` / `.env.development.local` / `.env.staging` / `credentials.json` / `key.pem` / **`.env.evil.example`（→ `.env` への symlink）**
- **読める**: `.env.example` / `.env.live.example` / `.env.production.example`

`.env` を指す symlink をテンプレート名で置いても deny のままなので、**テンプレート名を装った秘密の持ち出しはできない**。

generator が実際に render した worker `settings.local.json`（絶対 path の `denyRead` + 相対 `allowRead` という本番の形）でも同結果を確認済み。

## 自動チェック

- byte drift OK / semantic drift OK（fixture 11 件を再 render、差分は `allowRead` の +4 行のみ）
- `pytest` 2087 passed / shell テスト 912 passed
- `check_role_configs` OK / link audit は既存指摘のみ
- Codex review round 1 で Blocker / Major / Minor ともに指摘なし

## 迂回率（ベースライン記録。効果測定ではない）

`~/.claude/projects/*worktrees*/*.jsonl` 369 本、Bash tool_use **11368 件中 6697 件 (58%)** が `dangerouslyDisableSandbox`。#959 記載の 368 本 / 59% とほぼ同値。**本修正の効果は今後の worker にしか現れないので、この数字は「修正前」の値である。**

## 付随して見つけたこと（本 PR では触っていない）

- `denyRead` の `.env` / `.env.*` は **project root 直下にしか効かない**（`sub/.env` は sandbox 内で読めた）。同じ設定の `**/credentials*` / `**/*.pem` は再帰的に効いているので、**再帰させたければ `**/` 前置が要る**という差。→ 別 Issue
- `.claude/settings.json` は sandbox 内で read-only マウントされており、この 1 ファイルの編集だけ sandbox を外す必要があった。→ #959 の「なぜ外すのか」の実例として別 Issue

Refs #959
