### PR TITLE
Make the Codex gate detectable when it silently reviews nothing

### DIFF
--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -169,10 +169,14 @@ Get-Command codex -ErrorAction SilentlyContinue
 
 ```bash
 # CODEX_HOME は「書き込み可能かつ一時ディレクトリでない」場所を指すこと（理由は直下の注記）。
+# 上書きする前に、既存の（認証済みの）codex home を控えてリンク元にする。
+# 既定以外の CODEX_HOME で認証している環境で ~/.codex 決め打ちにすると、
+# リンクが dangling になるか無関係な資格情報を指してしまうため。
+CODEX_SRC="${CODEX_HOME:-$HOME/.codex}"
 export CODEX_HOME="$PWD/.codex-home"
 mkdir -p "$CODEX_HOME"
-ln -sf ~/.codex/auth.json   "$CODEX_HOME/auth.json"
-ln -sf ~/.codex/config.toml "$CODEX_HOME/config.toml"
+ln -sf "$CODEX_SRC/auth.json"   "$CODEX_HOME/auth.json"
+ln -sf "$CODEX_SRC/config.toml" "$CODEX_HOME/config.toml"
 
 # ログは worker ごとに分ける（$TMPDIR は並走 worker で共有されるため、固定名だと
 # 別 worker の "succeeded in" を自分の成立根拠に取り違える）。
@@ -209,12 +213,17 @@ echo "codex exit status: $codex_status"
 
 ```bash
 # 肯定的証拠: 実際に実行されて成功したコマンドが 1 つ以上あること
-grep -cE '^ *succeeded in ' "$CODEX_REVIEW_LOG"
+grep -cE '^ *succeeded in [0-9]+(ms|s|m)' "$CODEX_REVIEW_LOG"
 # 否定的証拠: 実行に失敗したコマンドが 1 つも無いこと
-grep -cE '^ *failed in ' "$CODEX_REVIEW_LOG"
+grep -cE '^ *failed in [0-9]+(ms|s|m)' "$CODEX_REVIEW_LOG"
 ```
 
-**この 2 つは必ず行頭アンカー（`^ *`）付きで数えること。** ログには**レビュー対象の diff 本文がそのまま載る**ため、`exec_command failed` や `Refusing to create helper` のような素の文字列 grep は、**diff 側にその文字列が出てくるだけで自分自身にマッチする**（本節を含む差分をレビューすると実際に起きる）。codex 実行ログの行は `succeeded in` / `failed in` が行頭側に来る形なので、アンカーすればこの自己マッチを踏まない。
+**この 2 つは必ず行頭アンカー（`^ *`）と実行時間（`[0-9]+(ms|s|m)`）の両方を付けて数えること。** ログには**レビュー対象の diff 本文**も**codex が実行したコマンドの出力**もそのまま載るため、素の文字列 grep は自分自身にマッチする。実測で 2 種類の自己マッチを確認している:
+
+- `exec_command failed` / `Refusing to create helper` のような素の文字列 grep は、**本節を含む差分をレビューすると diff 側の記述にマッチする**（行頭アンカーで回避できる）
+- 行頭アンカーだけでは足りない: codex がバイナリを読んだ出力に ` failed in TUI` のような**文字列断片**が現れ、`^ *failed in ` にマッチしてしまう（実測で偽陽性 2 件）
+
+codex 実行ログの本物の記録は必ず `succeeded in 0ms:` のように**実行時間を伴う**ので、時間まで含めてアンカーすれば両方の自己マッチを踏まない。
 
 - **ゲート成立**: 1 つ目が **1 以上** かつ 2 つ目が **0**、**かつ `codex_status` が 0**。このときだけ「codex clean」と報告してよい
 - **ゲート未成立（空の合格）**: 1 つ目が **0**、または 2 つ目が **1 以上**、または `codex_status` が非 0。出力がどれだけ合格に読めても**ゲートは回っていない**

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -168,11 +168,47 @@ Get-Command codex -ErrorAction SilentlyContinue
 - `available` の場合: 以下のコマンドを**前景実行**する（`--base` にはこのブランチのベース（通常 `origin/main`）を渡す。**ローカル `main` ではなく remote-tracking の `origin/main`** を使うのは、共有 clone のローカル `main` が古いと別タスク差分を巻き込む誤レビューになるため。参照前に `git fetch origin` を 1 回（着手時 pull 済みでも review 直前に最新化。fetch 不能でも review は継続）。stdin は `< /dev/null` で明示クローズ。背景化 `&` + ログ redirect は完了を待たず指摘を読まずに完了報告してゲートを素通りする事故を招くため避ける）
 
 ```bash
