### PR TITLE
fix(claude): sandbox の .env deny を再帰化し、並走タスクの秘密漏れを塞ぐ

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -100,11 +100,15 @@
     "filesystem": {
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         ".env",
         ".env.*",
+        "**/.env",
+        "**/.env.*",
         "**/credentials*",
         "**/*.pem"
       ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,48 @@
 
 ### Fixed
 
+- sandbox の `.env` deny が **project root 直下にしか効かず**、サブディレクトリの秘密ファイルが
+  読めていた問題を、deny / allow 両方の再帰化で解消 (#961)。
+  [`tools/org_extension_schema.json`](tools/org_extension_schema.json) の全 11 個の
+  `sandbox.filesystem` body (`roles.{secretary,dispatcher,curator}` +
+  `worker_roles.{default,claude-org-self-edit,doc-audit}` の各 pattern) と
+  [`.claude/settings.json`](.claude/settings.json) で、`denyRead` に `**/.env` / `**/.env.*` を、
+  `allowRead` に `**/.env.example` / `**/.env.*.example` を追加した
+  (`layer2Fallback` を持つエントリには `Read(**/.env)` / `Read(**/.env.*)` も追随。
+  bypassPermissions で Layer 2 が no-op になる dispatcher は #960 同様 `layer2Fallback` を持たない)。
+  素の `.env` / `.env.*` グロブは project root にしか束縛されず、**`**/` 前置の有無だけ**が
+  同じ `denyRead` 内の `**/credentials*` / `**/*.pem` との差だった。
+  **実害はタスク横断の秘密漏れ**である: Pattern A の worker (worker_dir = プロジェクトディレクトリ) からは
+  兄弟 worktree が worker_dir の 1 階層下に見えるため、**並走中の別タスクの**
+  `.worktrees/<別タスク>/.env.live` が読めていた (Pattern B は worker_dir 自体が worktree root なので非該当)。
+  実機の kura ツリーで、修正前は兄弟 worktree の `.env.live` 6 件が読め、修正後は全件 deny になることを確認した
+  (中身は読み出していない)。
+  **deny と allow の再帰化は不可分**で、同じ変更で入れる必要がある: 再帰 deny だけを入れると
+  Claude Code 2.1.245 実機で `sub/.env.example` / `sub/.env.live.example` が deny に転び、
+  #960 が直した #959 摩擦 1 がサブディレクトリで再発する。
+  root 直下のエントリは**置換ではなく併記**で残しており (`.env` と `**/.env` の両方)、
+  `**/` が 0 階層にマッチするか否かに依存せず #960 の root 挙動が保たれる。
+  **残存ギャップ (Layer 2)**: `permissions.deny` も同じ非対称を抱えている (root 限定の `Read(.env)` /
+  `Read(.env.*)` の隣に再帰的な `Read(**/credentials*)` が並ぶ) ため、Layer 3 が効かない場合
+  (sandbox 不在で `failIfUnavailable: false` により fall-open / WSL の realpath escape による suppression) は
+  `Read` ツール経由でサブディレクトリの秘密に届く。本 PR では**あえて触っていない**:
+  `permissions.deny` は claude-org-runtime にバンドルされた schema 側の所有物で、
+  `tools/check_runtime_schema_drift.py` の byte 比較は ja 固有の `sandbox` body しか除外しないため、
+  ja 単独で編集すると drift check が fail する。解消には runtime のリリースと再 pin が要る (follow-up)。
+  今回の実害を塞いでいるのは Layer 3 側であり、Layer 2 は fall-open 時の backstop。
+  **残存ギャップ (dispatcher)**: `roles.dispatcher` は `.env` deny を `claude_org_path` に、
+  `allowRead` (アンカー指定不可の素の相対文字列) を project root = `<claude_org_path>/.dispatcher` に
+  解決するため、carve-out が `.dispatcher/` 配下にしか効かない。#960 の root carve-out も同じ理由で
+  この role には元から効いておらず、本変更は carve-out が届かない deny 領域を root から全深度へ広げる。
+  現状の実害は無い (このリポジトリは `.env.example` を 1 件も追跡していない) が、
+  根治には runtime 側で `allowRead` のアンカー指定サポートが要る。
+  実機検証 (Claude Code 2.1.245, Linux/WSL2 bwrap): `sub/.env` / `sub/.env.local` / `sub/deep/.env` は deny、
+  `sub/.env.example` / `sub/.env.live.example` は読める、`../.env` を指す `sub/.env.evil.example` symlink は deny、
+  root 直下の挙動は #960 から不変。generator が実際に render した Pattern A worker の
+  `settings.local.json` (絶対 path の `denyRead` + 相対 `allowRead`) でも同結果。
+  不変条件は
+  [`docs/contracts/role-pattern-sandbox-contract.md`](docs/contracts/role-pattern-sandbox-contract.md) §1.5 に追記した。
+
 - sandbox の `.env.*` deny がコミット済みテンプレート `.env.example` まで巻き込んでいた問題を、
   Layer 3 の `allowRead` carve-out で解消 (#959 摩擦 1)。
   [`tools/org_extension_schema.json`](tools/org_extension_schema.json) の全 11 個の

--- a/docs/contracts/role-pattern-sandbox-contract.md
+++ b/docs/contracts/role-pattern-sandbox-contract.md
@@ -164,8 +164,12 @@ enumerate:
 Every `denyRead` cell in this contract that reads `.env.*` is to be read with
 one exception, uniform across all roles and all patterns:
 
-> Layer 3 `allowRead`: `.env.example`, `.env.*.example` — committed template
-> files are re-opened inside the `.env.*` denied region.
+> Layer 3 `allowRead`: `.env.example`, `.env.*.example`, `**/.env.example`,
+> `**/.env.*.example` — committed template files are re-opened inside the
+> `.env` denied region, at the project root and at every depth below it.
+
+Every `.env` `denyRead` cell is likewise to be read as a **pair**, root-anchored
+plus recursive: `.env` + `**/.env`, and `.env.*` + `**/.env.*`.
 
 The `.env.*` glob matches committed `.env.example` / `.env.live.example`
 templates, which carry no secrets. Denying them produced real friction (a
@@ -193,6 +197,54 @@ Two properties of the carve-out matter for this contract:
   `.env` stays denied (verified on 2.1.245): the sandbox refuses to restore an
   `allowRead` entry whose symlink escapes the expected location, so a
   template-shaped name cannot be used to smuggle a secret out.
+- **Both halves are recursive, or neither.** `claude-org-ja#961`: a bare
+  `.env` / `.env.*` glob binds only at the project root, so a `.env` one
+  directory down stayed readable while the neighbouring `**/credentials*` /
+  `**/*.pem` entries — identical but for the `**/` prefix — denied
+  recursively. The invariant is therefore that the deny pair and the
+  `allowRead` carve-out are widened **together, in the same change**: adding
+  `**/.env.*` alone was measured on 2.1.245 to flip `sub/.env.example` and
+  `sub/.env.live.example` to denied, reproducing one level down exactly the
+  §1.5 friction this section exists to prevent. A change that lands one half
+  without the other violates this contract.
+- **Recursive entries are added, not substituted.** The root-anchored `.env` /
+  `.env.*` entries stay in every body alongside `**/.env` / `**/.env.*`. This
+  keeps root behaviour independent of whether `**/` matches zero path segments
+  in the sandbox's glob implementation, which this contract does not pin down.
+- **Why it matters across patterns.** With the root-only form, a Pattern A
+  worker (worker_dir = the project directory) could read
+  `.worktrees/<other-task>/.env` — the secrets of a *concurrently running*
+  task — because sibling worktrees live one level below worker_dir. Pattern B
+  workers were never exposed to their own secret this way, since their
+  worker_dir *is* the worktree root. Verified on a live tree: 6 sibling
+  `.env.live` files readable before the fix, all denied after.
+- **Residual gap — the Layer 2 mirrors are still root-only.** §1.5's "the
+  Layer 2 mirrors stay broad" means *not narrowed to exclude templates*; it
+  never meant *recursive*. The `permissions.deny` arrays carry the same
+  asymmetry this section is about (root-only `Read(.env)` / `Read(.env.*)`
+  beside recursive `Read(**/credentials*)`), so nested secrets remain
+  reachable through the `Read` tool whenever Layer 3 is *not* in force —
+  sandbox unavailable under `failIfUnavailable: false`, or the entry
+  suppressed by a WSL realpath escape — which is precisely the fall-back
+  case the mirror exists for. It is deliberately unchanged here:
+  `permissions.deny` is owned by the schema bundled with
+  `claude-org-runtime`, and [`tools/check_runtime_schema_drift.py`](../../tools/check_runtime_schema_drift.py)
+  strips only ja's own `sandbox` bodies before comparing bytes, so editing
+  these arrays in ja alone fails the drift check. Closing it needs a
+  coordinated runtime release plus a re-pin. Layer 3 is what closes the
+  reported exposure; this is the backstop that has yet to follow.
+- **Residual gap — the dispatcher's anchors do not match.** `roles.dispatcher`
+  anchors its `.env` denies at `claude_org_path`, but its project root (the
+  resolution base for the plain-string `allowRead` entries) is
+  `<claude_org_path>/.dispatcher`. The carve-out therefore covers only
+  templates at or below `.dispatcher/`, while the deny spans the whole org
+  repo. This predates the recursion work — the §1.5 root carve-out was
+  already inert for this role — but recursion widens the uncovered region
+  from the repo root to every depth. It is not expressible today:
+  `allowRead` has no structured-anchor form and is forwarded verbatim. The
+  invariant above ("both halves, or neither") is therefore satisfied for
+  every role whose allow and deny share an anchor, and knowingly waived for
+  this one; closing it needs runtime support for anchored `allowRead`.
 
 ---
 

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
@@ -158,11 +158,15 @@
       ],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/co/.curator/.env",
+        "/home/u/co/.curator/**/.env",
         "/home/u/co/.curator/.env.*",
+        "/home/u/co/.curator/**/.env.*",
         "/home/u/co/.curator/**/credentials*",
         "/home/u/co/.curator/**/*.pem"
       ],

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
@@ -71,13 +71,17 @@
       ],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/co/**/credentials*",
         "/home/u/co/**/*.pem",
         "/home/u/co/.env",
-        "/home/u/co/.env.*"
+        "/home/u/co/**/.env",
+        "/home/u/co/.env.*",
+        "/home/u/co/**/.env.*"
       ],
       "denyWrite": [
         "/home/u/co/tools",

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
@@ -68,11 +68,15 @@
       "additionalDirectories": [],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/co/.env",
+        "/home/u/co/**/.env",
         "/home/u/co/.env.*",
+        "/home/u/co/**/.env.*",
         "/home/u/co/**/credentials*",
         "/home/u/co/**/*.pem"
       ],

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_A.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_A.json
@@ -75,11 +75,15 @@
       ],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/workers/proj/.env",
