### PR TITLE
watcher ペインの張り先と分割方向を幾何から決定的に選ぶ

### DIFF
--- a/.claude/skills/pr-watch-pane/SKILL.md
+++ b/.claude/skills/pr-watch-pane/SKILL.md
@@ -18,6 +18,8 @@ allowed-tools:
   - Bash(gh repo view:*)
   - Bash(bash tools/journal_append.sh:*)
   - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python3 tools/pick_watcher_anchor.py:*)
+  - Bash(py -3 tools/pick_watcher_anchor.py:*)
   - mcp__org-broker__list_panes
   - mcp__org-broker__spawn_pane
   - mcp__org-broker__set_pane_identity
@@ -171,12 +173,60 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
 
 ## Step 3: 監視ペインの spawn
 
-`mcp__org-broker__spawn_pane` で CLI watcher ペインを起動する（`<...>` は Step 1 / 引数で確定した値に置換）:
+### Step 3-0: 張り先（アンカー）を幾何で決める（Refs #335）
+
+spawn の前に、**どのペインを split 起点にするか**を決定的ツールで求める。target は
+固定しない（旧版の `target="dispatcher"` 固定が 2026-08-30 の実害を生んだ経緯は下記
+「なぜ固定アンカーをやめたか」を参照）。
+
+1. `mcp__org-broker__list_panes` を呼び、返却された `panes` 配列（`id` / `name` / `role` /
+   `x` / `y` / `width` / `height`）をそのまま JSON として控える。
+2. その JSON を `tools/pick_watcher_anchor.py` に stdin で流し、候補リストを得る
+   （既定入力が stdin なので中間ファイルを作らない。ファイル経由なら `--panes-json <path>`）:
+
+   ```bash
+   python3 tools/pick_watcher_anchor.py --format text <<'PANES'
+   {"panes": [ ... list_panes の返却をそのまま貼る ... ]}
+   PANES
+   ```
+
+   （Windows は `py -3 tools/pick_watcher_anchor.py ...`。POSIX 側は `python` エイリアスが
+   無い環境があるため `python3` で呼ぶ。transport は `ORG_TRANSPORT` から自動解決される
+   ので通常は指定不要。明示するなら `--transport {broker|renga}`。）
+3. 出力の `candidates` が **rank 1 から順に試す張り先**。各候補は `target`（pane name）と
+   `direction`（`vertical` / `horizontal`）を持つので、**両方をそのまま次の
+   `spawn_pane` 引数に使う**（direction も候補ごとに変わる。`vertical` 固定ではない）。
+   direction は「両方向を評価し、親側に残る子が大きい方を採る」規則（runtime の
+   `_split_options` と同一。同値性は unit test で固定）。**窓口が direction を自分で
+   決めない**: 2026-08-30 に 397x53 の secretary へ `horizontal` で張って窓口ペインを
+   397x13 まで潰した実害があり、幅広の rect では `vertical` が選ばれる。
+4. `candidates` が空（exit code 2 / `capacity_exhausted: true`）のときだけ、**このタブに
+   watcher を置く余地が本当に無い**。spawn を試みず、`rejected` の各行（どのペインが
+   どの床値でどう落ちたか）を添えて人間に報告し、指示を仰ぐ。
+
+出力の `pane_cap_reached` は**助言であって判定ではない**: 「このタブのペイン数が renga の
+per-tab 上限（`RENGA_MAX_PANES` = 16）に達している」という事実で、renga ではこれ以降の
+spawn が幾何によらず拒否される。既定の broker には per-tab 上限が無い（各ペインが独立
+セッション）ので、`capacity_exhausted` はこの値では動かない。`[split_refused]` が続いた
+ときの人間報告に添える材料として使う。
+
+ツールが守る床値（`MIN_PANE` 20x5 / `SECRETARY_MIN` 120x30 / `DISPATCHER_MIN_WIDTH` 80）は
+`claude_org_runtime.dispatcher.runner` の定数を **import して** 使う（skill 側にも
+ツール側にも値を写経しない）。優先度は **dispatcher →（既存 watcher ペイン。dispatcher
+隣接を先）→ secretary**、dispatcher が自身の comfort 幅を割っている場合だけ最後尾へ降格。
+secretary を張り先に使うのはユーザー承認済み（2026-08-30）で、`SECRETARY_MIN_*` を
+満たす split のみ候補になる。既存 watcher には attention watcher（`role="attention"`）も
+含む。worker / curator ペインは候補に入れない（稼働中の作業ビューポートを watcher が
+食わないため）。
+
+### Step 3-1: spawn
+
+`mcp__org-broker__spawn_pane` で CLI watcher ペインを起動する（`<...>` は Step 1 / 3-0 / 引数で確定した値に置換）:
 
 ```
 mcp__org-broker__spawn_pane(
-  target="dispatcher",
-  direction="vertical",
+  target="<Step 3-0 の候補 target>",
+  direction="<Step 3-0 の候補 direction>",
   role="watcher",
   name="pr-watch-<PR>",
   cwd="<JA_ROOT 絶対パス>",
@@ -235,9 +285,15 @@ mcp__org-broker__spawn_pane(
     さらに push が失敗した場合は `pr_watch` が `notify_failed` イベントを fail-loud で記録する
     （silent no-op の全廃）。
 
-- `target="dispatcher"`: 同一タブ scope の安定アンカー（attention watcher と同じく
-  dispatcher を split 起点にする）。broker では各ペインが detached 独立セッションだが、
-  addressing scope（同一タブ MUST、contract Surface 4.2）を満たすため既存ペインを起点に取る。
+- `target` / `direction`: **Step 3-0 のツールが返した候補**をそのまま使う。broker では
+  各ペインが detached 独立セッションだが、addressing scope（同一タブ MUST、contract
+  Surface 4.2）を満たすため既存ペインを起点に取る点は不変。
+  - **なぜ固定アンカーをやめたか（Refs #335）**: 旧版は `target="dispatcher"` 固定だった。
+    2026-08-30、幅 24 まで細った dispatcher に張ろうとして `[split_refused]` になり、
+    397x53 の secretary ペインが丸ごと空いているのに窓口が「タブ満杯」と誤読して worker
+    派遣を待機させる実害が出た。`[split_refused]` は**その target を割れないという局所の
+    事実**であって、タブ全体の容量を語らない。よって張り先は毎回 `list_panes` の幾何から
+    決定的に選び直す（renga 側のコード分離は suisya-systems/renga#335）。
 - `role="watcher"`: list_panes で監視ペインを識別する表示ラベル（attention watcher の
   `role="attention"` と同じく canonical 4 role 以外のラベル。broker では token の auth tier
   は spawn 時に固定で、role ラベルは tier を変えない — Surface 8）。
@@ -298,11 +354,22 @@ mcp__org-broker__spawn_pane(
 **spawn 失敗時の分岐**（MCP 結果テキストの `[<code>]` で判定。詳細は
 [`.claude/skills/org-delegate/references/renga-error-codes.md`](../org-delegate/references/renga-error-codes.md)）:
 
-- `[split_refused]`（broker free-pane なし / MIN_PANE 割れ）→「監視ペインを作る空きが
-  ありません（ターミナルが狭い / pane 上限）。ターミナルを広げるか不要ペインを閉じてから
-  再実行してください」と報告して中断。
-- `[pane_not_found]`（`target="dispatcher"` 不在）→「dispatcher ペインが見つかりません。
-  `/org-start` を先に実行してください」と報告して中断。
+- `[split_refused]` → **候補リストを rank 順に 1 段ずつ降りて再試行する（各候補は 1 回だけ）**。**このコードは「その target を
+  今の幾何では割れない」というターゲット局所の失敗を含む**（free-pane 不足だけでなく、
+  細ったアンカー 1 枚の MIN_PANE 割れでも返る）。**1 件の拒否からタブ満杯と結論しない —
+  容量判断は Step 3-0 の幾何計算（`list_panes` × 床値）だけが行う**:
+  1. Step 3-0 の `candidates` から**次の rank** を取り、その `target` / `direction` で
+     Step 3-1 の spawn を **1 回だけ**再試行する。
+  2. 再試行も `[split_refused]` なら、さらに次の rank へ進む（`candidates` の末尾まで）。
+     レイアウトが動いた疑いがあるときは Step 3-0 を 1 度だけ引き直してよい。
+  3. **`candidates` を使い切ったときだけ**「監視ペインを作る空きがありません（ターミナルが
+     狭い / pane 上限）。ターミナルを広げるか不要ペインを閉じてから再実行してください」と
+     報告して中断する。報告には試した target 一覧と Step 3-0 の `rejected` 行（どの床値で
+     落ちたか）を添える。
+- `[pane_not_found]`（候補 target が既に消えている）→ レイアウトが spawn 前後で動いた
+  race。Step 3-0（`list_panes` → ツール）を **1 度だけ**引き直して最新の rank 1 で再試行する。
+  引き直しても候補が空 / 同じく `[pane_not_found]` なら、`/org-start` 未実行を含む想定外
+  として状況を人間に報告して中断。
 - `[name_in_use]` / `[name_taken]` → **live pane と stale 登録簿を切り分ける**（前 watcher の
   self-close で tmux ペインは消えたが broker 登録簿に name binding が残る「二層の不整合」を
   自己回復する）:

--- a/.claude/skills/pr-watch-pane/SKILL.md.in
+++ b/.claude/skills/pr-watch-pane/SKILL.md.in
@@ -18,6 +18,8 @@ allowed-tools:
   - Bash(gh repo view:*)
   - Bash(bash tools/journal_append.sh:*)
   - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python3 tools/pick_watcher_anchor.py:*)
+  - Bash(py -3 tools/pick_watcher_anchor.py:*)
   - mcp__renga-peers__list_panes
   - mcp__renga-peers__spawn_pane
   - mcp__renga-peers__set_pane_identity
@@ -165,12 +167,60 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
 
 ## Step 3: 監視ペインの spawn
 
-`{{FQ}}spawn_pane` で CLI watcher ペインを起動する（`<...>` は Step 1 / 引数で確定した値に置換）:
+### Step 3-0: 張り先（アンカー）を幾何で決める（Refs #335）
+
+spawn の前に、**どのペインを split 起点にするか**を決定的ツールで求める。target は
+固定しない（旧版の `target="dispatcher"` 固定が 2026-08-30 の実害を生んだ経緯は下記
+「なぜ固定アンカーをやめたか」を参照）。
+
+1. `{{FQ}}list_panes` を呼び、返却された `panes` 配列（`id` / `name` / `role` /
+   `x` / `y` / `width` / `height`）をそのまま JSON として控える。
+2. その JSON を `tools/pick_watcher_anchor.py` に stdin で流し、候補リストを得る
+   （既定入力が stdin なので中間ファイルを作らない。ファイル経由なら `--panes-json <path>`）:
+
+   ```bash
+   python3 tools/pick_watcher_anchor.py --format text <<'PANES'
+   {"panes": [ ... list_panes の返却をそのまま貼る ... ]}
+   PANES
+   ```
+
+   （Windows は `py -3 tools/pick_watcher_anchor.py ...`。POSIX 側は `python` エイリアスが
+   無い環境があるため `python3` で呼ぶ。transport は `ORG_TRANSPORT` から自動解決される
+   ので通常は指定不要。明示するなら `--transport {broker|renga}`。）
+3. 出力の `candidates` が **rank 1 から順に試す張り先**。各候補は `target`（pane name）と
+   `direction`（`vertical` / `horizontal`）を持つので、**両方をそのまま次の
+   `spawn_pane` 引数に使う**（direction も候補ごとに変わる。`vertical` 固定ではない）。
+   direction は「両方向を評価し、親側に残る子が大きい方を採る」規則（runtime の
+   `_split_options` と同一。同値性は unit test で固定）。**窓口が direction を自分で
+   決めない**: 2026-08-30 に 397x53 の secretary へ `horizontal` で張って窓口ペインを
+   397x13 まで潰した実害があり、幅広の rect では `vertical` が選ばれる。
+4. `candidates` が空（exit code 2 / `capacity_exhausted: true`）のときだけ、**このタブに
+   watcher を置く余地が本当に無い**。spawn を試みず、`rejected` の各行（どのペインが
+   どの床値でどう落ちたか）を添えて人間に報告し、指示を仰ぐ。
+
+出力の `pane_cap_reached` は**助言であって判定ではない**: 「このタブのペイン数が renga の
+per-tab 上限（`RENGA_MAX_PANES` = 16）に達している」という事実で、renga ではこれ以降の
+spawn が幾何によらず拒否される。既定の broker には per-tab 上限が無い（各ペインが独立
+セッション）ので、`capacity_exhausted` はこの値では動かない。`[split_refused]` が続いた
+ときの人間報告に添える材料として使う。
+
+ツールが守る床値（`MIN_PANE` 20x5 / `SECRETARY_MIN` 120x30 / `DISPATCHER_MIN_WIDTH` 80）は
+`claude_org_runtime.dispatcher.runner` の定数を **import して** 使う（skill 側にも
+ツール側にも値を写経しない）。優先度は **dispatcher →（既存 watcher ペイン。dispatcher
+隣接を先）→ secretary**、dispatcher が自身の comfort 幅を割っている場合だけ最後尾へ降格。
+secretary を張り先に使うのはユーザー承認済み（2026-08-30）で、`SECRETARY_MIN_*` を
+満たす split のみ候補になる。既存 watcher には attention watcher（`role="attention"`）も
+含む。worker / curator ペインは候補に入れない（稼働中の作業ビューポートを watcher が
+食わないため）。
+
+### Step 3-1: spawn
+
+`{{FQ}}spawn_pane` で CLI watcher ペインを起動する（`<...>` は Step 1 / 3-0 / 引数で確定した値に置換）:
 
 ```
 {{FQ}}spawn_pane(
-  target="dispatcher",
-  direction="vertical",
+  target="<Step 3-0 の候補 target>",
+  direction="<Step 3-0 の候補 direction>",
   role="watcher",
   name="pr-watch-<PR>",
   cwd="<JA_ROOT 絶対パス>",
@@ -229,9 +279,15 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
     さらに push が失敗した場合は `pr_watch` が `notify_failed` イベントを fail-loud で記録する
     （silent no-op の全廃）。
 
-- `target="dispatcher"`: 同一タブ scope の安定アンカー（attention watcher と同じく
-  dispatcher を split 起点にする）。broker では各ペインが detached 独立セッションだが、
-  addressing scope（同一タブ MUST、contract Surface 4.2）を満たすため既存ペインを起点に取る。
+- `target` / `direction`: **Step 3-0 のツールが返した候補**をそのまま使う。broker では
+  各ペインが detached 独立セッションだが、addressing scope（同一タブ MUST、contract
+  Surface 4.2）を満たすため既存ペインを起点に取る点は不変。
+  - **なぜ固定アンカーをやめたか（Refs #335）**: 旧版は `target="dispatcher"` 固定だった。
+    2026-08-30、幅 24 まで細った dispatcher に張ろうとして `[split_refused]` になり、
+    397x53 の secretary ペインが丸ごと空いているのに窓口が「タブ満杯」と誤読して worker
+    派遣を待機させる実害が出た。`[split_refused]` は**その target を割れないという局所の
+    事実**であって、タブ全体の容量を語らない。よって張り先は毎回 `list_panes` の幾何から
+    決定的に選び直す（renga 側のコード分離は suisya-systems/renga#335）。
 - `role="watcher"`: list_panes で監視ペインを識別する表示ラベル（attention watcher の
   `role="attention"` と同じく canonical 4 role 以外のラベル。broker では token の auth tier
   は spawn 時に固定で、role ラベルは tier を変えない — Surface 8）。
@@ -292,11 +348,22 @@ context リセットと無関係）に監視が継続し、人間が tmux ペイ
 **spawn 失敗時の分岐**（MCP 結果テキストの `[<code>]` で判定。詳細は
 [`.claude/skills/org-delegate/references/renga-error-codes.md`](../org-delegate/references/renga-error-codes.md)）:
 
-- `[split_refused]`（broker free-pane なし / MIN_PANE 割れ）→「監視ペインを作る空きが
-  ありません（ターミナルが狭い / pane 上限）。ターミナルを広げるか不要ペインを閉じてから
-  再実行してください」と報告して中断。
-- `[pane_not_found]`（`target="dispatcher"` 不在）→「dispatcher ペインが見つかりません。
-  `/org-start` を先に実行してください」と報告して中断。
+- `[split_refused]` → **候補リストを rank 順に 1 段ずつ降りて再試行する（各候補は 1 回だけ）**。**このコードは「その target を
+  今の幾何では割れない」というターゲット局所の失敗を含む**（free-pane 不足だけでなく、
+  細ったアンカー 1 枚の MIN_PANE 割れでも返る）。**1 件の拒否からタブ満杯と結論しない —
+  容量判断は Step 3-0 の幾何計算（`list_panes` × 床値）だけが行う**:
+  1. Step 3-0 の `candidates` から**次の rank** を取り、その `target` / `direction` で
+     Step 3-1 の spawn を **1 回だけ**再試行する。
+  2. 再試行も `[split_refused]` なら、さらに次の rank へ進む（`candidates` の末尾まで）。
+     レイアウトが動いた疑いがあるときは Step 3-0 を 1 度だけ引き直してよい。
+  3. **`candidates` を使い切ったときだけ**「監視ペインを作る空きがありません（ターミナルが
+     狭い / pane 上限）。ターミナルを広げるか不要ペインを閉じてから再実行してください」と
+     報告して中断する。報告には試した target 一覧と Step 3-0 の `rejected` 行（どの床値で
+     落ちたか）を添える。
+- `[pane_not_found]`（候補 target が既に消えている）→ レイアウトが spawn 前後で動いた
+  race。Step 3-0（`list_panes` → ツール）を **1 度だけ**引き直して最新の rank 1 で再試行する。
+  引き直しても候補が空 / 同じく `[pane_not_found]` なら、`/org-start` 未実行を含む想定外
+  として状況を人間に報告して中断。
 - `[name_in_use]` / `[name_taken]` → **live pane と stale 登録簿を切り分ける**（前 watcher の
   self-close で tmux ペインは消えたが broker 登録簿に name binding が残る「二層の不整合」を
   自己回復する）:

--- a/tools/pick_watcher_anchor.py
+++ b/tools/pick_watcher_anchor.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+"""Pick the split anchor(s) for a watcher pane, deterministically (Refs #335).
+
+## Why this exists
+
+``/pr-watch-pane`` used to hard-code ``target="dispatcher"`` as the split
+anchor for the CI-watch pane. On 2026-08-30 the dispatcher pane was 24
+columns wide, so the split was refused (``[split_refused]``) while the
+secretary pane (397x53) sat entirely free. The skill read that single
+target-local refusal as "the tab is full" and stalled worker dispatch.
+
+``[split_refused]`` is **target-local**: it says the pane you aimed at
+cannot be halved, not that the tab has no room. Deciding "no room" is a
+geometry question over *every* pane, and a geometry question belongs in a
+deterministic tool rather than in prose the reader re-derives each time.
+This module answers it: given the ``list_panes`` snapshot, it returns the
+anchors that can actually absorb a watcher, in priority order, so the
+skill can retry the next candidate and only report "out of capacity" when
+the list is exhausted.
+
+## Floors: the runtime is the SoT
+
+``MIN_PANE_WIDTH`` / ``MIN_PANE_HEIGHT`` / ``SECRETARY_MIN_WIDTH`` /
+``SECRETARY_MIN_HEIGHT`` / ``DISPATCHER_MIN_WIDTH`` are imported from
+``claude_org_runtime.dispatcher.runner`` -- the same constants the
+dispatcher's balanced split enforces. They are NOT transcribed here: a
+private copy that drifts from the runtime reproduces exactly the class of
+inexplicable ``[split_refused]`` this tool exists to explain.
+
+``_FALLBACK_FLOORS`` is a last-resort mirror used only when the runtime is
+not importable at all (a bare checkout, a broken venv), and every output
+carries ``constants_source`` so a consumer can tell which one it got.
+``tools/test_pick_watcher_anchor.py`` asserts the mirror equals the
+runtime's values whenever the runtime is installed, so the fallback cannot
+drift silently.
+
+## Priority order
+
+1. ``dispatcher`` -- the historical anchor, kept first while its own (left)
+   child stays >= ``DISPATCHER_MIN_WIDTH``. This mirrors the runtime's
+   dispatcher-first-then-demote rule (``runner._ROLE_PRIORITY`` /
+   ``_DISPATCHER_NARROW_PRIORITY``).
+2. ``watcher`` / ``attention`` -- an already-resident watcher pane (a
+   previous ``pr-watch-*`` pane, or the attention watcher, which
+   ``/org-attention-start`` registers under ``role="attention"``).
+   Watchers are low-content panes, so halving one costs the operator the
+   least; the ones adjacent to the dispatcher come first so watchers keep
+   stacking in one zone instead of scattering across the frame.
+3. ``secretary`` -- allowed as an anchor (user-approved 2026-08-30) but
+   last, and only when the split clears the ``SECRETARY_MIN_*`` floors so
+   the human-facing viewport stays usable.
+4. a dispatcher already narrowed to ``DISPATCHER_MIN_WIDTH`` -- strict last
+   resort, below the secretary, same as the runtime's demotion.
+
+Ties inside a tier break by larger remaining child first, then by pane id
+ascending, so the ordering is total and reproducible.
+
+Any other role (``worker``, ``curator``, ...) is never offered: a watcher
+must not eat a working pane's viewport.
+
+## Direction is chosen too, not assumed
+
+Each candidate carries a ``direction``. Both are evaluated and the one
+leaving the roomier remaining child wins (ties favour ``vertical``), which
+is the runtime's own rule -- ``test_split_options_match_the_runtime_algorithm``
+pins this re-implementation to ``runner._split_options`` over a grid.
+
+This is load-bearing, not cosmetic: on 2026-08-30 a watcher was hand-placed
+on the 397x53 secretary with ``direction="horizontal"``, cutting the
+human's interactive pane to 397x13 -- 397 columns for a log tail, paid for
+with the height of the pane a person reads and types in. On a wide, short
+rect the metric rule picks ``vertical`` and that inversion cannot recur.
+
+## The floors veto under renga, and only rank under broker
+
+The rect ceiling is renga's physical constraint: one tab tiled across every
+pane, so a child below the floors cannot exist. Under the default broker
+transport each pane is an independent detached session with its own
+terminal size, and the runtime's own capacity policy bypasses the rect
+geometry there entirely (``max_concurrent_workers``). A broker pane whose
+snapshot reports a small -- or zero, as a logical pane's does -- rect
+therefore says nothing about whether another pane can be spawned off it.
+
+So the floors are applied as a **veto under renga** and as **ranking only
+under broker**: a broker anchor that fails the floors is demoted to a
+``non-geometric`` tail rather than rejected, and ``capacity_exhausted``
+under broker means "no anchor-role pane exists at all", never "every rect
+is too small". Reporting geometric exhaustion on a transport that has no
+rect ceiling would manufacture the same false "the tab is full" this tool
+exists to prevent.
+
+The transport comes from ``tools.transport.resolve()`` (``--transport``
+overrides it).
+
+## CLI
+
+    python3 tools/pick_watcher_anchor.py --panes-json panes.json
+    mcp list_panes output | python3 tools/pick_watcher_anchor.py
+
+Exit codes: 0 = at least one candidate, 2 = no candidate (genuine capacity
+exhaustion -- report to the human), 1 = malformed input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+try:
+    from tools import transport as _transport
+except Exception:  # pragma: no cover - bare checkout without the seam
+    _transport = None
+
+TRANSPORTS = ("broker", "renga")
+
+
+def resolve_transport(explicit: Optional[str] = None) -> str:
+    """Resolve the active transport flag, falling back to ``broker``.
+
+    ``tools.transport`` is the ja seam over the runtime's transport
+    descriptor. When it cannot be imported (bare checkout, missing
+    runtime) fall back to the code default rather than raising: the
+    fallback only widens what is offered, since broker treats the floors
+    as ranking rather than as a veto.
+    """
+    if explicit:
+        return explicit
+    if _transport is not None:
+        try:
+            return _transport.resolve()
+        except Exception:
+            pass
+    return "broker"
+
+# ---------------------------------------------------------------------------
+# Floors (SoT = claude_org_runtime.dispatcher.runner)
+# ---------------------------------------------------------------------------
+
+# Mirror of the runtime constants, used ONLY when the runtime cannot be
+# imported. Kept honest by test_pick_watcher_anchor.TestFloorDrift.
+_FALLBACK_FLOORS = {
+    "min_pane_width": 20,
+    "min_pane_height": 5,
+    "secretary_min_width": 120,
+    "secretary_min_height": 30,
+    "dispatcher_min_width": 80,
+}
+
+# renga's per-tab pane cap (layout_ops MAX_PANES). Reported, never used as a
+# verdict -- see ``pane_cap_reached`` in :func:`build_result`.
+_FALLBACK_RENGA_MAX_PANES = 16
+
+try:  # pragma: no cover - trivial import branch
+    from claude_org_runtime.dispatcher import runner as _runner
+
+    FLOORS = {
+        "min_pane_width": _runner.MIN_PANE_WIDTH,
+        "min_pane_height": _runner.MIN_PANE_HEIGHT,
+        "secretary_min_width": _runner.SECRETARY_MIN_WIDTH,
+        "secretary_min_height": _runner.SECRETARY_MIN_HEIGHT,
+        "dispatcher_min_width": _runner.DISPATCHER_MIN_WIDTH,
+    }
+    RENGA_MAX_PANES = _runner.RENGA_MAX_PANES
+    CONSTANTS_SOURCE = "claude_org_runtime.dispatcher.runner"
+except Exception:  # pragma: no cover - exercised via monkeypatch in tests
+    FLOORS = dict(_FALLBACK_FLOORS)
+    RENGA_MAX_PANES = _FALLBACK_RENGA_MAX_PANES
+    CONSTANTS_SOURCE = "fallback-mirror"
+
+
+# Tier ranks. Higher wins. The dispatcher's demoted rank sits below every
+# other tier, mirroring runner._DISPATCHER_NARROW_PRIORITY.
+TIER_DISPATCHER = 3
+TIER_WATCHER = 2
+TIER_SECRETARY = 1
+TIER_DISPATCHER_NARROW = 0
+# Broker-only tail: an anchor whose rect fails the floors. Below every
+# geometric tier, but still offered, because broker has no rect ceiling.
+TIER_NON_GEOMETRIC = -1
+
+# Roles that may host a watcher split. ``attention`` is the attention
+# watcher's own role label (``/org-attention-start``); it belongs to the
+# same low-content watcher tier as ``pr-watch-*``, and leaving it out
+# would report capacity exhaustion in a layout where it is the only
+# splittable pane.
+WATCHER_ROLES = ("watcher", "attention")
+ANCHOR_ROLES = ("dispatcher",) + WATCHER_ROLES + ("secretary",)
+
+# Within the broker non-geometric tail the geometric tiers no longer
+# apply, so keep the same role preference by hand.
+_ROLE_TAIL_ORDER = {"dispatcher": 0, "watcher": 1, "attention": 1, "secretary": 2}
+
+_TRAILING_DIGITS = re.compile(r"(\d+)\s*$")
+
+
+class PaneInputError(ValueError):
+    """The panes payload is not a usable list_panes snapshot."""
+
+
+@dataclass(frozen=True)
+class Pane:
+    id: str
+    name: Optional[str]
+    role: Optional[str]
+    x: int
+    y: int
+    width: int
+    height: int
+
+    @property
+    def id_key(self) -> int:
+        """Numeric tie-breaker derived from the trailing digits of ``id``.
+
+        Pane ids are ``%16`` under tmux and ``w1:p3`` under herdr; both end
+        in the pane number, which is the ordering the runtime uses too.
+        An id with no digits sorts last rather than raising -- ordering is
+        a comfort here, not a correctness property.
+        """
+        m = _TRAILING_DIGITS.search(self.id)
+        return int(m.group(1)) if m else sys.maxsize
+
+
+@dataclass
+class Candidate:
+    target: str
+    target_id: str
+    role: str
+    tier: str
+    direction: str
+    new_w: int
+    new_h: int
+    metric: int
+    reason: str
+    _sort: tuple = field(default=(), repr=False, compare=False)
+
+    def to_jsonable(self, rank: int) -> dict:
+        return {
+            "rank": rank,
+            "target": self.target,
+            "target_id": self.target_id,
+            "role": self.role,
+            "tier": self.tier,
+            "direction": self.direction,
+            "new_w": self.new_w,
+            "new_h": self.new_h,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class Rejection:
+    target: Optional[str]
+    target_id: str
+    role: Optional[str]
+    reason: str
+
+    def to_jsonable(self) -> dict:
+        return {
+            "target": self.target,
+            "target_id": self.target_id,
+            "role": self.role,
+            "reason": self.reason,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_panes(payload: Any) -> list[Pane]:
+    """Normalise a ``list_panes`` payload into :class:`Pane` records.
+
+    Accepts the MCP ``structuredContent`` shape (``{"panes": [...]}``) and a
+    bare list, since callers paste either.
+    """
+    if isinstance(payload, dict):
+        raw = payload.get("panes")
+        if raw is None:
+            raise PaneInputError("payload has no 'panes' key")
+    else:
+        raw = payload
+    if not isinstance(raw, list):
+        raise PaneInputError("'panes' is not a list")
+
+    panes: list[Pane] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise PaneInputError(f"panes[{i}] is not an object")
+        try:
+            width = entry.get("width", entry.get("w"))
+            height = entry.get("height", entry.get("h"))
+            panes.append(
+                Pane(
+                    id=str(entry["id"]),
+                    name=entry.get("name"),
+                    role=entry.get("role"),
+                    x=int(entry.get("x", 0)),
+                    y=int(entry.get("y", 0)),
+                    width=int(width),
+                    height=int(height),
+                )
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise PaneInputError(f"panes[{i}] has malformed geometry: {exc}") from exc
+    return panes
+
+
+# ---------------------------------------------------------------------------
+# Geometry
+# ---------------------------------------------------------------------------
+
+
+def rect_adjacent(a: Pane, b: Pane) -> bool:
+    """True when ``a`` and ``b`` share an edge (same rule as the runtime)."""
+    horizontal_share = (a.x + a.width == b.x or b.x + b.width == a.x) and (
+        max(a.y, b.y) < min(a.y + a.height, b.y + b.height)
+    )
+    vertical_share = (a.y + a.height == b.y or b.y + b.height == a.y) and (
+        max(a.x, b.x) < min(a.x + a.width, b.x + b.width)
+    )
+    return horizontal_share or vertical_share
+
+
+def split_options(pane: Pane) -> list[tuple[str, int, int, int]]:
+    """Return ``(direction, new_w, new_h, metric)`` for the splits that fit.
+
+    Both directions are evaluated -- vertical halves the width, horizontal
+    halves the height -- and a direction survives only if the resulting
+    child clears ``MIN_PANE_*`` (plus ``SECRETARY_MIN_*`` for the
+    secretary). ``metric`` is the size along the halved dimension, so a
+    bigger metric means a roomier child.
+    """
+    options: list[tuple[str, int, int, int]] = []
+    for direction, new_w, new_h, metric in (
+        ("vertical", pane.width // 2, pane.height, pane.width // 2),
+        ("horizontal", pane.width, pane.height // 2, pane.height // 2),
+    ):
+        if new_w < FLOORS["min_pane_width"] or new_h < FLOORS["min_pane_height"]:
+            continue
+        if pane.role == "secretary" and (
+            new_w < FLOORS["secretary_min_width"]
+            or new_h < FLOORS["secretary_min_height"]
+        ):
+            continue
+        options.append((direction, new_w, new_h, metric))
+    return options
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+def _floor_reject_reason(pane: Pane) -> str:
+    if pane.role == "secretary":
+        return (
+            "neither direction clears the floors "
+            f"({FLOORS['min_pane_width']}x{FLOORS['min_pane_height']} plus the "
+            f"secretary floor {FLOORS['secretary_min_width']}x"
+            f"{FLOORS['secretary_min_height']}); pane is "
+            f"{pane.width}x{pane.height}"
+        )
+    return (
+        "neither direction clears the floor "
+        f"{FLOORS['min_pane_width']}x{FLOORS['min_pane_height']}; pane is "
+        f"{pane.width}x{pane.height}"
+    )
+
+
+def _non_geometric_direction(pane: Pane) -> tuple[str, int, int, int]:
+    """Direction for a broker anchor whose rect fails the floors.
+
+    Halve the longer side so the reported shape stays plausible; the
+    numbers are informational under broker, where the child pane gets its
+    own terminal size rather than a slice of this rect.
+    """
+    if pane.height > pane.width:
+        return ("horizontal", pane.width, pane.height // 2, pane.height // 2)
+    return ("vertical", pane.width // 2, pane.height, pane.width // 2)
+
+
+def pick(
+    panes: list[Pane], transport: str = "broker"
+) -> tuple[list[Candidate], list[Rejection]]:
+    """Return ``(candidates, rejections)`` -- candidates in priority order.
+
+    Under ``renga`` the floors veto a pane; under ``broker`` they only rank
+    it (see the module docstring).
+    """
+    floors_veto = transport == "renga"
+    dispatcher = next((p for p in panes if p.role == "dispatcher"), None)
+
+    candidates: list[Candidate] = []
+    rejections: list[Rejection] = []
+
+    for pane in panes:
+        if pane.role not in ANCHOR_ROLES:
+            rejections.append(
+                Rejection(
+                    pane.name,
+                    pane.id,
+                    pane.role,
+                    "role is not an anchor role "
+                    f"({'/'.join(ANCHOR_ROLES)}); a watcher must not halve a "
+                    "working pane",
+                )
+            )
+            continue
+        if pane.name is None:
+            # spawn_pane addresses the anchor by name; an unnamed pane is
+            # not addressable, so it cannot be offered as a target.
+            rejections.append(
+                Rejection(None, pane.id, pane.role, "pane has no name to target")
+            )
+            continue
+
+        options = split_options(pane)
+        if not options:
+            if floors_veto:
+                rejections.append(
+                    Rejection(pane.name, pane.id, pane.role, _floor_reject_reason(pane))
+                )
+                continue
+            # broker: the rect is not a ceiling here, so keep the pane as a
+            # last-resort candidate instead of calling the tab full.
+            direction, new_w, new_h, metric = _non_geometric_direction(pane)
+            candidates.append(
+                Candidate(
+                    target=pane.name,
+                    target_id=pane.id,
+                    role=pane.role,
+                    tier="non-geometric",
+                    direction=direction,
+                    new_w=new_w,
+                    new_h=new_h,
+                    metric=metric,
+                    reason=(
+                        "broker fallback: this rect fails the floors ("
+                        f"{pane.width}x{pane.height}), but broker panes are "
+                        "independent detached sessions with no rect ceiling, "
+                        "so the geometry is not a refusal"
+                    ),
+                    _sort=(
+                        -TIER_NON_GEOMETRIC,
+                        _ROLE_TAIL_ORDER.get(pane.role or "", 9),
+                        -metric,
+                        pane.id_key,
+                        pane.name,
+                    ),
+                )
+            )
+            continue
+
+        # Both directions may fit; take the roomier child. max() keeps the
+        # first maximal element and vertical is listed first, so ties
+        # deterministically favour the vertical split.
+        direction, new_w, new_h, metric = max(options, key=lambda o: o[3])
+
+        if pane.role == "dispatcher":
+            vertical = next((o for o in options if o[0] == "vertical"), None)
+            if vertical is not None and vertical[1] >= FLOORS["dispatcher_min_width"]:
+                direction, new_w, new_h, metric = vertical
+                tier_rank, tier = TIER_DISPATCHER, "dispatcher"
+                reason = (
+                    "primary anchor: vertical split leaves the dispatcher "
+                    f"{new_w} cols, at or above the {FLOORS['dispatcher_min_width']}"
+                    "-col comfort floor"
+                )
+            else:
+                tier_rank, tier = TIER_DISPATCHER_NARROW, "dispatcher-narrow"
+                reason = (
+                    "last resort: the dispatcher is already at or below its "
+                    f"{FLOORS['dispatcher_min_width']}-col comfort floor, so "
+                    "splitting it again squeezes the monitoring viewport"
+                )
+        elif pane.role in WATCHER_ROLES:
+            tier_rank, tier = TIER_WATCHER, "watcher"
+            adjacent = dispatcher is not None and rect_adjacent(pane, dispatcher)
+            reason = (
+                "resident watcher pane (low-content, cheapest to halve)"
+                + (
+                    "; adjacent to the dispatcher so watchers stay in one zone"
+                    if adjacent
+                    else ""
+                )
+            )
+        else:  # secretary
+            tier_rank, tier = TIER_SECRETARY, "secretary"
+            reason = (
+                "secretary is a permitted anchor (approved 2026-08-30) and the "
+                f"split leaves {new_w}x{new_h}, clearing the secretary floor "
+                f"{FLOORS['secretary_min_width']}x{FLOORS['secretary_min_height']}"
+            )
+
+        adjacency_rank = 0
+        if pane.role in WATCHER_ROLES:
+            adjacency_rank = (
+                0 if dispatcher is not None and rect_adjacent(pane, dispatcher) else 1
+            )
+
+        candidates.append(
+            Candidate(
+                target=pane.name,
+                target_id=pane.id,
+                role=pane.role,
+                tier=tier,
+                direction=direction,
+                new_w=new_w,
+                new_h=new_h,
+                metric=metric,
+                reason=reason,
+                _sort=(-tier_rank, adjacency_rank, -metric, pane.id_key, pane.name),
+            )
+        )
+
+    candidates.sort(key=lambda c: c._sort)
+    return candidates, rejections
+
+
+def build_result(panes: list[Pane], transport: str = "broker") -> dict:
+    """Assemble the JSON result for ``panes`` under ``transport``.
+
+    ``pane_cap_reached`` reports that the snapshot already holds renga's
+    per-tab pane cap (``RENGA_MAX_PANES``). It is **transport-scoped, like
+    the floors**: under renga the cap is a real ceiling -- every further
+    spawn is refused whatever the geometry says -- so it sets
+    ``capacity_exhausted`` and the skill reports the condition instead of
+    walking a candidate list that cannot succeed. Under broker each pane is
+    its own detached session with no per-tab ceiling, so there the count is
+    reported and nothing else; treating it as a verdict would manufacture
+    the very false "the tab is full" this tool exists to prevent.
+    """
+    candidates, rejections = pick(panes, transport)
+    pane_cap_reached = len(panes) >= RENGA_MAX_PANES
+    cap_is_a_ceiling = transport == "renga" and pane_cap_reached
+    return {
+        "constants_source": CONSTANTS_SOURCE,
+        "transport": transport,
+        "floors": dict(FLOORS),
+        "pane_count": len(panes),
+        "renga_max_panes": RENGA_MAX_PANES,
+        "pane_cap_reached": pane_cap_reached,
+        "pane_cap_is_a_ceiling": cap_is_a_ceiling,
+        "candidates": [c.to_jsonable(i + 1) for i, c in enumerate(candidates)],
+        "rejected": [r.to_jsonable() for r in rejections],
+        "capacity_exhausted": not candidates or cap_is_a_ceiling,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _render_text(result: dict) -> str:
+    lines = []
+    floors = result["floors"]
+    lines.append(
+        "floors: MIN_PANE {min_pane_width}x{min_pane_height} / SECRETARY_MIN "
+        "{secretary_min_width}x{secretary_min_height} / DISPATCHER_MIN_WIDTH "
+        "{dispatcher_min_width}".format(**floors)
+        + f" (from {result['constants_source']})"
+    )
+    lines.append(
+        f"transport: {result['transport']}"
+        + (
+            " (floors veto: a pane below them is not offered)"
+            if result["transport"] == "renga"
+            else " (floors rank only: broker panes are independent sessions "
+            "with no rect ceiling)"
+        )
+    )
+    if result["pane_cap_reached"]:
+        lines.append(
+            f"note: this snapshot holds {result['pane_count']} panes, at or "
+            f"over renga's per-tab cap of {result['renga_max_panes']}"
+            + (
+                " -- under renga that refuses every further spawn regardless "
+                "of geometry, so capacity is exhausted"
+                if result["pane_cap_is_a_ceiling"]
+                else " (advisory only: the broker transport has no per-tab cap)"
+            )
+        )
+    if result["candidates"] and not result["pane_cap_is_a_ceiling"]:
+        lines.append("candidates (try in order):")
+        for c in result["candidates"]:
+            lines.append(
+                f"  {c['rank']}. target={c['target']} (id={c['target_id']}, "
+                f"role={c['role']}, tier={c['tier']}) direction={c['direction']} "
+                f"-> {c['new_w']}x{c['new_h']} -- {c['reason']}"
+            )
+    elif result["pane_cap_is_a_ceiling"]:
+        lines.append(
+            "candidates: SUPPRESSED - the renga per-tab pane cap is reached, "
+            "so no spawn can succeed (capacity exhausted)"
+        )
+    else:
+        lines.append("candidates: NONE - every pane fails the floors (capacity exhausted)")
+    if result["rejected"]:
+        lines.append("rejected:")
+        for r in result["rejected"]:
+            lines.append(
+                f"  - target={r['target']} (id={r['target_id']}, role={r['role']}): "
+                f"{r['reason']}"
+            )
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="pick_watcher_anchor",
+        description=(
+            "Pick the split anchor(s) for a watcher pane from a list_panes "
+            "snapshot, in priority order (dispatcher -> resident watcher -> "
+            "secretary), honouring the runtime's pane floors."
+        ),
+    )
+    p.add_argument(
+        "--panes-json",
+        default="-",
+        help="path to the list_panes JSON snapshot ('-' = stdin, the default).",
+    )
+    p.add_argument(
+        "--transport",
+        choices=TRANSPORTS,
+        default=None,
+        help=(
+            "active transport (default: resolve via ORG_TRANSPORT / the code "
+            "default). Under renga the pane floors veto an anchor; under "
+            "broker they only rank it."
+        ),
+    )
+    p.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="output format (default: json).",
+    )
+    return p
+
+
+def main(argv: Optional[list] = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.panes_json == "-":
+        raw = sys.stdin.read()
+    else:
+        with open(args.panes_json, encoding="utf-8") as fh:
+            raw = fh.read()
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"pick_watcher_anchor: input is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        panes = parse_panes(payload)
+    except PaneInputError as exc:
+        print(f"pick_watcher_anchor: {exc}", file=sys.stderr)
+        return 1
+
+    result = build_result(panes, resolve_transport(args.transport))
+    if args.format == "json":
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        print(_render_text(result))
+    return 2 if result["capacity_exhausted"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_pick_watcher_anchor.py
+++ b/tools/test_pick_watcher_anchor.py
@@ -1,0 +1,402 @@
+"""Unit tests for tools/pick_watcher_anchor.py (Refs #335).
+
+The tool's contract is an *ordering* over anchors, so the tests are fixed
+geometry fixtures with an asserted candidate order rather than spot checks
+on individual predicates:
+
+* the 2026-08-30 incident layout (narrow dispatcher + free secretary) must
+  not yield "no capacity" -- the secretary must be offered;
+* the healthy layout must keep the dispatcher first, so this change does
+  not silently move every watcher off its historical anchor;
+* the genuinely-full layout must yield zero candidates and exit 2 under
+  renga -- the only state the skill may report as "out of capacity" -- while
+  the same layout under broker keeps the anchors, since broker panes are
+  independent sessions with no rect ceiling;
+* the floor mirror must equal the runtime's constants.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pick_watcher_anchor as pwa  # noqa: E402
+
+
+def pane(id_, name, role, x, y, w, h) -> dict:
+    return {"id": id_, "name": name, "role": role, "x": x, "y": y, "width": w, "height": h}
+
+
+def names(result: dict) -> list:
+    return [c["target"] for c in result["candidates"]]
+
+
+# The 2026-08-30 incident: the dispatcher had been halved down to 24 cols
+# (below MIN_PANE_WIDTH once halved again) while the secretary sat free at
+# 397x53. The old skill aimed at the dispatcher, got [split_refused], and
+# concluded the tab was full.
+INCIDENT_LAYOUT = [
+    pane("%1", "secretary", "secretary", 0, 0, 397, 53),
+    pane("%2", "dispatcher", "dispatcher", 0, 54, 24, 30),
+    pane("%3", "worker-alpha", "worker", 25, 54, 180, 30),
+]
+
+# Steady state right after /org-start: a wide dispatcher that can still
+# absorb a watcher without dropping below its comfort floor.
+HEALTHY_LAYOUT = [
+    pane("%1", "secretary", "secretary", 0, 0, 280, 43),
+    pane("%2", "dispatcher", "dispatcher", 0, 44, 280, 43),
+]
+
+# Everything is at or under the floors: no anchor can be halved at all.
+FULL_LAYOUT = [
+    pane("%1", "secretary", "secretary", 0, 0, 100, 20),
+    pane("%2", "dispatcher", "dispatcher", 0, 21, 30, 6),
+    pane("%3", "pr-watch-900", "watcher", 31, 21, 30, 6),
+]
+
+
+class TestOrdering(unittest.TestCase):
+    def test_incident_layout_falls_back_to_secretary(self):
+        result = pwa.build_result(pwa.parse_panes(INCIDENT_LAYOUT))
+        self.assertFalse(result["capacity_exhausted"])
+        # The dispatcher is 24 cols: a vertical split leaves 12 < MIN_PANE_WIDTH
+        # and a horizontal one leaves 24x15, which clears the floors -- so it
+        # is still offered, but demoted below the secretary because it is
+        # under DISPATCHER_MIN_WIDTH.
+        self.assertEqual(names(result), ["secretary", "dispatcher"])
+        self.assertEqual(result["candidates"][0]["tier"], "secretary")
+        self.assertEqual(result["candidates"][1]["tier"], "dispatcher-narrow")
+
+    def test_healthy_layout_keeps_dispatcher_first(self):
+        result = pwa.build_result(pwa.parse_panes(HEALTHY_LAYOUT))
+        self.assertEqual(names(result), ["dispatcher", "secretary"])
+        first = result["candidates"][0]
+        self.assertEqual(first["tier"], "dispatcher")
+        self.assertEqual(first["direction"], "vertical")
+        self.assertEqual(first["new_w"], 140)
+
+    def test_resident_watcher_ranks_between_dispatcher_and_secretary(self):
+        layout = [
+            pane("%1", "secretary", "secretary", 0, 0, 280, 43),
+            pane("%2", "dispatcher", "dispatcher", 0, 44, 200, 43),
+            pane("%3", "pr-watch-900", "watcher", 200, 44, 180, 43),
+        ]
+        result = pwa.build_result(pwa.parse_panes(layout))
+        self.assertEqual(
+            names(result), ["dispatcher", "pr-watch-900", "secretary"]
+        )
+
+    def test_watcher_adjacent_to_dispatcher_wins_over_a_roomier_detached_one(self):
+        # The detached watcher is wider (metric 90 vs 60), so only the
+        # adjacency key can put the adjacent one first.
+        layout = [
+            pane("%1", "secretary", "secretary", 0, 0, 400, 40),
+            pane("%2", "dispatcher", "dispatcher", 0, 40, 60, 40),
+            pane("%3", "pr-watch-adj", "watcher", 60, 40, 120, 40),
+            pane("%4", "pr-watch-far", "watcher", 220, 40, 180, 40),
+        ]
+        result = pwa.build_result(pwa.parse_panes(layout))
+        watchers = [c["target"] for c in result["candidates"] if c["role"] == "watcher"]
+        self.assertEqual(watchers, ["pr-watch-adj", "pr-watch-far"])
+
+    def test_attention_pane_ranks_in_the_watcher_tier(self):
+        # /org-attention-start registers its pane as role="attention", not
+        # "watcher"; excluding it would report capacity exhaustion in a
+        # layout where it is the only splittable pane.
+        layout = [
+            pane("%1", "secretary", "secretary", 0, 0, 200, 40),
+            pane("%2", "dispatcher", "dispatcher", 0, 40, 30, 40),
+            pane("%3", "attention", "attention", 30, 40, 170, 40),
+        ]
+        result = pwa.build_result(pwa.parse_panes(layout))
+        self.assertFalse(result["capacity_exhausted"])
+        self.assertEqual(result["candidates"][0]["target"], "attention")
+        self.assertEqual(result["candidates"][0]["tier"], "watcher")
+
+    def test_working_panes_are_never_offered(self):
+        result = pwa.build_result(pwa.parse_panes(INCIDENT_LAYOUT))
+        self.assertNotIn("worker-alpha", names(result))
+        rejected = {r["target"]: r["reason"] for r in result["rejected"]}
+        self.assertIn("worker-alpha", rejected)
+        self.assertIn("not an anchor role", rejected["worker-alpha"])
+
+    def test_unnamed_pane_is_not_targetable(self):
+        layout = [pane("%9", None, "dispatcher", 0, 0, 280, 43)]
+        result = pwa.build_result(pwa.parse_panes(layout))
+        self.assertEqual(result["candidates"], [])
+        self.assertEqual(result["rejected"][0]["reason"], "pane has no name to target")
+
+    def test_ordering_is_independent_of_input_order(self):
+        forward = pwa.build_result(pwa.parse_panes(INCIDENT_LAYOUT))
+        reverse = pwa.build_result(pwa.parse_panes(list(reversed(INCIDENT_LAYOUT))))
+        self.assertEqual(names(forward), names(reverse))
+
+
+class TestDirection(unittest.TestCase):
+    """Direction is chosen by the tool, never assumed by the caller.
+
+    2026-08-30: a watcher was hand-placed on the 397x53 secretary with
+    direction="horizontal", cutting the human's interactive pane down to
+    397x13 -- giving a log tail 397 columns while taking the height off the
+    pane a person reads and types in. Both directions are evaluated and the
+    one leaving the roomier remaining child wins, which on a wide-and-short
+    rect is the vertical split.
+    """
+
+    def test_wide_secretary_splits_vertically(self):
+        layout = [pane("%1", "secretary", "secretary", 0, 0, 397, 53)]
+        result = pwa.build_result(pwa.parse_panes(layout))
+        first = result["candidates"][0]
+        self.assertEqual(first["target"], "secretary")
+        self.assertEqual(first["direction"], "vertical")
+        self.assertEqual((first["new_w"], first["new_h"]), (198, 53))
+
+    def test_tall_narrow_pane_splits_horizontally(self):
+        # 200 wide halves to 100 (still >= MIN_PANE_WIDTH) with metric 100,
+        # while halving the 300 height gives metric 150 -- the roomier child.
+        layout = [pane("%1", "pr-watch-900", "watcher", 0, 0, 200, 300)]
+        result = pwa.build_result(pwa.parse_panes(layout))
+        self.assertEqual(result["candidates"][0]["direction"], "horizontal")
+
+    def test_only_the_fitting_direction_is_offered(self):
+        # 40 wide halves to 20 (== MIN_PANE_WIDTH, fits); 8 tall halves to 4
+        # < MIN_PANE_HEIGHT, so horizontal is not an option at all.
+        layout = [pane("%1", "pr-watch-900", "watcher", 0, 0, 40, 8)]
+        result = pwa.build_result(pwa.parse_panes(layout))
+        self.assertEqual(result["candidates"][0]["direction"], "vertical")
+
+    def test_split_options_match_the_runtime_algorithm(self):
+        """Drift check: our split_options must equal the runtime's.
+
+        The floors are imported, but the direction rule itself is
+        re-implemented here rather than calling the runtime's private
+        ``_split_options``. This pins the two together over a grid so the
+        re-implementation cannot drift into a different direction choice.
+        """
+        try:
+            from claude_org_runtime.dispatcher import runner
+        except ImportError:  # pragma: no cover
+            self.skipTest("claude-org-runtime not installed")
+        for role in ("secretary", "dispatcher", "worker"):
+            for w in (0, 19, 40, 100, 200, 241, 397):
+                for h in (0, 4, 8, 30, 53, 61, 300):
+                    ours = pwa.split_options(
+                        pwa.Pane("%1", "p", role, 0, 0, w, h)
+                    )
+                    theirs = runner._split_options(
+                        runner.Pane(
+                            id=1, name="p", role=role, focused=False,
+                            x=0, y=0, width=w, height=h,
+                        )
+                    )
+                    self.assertEqual(ours, theirs, f"{role} {w}x{h}")
+
+
+class TestSecretaryFloor(unittest.TestCase):
+    def test_secretary_below_its_floor_is_rejected_with_its_own_reason(self):
+        # 200 wide halves to 100 < SECRETARY_MIN_WIDTH (120); 40 tall halves
+        # to 20 < SECRETARY_MIN_HEIGHT (30). Both directions fail.
+        layout = [pane("%1", "secretary", "secretary", 0, 0, 200, 40)]
+        result = pwa.build_result(pwa.parse_panes(layout), "renga")
+        self.assertTrue(result["capacity_exhausted"])
+        self.assertIn("secretary floor", result["rejected"][0]["reason"])
+
+
+class TestCapacityExhausted(unittest.TestCase):
+    def test_full_layout_yields_no_candidate_under_renga(self):
+        result = pwa.build_result(pwa.parse_panes(FULL_LAYOUT), "renga")
+        self.assertTrue(result["capacity_exhausted"])
+        self.assertEqual(result["candidates"], [])
+        self.assertEqual(len(result["rejected"]), 3)
+
+    def test_broker_keeps_floor_failing_anchors_as_a_last_resort_tail(self):
+        # Broker panes are independent detached sessions: a small rect is
+        # not a refusal, so the same layout must NOT read as "tab full".
+        result = pwa.build_result(pwa.parse_panes(FULL_LAYOUT), "broker")
+        self.assertFalse(result["capacity_exhausted"])
+        self.assertEqual(
+            [c["tier"] for c in result["candidates"]],
+            ["non-geometric", "non-geometric", "non-geometric"],
+        )
+        # Role preference survives into the tail.
+        self.assertEqual(
+            names(result), ["dispatcher", "pr-watch-900", "secretary"]
+        )
+
+    def test_broker_zero_geometry_logical_pane_is_still_offered(self):
+        # The broker secretary is a logical bookkeeping pane; its rect can
+        # be reported as 0x0 and must not read as capacity exhaustion.
+        layout = [pane("%1", "secretary", "secretary", 0, 0, 0, 0)]
+        result = pwa.build_result(pwa.parse_panes(layout), "broker")
+        self.assertFalse(result["capacity_exhausted"])
+        self.assertEqual(result["candidates"][0]["target"], "secretary")
+
+    def test_broker_exhaustion_means_no_anchor_role_pane_at_all(self):
+        layout = [pane("%1", "worker-a", "worker", 0, 0, 280, 43)]
+        result = pwa.build_result(pwa.parse_panes(layout), "broker")
+        self.assertTrue(result["capacity_exhausted"])
+
+    def test_geometric_tiers_still_outrank_the_broker_tail(self):
+        layout = [
+            pane("%1", "secretary", "secretary", 0, 0, 280, 43),
+            pane("%2", "dispatcher", "dispatcher", 0, 44, 10, 3),
+        ]
+        result = pwa.build_result(pwa.parse_panes(layout), "broker")
+        self.assertEqual(names(result), ["secretary", "dispatcher"])
+        self.assertEqual(result["candidates"][1]["tier"], "non-geometric")
+
+
+class TestPaneCap(unittest.TestCase):
+    """The renga per-tab cap is reported, never turned into a verdict."""
+
+    def _capped_layout(self):
+        layout = [pane("%1", "secretary", "secretary", 0, 0, 280, 43)]
+        # Fill the tab up to the cap with panes that are not anchor roles,
+        # so only the cap itself distinguishes this from HEALTHY_LAYOUT.
+        for i in range(2, pwa.RENGA_MAX_PANES + 1):
+            layout.append(pane(f"%{i}", f"worker-{i}", "worker", 0, 44, 20, 5))
+        return layout
+
+    def test_cap_is_advisory_under_broker(self):
+        result = pwa.build_result(pwa.parse_panes(self._capped_layout()), "broker")
+        self.assertTrue(result["pane_cap_reached"])
+        self.assertFalse(result["pane_cap_is_a_ceiling"])
+        self.assertEqual(result["pane_count"], pwa.RENGA_MAX_PANES)
+        # The secretary is still splittable and broker has no per-tab cap,
+        # so the geometry verdict stands.
+        self.assertFalse(result["capacity_exhausted"])
+        self.assertEqual(names(result), ["secretary"])
+
+    def test_cap_is_a_ceiling_under_renga(self):
+        result = pwa.build_result(pwa.parse_panes(self._capped_layout()), "renga")
+        self.assertTrue(result["pane_cap_is_a_ceiling"])
+        # renga refuses every further spawn at the cap, so walking the
+        # candidate list could only collect [split_refused] responses.
+        self.assertTrue(result["capacity_exhausted"])
+
+    def test_cap_is_not_reported_below_the_cap(self):
+        result = pwa.build_result(pwa.parse_panes(HEALTHY_LAYOUT), "renga")
+        self.assertFalse(result["pane_cap_reached"])
+
+    def test_cap_note_is_rendered_in_text_output(self):
+        buf = io.StringIO()
+        payload = json.dumps({"panes": self._capped_layout()})
+        with mock.patch.object(sys, "stdin", io.StringIO(payload)):
+            with redirect_stdout(buf):
+                rc = pwa.main(["--format", "text", "--transport", "broker"])
+        self.assertEqual(rc, 0)
+        self.assertIn("per-tab cap", buf.getvalue())
+
+    def test_cap_exhaustion_exits_two_under_renga(self):
+        buf = io.StringIO()
+        payload = json.dumps({"panes": self._capped_layout()})
+        with mock.patch.object(sys, "stdin", io.StringIO(payload)):
+            with redirect_stdout(buf):
+                rc = pwa.main(["--format", "text", "--transport", "renga"])
+        self.assertEqual(rc, 2)
+        self.assertIn("SUPPRESSED", buf.getvalue())
+
+    def test_cap_mirror_matches_runtime(self):
+        try:
+            from claude_org_runtime.dispatcher import runner
+        except ImportError:  # pragma: no cover
+            self.skipTest("claude-org-runtime not installed")
+        self.assertEqual(pwa._FALLBACK_RENGA_MAX_PANES, runner.RENGA_MAX_PANES)
+
+
+class TestCli(unittest.TestCase):
+    def _run(self, payload, extra=None):
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stdin", io.StringIO(json.dumps(payload))):
+            with redirect_stdout(buf):
+                rc = pwa.main(extra or [])
+        return rc, buf.getvalue()
+
+    def test_exit_zero_and_json_on_candidates(self):
+        rc, out = self._run({"panes": HEALTHY_LAYOUT})
+        self.assertEqual(rc, 0)
+        self.assertEqual(json.loads(out)["candidates"][0]["target"], "dispatcher")
+
+    def test_exit_two_when_capacity_exhausted(self):
+        rc, _ = self._run({"panes": FULL_LAYOUT}, ["--transport", "renga"])
+        self.assertEqual(rc, 2)
+
+    def test_transport_flag_selects_the_floor_regime(self):
+        rc, out = self._run({"panes": FULL_LAYOUT}, ["--transport", "broker"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(json.loads(out)["transport"], "broker")
+
+    def test_bare_list_payload_is_accepted(self):
+        rc, out = self._run(HEALTHY_LAYOUT)
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(json.loads(out)["candidates"]), 2)
+
+    def test_text_format_is_ascii_only(self):
+        # CLI output must survive a cp932 console (worker Windows rule).
+        rc, out = self._run({"panes": INCIDENT_LAYOUT}, ["--format", "text"])
+        self.assertEqual(rc, 0)
+        out.encode("ascii")
+        self.assertIn("candidates (try in order):", out)
+
+    def test_help_is_ascii_only(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            with self.assertRaises(SystemExit):
+                pwa.main(["--help"])
+        buf.getvalue().encode("ascii")
+
+    def test_malformed_payload_exits_one(self):
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stdin", io.StringIO('{"panes": [{"id": "%1"}]}')):
+            with redirect_stdout(buf):
+                rc = pwa.main([])
+        self.assertEqual(rc, 1)
+
+    def test_non_json_input_exits_one(self):
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stdin", io.StringIO("not json")):
+            with redirect_stdout(buf):
+                rc = pwa.main([])
+        self.assertEqual(rc, 1)
+
+
+class TestFloorDrift(unittest.TestCase):
+    """The fallback mirror must not drift from the runtime constants."""
+
+    def test_mirror_matches_runtime(self):
+        try:
+            from claude_org_runtime.dispatcher import runner
+        except ImportError:  # pragma: no cover - runtime is a hard dep in CI
+            self.skipTest("claude-org-runtime not installed")
+        self.assertEqual(
+            pwa._FALLBACK_FLOORS,
+            {
+                "min_pane_width": runner.MIN_PANE_WIDTH,
+                "min_pane_height": runner.MIN_PANE_HEIGHT,
+                "secretary_min_width": runner.SECRETARY_MIN_WIDTH,
+                "secretary_min_height": runner.SECRETARY_MIN_HEIGHT,
+                "dispatcher_min_width": runner.DISPATCHER_MIN_WIDTH,
+            },
+        )
+
+    def test_live_floors_come_from_the_runtime_when_it_is_installed(self):
+        try:
+            import claude_org_runtime.dispatcher.runner  # noqa: F401
+        except ImportError:  # pragma: no cover
+            self.skipTest("claude-org-runtime not installed")
+        self.assertEqual(
+            pwa.CONSTANTS_SOURCE, "claude_org_runtime.dispatcher.runner"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_pick_watcher_anchor.py
+++ b/tools/test_pick_watcher_anchor.py
@@ -13,6 +13,15 @@ on individual predicates:
   the same layout under broker keeps the anchors, since broker panes are
   independent sessions with no rect ceiling;
 * the floor mirror must equal the runtime's constants.
+
+**The pane sizes in these fixtures are observed examples, not spec
+values.** 397x53 / 24 wide are what the 2026-08-30 incident happened to
+measure; 280x43 and 80x24 stand in for a laptop and a small terminal.
+Terminal geometry is per-environment, so nothing in ``pick()`` keys on a
+particular size -- the only absolute numbers in the tool are the runtime
+floor mirror (pinned by ``TestFloorDrift``) and prose in its docstring.
+A fixture size may be changed freely as long as its relation to the
+floors is preserved.
 """
 
 from __future__ import annotations
@@ -54,6 +63,15 @@ INCIDENT_LAYOUT = [
 HEALTHY_LAYOUT = [
     pane("%1", "secretary", "secretary", 0, 0, 280, 43),
     pane("%2", "dispatcher", "dispatcher", 0, 44, 280, 43),
+]
+
+# A small terminal (80x24 class), tiled the usual way. Nothing here is
+# splittable *comfortably*, which is the point: the tool should degrade
+# through its tiers rather than jump to "no capacity".
+SMALL_TERMINAL_LAYOUT = [
+    pane("%1", "secretary", "secretary", 0, 0, 80, 12),
+    pane("%2", "dispatcher", "dispatcher", 0, 12, 40, 12),
+    pane("%3", "worker-a", "worker", 40, 12, 40, 12),
 ]
 
 # Everything is at or under the floors: no anchor can be halved at all.
@@ -153,12 +171,33 @@ class TestDirection(unittest.TestCase):
     """
 
     def test_wide_secretary_splits_vertically(self):
+        # 397x53 is the size the incident was measured at, not a spec value.
         layout = [pane("%1", "secretary", "secretary", 0, 0, 397, 53)]
         result = pwa.build_result(pwa.parse_panes(layout))
         first = result["candidates"][0]
         self.assertEqual(first["target"], "secretary")
         self.assertEqual(first["direction"], "vertical")
         self.assertEqual((first["new_w"], first["new_h"]), (198, 53))
+
+    def test_direction_rule_holds_across_terminal_sizes(self):
+        # Sizes are examples spanning small / medium / large; the assertion
+        # is the *rule* (halve the longer side -> the roomier child), not a
+        # per-size constant. Watcher role keeps SECRETARY_MIN out of it.
+        cases = [
+            (40, 10, "vertical"),    # small, wide
+            (24, 40, "horizontal"),  # small, tall
+            (160, 48, "vertical"),   # medium, wide
+            (60, 120, "horizontal"), # medium, tall
+            (397, 53, "vertical"),   # the 2026-08-30 measurement
+            (200, 300, "horizontal"),
+        ]
+        for w, h, expected in cases:
+            with self.subTest(size=f"{w}x{h}"):
+                layout = [pane("%1", "pr-watch-900", "watcher", 0, 0, w, h)]
+                result = pwa.build_result(pwa.parse_panes(layout))
+                self.assertEqual(
+                    result["candidates"][0]["direction"], expected
+                )
 
     def test_tall_narrow_pane_splits_horizontally(self):
         # 200 wide halves to 100 (still >= MIN_PANE_WIDTH) with metric 100,
@@ -199,6 +238,53 @@ class TestDirection(unittest.TestCase):
                         )
                     )
                     self.assertEqual(ours, theirs, f"{role} {w}x{h}")
+
+
+class TestSmallTerminalDegradation(unittest.TestCase):
+    """Degrade through the tiers on a small terminal, then report zero.
+
+    The failure this guards against is the mirror image of the incident:
+    concluding "no capacity" while something is still splittable, and
+    conversely offering a candidate when nothing is.
+    """
+
+    def test_small_terminal_still_offers_the_narrow_dispatcher(self):
+        # secretary 80x12 fails SECRETARY_MIN in both directions; the
+        # 40x12 dispatcher halves to 20x12, clearing MIN_PANE but sitting
+        # under DISPATCHER_MIN_WIDTH -- so it is offered, demoted.
+        result = pwa.build_result(pwa.parse_panes(SMALL_TERMINAL_LAYOUT), "renga")
+        self.assertFalse(result["capacity_exhausted"])
+        self.assertEqual(names(result), ["dispatcher"])
+        self.assertEqual(result["candidates"][0]["tier"], "dispatcher-narrow")
+        secretary_reason = next(
+            r["reason"] for r in result["rejected"] if r["target"] == "secretary"
+        )
+        self.assertIn("secretary floor", secretary_reason)
+
+    def test_one_notch_smaller_yields_zero_candidates(self):
+        # One notch tighter: 19 wide halves to 9 (< MIN_PANE_WIDTH 20) and
+        # 8 tall halves to 4 (< MIN_PANE_HEIGHT 5), so neither direction
+        # fits for any anchor and the secretary still fails its own floor.
+        layout = [
+            pane("%1", "secretary", "secretary", 0, 0, 80, 8),
+            pane("%2", "dispatcher", "dispatcher", 0, 8, 19, 8),
+            pane("%3", "pr-watch-900", "watcher", 19, 8, 19, 8),
+        ]
+        result = pwa.build_result(pwa.parse_panes(layout), "renga")
+        self.assertTrue(result["capacity_exhausted"])
+        self.assertEqual(result["candidates"], [])
+
+    def test_zero_candidates_exits_two_for_the_skill_to_report(self):
+        layout = [
+            pane("%1", "secretary", "secretary", 0, 0, 80, 8),
+            pane("%2", "dispatcher", "dispatcher", 0, 8, 19, 8),
+        ]
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stdin", io.StringIO(json.dumps(layout))):
+            with redirect_stdout(buf):
+                rc = pwa.main(["--transport", "renga"])
+        self.assertEqual(rc, 2)
+        self.assertTrue(json.loads(buf.getvalue())["capacity_exhausted"])
 
 
 class TestSecretaryFloor(unittest.TestCase):


### PR DESCRIPTION
## 背景

`/pr-watch-pane` は watcher を常に `target="dispatcher"` / `direction="vertical"` 固定で張っていた。2026-08-30 にこれが 2 つの実害を出した。

1. 幅 24 桁まで細くなった dispatcher ペインへの spawn が `[split_refused]` で拒否され、窓口がそれを「タブ満杯」と読んで worker 派遣を待機させた。同じタブに 397x53 の secretary ペインが丸ごと空いており、実際には容量があった。`[split_refused]` は「上限到達」と「対象が小さすぎ」を 1 コードで返すため、1 件の拒否からタブ全体の容量は導けない（分離は suisya-systems/renga#335 で起票済み）。
2. 復旧のため secretary ペインを張り先にした際、`direction` を取り違えて上段を高さ方向に 3 分割し、対話に使う窓口ペインが 397x13 まで潰れた。ログを流すだけの watcher が幅 397 を占め、人間が読み書きするペインの高さが削られる逆配分になった。

どちらも「その場の判断」に委ねられていたことが原因なので、判定をツールに移す。

## 変更

- **`tools/pick_watcher_anchor.py` を新設**。`list_panes` の幾何を入力に、分割可能なアンカーを優先度順（dispatcher → 既存 watcher（dispatcher 隣接を先）→ secretary。comfort 幅を割った dispatcher は最後尾へ降格）で返す。worker / curator は稼働中の作業ビューポートなので候補にしない。
- **分割方向もツールが決める**。候補ごとに vertical / horizontal を両方評価し、親側に残る子が大きい方を採る（同値なら vertical）。397x53 の secretary に対して `vertical` が選ばれることを fixture で固定した。
- **床値は `claude_org_runtime.dispatcher.runner` から import** する（写経しない）。runtime 不在時のみ使うミラー定数は drift test で固定。分割可否の判定アルゴリズムは private API に運用手順を吊るさないため再実装し、runtime の `_split_options` と同値であることを grid 比較テストで pin した。
- **transport で床値の効き方を分ける**。renga では床値が veto、broker では順位付けのみ（broker のペインは独立した detached セッションで rect 上限がなく、論理的な窓口ペインは 0x0 を返しうる）。全 transport で veto にすると、rect を持たない broker で偽の「タブ満杯」を作り、この PR が潰した誤読を別経路で再生産してしまう。renga の per-tab 上限に達している場合のみ、それ自体を容量枯渇として扱う。
- **`[split_refused]` の分岐を書き換え**。「このコードはターゲット局所の失敗を含む。1 件の拒否からタブ満杯と結論しない。容量判断は幾何計算のみが行う」旨を明記し、候補を順位どおり 1 段ずつ（各 1 回）試し、候補を使い切ったときだけ容量不足として人間に報告する。`[pane_not_found]` も race として 1 度だけ引き直す。

Step 5 の close 手順・freshness gate・stale binding allowlist は変更していない。

## 検証

`tools/test_pick_watcher_anchor.py` 34 tests（事故当日のレイアウト / 健全レイアウト / 隣接順 / attention ペイン / 満杯 / transport 別の床値 / direction fixture / runtime parity / CLI exit code）。全体は `unittest discover -s tools` 1106 OK、`-s tests` 1018 OK、skill drift check・Group B selector check ともに clean。Codex レビューはゲート成立、最終ラウンドで指摘なし。

Refs suisya-systems/renga#335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXZRnN344fdTBn5YnTEqQj