-codex exec review --base origin/main -m gpt-5.6-sol -c model_reasoning_effort=medium < /dev/null
+# CODEX_HOME は「書き込み可能かつ一時ディレクトリでない」場所を指すこと（理由は直下の注記）。
+export CODEX_HOME="$PWD/.codex-home"
+mkdir -p "$CODEX_HOME"
+ln -sf ~/.codex/auth.json   "$CODEX_HOME/auth.json"
+ln -sf ~/.codex/config.toml "$CODEX_HOME/config.toml"
+
+codex exec review --base origin/main -m gpt-5.6-sol -c model_reasoning_effort=medium \
+  -c sandbox_mode='"read-only"' < /dev/null 2>&1 | tee "$TMPDIR/codex-review.log"
 ```
+
+**`CODEX_HOME` を退避する理由と、退避先の条件（重要。ここを外すと後述の「空の合格」を踏む）**: 既定の `CODEX_HOME`（`~/.codex`）はワーカーのサンドボックスで書き込み不可なため、codex は自分の実行ヘルパー（`codex-linux-sandbox`）を配置できない。ヘルパーが無いと codex は**コマンドを 1 つも実行できず、`git diff` を一度も読まないままレビューを終える**。
+
+退避先は次の 2 条件を**両方**満たすこと:
+- **書き込み可能**であること
+- **一時ディレクトリ配下でない**こと — codex は `codex_home` が temp dir 配下だとヘルパー配置を拒否する（`Refusing to create helper binaries under temporary dir "..."`）
+
+**したがって `CODEX_HOME` は `$TMPDIR` 配下に置いてはならない。** 上記「書き込み可能範囲と、書き込みを拒否されたときの対処」節の「一時ファイルは `$TMPDIR` 配下へ」という一般則に対する**明示的な例外**である。`$TMPDIR` を指定すると、症状が「正直なエラー」ではなく「空の合格」（下記）に化けるため、一般則をそのまま適用するより危険になる。ワーカー作業ディレクトリ配下（上例の `$PWD/.codex-home`）は両条件を満たす。`.codex-home` は成果物ではないので **commit しないこと**（`git add -u` と新規ファイルの明示 add を使っていれば混入しない。混入していないことを `git status` で確認する）。
+
+`-c sandbox_mode='"read-only"'` は **codex 自身の内側サンドボックスを read-only に締める**設定であり、ワーカーを包む外側の Claude Code サンドボックスには一切触れない。**緩める方向の設定ではない**（明示するのは、実行環境の `config.toml` に依存せず常に同じ条件で回すため）。**`sandbox_mode` を `danger-full-access` 等の緩める方向へ変えて回避を試みてはならない** — 安全分類器に拒否されるうえ、そもそも真因は「緩さが足りないこと」ではなく上記の `CODEX_HOME` の配置である。
 
 - review surface は内蔵レビュープロンプトで Blocker/Major 相当（P1/P2 等）を返す。**前景で出力を読んでから次に進む**（応答が長く来ない稀なケースのみ中断して skip 可）。**large diff（100 行超目安）では effort を上げない**（high-effort review は大 diff でスケールせず直打ちより遅くなる）。
 - review surface は危険側 Major（false positive で gate 誤通過する系）は守るが、benign な safe-side Major（過剰 polling 方向の false negative）や ReDoS 級の付加バグを取りこぼしうる。設計に近い変更で深掘りが要る場合は窓口に design review 併用を相談する。詳細・実測根拠の SoT は [`knowledge/curated/codex.md`](../../../../knowledge/curated/codex.md)。
+
+**「空の合格」を検出する（`available` かつエラー表示も無いのにゲートが未成立のケース）**: 上記の `CODEX_HOME` 設定を外した状態で回すと、codex は `git diff` を一度も実行しないまま **「指摘なし」と読める文面を返して正常終了する**。これは最も危険な失敗モードで、**出力の文面を読むだけでは正常な合格と区別できない**。実測で確認された性質は次のとおり:
+
+- **終了コードは判定に使えない** — 空の合格でも **exit 0** を返す
+- **出力の但し書きも判定に使えない** — 「sandbox が起動できなかったので確度が低い」旨の但し書きが付くことはあるが、**環境によっては但し書きが消え、`No actionable findings were identified` という素の合格文だけになる**。文面の有無に依存した判定をしてはならない
+
+したがって、**「エラーが出ていないこと」（否定的証拠）ではなく「コマンドが実際に実行されたこと」（肯定的証拠）で判定する**。上記コマンドは出力を `$TMPDIR/codex-review.log` に保存しているので、review 後に必ず次を実行し、**両方の条件を満たすことを確認してから**指摘の中身を読むこと:
+
+```bash
+# 肯定的証拠: 実際に実行されて成功したコマンドが 1 つ以上あること
+grep -cE '^ *succeeded in ' "$TMPDIR/codex-review.log"
+# 否定的証拠: ヘルパー起動に失敗した形跡が 1 つも無いこと
+grep -c 'exec_command failed' "$TMPDIR/codex-review.log"
+```
+
+- **ゲート成立**: 1 つ目が **1 以上** かつ 2 つ目が **0**。このときだけ「codex clean」と報告してよい
+- **ゲート未成立（空の合格）**: 1 つ目が **0**、または 2 つ目が **1 以上**。出力がどれだけ合格に読めても**ゲートは回っていない**
+
+**空の合格を「ゲート通過」として報告してはならない。** 検出したらまず上記の `CODEX_HOME` 設定を見直して再実行する（`$TMPDIR` 配下を指していないか、を最初に疑う）。それでもゲートが成立しない場合は、「codex clean」と報告せず、**「Codex ゲート未成立（diff 未読の空の合格、HEAD=`<sha>`）」と明示して完了報告し、窓口の判断を仰ぐ**。判定に使った上記 2 つの数値も報告に添えること。ゲートが回らないこと自体は報告すれば済むが、回っていないゲートを回ったことにすると検証深度 `full` が実質無検査になる。
 
 **安全機構に掛かって review 処理が進められない場合（`available` だが safety block）**: diff 内容（セキュリティ検証タスク等）がモデルの安全分類器に掛かり、`codex exec review` の処理自体を完了できないことがある。**この skip は上記「`unavailable` の skip」とは意味が異なる** — codex は available なのにゲートが**未成立**の状態であり、「codex clean」ではない。安全機構を回避する言い換え・プロンプト改変は**しない**（モデル安全機構に掛かる処理は回避せずスキップして報告するのが原則）。正式なリカバリは以下:
 - **正式リカバリ = 新規セッション化（continuation spawn）**: 同一 worktree・同一ブランチで、既に積んだ commit を引き継いだ新しい worker セッションを起こし、そのクリーンな context で `codex exec review` を再実行する（窓口にセッション再起動を依頼する）。完了報告には引き継いだ **HEAD SHA** を明記し、どの commit に対して review が成立したかを追跡可能にする

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -174,8 +174,17 @@ mkdir -p "$CODEX_HOME"
 ln -sf ~/.codex/auth.json   "$CODEX_HOME/auth.json"
 ln -sf ~/.codex/config.toml "$CODEX_HOME/config.toml"
 
+# ログは worker ごとに分ける（$TMPDIR は並走 worker で共有されるため、固定名だと
+# 別 worker の "succeeded in" を自分の成立根拠に取り違える）。
+CODEX_REVIEW_LOG="$TMPDIR/codex-review-$(basename "$PWD").log"
+
+# pipefail が無いとパイプの終了コードは tee のものになり、codex 側の失敗が隠れる。
+set -o pipefail
 codex exec review --base origin/main -m gpt-5.6-sol -c model_reasoning_effort=medium \
-  -c sandbox_mode='"read-only"' < /dev/null 2>&1 | tee "$TMPDIR/codex-review.log"
+  -c sandbox_mode='"read-only"' < /dev/null 2>&1 | tee "$CODEX_REVIEW_LOG"
+codex_status=$?
+set +o pipefail
+echo "codex exit status: $codex_status"
 ```
 
 **`CODEX_HOME` を退避する理由と、退避先の条件（重要。ここを外すと後述の「空の合格」を踏む）**: 既定の `CODEX_HOME`（`~/.codex`）はワーカーのサンドボックスで書き込み不可なため、codex は自分の実行ヘルパー（`codex-linux-sandbox`）を配置できない。ヘルパーが無いと codex は**コマンドを 1 つも実行できず、`git diff` を一度も読まないままレビューを終える**。