+        "/home/u/workers/proj/**/.env",
         "/home/u/workers/proj/.env.*",
+        "/home/u/workers/proj/**/.env.*",
         "/home/u/workers/proj/**/credentials*",
         "/home/u/workers/proj/**/*.pem"
       ],

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_B.json
@@ -98,11 +98,15 @@
       ],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/workers/proj/.worktrees/T123/.env",
+        "/home/u/workers/proj/.worktrees/T123/**/.env",
         "/home/u/workers/proj/.worktrees/T123/.env.*",
+        "/home/u/workers/proj/.worktrees/T123/**/.env.*",
         "/home/u/workers/proj/.worktrees/T123/**/credentials*",
         "/home/u/workers/proj/.worktrees/T123/**/*.pem"
       ],

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_default_C.json
@@ -75,11 +75,15 @@
       ],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/workers/T123/.env",
+        "/home/u/workers/T123/**/.env",
         "/home/u/workers/T123/.env.*",
+        "/home/u/workers/T123/**/.env.*",
         "/home/u/workers/T123/**/credentials*",
         "/home/u/workers/T123/**/*.pem"
       ],

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_A.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_A.json
@@ -75,11 +75,15 @@
       ],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/work/wd/.env",
+        "/home/u/work/wd/**/.env",
         "/home/u/work/wd/.env.*",