@@ -196,17 +205,21 @@ codex exec review --base origin/main -m gpt-5.6-sol -c model_reasoning_effort=me
 - **終了コードは判定に使えない** — 空の合格でも **exit 0** を返す
 - **出力の但し書きも判定に使えない** — 「sandbox が起動できなかったので確度が低い」旨の但し書きが付くことはあるが、**環境によっては但し書きが消え、`No actionable findings were identified` という素の合格文だけになる**。文面の有無に依存した判定をしてはならない
 
-したがって、**「エラーが出ていないこと」（否定的証拠）ではなく「コマンドが実際に実行されたこと」（肯定的証拠）で判定する**。上記コマンドは出力を `$TMPDIR/codex-review.log` に保存しているので、review 後に必ず次を実行し、**両方の条件を満たすことを確認してから**指摘の中身を読むこと:
+したがって、**「エラーが出ていないこと」（否定的証拠）ではなく「コマンドが実際に実行されたこと」（肯定的証拠）で判定する**。上記コマンドは出力を `$CODEX_REVIEW_LOG` に保存しているので、review 後に必ず次を実行し、**両方の条件を満たすことを確認してから**指摘の中身を読むこと:
 
 ```bash
 # 肯定的証拠: 実際に実行されて成功したコマンドが 1 つ以上あること
-grep -cE '^ *succeeded in ' "$TMPDIR/codex-review.log"
-# 否定的証拠: ヘルパー起動に失敗した形跡が 1 つも無いこと
-grep -c 'exec_command failed' "$TMPDIR/codex-review.log"
+grep -cE '^ *succeeded in ' "$CODEX_REVIEW_LOG"
+# 否定的証拠: 実行に失敗したコマンドが 1 つも無いこと
+grep -cE '^ *failed in ' "$CODEX_REVIEW_LOG"
 ```
 