+        "/home/u/work/wd/**/.env.*",
         "/home/u/work/wd/**/credentials*",
         "/home/u/work/wd/**/*.pem"
       ],

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_B.json
@@ -98,11 +98,15 @@
       ],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/workers/proj/.worktrees/T123/.env",
+        "/home/u/workers/proj/.worktrees/T123/**/.env",
         "/home/u/workers/proj/.worktrees/T123/.env.*",
+        "/home/u/workers/proj/.worktrees/T123/**/.env.*",
         "/home/u/workers/proj/.worktrees/T123/**/credentials*",
         "/home/u/workers/proj/.worktrees/T123/**/*.pem"
       ],

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_doc_audit_C.json
@@ -75,11 +75,15 @@
       ],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/workers/T123/.env",
+        "/home/u/workers/T123/**/.env",
         "/home/u/workers/T123/.env.*",
+        "/home/u/workers/T123/**/.env.*",
         "/home/u/workers/T123/**/credentials*",
         "/home/u/workers/T123/**/*.pem"
       ],

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_B.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_B.json
@@ -93,11 +93,15 @@
       ],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/co/.worktrees/T123/.env",
+        "/home/u/co/.worktrees/T123/**/.env",
         "/home/u/co/.worktrees/T123/.env.*",
+        "/home/u/co/.worktrees/T123/**/.env.*",
         "/home/u/co/.worktrees/T123/**/credentials*",
         "/home/u/co/.worktrees/T123/**/*.pem"
       ],

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_C.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/worker_self_edit_C.json
@@ -69,11 +69,15 @@
       "additionalDirectories": [],
       "allowRead": [
         ".env.example",
-        ".env.*.example"
+        ".env.*.example",
+        "**/.env.example",
+        "**/.env.*.example"
       ],
       "denyRead": [
         "/home/u/co/.env",
+        "/home/u/co/**/.env",
         "/home/u/co/.env.*",
+        "/home/u/co/**/.env.*",
         "/home/u/co/**/credentials*",
         "/home/u/co/**/*.pem"
       ],

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -27,7 +27,7 @@
     "block-dispatcher-out-of-scope.sh"
   ],
   "$comment_roles_sandbox": "Phase 1 schema surface: each entry under `roles.<role>` may also include an optional `sandbox` object using the same shape and structured-anchor entry form documented under `worker_roles.$comment_sandbox` / `worker_roles.$comment_sandbox_anchor`. This lets secretary / dispatcher / curator declare Layer 3 sandbox intent alongside the existing Layer 2 `required_allow` / `required_deny` audit constraints. Roles without `sandbox` are treated as sandbox-disabled (backward compatible). Phase 1 PR3 (Refs claude-org-ja#378 #376) lands concrete bodies for `roles.secretary` / `roles.dispatcher` / `roles.curator`; each role's per-`sandbox` `$comment_sandbox` field documents the contract sections it is driven from and which prescriptions are deferred (e.g. curator knowledge/raw move-only is operation-semantic and not mechanizable here). `worker_roles.*` concrete bodies are NOT landed in PR3 — they need a `sandbox_by_pattern` schema decision (deferred to PR4). See `docs/contracts/role-pattern-sandbox-contract.md` for the contract that all bodies must satisfy.",