-- **ゲート成立**: 1 つ目が **1 以上** かつ 2 つ目が **0**。このときだけ「codex clean」と報告してよい
-- **ゲート未成立（空の合格）**: 1 つ目が **0**、または 2 つ目が **1 以上**。出力がどれだけ合格に読めても**ゲートは回っていない**
+**この 2 つは必ず行頭アンカー（`^ *`）付きで数えること。** ログには**レビュー対象の diff 本文がそのまま載る**ため、`exec_command failed` や `Refusing to create helper` のような素の文字列 grep は、**diff 側にその文字列が出てくるだけで自分自身にマッチする**（本節を含む差分をレビューすると実際に起きる）。codex 実行ログの行は `succeeded in` / `failed in` が行頭側に来る形なので、アンカーすればこの自己マッチを踏まない。
+
+- **ゲート成立**: 1 つ目が **1 以上** かつ 2 つ目が **0**、**かつ `codex_status` が 0**。このときだけ「codex clean」と報告してよい
+- **ゲート未成立（空の合格）**: 1 つ目が **0**、または 2 つ目が **1 以上**、または `codex_status` が非 0。出力がどれだけ合格に読めても**ゲートは回っていない**
+
+**終了コードの扱い（上の「判定に使えない」との関係）**: exit 0 は成立の**十分条件ではない**（空の合格でも 0 になる）。一方で**非 0 は失格条件として使える** — codex が 1 コマンド実行後に API / 認証 / 安全機構で異常終了した場合、マーカー数だけ見ると成立条件を満たしてしまうため、`codex_status` を追加の必要条件として併用する。
 
 **空の合格を「ゲート通過」として報告してはならない。** 検出したらまず上記の `CODEX_HOME` 設定を見直して再実行する（`$TMPDIR` 配下を指していないか、を最初に疑う）。それでもゲートが成立しない場合は、「codex clean」と報告せず、**「Codex ゲート未成立（diff 未読の空の合格、HEAD=`<sha>`）」と明示して完了報告し、窓口の判断を仰ぐ**。判定に使った上記 2 つの数値も報告に添えること。ゲートが回らないこと自体は報告すれば済むが、回っていないゲートを回ったことにすると検証深度 `full` が実質無検査になる。
 