-  "$comment_sandbox_allow_read": "Refs claude-org-ja#959 (friction 1): every `sandbox.filesystem` body in this schema carries `allowRead: [\".env.example\", \".env.*.example\"]` alongside the credential `denyRead` set. WHY: the `.env.*` deny glob also matches committed template files (`.env.example`, `.env.live.example`), which hold no secrets. The 2026-08-25 kura report (`test_local_env` failing on `.env.example` with PermissionError inside the sandbox) is a direct instance, and such friction is one of the documented reasons workers reach for `dangerouslyDisableSandbox` (#959 measured 59% of worker Bash calls bypassing the sandbox). Claude Code has no negation syntax inside `denyRead` — a `!.env.example` entry was verified on a real 2.1.245 session to leave the file denied — so the carve-out is expressed with the documented `filesystem.allowRead` key (https://code.claude.com/docs/en/sandboxing: \"re-allow specific paths within a denied region using `sandbox.filesystem.allowRead`\" / \"When read rules overlap, the more specific path wins\"). Verified on Claude Code 2.1.245 (Linux/WSL2 bwrap) with this exact pair: `.env` / `.env.local` / `.env.production` / `.env.development.local` / `.env.staging` stay denied, `.env.example` / `.env.live.example` / `.env.production.example` become readable, and a `.env.evil.example` symlink pointing at `.env` stays DENIED (the sandbox refuses to restore an allowRead entry whose symlink escapes the expected location), so the carve-out cannot be abused to smuggle a secret through a template-shaped name. SHAPE: `allowRead` entries are plain relative strings, NOT the structured-anchor form used by `denyRead` / `denyWrite` — the runtime generator normalizes only those two layer keys and forwards any other `filesystem` key verbatim, so a structured object here would land in the rendered settings.local.json as an object Claude Code cannot parse. A relative sandbox path resolves against the project root for project settings (https://code.claude.com/docs/en/sandboxing), which for a rendered worker file is worker_dir — the same anchor the neighbouring `denyRead` entries declare explicitly. NO Layer-2 counterpart: the `layer2Fallback` strings and the `permissions.deny` mirrors keep the broad `Read(.env.*)` form, because Layer 2 resolves deny-over-allow (verified on 2.1.245: `Read(.env.*)` in `permissions.deny` blocks the Read tool on `.env.example` even with a matching `permissions.allow` entry). Narrowing Layer 2 would require enumerating secret filenames, which cannot be made exhaustive, so the mirror deliberately stays on the safe side: the Read tool still refuses templates, while Bash — the path the reported friction actually takes — is governed by Layer 3 and now succeeds.",
+  "$comment_sandbox_allow_read": "Refs claude-org-ja#959 (friction 1) and #961 (recursion): every `sandbox.filesystem` body in this schema carries `allowRead: [\".env.example\", \".env.*.example\", \"**/.env.example\", \"**/.env.*.example\"]` alongside the credential `denyRead` set, whose `.env` entries are likewise paired as `.env` + `**/.env` and `.env.*` + `**/.env.*`. WHY: the `.env.*` deny glob also matches committed template files (`.env.example`, `.env.live.example`), which hold no secrets. The 2026-08-25 kura report (`test_local_env` failing on `.env.example` with PermissionError inside the sandbox) is a direct instance, and such friction is one of the documented reasons workers reach for `dangerouslyDisableSandbox` (#959 measured 59% of worker Bash calls bypassing the sandbox). Claude Code has no negation syntax inside `denyRead` — a `!.env.example` entry was verified on a real 2.1.245 session to leave the file denied — so the carve-out is expressed with the documented `filesystem.allowRead` key (https://code.claude.com/docs/en/sandboxing: \"re-allow specific paths within a denied region using `sandbox.filesystem.allowRead`\" / \"When read rules overlap, the more specific path wins\"). Verified on Claude Code 2.1.245 (Linux/WSL2 bwrap) with this exact pair: `.env` / `.env.local` / `.env.production` / `.env.development.local` / `.env.staging` stay denied, `.env.example` / `.env.live.example` / `.env.production.example` become readable, and a `.env.evil.example` symlink pointing at `.env` stays DENIED (the sandbox refuses to restore an allowRead entry whose symlink escapes the expected location), so the carve-out cannot be abused to smuggle a secret through a template-shaped name. SHAPE: `allowRead` entries are plain relative strings, NOT the structured-anchor form used by `denyRead` / `denyWrite` — the runtime generator normalizes only those two layer keys and forwards any other `filesystem` key verbatim, so a structured object here would land in the rendered settings.local.json as an object Claude Code cannot parse. A relative sandbox path resolves against the project root for project settings (https://code.claude.com/docs/en/sandboxing), which for a rendered worker file is worker_dir — the same anchor the neighbouring `denyRead` entries declare explicitly. NO Layer-2 counterpart: the `layer2Fallback` strings and the `permissions.deny` mirrors keep the broad `Read(.env.*)` form, because Layer 2 resolves deny-over-allow (verified on 2.1.245: `Read(.env.*)` in `permissions.deny` blocks the Read tool on `.env.example` even with a matching `permissions.allow` entry). Narrowing Layer 2 would require enumerating secret filenames, which cannot be made exhaustive, so the mirror deliberately stays on the safe side: the Read tool still refuses templates, while Bash — the path the reported friction actually takes — is governed by Layer 3 and now succeeds. RECURSION (#961): a bare `.env` / `.env.*` glob matches ONLY the project root, so before this pairing every `.env` in a SUBDIRECTORY was readable inside the sandbox \u2014 measured on Claude Code 2.1.245 (Linux/WSL2 bwrap): `sub/.env`, `sub/.env.local` and `sub/deep/.env` all read fine, while the neighbouring `**/credentials*` / `**/*.pem` entries denied `sub/credentials.json` / `sub/key.pem`. The difference was purely the `**/` prefix. The real-world consequence was cross-task secret exposure: a Pattern A worker (worker_dir = the project directory) could read `.worktrees/<other-task>/.env.live` for every sibling worktree \u2014 verified on the live kura tree, where 6 sibling `.env.live` files were readable before the fix and all denied after. Pattern B workers were unaffected because their own `.env.live` sits at worker_dir root. THE DENY AND ALLOW HALVES ARE INSEPARABLE: adding `**/.env.*` WITHOUT the matching `**/.env.*.example` allow re-breaks templates one level down \u2014 measured on the same build, `sub/.env.example` / `sub/.env.live.example` flipped to DENIED, reproducing the #959 friction 1 that #960 had just fixed. Never land one half alone. The root-anchored entries are RETAINED alongside the recursive ones rather than replaced, so the #960 root behaviour is preserved by construction and does not depend on whether `**/` matches zero path segments in this glob implementation. Symlinks do not widen the carve-out: `sub/.env.evil.example` pointing at `../.env` stayed DENIED on the same build. LAYER 2 UNDER #961 (KNOWN GAP, NOT FIXED HERE): \"broad\" in the paragraph above meant \"not narrowed to exclude templates\" \u2014 it did NOT mean recursive. The `permissions.deny` mirrors in `worker_roles.{default,claude-org-self-edit,doc-audit}.permissions.deny` carry the SAME root-only `Read(.env)` / `Read(.env.*)` asymmetry against their own recursive `Read(**/credentials*)` / `Read(**/*.pem)` neighbours, so nested secrets stay reachable via the `Read` tool whenever Layer 3 is not in force \u2014 sandbox unavailable (`failIfUnavailable: false` falls open) or the entry suppressed by a WSL realpath escape \u2014 which is exactly the case Layer 2 exists to cover. This was deliberately NOT changed in #961: `permissions.deny` is owned by the schema BUNDLED with claude-org-runtime, and `check_runtime_schema_drift.py` strips only the ja-only `sandbox` bodies before its byte comparison, so editing these arrays in ja alone fails the byte drift check. Closing it requires a coordinated claude-org-runtime release plus a re-pin in pyproject.toml / requirements.txt, tracked as follow-up work rather than smuggled in here. The Layer-3 recursion above is what actually closes the reported exposure; this mirror is the fall-open backstop. DISPATCHER ANCHOR GAP (residual, pre-existing): `roles.dispatcher` anchors its `.env` denies at `claude_org_path` while its project root (and therefore the resolution base for the plain-string `allowRead` entries) is worker_dir = `<claude_org_path>/.dispatcher`. The carve-out consequently applies only to templates at or below `.dispatcher/`, while the deny reaches the whole org repo; a `<claude_org_path>/<subdir>/.env.example` would be denied with no way to re-allow it. This is NOT introduced here \u2014 #960's root-level carve-out was already inert for this role for the same reason \u2014 but #961 widens the denied region it fails to cover from the repo root to every depth. It cannot be expressed today: `allowRead` has no structured-anchor form and is forwarded verbatim (a `{claude_org_path}` placeholder would land literally, and `settings show` does not even surface the key). The practical impact on this repo is currently nil \u2014 it tracks no `.env.example` files at all \u2014 and org-role settings are hand-maintained rather than generated, so this body is inspection surface. Fixing it properly needs runtime support for anchored `allowRead` entries.",
   "roles": {
     "repo_shared": {
       "description": "Repo-shared settings (.claude/settings.json) — tracked in git; hosts repo-wide safety hooks (block-no-verify, block-dangerous-git).",
@@ -167,7 +167,7 @@
         "enabled": true,
         "filesystem": {
           "additionalDirectories": [],
-          "allowRead": [".env.example", ".env.*.example"],
+          "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
           "denyRead": [
             {
               "anchor": "worker_dir",
@@ -177,9 +177,21 @@
             },
             {
               "anchor": "worker_dir",
+              "path": "**/.env",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/.env)"
+            },
+            {
+              "anchor": "worker_dir",
               "path": ".env.*",
               "suppressOnSymlinkEscape": true,
               "layer2Fallback": "Read(.env.*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/.env.*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/.env.*)"
             },
             {
               "anchor": "worker_dir",
@@ -266,7 +278,7 @@
           "additionalDirectories": [
             "{claude_org_path}"
           ],
-          "allowRead": [".env.example", ".env.*.example"],
+          "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
           "denyRead": [
             {
               "anchor": "home",
@@ -300,7 +312,17 @@
             },
             {
               "anchor": "claude_org_path",
+              "path": "**/.env",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
               "path": ".env.*",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "**/.env.*",
               "suppressOnSymlinkEscape": true
             }
           ],
@@ -362,7 +384,7 @@
           "additionalDirectories": [
             "{claude_org_path}/knowledge"
           ],
-          "allowRead": [".env.example", ".env.*.example"],
+          "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
           "denyRead": [
             {
               "anchor": "worker_dir",
@@ -372,9 +394,21 @@
             },
             {
               "anchor": "worker_dir",
+              "path": "**/.env",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/.env)"
+            },
+            {
+              "anchor": "worker_dir",
               "path": ".env.*",
               "suppressOnSymlinkEscape": true,
               "layer2Fallback": "Read(.env.*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/.env.*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/.env.*)"
             },
             {
               "anchor": "worker_dir",
@@ -545,10 +579,12 @@
             "additionalDirectories": [
               "{claude_org_path}/knowledge/raw"
             ],
-            "allowRead": [".env.example", ".env.*.example"],
+            "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": "**/.env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/.env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env.*)"},
               {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
               {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
               {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
@@ -568,10 +604,12 @@
               "{base_clone}/.git/packed-refs",
               "{claude_org_path}/knowledge/raw"
             ],
-            "allowRead": [".env.example", ".env.*.example"],
+            "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": "**/.env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/.env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env.*)"},
               {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
               {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
               {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
@@ -587,10 +625,12 @@
             "additionalDirectories": [
               "{claude_org_path}/knowledge/raw"
             ],
-            "allowRead": [".env.example", ".env.*.example"],
+            "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": "**/.env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/.env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env.*)"},
               {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
               {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
               {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
@@ -742,10 +782,12 @@
               "{base_clone}/.git/refs/heads/{branch_ref}",
               "{base_clone}/.git/packed-refs"
             ],
-            "allowRead": [".env.example", ".env.*.example"],
+            "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": "**/.env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/.env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env.*)"},
               {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
               {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
               {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
@@ -759,10 +801,12 @@
           "enabled": true,
           "filesystem": {
             "additionalDirectories": [],
-            "allowRead": [".env.example", ".env.*.example"],
+            "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": "**/.env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/.env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env.*)"},
               {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
               {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
               {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
@@ -903,10 +947,12 @@
             "additionalDirectories": [
               "{worker_dir}/.claude/plans"
             ],
-            "allowRead": [".env.example", ".env.*.example"],
+            "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": "**/.env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/.env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env.*)"},
               {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
               {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
               {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
@@ -929,10 +975,12 @@
               "{base_clone}/.git/refs/heads/{branch_ref}",
               "{base_clone}/.git/packed-refs"
             ],
-            "allowRead": [".env.example", ".env.*.example"],
+            "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": "**/.env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/.env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env.*)"},
               {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
               {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
               {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
@@ -955,10 +1003,12 @@
             "additionalDirectories": [
               "{worker_dir}/.claude/plans"
             ],
-            "allowRead": [".env.example", ".env.*.example"],
+            "allowRead": [".env.example", ".env.*.example", "**/.env.example", "**/.env.*.example"],
             "denyRead": [
               {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": "**/.env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env)"},
               {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/.env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/.env.*)"},
               {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
               {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
               {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},


### PR DESCRIPTION
sandbox の `denyRead` にある `.env` / `.env.*` は project root 直下にしか効かず、サブディレクトリの `.env` が読めた。同じ `denyRead` の `**/credentials*` / `**/*.pem` は再帰的に効いており、**差は `**/` 前置の有無**だった。

**実害**: Pattern A の worker から `.worktrees/<別タスク>/.env.live` が読めた。kura には本物の秘密ファイル `.env.live` が worktree 複製を含めて 7 箇所存在し、並走 worker の秘密が読める状態だった。

## 変更内容

全 11 個の `sandbox.filesystem` body（`roles.{secretary,dispatcher,curator}` + `worker_roles.{default,claude-org-self-edit,doc-audit}` の各 pattern A/B/C）と `.claude/settings.json` に対して:

1. **`denyRead` の再帰化** — `**/.env` / `**/.env.*` を追加
2. **`allowRead` の追随（不可分）** — `**/.env.example` / `**/.env.*.example` を追加。再帰 deny だけ入れると `sub/.env.example` が deny に転ぶことを実機で測定済み（#959 摩擦 1 のサブディレクトリ再発）
3. **`layer2Fallback` 追随** — `Read(**/.env)` / `Read(**/.env.*)` を追加。dispatcher は `bypassPermissions` で Layer 2 が no-op のため #960 同様 `layer2Fallback` を持たない形を維持
4. `docs/contracts/role-pattern-sandbox-contract.md` §1.5 に不変条件を追記（両半分は同時に広げる / 追加であって置換ではない / Pattern 間で効き方が違う理由 / 残存ギャップ）

## 設計判断

**置換ではなく併記した。** root 直下の `.env` / `.env.*` は残したまま再帰版を足している。却下案は `.env` を `**/.env` で置換する案だが、glob 実装が `**/` を 0 階層にマッチさせる保証が無く、受け入れ条件「root 挙動が #960 から不変」を実装依存にしてしまうため。

**deny と allow を同一変更で入れた。** 片方だけの PR は成立しない（Issue #961 の指示）。実機で片half の害を測定して裏を取っている。

## 実機検証（Claude Code 2.1.245, Linux/WSL2 bwrap）

修正前後を同一 fixture で比較（`claude -p` + 各設定を `settings.local.json` に置いて実行）:

| 対象 | 修正前 | 修正後 |
|---|---|---|
| `sub/.env` / `sub/.env.local` / `sub/deep/.env` | **読めた** | deny |
| `.worktrees/other-task/.env.live` | **読めた** | deny |
| `sub/.env.example` / `sub/.env.live.example` | 読めた | 読める（維持） |
| root 直下 | — | #960 から不変 |
| `../.env` を指す `sub/.env.evil.example` symlink | deny | deny |

generator が実際に render した Pattern A worker の `settings.local.json`（絶対 path の `denyRead` + 相対 `allowRead`）でも同結果。

**実害の最終確認**: 実機の kura ツリーで Pattern A worker（worker_dir = kura プロジェクトディレクトリ）から、兄弟 worktree の `.env.live` が **修正前は 6 件読め、修正後は全件 deny**。中身は一切読み出していない・ログにも出していない。

検証用の一時ファイル（`tmp/sandbox-verify` 配下のダミー `.env` 等）は削除済み。worktree 内に `.env*` は 1 件も残っていない。

## テスト

byte / semantic drift check OK・`pytest` 2087 passed / 6 skipped・shell 912/912 passed。

Codex review round 1 で 2 件、round 2 で Blocker / Major ゼロ。round 1 の 2 件はどちらも実在を確認したうえで**本 PR の射程外**と判断し、コード変更を入れず残存ギャップとして文書化した（下記）。

## 残存ギャップ（本 PR では直さない・別 Issue 化）

**1. Layer 2 も root 限定** — `worker_roles.*.permissions.deny` の `Read(.env)` / `Read(.env.*)` も同じ非対称を持つ。Layer 3 が効かない場合（sandbox 不在の fall-open / WSL suppression）は Read ツールでサブディレクトリの秘密に届く。

一度 `Read(**/.env)` を追加して実装したが **byte drift check が fail** した: `permissions.deny` は claude-org-runtime にバンドルされた schema 側の所有物で、drift check の byte 比較は ja 固有の `sandbox` body しか除外しないため。解消には **runtime のリリースと再 pin** が要るので revert した。実害の主経路は Layer 3 側で本 PR が塞いでおり、これは fall-open 時の backstop。

**2. dispatcher の anchor 不一致** — deny は `claude_org_path` に、`allowRead` は project root（= `<claude_org_path>/.dispatcher`）に解決されるため、carve-out が `.dispatcher/` 配下にしか効かない。`allowRead` はアンカー指定形を持たず verbatim 転送されるため現状は表現不能。

**影響の切り分け**（誤読を避けるため明記する）:
- `<claude_org_path>/.env.example`（repo root 直下のテンプレート）は #960 の carve-out が anchor 不一致で inert なため **本変更の前から deny**。ここは変わらない
- `<claude_org_path>/<subdir>/.env.example`（ネストしたテンプレート）が **本変更で新たに deny 側に入る**。従来は deny 自体が root 限定だったので素通りで読めていた

このリポジトリは `.env.example` を 1 件も追跡していないため**現時点の実害はゼロ**。根治には runtime 側で `allowRead` に anchor 指定（`denyRead` / `denyWrite` と同じ structured-anchor 形）のサポートが要る。**1 と同じ runtime 側の作業**なので 1 本にまとめられる可能性がある。

Closes #961