### PR DESCRIPTION
## Why

Under a worker sandbox, `codex exec review` can return text that reads as a clean pass while never having run `git diff` at all. The default `CODEX_HOME` (`~/.codex`) is not writable, so codex cannot place its execution helper, executes no commands, and still exits 0.

This is the worst shape of failure: `full` verification depth reports "Codex gate passed, no findings" when nothing was inspected. Exit code does not distinguish it (an empty pass is also 0), and neither does the wording — a disclaimer about the sandbox appears in some environments and is absent in others.

Measured across five conditions with a probe containing planted defects:

| `CODEX_HOME` | Result |
|---|---|
| default `~/.codex` | fails to start, no output — an honest failure |
| `$TMPDIR/...` | empty pass, exit 0, detects none of the planted P1s |
| same + helper on `PATH` | empty pass, exit 0 |
| `$PWD/.codex-home` | normal, detects all planted defects |

`$TMPDIR` is actively worse than the default: codex refuses to place helpers under a temporary directory, so an honest error becomes a silent pass. The destination must be both writable and outside a temp directory.

## What changes

Documents in the worker brief template:

- The `CODEX_HOME` relocation, with both conditions stated and `$TMPDIR` explicitly excluded — this is a deliberate exception to the general "temporary files go under `$TMPDIR`" rule added in #965, and the exception is named as such so the general rule is not applied here by mistake
- That `-c sandbox_mode='"read-only"'` tightens codex's own inner sandbox rather than loosening anything, so a reader does not reach for `danger-full-access`
- How to detect an empty pass, using positive evidence (a command actually ran) rather than the absence of an error

## Detection is anchored on execution time, not on the bare string

The first form of this check produced false positives twice, both found by running it against this change's own diff:

- A bare string match hits the literal `exec_command failed` written in the diff under review
- Anchoring to line start still hits a fragment in codex's own output when it reads a binary

Both are fixed by anchoring through the execution duration (`^ *failed in [0-9]+(ms|s|m)`). The two false-positive shapes are recorded in the document so the next person does not re-derive them.

Two further robustness fixes, both from Codex review:

- The review log filename now includes the working directory basename. `$TMPDIR` is shared between concurrently running workers, so a fixed name lets one worker read another worker's success marker as evidence for its own gate.
- The pre-existing `CODEX_HOME` is preserved as the link source instead of hardcoding `~/.codex`, which would dangle or point at unrelated credentials in environments authenticated elsewhere.

`set -o pipefail` plus an explicit status capture is added because the pipeline's exit code otherwise belongs to `tee` and hides an abnormal codex exit. Exit 0 remains insufficient on its own and is used only as a disqualifying condition.

## Verification

The recommended form was run against this change's own diff: `succeeded` = 4, `failed` = 0, codex exit status 0. Codex self-review ran 3 rounds and stopped at the round cap.

## Known gap, tracked separately

The other instruction surfaces a worker receives — `tools/templates/worker_brief_normal.md`, `worker_brief_self_edit.md`, `instruction-template.md`, and `knowledge/curated/codex.md` — still carry the bare `codex exec review` form. A worker reads those alongside this template, so the gap is not fully closed until they are updated. Codex raised this in all three rounds. Follow-up work covers them.