### PR TITLE
再 push 後の watcher 不在を events の時系列で機械検出する

### DIFF
--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -294,6 +294,28 @@ pr-watch から `PR_MERGED_HEAD_UNCONFIRMED: PR #<n> (head=<merged_short>, last 
   `[pane_not_found]`（自己クローズ済みで正常、skip してよい）。修正後の再 push では新たに
   [`/pr-watch-pane <PR>`](../pr-watch-pane/SKILL.md) を起動し直し、その新しい pane_id / head を
   追跡し直す（旧イベントの重複配送は head 不一致で superseded 判定になり新 watcher を誤 close しない）。
+- **再 push したら watcher が「その push より後に」起動されているかを機械確認する（Refs #978）**:
+  修正の再 push は「worker の報告 → 窓口の push」と別ターンに分かれるため、watcher の立て直しが
+  窓口の記憶頼みになり、実際に落ちた（2026-08-30、PR #73 で 2 回目の再 push 以降 誰も CI を見て
+  いない状態が続き、ユーザーの指摘で発覚）。**`list_panes` に `pr-watch-<PR>` が居ることを根拠に
+  してはならない**: herdr / renga では監視終了後もペインが自己 close せず、死んだ watch と生きて
+  いる watch が外見上区別できない（これが同インシデントの誤判定そのもの）。判定は events の
+  時系列で行う:
+  ```bash
+  python3 tools/watcher_restart_guard.py check --task <task_id>
+  ```
+  exit 0 なら「最後の push より後に開始された watcher がある」。**exit 3 なら watcher が現 head を
+  見ていない**ので [`/pr-watch-pane <PR>`](../pr-watch-pane/SKILL.md) を起動し直してから次へ進む
+  （`stale`＝前 push の watcher しか居ない / `missing`＝一度も起動されていない /
+  `ended_inconclusive`＝watch が CI の答えを出さずに終了した（`incomplete` / `indeterminate` /
+  timeout。`indeterminate` は watcher 自身が再起動を要求している） / `ended_stale_head`＝出た判定が
+  前 head のもの）。exit 2 は task から PR を特定できない状態なので、先に `tools/set_run_pr_open.py`
+  で `runs.pr_url` を back-fill する。**exit 3 のまま「CI 走行中」とユーザーに報告しない** —
+  それが同インシデントで起きたことである。
+  なお `bash tools/journal_append.sh fix_pushed ...` を打った時点で同じ判定が stderr に出る
+  （post-check。push 直後は watcher 再起動前なので exit 3 相当が出るのが正常で、これは異常通知では
+  なく「次にやること」の提示）。判定ロジックの一次情報源は
+  [`docs/journal-events.md`](../../../docs/journal-events.md) と当該ツールの module docstring。
 - **再指示の前に dispatcher の監視フラグを解除する（Issue #658、T6 監視再開契約）**: worker が完了報告済み（完了時に §2a で secretary が dispatcher へ `WORKER_COMPLETION_NOTED` を送り `completion_reported_at` が立っている）の場合、追指示を送る**前に** dispatcher へ `WORKER_REOPENED` を **best-effort・非 blocking** で送り、`completion_reported_at` を `null` に clear させる。再指示は secretary→worker 直送で dispatcher が経路上に居ないため、この明示解除が dispatcher の PANE_OUTPUT_WITHOUT_PEER_MSG 検知（[`.dispatcher/references/worker-monitoring.md`](../../../.dispatcher/references/worker-monitoring.md) Step 5.2）の **fast-path 解除**になる。dispatcher 応答は待たない（dispatcher は `/loop 3m` の通常 `check_messages` で反映）。解除が無いと sticky skip のまま、awaiting_review→in_progress のレビュー修正中に発生する本物の silent dead-lock を見逃す。**`WORKER_REOPENED` が取りこぼされても、この直後の `run.status='in_use'` 遷移（下記、StateWriter が決定的に書く）が reliable backstop として働き、dispatcher が `runs.status == 'in_use'` を観測して監視を self-heal で再開する**（best-effort な解除通知だけに依存せず危険側に倒れない、Issue #658 P2）。本文に task_id と reopened_at（ISO-8601 UTC）を含める:
   ```
   mcp__org-broker__send_message(to_id="dispatcher", message="WORKER_REOPENED: worker-<task_id> (task_id=<task_id>, reopened_at=<ISO-8601 UTC>)")

--- a/.claude/skills/org-pull-request/SKILL.md.in
+++ b/.claude/skills/org-pull-request/SKILL.md.in
@@ -286,6 +286,28 @@ pr-watch から `PR_MERGED_HEAD_UNCONFIRMED: PR #<n> (head=<merged_short>, last 
   `[pane_not_found]`（自己クローズ済みで正常、skip してよい）。修正後の再 push では新たに
   [`/pr-watch-pane <PR>`](../pr-watch-pane/SKILL.md) を起動し直し、その新しい pane_id / head を
   追跡し直す（旧イベントの重複配送は head 不一致で superseded 判定になり新 watcher を誤 close しない）。
+- **再 push したら watcher が「その push より後に」起動されているかを機械確認する（Refs #978）**:
+  修正の再 push は「worker の報告 → 窓口の push」と別ターンに分かれるため、watcher の立て直しが
+  窓口の記憶頼みになり、実際に落ちた（2026-08-30、PR #73 で 2 回目の再 push 以降 誰も CI を見て
+  いない状態が続き、ユーザーの指摘で発覚）。**`list_panes` に `pr-watch-<PR>` が居ることを根拠に
+  してはならない**: herdr / renga では監視終了後もペインが自己 close せず、死んだ watch と生きて
+  いる watch が外見上区別できない（これが同インシデントの誤判定そのもの）。判定は events の
+  時系列で行う:
+  ```bash
+  python3 tools/watcher_restart_guard.py check --task <task_id>
+  ```
+  exit 0 なら「最後の push より後に開始された watcher がある」。**exit 3 なら watcher が現 head を
+  見ていない**ので [`/pr-watch-pane <PR>`](../pr-watch-pane/SKILL.md) を起動し直してから次へ進む
+  （`stale`＝前 push の watcher しか居ない / `missing`＝一度も起動されていない /
+  `ended_inconclusive`＝watch が CI の答えを出さずに終了した（`incomplete` / `indeterminate` /
+  timeout。`indeterminate` は watcher 自身が再起動を要求している） / `ended_stale_head`＝出た判定が
+  前 head のもの）。exit 2 は task から PR を特定できない状態なので、先に `tools/set_run_pr_open.py`
+  で `runs.pr_url` を back-fill する。**exit 3 のまま「CI 走行中」とユーザーに報告しない** —
+  それが同インシデントで起きたことである。
+  なお `bash tools/journal_append.sh fix_pushed ...` を打った時点で同じ判定が stderr に出る
+  （post-check。push 直後は watcher 再起動前なので exit 3 相当が出るのが正常で、これは異常通知では
+  なく「次にやること」の提示）。判定ロジックの一次情報源は
+  [`docs/journal-events.md`](../../../docs/journal-events.md) と当該ツールの module docstring。
 - **再指示の前に dispatcher の監視フラグを解除する（Issue #658、T6 監視再開契約）**: worker が完了報告済み（完了時に §2a で secretary が dispatcher へ `WORKER_COMPLETION_NOTED` を送り `completion_reported_at` が立っている）の場合、追指示を送る**前に** dispatcher へ `WORKER_REOPENED` を **best-effort・非 blocking** で送り、`completion_reported_at` を `null` に clear させる。再指示は secretary→worker 直送で dispatcher が経路上に居ないため、この明示解除が dispatcher の PANE_OUTPUT_WITHOUT_PEER_MSG 検知（[`.dispatcher/references/worker-monitoring.md`](../../../.dispatcher/references/worker-monitoring.md) Step 5.2）の **fast-path 解除**になる。dispatcher 応答は待たない（dispatcher は `/loop 3m` の通常 `check_messages` で反映）。解除が無いと sticky skip のまま、awaiting_review→in_progress のレビュー修正中に発生する本物の silent dead-lock を見逃す。**`WORKER_REOPENED` が取りこぼされても、この直後の `run.status='in_use'` 遷移（下記、StateWriter が決定的に書く）が reliable backstop として働き、dispatcher が `runs.status == 'in_use'` を観測して監視を self-heal で再開する**（best-effort な解除通知だけに依存せず危険側に倒れない、Issue #658 P2）。本文に task_id と reopened_at（ISO-8601 UTC）を含める:
   ```
   {{FQ}}send_message(to_id="dispatcher", message="WORKER_REOPENED: worker-<task_id> (task_id=<task_id>, reopened_at=<ISO-8601 UTC>)")

--- a/.claude/skills/pr-watch-pane/SKILL.md
+++ b/.claude/skills/pr-watch-pane/SKILL.md
@@ -493,6 +493,23 @@ mcp__org-broker__spawn_pane(
 
    Windows native では `py -3 tools/journal_append.py pr_watch_pane_started pr=<PR> repo=<OWNER/REPO> pane_id=<N>`。
 
+   **この行は監査ログではなく、watcher 生存判定の一次証拠である（Refs #978）**: 記録を落とすと
+   [`tools/watcher_restart_guard.py`](../../../tools/watcher_restart_guard.py) は「watcher なし」
+   （`missing`）と判定する（画面にペインが見えていてもである — ペインの存在は監視の生存を意味
+   しない、が同ガードの前提）。best-effort とは「失敗しても spawn 自体は巻き戻さない」の意味
+   であって、省略してよいという意味ではない。
+
+   記録したら、それが判定に反映されたことをその場で確認する:
+
+   ```bash
+   python3 tools/watcher_restart_guard.py check --task <task_id>
+   ```
+
+   exit 0（`live`）なら「最後の push より後に開始された watcher がある」ことが events の時系列
+   から機械的に確認できた状態。exit 3 が返る場合は 1. の記録が入っていないか、この watcher が
+   最後の push より前に起動している（＝立て直しが必要）。cross-repo で task が引けない場合は
+   `check --pr <PR> --repo <OWNER/REPO>` でもよい（run 行から baseline を逆引きする）。
+
 2. ユーザーに報告する:
 
    ```

--- a/.claude/skills/pr-watch-pane/SKILL.md.in
+++ b/.claude/skills/pr-watch-pane/SKILL.md.in
@@ -487,6 +487,23 @@ secretary を張り先に使うのはユーザー承認済み（2026-08-30）で
 
    Windows native では `py -3 tools/journal_append.py pr_watch_pane_started pr=<PR> repo=<OWNER/REPO> pane_id=<N>`。
 
+   **この行は監査ログではなく、watcher 生存判定の一次証拠である（Refs #978）**: 記録を落とすと
+   [`tools/watcher_restart_guard.py`](../../../tools/watcher_restart_guard.py) は「watcher なし」
+   （`missing`）と判定する（画面にペインが見えていてもである — ペインの存在は監視の生存を意味
+   しない、が同ガードの前提）。best-effort とは「失敗しても spawn 自体は巻き戻さない」の意味
+   であって、省略してよいという意味ではない。
+
+   記録したら、それが判定に反映されたことをその場で確認する:
+
+   ```bash
+   python3 tools/watcher_restart_guard.py check --task <task_id>
+   ```
+
+   exit 0（`live`）なら「最後の push より後に開始された watcher がある」ことが events の時系列
+   から機械的に確認できた状態。exit 3 が返る場合は 1. の記録が入っていないか、この watcher が
+   最後の push より前に起動している（＝立て直しが必要）。cross-repo で task が引けない場合は
+   `check --pr <PR> --repo <OWNER/REPO>` でもよい（run 行から baseline を逆引きする）。
+
 2. ユーザーに報告する:
 
    ```

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -386,12 +386,21 @@ spawn し、起動確認を済ませてから `pr_watch_pane_started` を書く�
 既に red の場合 watch は確認ステップの最中に `ci_completed` を出して終了し、
 terminal イベントが自分の起動行より**前**に並ぶ。watcher の時刻だけを起点に
 すると「起動行より後の terminal は無い ＝ live」と永久に答えることになる（ガード
-自身が同じ誤りを一段下で再現する）ため、この窓が空のときは baseline 以降の
-terminal を再検討し、**より前の watcher が所有者になりえない場合に限り**最新
-watcher のものとみなす。所有者候補が居る場合（push → watcher → `indeterminate`
-→ 再起動、という `indeterminate` への正規の対応手順）は再起動側が本当に生きて
-いるので `live` のまま。この推測が働いたときは出力の
-`terminal_precedes_watcher_row` で可視化される。
+自身が同じ誤りを一段下で再現する）。そこで watcher と terminal を時系列で
+**貪欲にペアリング**する: 古い watcher から順に「自分の起動時刻以降で、まだ
+誰にも取られていない最初の terminal」を 1 つ取り、baseline 以降で最後まで
+取られなかった terminal を最新 watcher に帰属させる。貪欲であることが両方向の
+誤りを同時に防ぐ — 前の watcher が terminal を「所有」できるのは**まだ消費して
+いない場合だけ**なので、`push → watcher → indeterminate → 再起動`（`indeterminate`
+への正規の対応手順）は `live` のまま、`watcher1 → failed → push →
+watcher2 の terminal → watcher2 の起動行`は「watcher2 は終了済み」と正しく読む。
+この帰属が働いたときは出力の `terminal_precedes_watcher_row` で可視化される。
+
+なお terminal 側の repo 欠落行は「watch が終わった証拠」としては採用するが
+**結論（非 trip の verdict）には使えない**（PR 番号は repo 間で衝突するので、
+別 repo の同番号 PR の `pr_merged` / legacy `ci_completed` がこちらを
+「監視済み」と証明してしまう）。この場合は `ended_inconclusive` になる。
+live DB の `pr_merged` 363 行中 45 行が repo を持たないため、実在する行形である。
 
 baseline の sha は `fix_pushed` payload の `commit` / `head` / `sha` の
 順で読む（catalog 上の名は `commit` だが、実際の emitter が書くのは

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -151,12 +151,21 @@ secretary, and the secretary is the actor that writes this one.
 
 | Event           | Typical fields                          | Writer    | Emitted by | Required for |
 |-----------------|-----------------------------------------|-----------|------------|--------------|
-| `fix_pushed`    | `task`, `branch`, `commit`              | secretary | secretary  | —            |
+| `fix_pushed`    | `task`, `branch`, `head` (別名 `commit` / `sha`) | secretary | secretary  | —            |
 | `pr_opened`     | `task`, `pr`, `url`                     | secretary | secretary  | —            |
 | `prs_opened`    | `count`, `prs[]`                        | secretary | secretary  | —            |
 | `pr_merged`     | `task`, `pr`, `repo`, `pr_url`, `merge_commit`, `head`, `merged_at`, `pattern`, `auto_completed` | run_complete_on_merge | `run_complete_on_merge.py` | —            |
 | `prs_merged`    | `count`, `prs[]`                        | secretary | secretary  | —            |
 | `prs_pushed`    | `count`, `branches[]`                   | secretary | secretary  | —            |
+
+`fix_pushed` の sha フィールドは、この catalog が長らく `commit` と書いて
+いた一方で、**実際の emitter は一貫して `head` を書いてきた**（本リポジトリ
+の live DB では 69 行中 `head` が 47 行、`commit` は 0 行、残り 22 行は
+sha を自由記述の `note` にしか持たない）。ここは表を実態側に合わせてある。
+読み手（現状 [`tools/watcher_restart_guard.py`](../tools/watcher_restart_guard.py)）は
+`commit` / `head` / `sha` の順に読むこと — 文書上の名前だけを読むと、その
+比較は本番では常に空振りする dead code になる。新規に書く側は `head` を
+使うのが望ましいが、既存 3 名のいずれも受理される。
 
 `pr_merged` is written by `tools/run_complete_on_merge.py` in the **same transaction** as
 `pr_state='merged'` / `commit` / `completed_at` (see the `append_event` call at
@@ -335,7 +344,72 @@ neither an unreadable probe nor a gh outage can wedge the watch.
 (`name="pr-watch-<PR>"`, `role="watcher"`) running `tools/pr-watch.sh`.
 It records that the watcher pane was launched; the actual CI verdict
 still arrives later as `ci_completed` from `tools/pr_watch.py` inside
-that pane.
+that pane. **This row used to be best-effort audit only** — nothing
+read it back. [`tools/watcher_restart_guard.py`](../tools/watcher_restart_guard.py)
+(Refs #978) makes it load-bearing: omitting the row, or a broker
+transport that fails to record it, makes the guard report `missing`
+even when a watcher pane genuinely exists on screen.
+
+`fix_pushed`、`pr_watch_pane_started`、および上記の terminal 系イベント
+（`ci_completed` / `pr_merged` / `pr_merged_no_run` /
+`pr_merged_head_unconfirmed` / `pr_merge_watch_timeout` /
+`pr_watch_aborted`）は、単体の監査ログとしてだけでなく、
+`tools/watcher_restart_guard.py` によって `events` テーブルの時系列順に
+読まれ、「最後の push より後に開始された watcher があるか」という
+1 つの predicate へ合成される。判定基準は「`pr-watch-<N>` という名前の
+pane が存在するか」では**ない**（herdr / renga transport では監視終了
+後も pane が自己 close せず、終わった watch と生きている watch が外見
+上区別できない — 2026-08-29 のインシデントはまさにこの誤判定で発生
+した）。判定基準は常に「baseline push（対象 task の最新 `fix_pushed`）
+より後の `(occurred_at, id)` を持つ `pr_watch_pane_started` があるか」
+であり、それ以降に terminal イベントが来ている場合は続けて「その watch
+は**答えを出して**終わったのか、単に**止まった**のか」を見る。
+
+- `ci_completed` の `status` が `passed` / `failed` のときだけ「CI が答え
+  を出した」と扱う。`incomplete`（checks が pending のまま retry budget
+  切れ）/ `indeterminate`（probe を一度も読めなかった。この行は
+  `retry_recommended` を伴う ＝ watcher 自身が再起動を要求している）/
+  `canceled` / `status` 未記録、および `pr_watch_aborted` /
+  `pr_merge_watch_timeout` は**答えのない終端**であり、現 head は無監視
+  なので `ended_inconclusive` で trip する。live DB の `ci_completed` の
+  約 7% がこの経路で終わっており、机上の分岐ではない。
+- `head` は**降格材料であって必須条件ではない**。答えが出た watch につい
+  て、baseline の sha と terminal の `head` が**両方読めて食い違うとき
+  だけ** `ended_stale_head`（前 push 向けの判定＝現 head は無監視）に降格
+  する。どちらかが欠けている場合は比較不能として `completed` に倒し、
+  欠落は出力に残す。sha が読めないことを trip 条件にすると健全な watch で
+  誤報が出て、「読み飛ばす習慣」というインシデントの原因そのものを再生産
+  するため。
+
+baseline の sha は `fix_pushed` payload の `commit` / `head` / `sha` の
+順で読む（catalog 上の名は `commit` だが、実際の emitter が書くのは
+`head` である点は下記 `fix_pushed` 行の注記を参照）。詳細な非対称マッチ
+ング規則（repo 欠落行の扱いが `pr_watch_pane_started` 側と terminal 側
+で逆になる理由を含む）はツール本体の module docstring が一次情報源で
+ある。
+
+`tools/journal_append.py` は `fix_pushed` の DB commit 成功後、同じ
+コネクション上でこの predicate を非致命的な post-check として実行し、
+`stderr` に結果を出す（`journal_append` 自身の exit code は変えない
+— 例外は握りつぶす）。push 直後は定義上まだ watcher が再起動されて
+いないため、判定は `stale` / `missing` になるのが通常であり、これは
+異常ではなく「次に必ずやるべき動作（`/pr-watch-pane` の再起動）」の
+リマインドとして出力される。`$ORG_WATCHER_GUARD=off`（`0` / `false`
+も可、大小文字無視）または非公開 CLI フラグ `--no-watcher-guard` で
+抑止できる（既定は有効）。
+
+`tools/watcher_restart_guard.py check --pr <N> --repo <owner/name>` /
+`check --task <task_id>` は同じ predicate を単発 CLI として提供し、
+exit code は `0`=`live`/`completed`（監視は説明がつく）、`3`=`stale`/
+`missing`/`ended_stale_head`/`ended_inconclusive`（watcher の再起動が
+必要 — 2026-08-29 のインシデントは `stale`）、`2`=`unresolved`（対象
+task から PR が特定できない）、`1`=usage / DB / schema エラー。**両形式は
+同じ baseline を見る**: `--pr` 形式は当該 PR を持つ run 行から task_id を
+逆引きして `fix_pushed` baseline を復元する（復元しないと `--pr` 形式は
+baseline を一切読まず、`stale` 分岐に到達できないまま exit 0 を返す ＝
+インシデントそのものを見逃す）。`audit` サブコマンドは `pr_state` が非
+terminal な run を全件評価し、1 件でも trip した verdict があれば exit 3
+を返す。
 
 ### Session lifecycle
 

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -381,6 +381,18 @@ pane が存在するか」では**ない**（herdr / renga transport では監�
   誤報が出て、「読み飛ばす習慣」というインシデントの原因そのものを再生産
   するため。
 
+**watch はその起動が記録される前に終わりうる**: `/pr-watch-pane` はペインを
+spawn し、起動確認を済ませてから `pr_watch_pane_started` を書くため、CI が
+既に red の場合 watch は確認ステップの最中に `ci_completed` を出して終了し、
+terminal イベントが自分の起動行より**前**に並ぶ。watcher の時刻だけを起点に
+すると「起動行より後の terminal は無い ＝ live」と永久に答えることになる（ガード
+自身が同じ誤りを一段下で再現する）ため、この窓が空のときは baseline 以降の
+terminal を再検討し、**より前の watcher が所有者になりえない場合に限り**最新
+watcher のものとみなす。所有者候補が居る場合（push → watcher → `indeterminate`
+→ 再起動、という `indeterminate` への正規の対応手順）は再起動側が本当に生きて
+いるので `live` のまま。この推測が働いたときは出力の
+`terminal_precedes_watcher_row` で可視化される。
+
 baseline の sha は `fix_pushed` payload の `commit` / `head` / `sha` の
 順で読む（catalog 上の名は `commit` だが、実際の emitter が書くのは
 `head` である点は下記 `fix_pushed` 行の注記を参照）。詳細な非対称マッチ
@@ -408,8 +420,10 @@ task から PR が特定できない）、`1`=usage / DB / schema エラー。**
 逆引きして `fix_pushed` baseline を復元する（復元しないと `--pr` 形式は
 baseline を一切読まず、`stale` 分岐に到達できないまま exit 0 を返す ＝
 インシデントそのものを見逃す）。`audit` サブコマンドは `pr_state` が非
-terminal な run を全件評価し、1 件でも trip した verdict があれば exit 3
-を返す。
+terminal な run を全件評価し、1 件でも trip した verdict があれば exit 3、
+trip は無いが `pr_url` を読めず**評価できなかった** run がある場合は exit 2
+を返す（評価できなかった open PR を exit 0 に混ぜると「全件確認済み」と読めて
+しまい、本ツールが消そうとしている silent miss そのものになる）。
 
 ### Session lifecycle
 

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -402,6 +402,15 @@ watcher2 の terminal → watcher2 の起動行`は「watcher2 は終了済み�
 「監視済み」と証明してしまう）。この場合は `ended_inconclusive` になる。
 live DB の `pr_merged` 363 行中 45 行が repo を持たないため、実在する行形である。
 
+**既知の限界**: terminal 系イベントは**どのペインが書いたか**を持たない
+（`--merge-watch` では 1 回の `pr_watch` が `ci_completed` と後続の
+`pr_merged` / `pr_merge_watch_timeout` を書くので、1 watcher : 1 terminal
+でもない）。このため旧ペインが残ったまま新 watcher を立てた状況では、旧ペイン
+発の遅れて来た行と新 watcher 自身の行を区別できず、新しい watch を「終了した」
+と読む。これは誤検知（余分な `/pr-watch-pane` 再起動が 1 回増えるだけで、
+無監視の PR を見逃す方向には倒れない）として受け入れている。厳密化するには
+terminal イベント側に pane 識別子を載せる必要があり、それは本ツールの範囲外。
+
 baseline の sha は `fix_pushed` payload の `commit` / `head` / `sha` の
 順で読む（catalog 上の名は `commit` だが、実際の emitter が書くのは
 `head` である点は下記 `fix_pushed` 行の注記を参照）。詳細な非対称マッチ

--- a/tools/journal_append.py
+++ b/tools/journal_append.py
@@ -19,6 +19,19 @@ Failure handling: any exception from the DB write path propagates to
 the caller as exit-code 1 with a stderr message. There is no
 file-append fallback in M4 — silently shadowing failures with a legacy
 jsonl write would let writes diverge from the SoT.
+
+Watcher-restart post-check (Refs #978): after a ``fix_pushed`` row is
+committed, this wrapper asks
+:func:`tools.watcher_restart_guard.post_push_check` whether the pushed
+PR has a CI watcher that started *after* this push, and prints the
+answer on stderr. The check lives here because the secretary is
+contractually required to emit ``fix_pushed`` on every push, so the
+nudge cannot be skipped by forgetting to run a separate tool — which is
+exactly how the incident happened. It is strictly advisory: the whole
+post-check is wrapped in ``try/except Exception`` and never changes this
+wrapper's exit code, because a guard that breaks the journal writer is
+worse than the bug it prevents. ``$ORG_WATCHER_GUARD=off`` (also ``0`` /
+``false``) and the hidden ``--no-watcher-guard`` flag suppress it.
 """
 
 from __future__ import annotations
@@ -48,7 +61,31 @@ def _parse_kv(pair: str) -> "tuple[str, str]":
     return key, val
 
 
-def _db_append(db_path: Path, event: str, payload: dict) -> None:
+def _run_watcher_guard(conn, payload: dict) -> None:
+    """Advisory Refs #978 post-check; never raises, never changes exit code.
+
+    Called only for a committed ``fix_pushed`` row. Every failure mode --
+    a missing module, an unreadable run, a broken stderr -- is swallowed:
+    the event is already durably recorded and losing a reminder must not
+    cost the caller the write.
+    """
+    try:
+        from tools.watcher_restart_guard import guard_disabled, post_push_check
+
+        if guard_disabled():
+            return
+        post_push_check(conn, payload)
+    except Exception:  # noqa: BLE001 - advisory only, see the docstring
+        pass
+
+
+def _db_append(
+    db_path: Path,
+    event: str,
+    payload: dict,
+    *,
+    watcher_guard: bool = True,
+) -> None:
     """M4 canonical path: DB write only (no jsonl side-output)."""
     from tools.state_db import apply_schema, connect
     from tools.state_db.discover import verify_or_exit
@@ -69,6 +106,10 @@ def _db_append(db_path: Path, event: str, payload: dict) -> None:
             actor = payload["actor"]
         writer.append_event(kind=event, actor=actor, payload=payload)
         writer.commit()
+        if watcher_guard and event == "fix_pushed":
+            # After the commit, on the same connection the write used, so
+            # the guard sees the row it is reacting to.
+            _run_watcher_guard(conn, payload if isinstance(payload, dict) else {})
     finally:
         conn.close()
 
@@ -100,6 +141,11 @@ def main(argv: "list[str] | None" = None) -> int:
         ),
     )
     parser.add_argument("--path", default=None, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--no-watcher-guard",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     args = parser.parse_args(argv)
 
     if args.path is not None:
@@ -131,7 +177,12 @@ def main(argv: "list[str] | None" = None) -> int:
     )
 
     try:
-        _db_append(db_path, args.event, payload)
+        _db_append(
+            db_path,
+            args.event,
+            payload,
+            watcher_guard=not args.no_watcher_guard,
+        )
         return 0
     except SystemExit:
         # verify_or_exit -> sys.exit on schema mismatch — let it through

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -437,7 +437,9 @@ _BRIEFING_PAYLOAD_FIELDS: dict[str, tuple[str, ...]] = {
     "design_approved":         ("task", "pr"),
     "drift_reaudit":           ("task", "reason"),
     # PR / push
-    "fix_pushed":              ("task", "branch", "commit"),
+    # Emitters write the sha as ``head``; ``commit`` is the name the event
+    # catalog used to document and is kept so an older row still renders.
+    "fix_pushed":              ("task", "branch", "head", "commit"),
     "pr_opened":               ("task", "pr"),
     "prs_opened":              ("count",),
     "pr_merged":               ("pr", "task"),

--- a/tools/test_watcher_restart_guard.py
+++ b/tools/test_watcher_restart_guard.py
@@ -278,12 +278,29 @@ class TestVerdicts(DbCase):
         v = guard.evaluate(self.conn, None, REPO, task_id=self.TASK)
         self.assertEqual((v.verdict, v.exit_code), ("unresolved", 2))
 
-    def test_terminal_before_the_watcher_does_not_end_it(self) -> None:
-        # A verdict from the PREVIOUS watch must not be read as ending the
-        # current one; otherwise a restart would report `completed`.
+    def test_terminal_before_the_watcher_needs_an_earlier_watcher_to_disown(self) -> None:
+        """Who owns a terminal that precedes the only watcher row?
+
+        With NO earlier ``pr_watch_pane_started`` on record there was no
+        previous watch to attribute it to (the launch row is mandatory), so
+        it belongs to this watcher, whose row simply landed late -- and the
+        watch is over. Reading it as "someone else's old verdict, we are
+        still live" is the race that lets a finished watch look alive.
+        """
         self.push(self.TASK, "c2c2c2c", _ts(10))
         self.ci(73, "failed", "c1c1c1c", _ts(20))
         self.watcher(73, _ts(30))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("ended_stale_head", 3))
+        self.assertTrue(v.terminal_precedes_watcher_row)
+
+    def test_an_earlier_watcher_disowns_it_and_the_restart_is_live(self) -> None:
+        # Same events, plus the previous watch's launch row: now the
+        # terminal has an owner and the newest watcher is a real restart.
+        self.push(self.TASK, "c2c2c2c", _ts(10))
+        self.watcher(73, _ts(15), pane_id="%1")
+        self.ci(73, "failed", "c1c1c1c", _ts(20))
+        self.watcher(73, _ts(30), pane_id="%2")
         v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
         self.assertEqual(v.verdict, "live")
         self.assertIsNone(v.terminal)
@@ -392,6 +409,25 @@ class TestResolution(DbCase):
 
 
 class TestAudit(DbCase):
+    def test_unreadable_pr_url_does_not_exit_0(self) -> None:
+        """An open PR that could not be CHECKED is not a clean bill.
+
+        `unresolved` is not a tripping verdict, so a plain "any tripped?"
+        exit rule reports the whole audit healthy while that PR was never
+        examined -- exactly the silent miss this tool removes.
+        """
+        self.add_run("t", pr_url="not-a-pr-url")
+        code, out, _err = self._run(["audit"])
+        self.assertEqual(code, guard.EXIT_UNRESOLVED)
+        self.assertIn("unresolved", out)
+
+    def test_a_trip_outranks_an_unresolved_run(self) -> None:
+        self.add_run("bad-url", pr_url="not-a-pr-url")
+        self.add_run("t", pr_url=f"https://github.com/{REPO}/pull/73")
+        self.push("t", "c1", _ts(10))
+        self.watcher(73, _ts(5))
+        self.assertEqual(self._run(["audit"])[0], guard.EXIT_TRIPPED)
+
     def test_exits_3_when_any_run_trips(self) -> None:
         self.add_run("t", pr_url=f"https://github.com/{REPO}/pull/73")
         self.push("t", "c1", _ts(10))
@@ -658,6 +694,58 @@ class TestSchemaAssumptions(DbCase):
         self.add_event_raw("ci_completed", '"nope"', _ts(30))
         v = guard.evaluate(self.conn, 73, REPO)
         self.assertEqual(v.verdict, "missing")
+
+
+class TestWatchEndingBeforeItsLaunchRow(DbCase):
+    """The launch row is appended AFTER the pane is spawned and verified.
+
+    A watch that finds CI already red can finish in that gap, so its
+    terminal event sorts before its own ``pr_watch_pane_started``. A
+    watcher-anchored window finds nothing after the launch row and would
+    answer ``live`` forever for a watch that is already over.
+    """
+
+    TASK = "t"
+
+    def test_terminal_recorded_before_the_launch_row_still_counts(self) -> None:
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(10))
+        self.ci(73, "failed", "bbbbbbb", _ts(20))     # watch finished first
+        self.watcher(73, _ts(30))                     # launch row lands late
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+        self.assertTrue(v.terminal_precedes_watcher_row)
+        self.assertEqual(v.terminal["kind"], "ci_completed")
+
+    def test_the_same_race_trips_when_the_watch_gave_no_verdict(self) -> None:
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(10))
+        self.ci(73, "indeterminate", "bbbbbbb", _ts(20))
+        self.watcher(73, _ts(30))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("ended_inconclusive", 3))
+
+    def test_a_restart_after_a_verdict_is_still_live(self) -> None:
+        """The documented response to ``indeterminate`` must not false-alarm.
+
+        Here an EARLIER watcher owns the terminal, so the newest one is a
+        genuine restart rather than a late launch row.
+        """
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(10))
+        self.watcher(73, _ts(20), pane_id="%1")
+        self.ci(73, "indeterminate", "bbbbbbb", _ts(30))
+        self.watcher(73, _ts(40), pane_id="%2")
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("live", 0))
+        self.assertFalse(v.terminal_precedes_watcher_row)
+        self.assertEqual(v.watcher["pane_id"], "%2")
+
+    def test_a_terminal_from_before_the_push_is_not_reattributed(self) -> None:
+        self.push(self.TASK, "aaaaaaaaaaaa", _ts(0))
+        self.ci(73, "failed", "aaaaaaa", _ts(10))
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(20))
+        self.watcher(73, _ts(30))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("live", 0))
+        self.assertFalse(v.terminal_precedes_watcher_row)
 
 
 class TestEmittedPayloadShapes(DbCase):

--- a/tools/test_watcher_restart_guard.py
+++ b/tools/test_watcher_restart_guard.py
@@ -1,0 +1,811 @@
+"""Tests for tools/watcher_restart_guard.py (Refs #978).
+
+The centrepiece is :class:`TestIncident978`, which replays the incident
+itself: push -> watcher -> red CI -> push again with no restart. Every
+other case exists to pin one of the asymmetries the module docstring
+argues for, because those are exactly the places where a well-meaning
+simplification would turn the guard back into "a pane is present".
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools import journal_append, watcher_restart_guard as guard  # noqa: E402
+from tools.state_db import apply_schema, connect  # noqa: E402
+
+REPO = "suisya-systems/claude-org-ja"
+OTHER_REPO = "suisya-systems/renga"
+
+
+def _ts(seconds: int) -> str:
+    """A deterministic ISO-8601 UTC stamp, ``seconds`` past a fixed epoch."""
+    return f"2026-08-29T10:{seconds // 60:02d}:{seconds % 60:02d}.000Z"
+
+
+class DbCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db_path = Path(self._tmp.name) / "state.db"
+        self.conn = connect(self.db_path)
+        self.addCleanup(self.conn.close)
+        apply_schema(self.conn)
+        self.conn.commit()
+
+    def _run(self, argv: list) -> "tuple[int, str, str]":
+        """Invoke the CLI against this case's DB, capturing both streams."""
+        out, err = io.StringIO(), io.StringIO()
+        stdout, stderr = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = out, err
+        try:
+            code = guard.main(["--db-path", str(self.db_path)] + argv)
+        finally:
+            sys.stdout, sys.stderr = stdout, stderr
+        return code, out.getvalue(), err.getvalue()
+
+    def add_event(self, kind: str, payload: dict, occurred_at: str) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO events (occurred_at, actor, kind, payload_json) "
+            "VALUES (?, ?, ?, ?)",
+            (occurred_at, "secretary", kind, json.dumps(payload)),
+        )
+        self.conn.commit()
+        return int(cur.lastrowid)
+
+    def add_event_raw(self, kind: str, payload_json: str, occurred_at: str) -> None:
+        self.conn.execute(
+            "INSERT INTO events (occurred_at, actor, kind, payload_json) "
+            "VALUES (?, 'secretary', ?, ?)",
+            (occurred_at, kind, payload_json),
+        )
+        self.conn.commit()
+
+    def add_run(
+        self,
+        task_id: str,
+        pr_url: str | None = None,
+        pr_state: str | None = "open",
+        status: str = "in_use",
+    ) -> None:
+        self.conn.execute(
+            "INSERT OR IGNORE INTO projects (id, slug, display_name) "
+            "VALUES (1, 'claude-org-ja', 'claude-org-ja')"
+        )
+        self.conn.execute(
+            "INSERT INTO runs (task_id, project_id, pattern, title, status, "
+            "pr_url, pr_state) VALUES (?, 1, 'A', ?, ?, ?, ?)",
+            (task_id, task_id, status, pr_url, pr_state),
+        )
+        self.conn.commit()
+
+    # convenience emitters -------------------------------------------------
+
+    def push(self, task: str, commit: str, at: str) -> int:
+        return self.add_event(
+            "fix_pushed", {"task": task, "branch": "fix/x", "commit": commit}, at
+        )
+
+    def watcher(self, pr, at: str, repo=REPO, pane_id: str = "%9") -> int:
+        payload: dict = {"pr": pr, "pane_id": pane_id}
+        if repo is not None:
+            payload["repo"] = repo
+        return self.add_event("pr_watch_pane_started", payload, at)
+
+    def ci(self, pr, status: str, head, at: str, repo=REPO) -> int:
+        payload: dict = {"pr": pr, "status": status, "head": head}
+        if repo is not None:
+            payload["repo"] = repo
+        return self.add_event("ci_completed", payload, at)
+
+
+class TestIncident978(DbCase):
+    """The exact 2026-08-29 sequence, replayed end to end."""
+
+    TASK = "ja-978-watcher-restart-guard"
+
+    def _replay_up_to_second_push(self) -> None:
+        self.push(self.TASK, "c1c1c1c1c1c1", _ts(10))
+        self.watcher(73, _ts(20))
+        self.ci(73, "failed", "c1c1c1c", _ts(60))
+        self.push(self.TASK, "c2c2c2c2c2c2", _ts(90))
+
+    def test_second_push_without_restart_is_stale(self) -> None:
+        self._replay_up_to_second_push()
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual(v.verdict, "stale")
+        self.assertEqual(v.exit_code, 3)
+        self.assertTrue(v.tripped)
+        # The evidence, not just the label, must be in the output.
+        self.assertEqual(v.baseline["commit"], "c2c2c2c2c2c2")
+        self.assertEqual(v.watcher["occurred_at"], _ts(20))
+        self.assertIn("/pr-watch-pane 73", v.remediation)
+
+    def test_restarting_the_watcher_flips_it_to_live(self) -> None:
+        self._replay_up_to_second_push()
+        self.watcher(73, _ts(100), pane_id="%12")
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual(v.verdict, "live")
+        self.assertEqual(v.exit_code, 0)
+        self.assertFalse(v.tripped)
+        self.assertIsNone(v.remediation)
+        self.assertEqual(v.watcher["pane_id"], "%12")
+
+    def test_a_live_pane_is_not_the_predicate(self) -> None:
+        """No pane state is consulted at all -- only event ordering."""
+        self._replay_up_to_second_push()
+        stale = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        # The same watcher row, moved after the push, is the only difference
+        # between the incident and a healthy run.
+        self.conn.execute(
+            "UPDATE events SET occurred_at = ? WHERE kind = 'pr_watch_pane_started'",
+            (_ts(120),),
+        )
+        self.conn.commit()
+        healthy = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((stale.verdict, healthy.verdict), ("stale", "live"))
+
+
+class TestVerdicts(DbCase):
+    TASK = "t"
+
+    def test_missing_when_no_watcher_row_exists(self) -> None:
+        self.push(self.TASK, "c1", _ts(10))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("missing", 3))
+        self.assertEqual(v.watcher_count, 0)
+
+    def test_completed_when_terminal_head_corroborates_the_push(self) -> None:
+        self.push(self.TASK, "abcdef1234567890", _ts(10))
+        self.watcher(73, _ts(20))
+        self.ci(73, "passed", "abcdef1", _ts(60))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+        self.assertEqual(v.terminal["kind"], "ci_completed")
+
+    def test_completed_on_merge_without_head_corroboration(self) -> None:
+        self.push(self.TASK, "abcdef1234567890", _ts(10))
+        self.watcher(73, _ts(20))
+        self.add_event("pr_merged", {"pr": 73, "repo": REPO}, _ts(60))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+
+    def test_ended_stale_head_when_the_verdict_is_for_an_older_head(self) -> None:
+        # The watcher restarted after the push, but the verdict it delivered
+        # describes the previous head (a race the watcher can genuinely hit).
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(10))
+        self.watcher(73, _ts(20))
+        self.ci(73, "failed", "aaaaaaa", _ts(60))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("ended_stale_head", 3))
+        self.assertIn("/pr-watch-pane 73", v.remediation)
+
+    def test_inconclusive_ci_status_trips_even_on_the_current_head(self) -> None:
+        """The watch stopped without answering -- head agreement is irrelevant.
+
+        ``pr_watch`` records ``head`` for these too, so a head-only rule
+        reads them as "the verdict is in for the commit you pushed" and
+        exits 0 while CI is still running and the pane is gone.
+        ``indeterminate`` even carries ``retry_recommended``: the watcher
+        itself is asking to be restarted.
+        """
+        for status in ("incomplete", "indeterminate", "canceled"):
+            with self.subTest(status=status):
+                self.setUp()
+                self.push(self.TASK, "bbbbbbbbbbbb", _ts(10))
+                self.watcher(73, _ts(20))
+                self.ci(73, status, "bbbbbbb", _ts(60))
+                v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+                self.assertEqual((v.verdict, v.exit_code), ("ended_inconclusive", 3))
+                self.assertTrue(v.tripped)
+                self.assertIn("/pr-watch-pane 73", v.remediation)
+
+    def test_unrecorded_ci_status_trips(self) -> None:
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(10))
+        self.watcher(73, _ts(20))
+        self.add_event(
+            "ci_completed", {"pr": 73, "repo": REPO, "head": "bbbbbbb"}, _ts(60)
+        )
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("ended_inconclusive", 3))
+
+    def test_legacy_result_key_is_read_as_the_status(self) -> None:
+        """A dozen rows in the live DB carry ``result`` instead of ``status``."""
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(10))
+        self.watcher(73, _ts(20))
+        self.add_event(
+            "ci_completed",
+            {"pr": 73, "repo": REPO, "head": "bbbbbbb", "result": "passed"},
+            _ts(60),
+        )
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+
+    def test_null_head_with_a_real_verdict_is_completed(self) -> None:
+        """An unreadable head is an absent comparison, never a mismatch.
+
+        About a third of ``ci_completed`` rows carry no ``head``. Tripping
+        on that absence would fire on healthy watches, and an alarm that
+        fires on the normal case is one the reader learns to skim past --
+        the same reflex that produced the incident.
+        """
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(10))
+        self.watcher(73, _ts(20))
+        self.ci(73, "passed", None, _ts(60))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+        self.assertIsNone(v.terminal["head"])
+
+    def test_watch_abort_kinds_are_terminal_and_warn(self) -> None:
+        for kind in ("pr_watch_aborted", "pr_merge_watch_timeout"):
+            with self.subTest(kind=kind):
+                self.setUp()
+                self.push(self.TASK, "bbbbbbbbbbbb", _ts(10))
+                self.watcher(73, _ts(20))
+                self.add_event(kind, {"pr": 73, "repo": REPO}, _ts(60))
+                v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+                self.assertEqual((v.verdict, v.exit_code), ("ended_inconclusive", 3))
+
+    def test_no_baseline_edge_reports_null_baseline(self) -> None:
+        self.watcher(73, _ts(20))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=None)
+        self.assertEqual((v.verdict, v.exit_code), ("live", 0))
+        self.assertIsNone(v.baseline)
+
+    def test_no_baseline_with_terminal_is_completed(self) -> None:
+        self.watcher(73, _ts(20))
+        self.ci(73, "passed", "abcdef1", _ts(60))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=None)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+        self.assertIsNone(v.baseline)
+
+    def test_no_baseline_and_no_watcher_is_missing(self) -> None:
+        v = guard.evaluate(self.conn, 73, REPO, task_id=None)
+        self.assertEqual((v.verdict, v.exit_code), ("missing", 3))
+
+    def test_unresolved_pr_number(self) -> None:
+        v = guard.evaluate(self.conn, None, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("unresolved", 2))
+
+    def test_terminal_before_the_watcher_does_not_end_it(self) -> None:
+        # A verdict from the PREVIOUS watch must not be read as ending the
+        # current one; otherwise a restart would report `completed`.
+        self.push(self.TASK, "c2c2c2c", _ts(10))
+        self.ci(73, "failed", "c1c1c1c", _ts(20))
+        self.watcher(73, _ts(30))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual(v.verdict, "live")
+        self.assertIsNone(v.terminal)
+
+
+class TestNormalisation(DbCase):
+    TASK = "t"
+
+    def test_str_and_int_pr_payloads_both_match(self) -> None:
+        self.push(self.TASK, "c1", _ts(10))
+        self.watcher("73", _ts(20))
+        self.assertEqual(
+            guard.evaluate(self.conn, 73, REPO, task_id=self.TASK).verdict, "live"
+        )
+        self.setUp()
+        self.push(self.TASK, "c1", _ts(10))
+        self.watcher(73, _ts(20))
+        self.assertEqual(
+            guard.evaluate(self.conn, "#73", REPO, task_id=self.TASK).verdict, "live"
+        )
+
+    def test_non_integer_pr_payload_never_matches(self) -> None:
+        self.push(self.TASK, "c1", _ts(10))
+        self.watcher("not-a-number", _ts(20))
+        self.assertEqual(
+            guard.evaluate(self.conn, 73, REPO, task_id=self.TASK).verdict, "missing"
+        )
+
+    def test_repo_case_and_git_suffix_are_normalised(self) -> None:
+        self.push(self.TASK, "c1", _ts(10))
+        self.watcher(73, _ts(20), repo="Suisya-Systems/Claude-Org-JA.git")
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual(v.verdict, "live")
+
+    def test_watcher_without_repo_is_not_counted_and_is_reported(self) -> None:
+        self.push(self.TASK, "c1", _ts(10))
+        self.watcher(73, _ts(20), repo=None)
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual(v.verdict, "missing")
+        self.assertEqual(len(v.ignored_unknown_repo), 1)
+        self.assertEqual(v.watcher_count, 0)
+
+    def test_terminal_without_repo_is_counted(self) -> None:
+        self.push(self.TASK, "abcdef1234", _ts(10))
+        self.watcher(73, _ts(20))
+        self.ci(73, "passed", "abcdef1", _ts(60), repo=None)
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual(v.verdict, "completed")
+
+    def test_same_millisecond_ordering_is_resolved_by_event_id(self) -> None:
+        # Watcher row written AFTER the push in the same millisecond: the
+        # autoincrement id is the only thing that distinguishes them.
+        self.push(self.TASK, "c1", _ts(10))
+        self.watcher(73, _ts(10))
+        self.assertEqual(
+            guard.evaluate(self.conn, 73, REPO, task_id=self.TASK).verdict, "live"
+        )
+
+        self.setUp()
+        # Same millisecond, opposite insertion order: the push wins.
+        self.watcher(73, _ts(10))
+        self.push(self.TASK, "c1", _ts(10))
+        self.assertEqual(
+            guard.evaluate(self.conn, 73, REPO, task_id=self.TASK).verdict, "stale"
+        )
+
+    def test_cross_repo_pr_number_collision_does_not_leak(self) -> None:
+        self.push("ja-task", "aaaaaaa", _ts(10))
+        self.push("renga-task", "bbbbbbb", _ts(11))
+        # Only the renga PR got a restarted watcher.
+        self.watcher(73, _ts(20), repo=OTHER_REPO)
+        ja = guard.evaluate(self.conn, 73, REPO, task_id="ja-task")
+        renga = guard.evaluate(self.conn, 73, OTHER_REPO, task_id="renga-task")
+        self.assertEqual(ja.verdict, "missing")
+        self.assertEqual(renga.verdict, "live")
+
+    def test_baseline_is_scoped_to_the_task(self) -> None:
+        self.push("other-task", "zzzz", _ts(90))
+        self.push(self.TASK, "c1", _ts(10))
+        self.watcher(73, _ts(20))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual(v.verdict, "live")
+        self.assertEqual(v.baseline["commit"], "c1")
+
+
+class TestResolution(DbCase):
+    def test_resolves_pr_and_repo_from_run_pr_url(self) -> None:
+        self.add_run("t", pr_url=f"https://github.com/{REPO}/pull/73")
+        res = guard.resolve_for_task(self.conn, "t")
+        self.assertEqual((res.pr, res.repo), ("73", REPO))
+
+    def test_falls_back_to_pr_opened_event(self) -> None:
+        self.add_run("t", pr_url=None)
+        self.add_event(
+            "pr_opened",
+            {"task": "t", "pr": 73, "url": f"https://github.com/{REPO}/pull/73"},
+            _ts(5),
+        )
+        res = guard.resolve_for_task(self.conn, "t")
+        self.assertEqual((res.pr, res.repo), ("73", REPO))
+
+    def test_unresolved_when_nothing_names_a_pr(self) -> None:
+        self.add_run("t", pr_url=None)
+        res = guard.resolve_for_task(self.conn, "t")
+        self.assertIsNone(res.pr)
+
+
+class TestAudit(DbCase):
+    def test_exits_3_when_any_run_trips(self) -> None:
+        self.add_run("t", pr_url=f"https://github.com/{REPO}/pull/73")
+        self.push("t", "c1", _ts(10))
+        self.watcher(73, _ts(5))  # started BEFORE the push
+        results = guard.audit(self.conn)
+        self.assertEqual([v.verdict for v in results], ["stale"])
+        self.assertTrue(any(v.tripped for v in results))
+        self.assertEqual(self._cli(["audit"]), 3)
+
+    def test_exits_0_when_none_trip(self) -> None:
+        self.add_run("t", pr_url=f"https://github.com/{REPO}/pull/73")
+        self.push("t", "c1", _ts(10))
+        self.watcher(73, _ts(20))
+        self.assertEqual(self._cli(["audit"]), 0)
+
+    def test_terminal_and_merged_runs_are_excluded(self) -> None:
+        self.add_run(
+            "done",
+            pr_url=f"https://github.com/{REPO}/pull/71",
+            pr_state="merged",
+            status="completed",
+        )
+        self.add_run(
+            "abandoned",
+            pr_url=f"https://github.com/{REPO}/pull/72",
+            pr_state="open",
+            status="abandoned",
+        )
+        self.assertEqual(guard.audit(self.conn), [])
+        self.assertEqual(self._cli(["audit"]), 0)
+
+    def test_null_pr_state_is_included(self) -> None:
+        self.add_run(
+            "t", pr_url=f"https://github.com/{REPO}/pull/73", pr_state=None
+        )
+        results = guard.audit(self.conn)
+        self.assertEqual([v.verdict for v in results], ["missing"])
+
+    def _cli(self, argv: list) -> int:
+        buf = io.StringIO()
+        stdout, stderr = sys.stdout, sys.stderr
+        sys.stdout = sys.stderr = buf
+        try:
+            return guard.main(["--db-path", str(self.db_path)] + argv)
+        finally:
+            sys.stdout, sys.stderr = stdout, stderr
+
+
+class TestCli(DbCase):
+    TASK = "t"
+
+    def test_check_by_pr_json_output_carries_the_evidence(self) -> None:
+        self.push(self.TASK, "c1", _ts(10))
+        self.watcher(73, _ts(20))
+        code, out, _ = self._run(["check", "--pr", "73", "--repo", REPO, "--json"])
+        payload = json.loads(out)
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["verdict"], "live")
+        # No run row holds PR 73, so task_for_pr() recovers nothing and the
+        # baseline is genuinely absent -- reported, not silently assumed.
+        self.assertIsNone(payload["baseline"])
+        self.assertEqual(payload["watcher"]["pane_id"], "%9")
+
+    def test_check_by_task_resolves_pr_and_baseline(self) -> None:
+        self.add_run(self.TASK, pr_url=f"https://github.com/{REPO}/pull/73")
+        self.push(self.TASK, "c1", _ts(10))
+        self.watcher(73, _ts(5))
+        code, out, _ = self._run(["check", "--task", self.TASK, "--json"])
+        payload = json.loads(out)
+        self.assertEqual(code, 3)
+        self.assertEqual(payload["verdict"], "stale")
+        self.assertEqual(payload["baseline"]["commit"], "c1")
+
+    def test_check_by_task_unresolved_exits_2(self) -> None:
+        self.add_run(self.TASK, pr_url=None)
+        code, _out, _err = self._run(["check", "--task", self.TASK, "--json"])
+        self.assertEqual(code, 2)
+
+    def test_check_requires_exactly_one_selector(self) -> None:
+        self.assertEqual(self._run(["check"])[0], 1)
+        self.assertEqual(
+            self._run(["check", "--pr", "73", "--task", self.TASK])[0], 1
+        )
+
+    def test_text_output_is_ascii(self) -> None:
+        self.push(self.TASK, "c1", _ts(10))
+        _code, out, _err = self._run(["check", "--pr", "73", "--repo", REPO])
+        out.encode("ascii")  # cp932 consoles: no em-dashes, no smart quotes
+        self.assertIn("verdict: missing", out)
+
+
+class TestJournalAppendWiring(DbCase):
+    TASK = "t"
+
+    def _append(self, argv: list, env: "dict | None" = None) -> "tuple[int, str]":
+        err = io.StringIO()
+        stderr = sys.stderr
+        sys.stderr = err
+        saved = {k: os.environ.get(k) for k in (env or {})}
+        try:
+            for k, v in (env or {}).items():
+                os.environ[k] = v
+            code = journal_append.main(["--db-path", str(self.db_path)] + argv)
+        finally:
+            sys.stderr = stderr
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+        return code, err.getvalue()
+
+    def _rows(self, kind: str) -> int:
+        return self.conn.execute(
+            "SELECT COUNT(*) FROM events WHERE kind = ?", (kind,)
+        ).fetchone()[0]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.add_run(self.TASK, pr_url=f"https://github.com/{REPO}/pull/73")
+
+    def test_fix_pushed_prints_the_next_action_block(self) -> None:
+        code, err = self._append(
+            ["fix_pushed", f"task={self.TASK}", "commit=c1"]
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(self._rows("fix_pushed"), 1)
+        self.assertIn("[watcher-guard] NEXT ACTION", err)
+        self.assertIn("/pr-watch-pane 73", err)
+
+    def test_guard_confirms_quietly_when_a_watcher_is_already_live(self) -> None:
+        # A watcher started at the same timestamp but a later event id still
+        # counts as after the push only if it is inserted after it, so this
+        # one is dated later on purpose.
+        code, err = self._append(["fix_pushed", f"task={self.TASK}", "commit=c1"])
+        self.assertEqual(code, 0)
+        self.watcher(73, "2099-01-01T00:00:00.000Z")
+        code, err = self._append(["fix_pushed", f"task={self.TASK}", "commit=c2"])
+        self.assertEqual(code, 0)
+        self.assertIn("[watcher-guard]", err)
+        self.assertNotIn("NEXT ACTION", err)
+
+    def test_guard_failure_never_breaks_the_write(self) -> None:
+        def boom(*a, **k):
+            raise RuntimeError("guard exploded")
+
+        original = guard.post_push_check
+        guard.post_push_check = boom
+        self.addCleanup(setattr, guard, "post_push_check", original)
+        code, err = self._append(["fix_pushed", f"task={self.TASK}", "commit=c1"])
+        self.assertEqual(code, 0)
+        self.assertEqual(self._rows("fix_pushed"), 1)
+        self.assertNotIn("watcher-guard", err)
+
+    def test_guard_is_silent_for_other_event_kinds(self) -> None:
+        code, err = self._append(["pr_opened", f"task={self.TASK}", "pr=73"])
+        self.assertEqual(code, 0)
+        self.assertNotIn("watcher-guard", err)
+
+    def test_env_off_suppresses_the_guard(self) -> None:
+        for value in ("off", "0", "FALSE"):
+            with self.subTest(value=value):
+                code, err = self._append(
+                    ["fix_pushed", f"task={self.TASK}", "commit=c1"],
+                    env={"ORG_WATCHER_GUARD": value},
+                )
+                self.assertEqual(code, 0)
+                self.assertNotIn("watcher-guard", err)
+
+    def test_hidden_flag_suppresses_the_guard(self) -> None:
+        code, err = self._append(
+            ["fix_pushed", f"task={self.TASK}", "commit=c1", "--no-watcher-guard"]
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(self._rows("fix_pushed"), 1)
+        self.assertNotIn("watcher-guard", err)
+
+
+class TestPostPushCheckUnit(DbCase):
+    def test_returns_none_without_a_task(self) -> None:
+        self.assertIsNone(guard.post_push_check(self.conn, {}, stream=io.StringIO()))
+
+    def test_returns_none_when_the_pr_cannot_be_resolved(self) -> None:
+        self.add_run("t", pr_url=None)
+        self.assertIsNone(
+            guard.post_push_check(self.conn, {"task": "t"}, stream=io.StringIO())
+        )
+
+    def test_notice_is_ascii(self) -> None:
+        self.add_run("t", pr_url=f"https://github.com/{REPO}/pull/73")
+        buf = io.StringIO()
+        v = guard.post_push_check(self.conn, {"task": "t"}, stream=buf)
+        self.assertEqual(v.verdict, "missing")
+        buf.getvalue().encode("ascii")
+
+
+class TestHelpers(unittest.TestCase):
+    def test_canonical_pr(self) -> None:
+        for raw, want in (
+            (73, "73"),
+            ("73", "73"),
+            (" #73 ", "73"),
+            ("073", "73"),
+            (None, None),
+            (True, None),
+            ("abc", None),
+            ("", None),
+            ({}, None),
+        ):
+            with self.subTest(raw=raw):
+                self.assertEqual(guard.canonical_pr(raw), want)
+
+    def test_canonical_repo(self) -> None:
+        self.assertEqual(guard.canonical_repo("A/B.git"), "a/b")
+        self.assertEqual(guard.canonical_repo("  A/B  "), "a/b")
+        self.assertIsNone(guard.canonical_repo(None))
+        self.assertIsNone(guard.canonical_repo("  "))
+
+    def test_head_corroborates_in_both_directions(self) -> None:
+        self.assertTrue(guard.head_corroborates("abcdef1234", "abcdef1"))
+        self.assertTrue(guard.head_corroborates("abcdef1", "abcdef1234"))
+        self.assertFalse(guard.head_corroborates("abcdef1", "999999"))
+        self.assertFalse(guard.head_corroborates(None, "abcdef1"))
+        self.assertFalse(guard.head_corroborates("abcdef1", None))
+
+    def test_guard_disabled(self) -> None:
+        for value, want in (
+            ("off", True),
+            ("0", True),
+            ("False", True),
+            ("on", False),
+            ("", False),
+        ):
+            with self.subTest(value=value):
+                self.assertIs(
+                    guard.guard_disabled({"ORG_WATCHER_GUARD": value}), want
+                )
+        self.assertFalse(guard.guard_disabled({}))
+
+    def test_exit_code_table_is_total(self) -> None:
+        for verdict in guard.TRIPPING_VERDICTS:
+            self.assertEqual(guard.VERDICT_EXIT_CODES[verdict], 3)
+
+    def test_remediation_names_only_the_canonical_route(self) -> None:
+        text = guard.remediation_text("73", REPO)
+        self.assertIn("/pr-watch-pane 73", text)
+        self.assertIn("pr-ci-watch.md", text)
+        text.encode("ascii")
+
+
+class TestSchemaAssumptions(DbCase):
+    def test_events_columns_used_by_the_guard_exist(self) -> None:
+        cols = {
+            r[1]
+            for r in self.conn.execute("PRAGMA table_info(events)").fetchall()
+        }
+        self.assertTrue({"id", "occurred_at", "kind", "payload_json"} <= cols)
+
+    def test_non_object_payload_is_tolerated(self) -> None:
+        # json_valid() is a CHECK on the column, so a payload can never be
+        # broken JSON -- but it CAN be a valid non-object (a list, a bare
+        # string). The loader must skip those rather than raise.
+        self.add_event_raw("pr_watch_pane_started", "[1, 2]", _ts(20))
+        self.add_event_raw("ci_completed", '"nope"', _ts(30))
+        v = guard.evaluate(self.conn, 73, REPO)
+        self.assertEqual(v.verdict, "missing")
+
+
+class TestEmittedPayloadShapes(DbCase):
+    """Pin the guard to what the emitters actually write, not to the catalog.
+
+    The event catalog documents ``fix_pushed`` as ``task, branch, commit``,
+    but no row in the live DB has ever carried ``commit``: the emitters
+    write ``head``. Reading only the documented key made the head
+    comparison dead code and turned every healthy watch into
+    ``ended_stale_head`` -- a guard that fires on the normal case, which is
+    worse than no guard.
+    """
+
+    TASK = "cadenza-belt-clone-source"
+
+    def push_with(self, key: str, sha: str, at: str) -> int:
+        return self.add_event(
+            "fix_pushed", {"task": self.TASK, "branch": "fix/x", key: sha}, at
+        )
+
+    def test_head_key_is_read_as_the_pushed_sha(self) -> None:
+        self.push_with("head", "6ef6291", _ts(10))
+        self.watcher(16, _ts(20))
+        self.ci(16, "passed", "6ef6291", _ts(60))
+        v = guard.evaluate(self.conn, 16, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+        self.assertEqual(v.baseline["commit"], "6ef6291")
+        self.assertEqual(v.baseline["commit_key"], "head")
+
+    def test_head_key_still_catches_a_stale_verdict(self) -> None:
+        self.push_with("head", "aaaaaaa", _ts(10))
+        self.watcher(16, _ts(20))
+        self.ci(16, "passed", "bbbbbbb", _ts(60))
+        v = guard.evaluate(self.conn, 16, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("ended_stale_head", 3))
+
+    def test_sha_only_in_free_text_note_is_absent_not_mismatched(self) -> None:
+        # 22 of 69 live rows look exactly like this.
+        self.add_event(
+            "fix_pushed", {"task": self.TASK, "note": "f059c6f pushed"}, _ts(10)
+        )
+        self.watcher(16, _ts(20))
+        self.ci(16, "passed", "6ef6291", _ts(60))
+        v = guard.evaluate(self.conn, 16, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+        self.assertIsNone(v.baseline["commit"])
+
+    def test_documented_commit_key_still_wins_when_present(self) -> None:
+        self.add_event(
+            "fix_pushed",
+            {"task": self.TASK, "commit": "1111111", "head": "2222222"},
+            _ts(10),
+        )
+        self.watcher(16, _ts(20))
+        v = guard.evaluate(self.conn, 16, REPO, task_id=self.TASK)
+        self.assertEqual(v.baseline["commit"], "1111111")
+        self.assertEqual(v.baseline["commit_key"], "commit")
+
+
+class TestPrFormRecoversTheBaseline(DbCase):
+    """``check --pr N`` must answer the same question as ``check --task``.
+
+    Without recovering the task from the run row the --pr form reads no
+    ``fix_pushed`` at all, so the ``stale`` branch is unreachable and the
+    documented shorthand exits 0 on the incident itself.
+    """
+
+    TASK = "ja-978-watcher-restart-guard"
+
+    def _incident(self) -> None:
+        self.add_run(self.TASK, pr_url=f"https://github.com/{REPO}/pull/73")
+        self.watcher(73, _ts(0))
+        self.ci(73, "failed", "aaaaaaa", _ts(30))
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(60))
+
+    def test_task_for_pr_finds_the_run(self) -> None:
+        self._incident()
+        self.assertEqual(guard.task_for_pr(self.conn, 73, REPO), self.TASK)
+
+    def test_pr_form_reports_stale_like_the_task_form(self) -> None:
+        self._incident()
+        code, out, _err = self._run(["check", "--pr", "73", "--repo", REPO])
+        self.assertEqual(code, 3)
+        self.assertIn("verdict: stale", out)
+        self.assertIn(self.TASK, out)
+
+    def test_task_for_pr_does_not_cross_repos(self) -> None:
+        self._incident()
+        self.assertIsNone(guard.task_for_pr(self.conn, 73, OTHER_REPO))
+
+    def test_unknown_pr_leaves_the_baseline_absent(self) -> None:
+        self.watcher(999, _ts(20))
+        v = guard.evaluate(
+            self.conn, 999, REPO, task_id=guard.task_for_pr(self.conn, 999, REPO)
+        )
+        self.assertIsNone(v.baseline)
+        self.assertEqual(v.verdict, "live")
+
+
+class TestHomeRepoIsNotAWildcard(DbCase):
+    """The origin fallback may only serve the one path its docstring names.
+
+    PR numbers collide across repos. Substituting this checkout's origin on
+    a path where the repo is already knowable lets a *different* repo's
+    watcher certify this PR as watched.
+    """
+
+    TASK = "cross-repo-task"
+
+    def test_post_push_check_warns_instead_of_guessing_the_repo(self) -> None:
+        # A run whose PR is known only through a pr_opened event with no
+        # url: the PR number resolves, the repo does not.
+        self.add_run(self.TASK, pr_url=None)
+        self.add_event("pr_opened", {"task": self.TASK, "pr": 73}, _ts(5))
+        self.push(self.TASK, "cafebabe", _ts(10))
+        # An unrelated watcher for THIS repo's PR #73.
+        self.watcher(73, _ts(20), repo=REPO)
+
+        out = io.StringIO()
+        v = guard.post_push_check(
+            self.conn, {"task": self.TASK, "commit": "cafebabe"}, stream=out
+        )
+        self.assertIsNone(v)
+        self.assertIn("could not determine OWNER/REPO", out.getvalue())
+        self.assertIn("/pr-watch-pane 73", out.getvalue())
+
+    def test_task_path_does_not_fall_back_to_the_home_repo(self) -> None:
+        self.add_run(self.TASK, pr_url=None)
+        self.add_event("pr_opened", {"task": self.TASK, "pr": 73}, _ts(5))
+        self.push(self.TASK, "cafebabe", _ts(10))
+        self.watcher(73, _ts(20), repo=REPO)
+
+        code, _out, err = self._run(["check", "--task", self.TASK])
+        self.assertEqual(code, guard.EXIT_UNRESOLVED)
+        self.assertIn("could not determine OWNER/REPO", err)
+
+    def test_explicit_repo_still_works_on_the_task_path(self) -> None:
+        self.add_run(self.TASK, pr_url=None)
+        self.add_event("pr_opened", {"task": self.TASK, "pr": 73}, _ts(5))
+        self.push(self.TASK, "cafebabe", _ts(10))
+        self.watcher(73, _ts(20), repo=OTHER_REPO)
+
+        code, out, _err = self._run(
+            ["check", "--task", self.TASK, "--repo", OTHER_REPO]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("verdict: live", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_watcher_restart_guard.py
+++ b/tools/test_watcher_restart_guard.py
@@ -343,11 +343,40 @@ class TestNormalisation(DbCase):
         self.assertEqual(len(v.ignored_unknown_repo), 1)
         self.assertEqual(v.watcher_count, 0)
 
-    def test_terminal_without_repo_is_counted(self) -> None:
+    def test_terminal_without_repo_ends_the_watch_but_cannot_certify_it(self) -> None:
+        """Admitted as evidence the watch is over; refused as a clean bill.
+
+        Both halves matter. Dropping the row would leave a finished watch
+        reading as ``live``; accepting it as a conclusion would let a
+        same-numbered PR in another repository certify this one -- and 45
+        live ``pr_merged`` rows carry no repo, so that row shape is real.
+        """
         self.push(self.TASK, "abcdef1234", _ts(10))
         self.watcher(73, _ts(20))
         self.ci(73, "passed", "abcdef1", _ts(60), repo=None)
         v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("ended_inconclusive", 3))
+        self.assertEqual(v.terminal["kind"], "ci_completed")
+        self.assertIsNone(v.terminal["repo"])
+
+    def test_a_repo_matched_terminal_still_certifies(self) -> None:
+        self.push(self.TASK, "abcdef1234", _ts(10))
+        self.watcher(73, _ts(20))
+        self.ci(73, "passed", "abcdef1", _ts(60))
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+
+    def test_legacy_result_key_is_echoed_in_the_evidence(self) -> None:
+        self.push(self.TASK, "abcdef1234", _ts(10))
+        self.watcher(73, _ts(20))
+        self.add_event(
+            "ci_completed",
+            {"pr": 73, "repo": REPO, "head": "abcdef1", "result": "passed"},
+            _ts(60),
+        )
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        # The evidence must not print null next to a verdict derived from it.
+        self.assertEqual(v.terminal["status"], "passed")
         self.assertEqual(v.verdict, "completed")
 
     def test_same_millisecond_ordering_is_resolved_by_event_id(self) -> None:
@@ -737,6 +766,33 @@ class TestWatchEndingBeforeItsLaunchRow(DbCase):
         self.assertEqual((v.verdict, v.exit_code), ("live", 0))
         self.assertFalse(v.terminal_precedes_watcher_row)
         self.assertEqual(v.watcher["pane_id"], "%2")
+
+    def test_a_spent_earlier_watcher_cannot_disown_the_new_terminal(self) -> None:
+        """An earlier watcher only disowns a terminal it has not consumed.
+
+        watcher1 -> failed -> push -> watcher2's terminal -> watcher2's
+        launch row. A rule that treats *any* earlier launch as a possible
+        owner hands watcher2's terminal to watcher1 -- whose own verdict
+        already came and went -- and reports the stopped watcher2 as live.
+        """
+        self.watcher(73, _ts(0), pane_id="%1")
+        self.ci(73, "failed", "aaaaaaa", _ts(10))
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(20))
+        self.ci(73, "failed", "bbbbbbb", _ts(30))     # watcher2's verdict
+        self.watcher(73, _ts(40), pane_id="%2")       # watcher2's launch row
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("completed", 0))
+        self.assertTrue(v.terminal_precedes_watcher_row)
+        self.assertEqual(v.terminal["head"], "bbbbbbb")
+
+    def test_the_same_shape_trips_when_the_new_verdict_is_inconclusive(self) -> None:
+        self.watcher(73, _ts(0), pane_id="%1")
+        self.ci(73, "failed", "aaaaaaa", _ts(10))
+        self.push(self.TASK, "bbbbbbbbbbbb", _ts(20))
+        self.ci(73, "incomplete", "bbbbbbb", _ts(30))
+        self.watcher(73, _ts(40), pane_id="%2")
+        v = guard.evaluate(self.conn, 73, REPO, task_id=self.TASK)
+        self.assertEqual((v.verdict, v.exit_code), ("ended_inconclusive", 3))
 
     def test_a_terminal_from_before_the_push_is_not_reattributed(self) -> None:
         self.push(self.TASK, "aaaaaaaaaaaa", _ts(0))

--- a/tools/watcher_restart_guard.py
+++ b/tools/watcher_restart_guard.py
@@ -115,6 +115,24 @@ degrades to ``completed`` with the missing evidence visible in the output.
 :data:`BASELINE_SHA_KEYS` is why the documented key and the emitted key are
 both read.
 
+## A watch can end before its launch is recorded
+
+The skill spawns the watcher pane, verifies it, and only then appends
+``pr_watch_pane_started``. A watch that finds CI already red can therefore
+emit ``ci_completed`` and exit while the operator is still on the
+verification step, leaving the terminal event sorted *before* the launch
+row. Anchoring the terminal window on the watcher alone would find nothing
+after it and answer ``live`` forever for a watch that is already over --
+the guard's own failure mode, reintroduced one level down.
+
+So when that window is empty, terminals since the baseline push are
+reconsidered, and one is attributed to the newest watcher unless an
+*earlier* watcher could own it. That exception matters: push -> watcher ->
+``indeterminate`` -> restart is the documented response to an inconclusive
+verdict, and the restarted watcher genuinely is live. The output flags the
+attribution with ``terminal_precedes_watcher_row`` so the inference is
+visible rather than assumed.
+
 Ordering compares ``(occurred_at, events.id)``. The schema's default
 timestamp has millisecond resolution, and a push followed immediately by a
 watcher restart really does land in the same millisecond, so the
@@ -141,9 +159,11 @@ visible instead of being passed off as a clean bill.
     python3 tools/watcher_restart_guard.py audit
 
 Exit codes: 0 = monitoring accounted for (``live`` / ``completed``, and for
-``audit`` no run tripped), 3 = a tripping verdict (``stale`` / ``missing``
-/ ``ended_stale_head`` / ``ended_inconclusive``), 2 = the PR could not be
-resolved, 1 = usage / DB / schema error.
+``audit`` every run checked and none tripped), 3 = a tripping verdict
+(``stale`` / ``missing`` / ``ended_stale_head`` / ``ended_inconclusive``),
+2 = the PR could not be resolved -- for ``audit`` that means an open PR
+went **unchecked**, which is a failure to answer and never a clean bill --
+1 = usage / DB / schema error.
 """
 
 from __future__ import annotations
@@ -415,6 +435,9 @@ class Verdict:
     terminal: Optional[dict] = None
     watcher_count: int = 0
     ignored_unknown_repo: list = field(default_factory=list)
+    # True when the terminal event was attributed to a watcher whose launch
+    # row landed after it -- a watch that ended before it was recorded.
+    terminal_precedes_watcher_row: bool = False
     reason: str = ""
     remediation: Optional[str] = None
 
@@ -552,6 +575,28 @@ def evaluate(
         )
 
     after = [e for e in terminals if _sort_key(e) >= _sort_key(newest_watcher)]
+    if not after:
+        # A watch can END BEFORE ITS LAUNCH IS RECORDED. The skill spawns the
+        # pane, inspects it, and only then appends ``pr_watch_pane_started``
+        # -- so a watch that finds CI already red can emit ``ci_completed``
+        # and exit while the operator is still on the verification step. The
+        # terminal then sorts BEFORE the watcher row, this window is empty,
+        # and a purely watcher-anchored rule answers ``live`` forever for a
+        # watch that is already over: the guard's own failure mode.
+        #
+        # Such a terminal is only attributable to the newest watcher when no
+        # EARLIER watcher could own it. If one could, the newest watcher is a
+        # genuine restart after that verdict (the documented response to an
+        # ``indeterminate``), and it really is live.
+        earlier = [w for w in watchers if _sort_key(w) < _sort_key(newest_watcher)]
+        after = [
+            e
+            for e in terminals
+            if (baseline is None or _sort_key(e) > _sort_key(baseline))
+            and not any(_sort_key(w) < _sort_key(e) for w in earlier)
+        ]
+        if after:
+            base.terminal_precedes_watcher_row = True
     if not after:
         return finish(
             "live",
@@ -961,7 +1006,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help="check every run with an open PR.",
         description=(
             "Check every run holding a non-terminal PR. Exit 3 if any run "
-            "trips, 0 otherwise."
+            "trips, 2 if none trip but a run's pr_url could not be read (that "
+            "PR went unchecked), 0 otherwise."
         ),
     )
     aud.add_argument(
@@ -1027,7 +1073,14 @@ def main(argv: Optional[list] = None) -> int:
                 )
             else:
                 print(render_audit(results))
-            return EXIT_TRIPPED if any(v.tripped for v in results) else EXIT_OK
+            if any(v.tripped for v in results):
+                return EXIT_TRIPPED
+            # An `unresolved` run was NOT checked -- its pr_url could not be
+            # read. Returning 0 would report an unexamined open PR as
+            # healthy, which is the silent-miss this tool exists to remove.
+            if any(v.verdict == "unresolved" for v in results):
+                return EXIT_UNRESOLVED
+            return EXIT_OK
 
         pr = args.pr
         repo = args.repo

--- a/tools/watcher_restart_guard.py
+++ b/tools/watcher_restart_guard.py
@@ -144,6 +144,23 @@ row`` reads as ended. The output flags the attribution with
 ``terminal_precedes_watcher_row`` so the inference is visible rather than
 assumed.
 
+### Known boundary: terminals carry no pane identity
+
+One ``pr_watch`` invocation can emit more than one terminal-kind row --
+with ``--merge-watch`` it emits ``ci_completed`` and later ``pr_merged`` or
+``pr_merge_watch_timeout`` -- and none of those rows names the pane that
+wrote it. So when an old pane is still resident while a replacement has
+been launched, a late row from the old pane is indistinguishable from the
+new watcher's own, and the guard reads the newer watch as ended.
+
+That is a false alarm, and it is accepted rather than fixed: distinguishing
+the two would require a pane id in the terminal payload, which no writer
+records today. It also fails in the safe direction -- one extra
+``/pr-watch-pane`` restart, never a silently unwatched PR -- which is the
+bias every other rule here is chosen for. Closing it properly means adding
+pane identity to the terminal events, at which point the attribution can
+become exact instead of positional.
+
 Ordering compares ``(occurred_at, events.id)``. The schema's default
 timestamp has millisecond resolution, and a push followed immediately by a
 watcher restart really does land in the same millisecond, so the

--- a/tools/watcher_restart_guard.py
+++ b/tools/watcher_restart_guard.py
@@ -91,8 +91,14 @@ The asymmetry is deliberate and load-bearing:
   watcher -- it cannot prove that *this* PR is being watched. It is
   reported as ``ignored_unknown_repo`` so the exclusion is visible rather
   than silent.
-* **Terminal evidence accepts a missing repo.** A row that may have ended
-  monitoring is counted even when under-specified.
+* **Terminal evidence accepts a missing repo as evidence, but never as a
+  conclusion.** A row that may have ended monitoring is counted even when
+  under-specified -- dropping it would let a finished watch read as
+  ``live``. It cannot, however, produce a non-tripping verdict: a repo-less
+  ``pr_merged`` or legacy ``ci_completed`` belonging to a same-numbered PR
+  in another repository would otherwise certify this one as accounted for.
+  Such a terminal yields ``ended_inconclusive`` instead. 45 of the live
+  DB's ``pr_merged`` rows carry no repo, so this is a real row shape.
 
 Both directions therefore fail toward "warn the operator", never toward
 "silently OK", which is the only safe bias for a guard whose false negative
@@ -125,13 +131,18 @@ row. Anchoring the terminal window on the watcher alone would find nothing
 after it and answer ``live`` forever for a watch that is already over --
 the guard's own failure mode, reintroduced one level down.
 
-So when that window is empty, terminals since the baseline push are
-reconsidered, and one is attributed to the newest watcher unless an
-*earlier* watcher could own it. That exception matters: push -> watcher ->
-``indeterminate`` -> restart is the documented response to an inconclusive
-verdict, and the restarted watcher genuinely is live. The output flags the
-attribution with ``terminal_precedes_watcher_row`` so the inference is
-visible rather than assumed.
+So watches and terminals are paired greedily in time order (see
+:func:`_terminal_of`): each watcher, oldest first, claims the earliest
+still-unclaimed terminal at or after its own start, and a terminal left
+unclaimed after the baseline push is attributed to the newest watcher. The
+greediness is what keeps this honest in both directions -- an earlier
+watcher only disowns a terminal it has not already consumed -- so
+``push -> watcher -> indeterminate -> restart`` (the documented response to
+an inconclusive verdict) reads as ``live``, while
+``watcher1 -> failed -> push -> watcher2's terminal -> watcher2's launch
+row`` reads as ended. The output flags the attribution with
+``terminal_precedes_watcher_row`` so the inference is visible rather than
+assumed.
 
 Ordering compares ``(occurred_at, events.id)``. The schema's default
 timestamp has millisecond resolution, and a push followed immediately by a
@@ -472,9 +483,71 @@ def _terminal_summary(row: EventRow) -> dict:
         "kind": row.kind,
         "occurred_at": row.occurred_at,
         "head": row.payload.get("head"),
-        "status": row.payload.get("status"),
+        # The NORMALISED status, so the evidence cannot contradict the
+        # verdict: legacy rows keep it under ``result``, and echoing the raw
+        # ``status`` key would print null next to a verdict derived from a
+        # value that was plainly there.
+        "status": _ci_status(row.payload),
+        "repo": row.payload.get("repo"),
         "event_id": row.event_id,
     }
+
+
+def _terminal_of(
+    newest_watcher: EventRow,
+    watchers: "list[EventRow]",
+    terminals: "list[EventRow]",
+    baseline: Optional[EventRow],
+) -> Optional[EventRow]:
+    """The terminal event that ended ``newest_watcher``, if any.
+
+    Watches and their terminals are paired greedily in time order: each
+    watcher, oldest first, claims the earliest still-unclaimed terminal at
+    or after its own start. A watcher with no claim is still running.
+
+    The pairing exists because a watch can END BEFORE ITS LAUNCH IS
+    RECORDED: the skill spawns the pane, verifies it, and only then appends
+    ``pr_watch_pane_started``, so a watch that finds CI already red can emit
+    ``ci_completed`` and exit while the operator is still verifying. Its
+    terminal then sorts before its own launch row. A rule that only looks
+    *after* the newest launch row finds nothing and answers ``live``
+    forever for a watch that is already over -- the guard's own failure
+    mode, one level down.
+
+    So a terminal left unclaimed after the pairing, and newer than the last
+    push, is attributed to the newest watcher. Greedy pairing is what keeps
+    that from misfiring in both directions: an earlier watcher only disowns
+    a terminal it has not already consumed, so
+    ``watcher1 -> failed -> push -> watcher2's terminal -> watcher2's launch
+    row`` correctly reports watcher2 as ended (watcher1's claim was spent on
+    its own verdict), while ``push -> watcher1 -> indeterminate -> restart``
+    -- the documented response to an inconclusive verdict -- correctly
+    reports the restart as live.
+    """
+    ordered_watchers = sorted(watchers, key=_sort_key)
+    ordered_terminals = sorted(terminals, key=_sort_key)
+    claimed: dict = {}
+    used: set = set()
+    for w in ordered_watchers:
+        for t in ordered_terminals:
+            if t.event_id in used:
+                continue
+            if _sort_key(t) >= _sort_key(w):
+                claimed[w.event_id] = t
+                used.add(t.event_id)
+                break
+
+    own = claimed.get(newest_watcher.event_id)
+    if own is not None:
+        return own
+
+    unclaimed = [
+        t
+        for t in ordered_terminals
+        if t.event_id not in used
+        and (baseline is None or _sort_key(t) > _sort_key(baseline))
+    ]
+    return unclaimed[-1] if unclaimed else None
 
 
 def evaluate(
@@ -530,13 +603,28 @@ def evaluate(
             continue
         watchers.append(e)
 
-    terminals = [
-        e
-        for e in events
-        if e.kind in TERMINAL_KINDS
-        and canonical_pr(e.payload.get("pr")) == pr_key
-        and canonical_repo(e.payload.get("repo")) in (None, repo_key)
-    ]
+    # Terminal evidence splits by whether it can be attributed to THIS repo.
+    # A repo-less row is still admitted -- it may well be the end of this
+    # watch, and dropping it would let a finished watch read as live -- but
+    # it may never produce a non-tripping verdict: with PR numbers colliding
+    # across repos, a repo-less `pr_merged` or a legacy `ci_completed` from
+    # another repository would otherwise certify this one as accounted for.
+    # 45 of the live DB's `pr_merged` rows carry no repo, so this is a real
+    # row shape, not a hypothetical one.
+    terminals: list[EventRow] = []
+    unattributable_terminals: list[EventRow] = []
+    for e in events:
+        if e.kind not in TERMINAL_KINDS:
+            continue
+        if canonical_pr(e.payload.get("pr")) != pr_key:
+            continue
+        row_repo = canonical_repo(e.payload.get("repo"))
+        if row_repo is None:
+            unattributable_terminals.append(e)
+            terminals.append(e)
+        elif row_repo == repo_key:
+            terminals.append(e)
+    unattributable_ids = {e.event_id for e in unattributable_terminals}
 
     base = Verdict(
         verdict="",
@@ -574,38 +662,27 @@ def evaluate(
             "pane proves nothing, the watch it belongs to predates the push",
         )
 
-    after = [e for e in terminals if _sort_key(e) >= _sort_key(newest_watcher)]
-    if not after:
-        # A watch can END BEFORE ITS LAUNCH IS RECORDED. The skill spawns the
-        # pane, inspects it, and only then appends ``pr_watch_pane_started``
-        # -- so a watch that finds CI already red can emit ``ci_completed``
-        # and exit while the operator is still on the verification step. The
-        # terminal then sorts BEFORE the watcher row, this window is empty,
-        # and a purely watcher-anchored rule answers ``live`` forever for a
-        # watch that is already over: the guard's own failure mode.
-        #
-        # Such a terminal is only attributable to the newest watcher when no
-        # EARLIER watcher could own it. If one could, the newest watcher is a
-        # genuine restart after that verdict (the documented response to an
-        # ``indeterminate``), and it really is live.
-        earlier = [w for w in watchers if _sort_key(w) < _sort_key(newest_watcher)]
-        after = [
-            e
-            for e in terminals
-            if (baseline is None or _sort_key(e) > _sort_key(baseline))
-            and not any(_sort_key(w) < _sort_key(e) for w in earlier)
-        ]
-        if after:
-            base.terminal_precedes_watcher_row = True
-    if not after:
+    terminal = _terminal_of(newest_watcher, watchers, terminals, baseline)
+    if terminal is None:
         return finish(
             "live",
-            "a watcher started after the last push and no terminal event has "
-            "arrived since",
+            "a watcher started after the last push and no terminal event is "
+            "attributable to it",
         )
-
-    terminal = max(after, key=_sort_key)
+    if _sort_key(terminal) < _sort_key(newest_watcher):
+        base.terminal_precedes_watcher_row = True
     base.terminal = _terminal_summary(terminal)
+
+    if terminal.event_id in unattributable_ids:
+        # Admitted as evidence that the watch may be over, but it names no
+        # repo, so it cannot certify THIS PR's monitoring as accounted for.
+        return finish(
+            "ended_inconclusive",
+            f"a {terminal.kind} for PR #{pr_key} is attributable to this "
+            "watcher but carries no repo, so it cannot be confirmed to be "
+            f"this PR's ({base.repo}); PR numbers collide across repos, so "
+            "treating it as a conclusion would be a guess",
+        )
 
     if terminal.kind in MERGE_TERMINAL_KINDS:
         return finish(

--- a/tools/watcher_restart_guard.py
+++ b/tools/watcher_restart_guard.py
@@ -1,0 +1,1172 @@
+#!/usr/bin/env python3
+"""Decide whether a PR is *actually* being watched, from the event log (Refs #978).
+
+## Why this exists
+
+On 2026-08-29 a PR went through the ordinary CI-fail loop: CI red -> the
+worker pushed a fix -> the secretary re-pushed -> and then nobody restarted
+the CI watcher. The secretary checked ``list_panes``, saw a live
+``pr-watch-73`` pane, and concluded monitoring was alive. It was not: the
+pane belonged to the watcher started before the *previous* push, which had
+already emitted its verdict and exited. Self-close does not work on the
+herdr / renga transports (only the broker tmux backend closes a finished
+watcher pane), so a dead watch and a live watch look identical from the
+outside. The run then sat unwatched until a human noticed.
+
+The mistake was not carelessness, it was using the wrong predicate. "Is a
+pane named ``pr-watch-<N>`` present?" answers a question about window
+decoration. The question that matters is:
+
+    **Is there a watcher that started AFTER the last push?**
+
+That one is answerable from evidence the org already records. Every push
+appends ``fix_pushed`` (the secretary is contractually required to emit it
+-- see the org-pull-request skill), every watcher launch appends
+``pr_watch_pane_started``, and every watch that ends appends a terminal
+event (``ci_completed`` / ``pr_merged`` / ...). Their time ordering in the
+``events`` table is the whole answer, and deriving it belongs in a
+deterministic tool rather than in prose an operator re-derives under
+pressure at the exact moment they are already distracted by a red CI.
+
+## Two surfaces, one predicate
+
+This module is the auditable half: a standalone CLI with exit codes, whose
+output carries every row the decision was made from, so a verdict can be
+checked rather than trusted. :func:`evaluate` is the same predicate as an
+importable function.
+
+The unforgettable half lives in :mod:`tools.journal_append`: after a
+``fix_pushed`` row is committed, it calls :func:`evaluate` for that task's
+PR and prints the remediation block on stderr. A separate tool can be
+forgotten -- that is precisely the failure this guard exists to prevent --
+whereas the ``fix_pushed`` emission cannot be, because it is the event that
+records the push in the first place.
+
+## Verdicts
+
+``live``
+    The newest watcher started strictly after the baseline push and no
+    terminal event has arrived since. Monitoring is alive.
+``completed``
+    A watcher started after the baseline push and a terminal event arrived
+    at or after it carrying an actual CI verdict (``passed`` / ``failed``)
+    that is not contradicted by the head, or the PR was merged. Monitoring
+    for the current head is legitimately over.
+``ended_inconclusive``
+    A watcher started after the baseline push, but the watch **stopped
+    without answering**: a ``ci_completed`` whose status is ``incomplete``
+    (checks stayed pending), ``indeterminate`` (no probe was ever readable
+    -- that row even carries ``retry_recommended``, the watcher asking to be
+    restarted), or ``canceled``, or a ``pr_watch_aborted`` /
+    ``pr_merge_watch_timeout``, or a status field that was never recorded.
+    Nobody is watching the current head, which is exactly the state this
+    tool exists to surface, so it trips. Roughly 7% of the
+    ``ci_completed`` rows in the live DB end this way, so this is a real
+    path and not a theoretical one.
+``ended_stale_head``
+    A watcher started after the baseline push and a verdict was reached,
+    but its head demonstrably belongs to an **older** push, so the current
+    head is unwatched.
+``stale``
+    Watchers exist for this PR, but the newest one started at or before the
+    baseline push. **This is the Issue #978 incident.**
+``missing``
+    No ``pr_watch_pane_started`` for this PR at all.
+``unresolved``
+    No PR could be resolved for the given task.
+
+## Matching rules (asymmetric on purpose)
+
+PR numbers are normalised to a canonical int-as-string on both sides,
+because payloads carry both ``73`` and ``"73"``; a payload PR that is not
+an integer never matches. Repos are compared case-insensitively with a
+trailing ``.git`` stripped. Repo is part of the key at all because PR
+numbers collide across repos -- the secretary runs from the ja root cwd and
+routinely handles PR #N in two different repositories on the same day.
+
+The asymmetry is deliberate and load-bearing:
+
+* **Positive evidence of monitoring requires an explicit repo match.** A
+  ``pr_watch_pane_started`` row with no ``repo`` field is NOT counted as a
+  watcher -- it cannot prove that *this* PR is being watched. It is
+  reported as ``ignored_unknown_repo`` so the exclusion is visible rather
+  than silent.
+* **Terminal evidence accepts a missing repo.** A row that may have ended
+  monitoring is counted even when under-specified.
+
+Both directions therefore fail toward "warn the operator", never toward
+"silently OK", which is the only safe bias for a guard whose false negative
+is an unwatched production PR.
+
+## The head is a demoter, not a requirement
+
+Once a watcher is known to have started after the push and to have reached
+a verdict, the head sha can only ever *demote* that verdict -- by proving
+it belongs to an older push. It cannot be required, because it is often
+simply unrecorded on one side or both: in the live DB no ``fix_pushed`` row
+carries the documented ``commit`` key at all (47 of 69 write ``head``
+instead, and 22 mention the sha only inside free-text ``note``), and about
+a third of ``ci_completed`` rows carry no ``head``. Tripping on an absent
+sha would fire on healthy watches, and a guard that cries wolf on the
+normal case teaches the reader to skim -- which is the same reflex that
+produced the original incident. So ``ended_stale_head`` is emitted only
+when **both** shas are readable and they disagree; an unreadable sha
+degrades to ``completed`` with the missing evidence visible in the output.
+:data:`BASELINE_SHA_KEYS` is why the documented key and the emitted key are
+both read.
+
+Ordering compares ``(occurred_at, events.id)``. The schema's default
+timestamp has millisecond resolution, and a push followed immediately by a
+watcher restart really does land in the same millisecond, so the
+autoincrement id is the tie-break. A watcher counts as "after" the push
+only when that pair is strictly greater.
+
+The baseline comes from the ``fix_pushed`` rows carrying the task id, so
+both entry points must have a task: ``check --task`` has one by
+construction, and ``check --pr`` recovers it from the run row holding that
+PR (:func:`task_for_pr`). Without that recovery the ``--pr`` form would
+have no baseline, the ``stale`` branch would be unreachable, and the
+documented shorthand would answer exit 0 on the very incident above.
+
+When there is genuinely no ``fix_pushed`` baseline (no run holds the PR, or
+the push was never recorded), the baseline is treated as absent rather than
+as "now": any watcher yields ``live`` / ``completed`` per the terminal
+rule, and the output reports ``baseline: null`` so the weaker evidence is
+visible instead of being passed off as a clean bill.
+
+## CLI
+
+    python3 tools/watcher_restart_guard.py check --pr 73 --repo owner/name
+    python3 tools/watcher_restart_guard.py check --task ja-978-watcher-restart-guard
+    python3 tools/watcher_restart_guard.py audit
+
+Exit codes: 0 = monitoring accounted for (``live`` / ``completed``, and for
+``audit`` no run tripped), 3 = a tripping verdict (``stale`` / ``missing``
+/ ``ended_stale_head`` / ``ended_inconclusive``), 2 = the PR could not be
+resolved, 1 = usage / DB / schema error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.state_db.queries import TERMINAL_STATUSES  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Event vocabulary
+# ---------------------------------------------------------------------------
+
+WATCHER_KIND = "pr_watch_pane_started"
+BASELINE_KIND = "fix_pushed"
+
+# Terminal kinds that end a watch by delivering a CI verdict. Their ``head``
+# is what decides whether the verdict describes the current push.
+CI_TERMINAL_KINDS: tuple[str, ...] = ("ci_completed",)
+
+# Terminal kinds that end a watch because the PR is merged. A merge needs no
+# head corroboration: there is nothing left to watch.
+MERGE_TERMINAL_KINDS: tuple[str, ...] = (
+    "pr_merged",
+    "pr_merged_no_run",
+    "pr_merged_head_unconfirmed",
+)
+
+# Terminal kinds that end a watch WITHOUT any verdict at all: the watch
+# stopped and no CI answer was ever recorded for any head.
+ABORT_TERMINAL_KINDS: tuple[str, ...] = (
+    "pr_merge_watch_timeout",
+    "pr_watch_aborted",
+)
+
+TERMINAL_KINDS: tuple[str, ...] = (
+    CI_TERMINAL_KINDS + MERGE_TERMINAL_KINDS + ABORT_TERMINAL_KINDS
+)
+
+# ``ci_completed`` carries the status under ``status``; a dozen older rows
+# in the live DB use ``result`` instead, so both are read.
+CI_STATUS_KEYS: tuple[str, ...] = ("status", "result")
+
+# The only two ``ci_completed`` statuses that mean "CI answered". The other
+# three that ``tools/pr_watch.py`` can record end the watch WITHOUT an
+# answer: ``incomplete`` (checks stayed pending until the retry budget ran
+# out), ``indeterminate`` (no probe response was ever parseable -- the row
+# even carries ``retry_recommended``, i.e. the watcher itself asking to be
+# restarted) and ``canceled``. Reaching one of those means the current head
+# is unwatched, which is the property this tool exists to detect, so they
+# must trip rather than read as a conclusion. A missing status is treated
+# the same way: unknown is not an answer.
+CONCLUSIVE_CI_STATUSES: tuple[str, ...] = ("passed", "failed")
+
+# Payload keys that may carry the pushed sha on a ``fix_pushed`` row. The
+# event catalog documents ``commit``, but every emitter in practice writes
+# ``head`` (in the live DB: 47 of 69 rows carry ``head``, 0 carry
+# ``commit``, and the remaining 22 bury the sha in free-text ``note``).
+# Reading only the documented key would make the head comparison dead code
+# and turn every healthy watch into a false alarm.
+BASELINE_SHA_KEYS: tuple[str, ...] = ("commit", "head", "sha")
+
+VERDICT_EXIT_CODES: dict[str, int] = {
+    "live": 0,
+    "completed": 0,
+    "ended_inconclusive": 3,
+    "ended_stale_head": 3,
+    "stale": 3,
+    "missing": 3,
+    "unresolved": 2,
+}
+
+TRIPPING_VERDICTS: tuple[str, ...] = (
+    "stale",
+    "missing",
+    "ended_stale_head",
+    "ended_inconclusive",
+)
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_UNRESOLVED = 2
+EXIT_TRIPPED = 3
+
+
+def remediation_text(pr: Optional[str], repo: Optional[str]) -> str:
+    """The one canonical restart route, and nothing else.
+
+    Naming an alternative here would be an invitation to take it: the
+    project rule (.claude/rules/pr-ci-watch.md) makes /pr-watch-pane the
+    only sanctioned route, and a PreToolUse hook denies the direct script
+    invocations, so a guard that hinted at them would be telling the
+    operator to walk into a machine-enforced refusal.
+    """
+    shown_pr = pr if pr is not None else "<PR>"
+    shown_repo = repo if repo is not None else "<owner/name>"
+    return (
+        f"Restart the watcher: /pr-watch-pane {shown_pr} "
+        f"(cross-repo: --repo {shown_repo}).\n"
+        "Do NOT start tools/pr-watch.* directly - see "
+        ".claude/rules/pr-ci-watch.md."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Normalisation
+# ---------------------------------------------------------------------------
+
+
+def canonical_pr(value: Any) -> Optional[str]:
+    """Normalise a PR number from a payload / CLI value to int-as-string.
+
+    Payloads carry both ``73`` and ``"73"`` depending on which writer
+    produced the row, and operators type ``#73``. Everything that is not an
+    integer PR number returns None and therefore never matches -- a guard
+    must not invent an equality it cannot justify.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return str(int(value)) if value.is_integer() else None
+    if not isinstance(value, str):
+        return None
+    s = value.strip().lstrip("#").strip()
+    if not s:
+        return None
+    try:
+        return str(int(s))
+    except ValueError:
+        return None
+
+
+def canonical_repo(value: Any) -> Optional[str]:
+    """Normalise ``OWNER/REPO`` for comparison (case-folded, no ``.git``)."""
+    if not isinstance(value, str):
+        return None
+    s = value.strip().strip("/")
+    if s.lower().endswith(".git"):
+        s = s[: -len(".git")]
+    s = s.strip()
+    if not s:
+        return None
+    return s.lower()
+
+
+def _sort_key(row: "EventRow") -> tuple:
+    """Total order over events: timestamp first, then the autoincrement id."""
+    return (row.occurred_at or "", row.event_id)
+
+
+def head_corroborates(baseline_commit: Any, head: Any) -> bool:
+    """True when ``head`` and ``baseline_commit`` denote the same commit.
+
+    One side is typically a short sha (``pr_watch`` records 7 chars) and the
+    other a full one, so the comparison is a prefix match in whichever
+    direction is longer. A missing value on either side is NOT corroboration:
+    an unresolved head is exactly the case where the guard must warn.
+    """
+    if not isinstance(baseline_commit, str) or not isinstance(head, str):
+        return False
+    a = baseline_commit.strip().lower()
+    b = head.strip().lower()
+    if not a or not b:
+        return False
+    return a.startswith(b) or b.startswith(a)
+
+
+def _baseline_sha(payload: dict) -> "tuple[Optional[str], Optional[str]]":
+    """The pushed sha on a ``fix_pushed`` payload, and the key it came from.
+
+    Returns ``(None, None)`` when the row records no sha at all -- 22 of the
+    69 rows in the live DB only mention it inside a free-text ``note``, and
+    a sha the guard cannot read is an absent comparison, never a mismatch.
+    """
+    for key in BASELINE_SHA_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip(), key
+    return None, None
+
+
+def _ci_status(payload: dict) -> Optional[str]:
+    """The normalised ``ci_completed`` status, or None when unrecorded."""
+    for key in CI_STATUS_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Event access
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EventRow:
+    event_id: int
+    occurred_at: str
+    kind: str
+    payload: dict
+
+    def to_jsonable(self) -> dict:
+        return {
+            "event_id": self.event_id,
+            "occurred_at": self.occurred_at,
+            "kind": self.kind,
+            "payload": self.payload,
+        }
+
+
+def _load_events(conn: sqlite3.Connection, kinds: tuple[str, ...]) -> list[EventRow]:
+    placeholders = ",".join("?" for _ in kinds)
+    rows = conn.execute(
+        "SELECT id, occurred_at, kind, payload_json FROM events "
+        f"WHERE kind IN ({placeholders}) ORDER BY occurred_at, id",
+        kinds,
+    ).fetchall()
+    out: list[EventRow] = []
+    for row in rows:
+        raw = row["payload_json"] if isinstance(row, sqlite3.Row) else row[3]
+        try:
+            payload = json.loads(raw) if raw else {}
+        except (TypeError, ValueError):
+            payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+        out.append(
+            EventRow(
+                event_id=row["id"] if isinstance(row, sqlite3.Row) else row[0],
+                occurred_at=(
+                    row["occurred_at"] if isinstance(row, sqlite3.Row) else row[1]
+                )
+                or "",
+                kind=row["kind"] if isinstance(row, sqlite3.Row) else row[2],
+                payload=payload,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The predicate
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Verdict:
+    verdict: str
+    exit_code: int
+    pr: Optional[str] = None
+    repo: Optional[str] = None
+    task_id: Optional[str] = None
+    baseline: Optional[dict] = None
+    watcher: Optional[dict] = None
+    terminal: Optional[dict] = None
+    watcher_count: int = 0
+    ignored_unknown_repo: list = field(default_factory=list)
+    reason: str = ""
+    remediation: Optional[str] = None
+
+    @property
+    def tripped(self) -> bool:
+        return self.verdict in TRIPPING_VERDICTS
+
+    def to_jsonable(self) -> dict:
+        return asdict(self)
+
+
+def _baseline_summary(row: EventRow) -> dict:
+    commit, key = _baseline_sha(row.payload)
+    return {
+        "occurred_at": row.occurred_at,
+        "commit": commit,
+        "commit_key": key,
+        "event_id": row.event_id,
+    }
+
+
+def _watcher_summary(row: EventRow) -> dict:
+    return {
+        "occurred_at": row.occurred_at,
+        "pane_id": row.payload.get("pane_id"),
+        "event_id": row.event_id,
+    }
+
+
+def _terminal_summary(row: EventRow) -> dict:
+    return {
+        "kind": row.kind,
+        "occurred_at": row.occurred_at,
+        "head": row.payload.get("head"),
+        "status": row.payload.get("status"),
+        "event_id": row.event_id,
+    }
+
+
+def evaluate(
+    conn: sqlite3.Connection,
+    pr: Any,
+    repo: Any,
+    task_id: Optional[str] = None,
+) -> Verdict:
+    """Decide whether ``pr`` in ``repo`` is watched by a post-push watcher.
+
+    ``task_id`` selects the ``fix_pushed`` baseline (its payload ``task``
+    field). Without one there is no baseline and the answer degrades to
+    "has this PR ever been watched, and did that watch end", which the
+    output makes visible via ``baseline: null``.
+    """
+    pr_key = canonical_pr(pr)
+    repo_key = canonical_repo(repo)
+    if pr_key is None:
+        return Verdict(
+            verdict="unresolved",
+            exit_code=VERDICT_EXIT_CODES["unresolved"],
+            pr=None,
+            repo=repo if isinstance(repo, str) else None,
+            task_id=task_id,
+            reason="no PR number could be resolved",
+        )
+
+    events = _load_events(conn, (WATCHER_KIND, BASELINE_KIND) + TERMINAL_KINDS)
+
+    baseline_rows = [
+        e
+        for e in events
+        if e.kind == BASELINE_KIND
+        and task_id is not None
+        and e.payload.get("task") == task_id
+    ]
+    baseline = max(baseline_rows, key=_sort_key) if baseline_rows else None
+
+    watchers: list[EventRow] = []
+    ignored_unknown_repo: list[dict] = []
+    for e in events:
+        if e.kind != WATCHER_KIND:
+            continue
+        if canonical_pr(e.payload.get("pr")) != pr_key:
+            continue
+        row_repo = canonical_repo(e.payload.get("repo"))
+        if row_repo is None:
+            # Positive evidence of monitoring must be explicit about which
+            # repo it monitors; see the module docstring's asymmetry note.
+            ignored_unknown_repo.append(e.to_jsonable())
+            continue
+        if row_repo != repo_key:
+            continue
+        watchers.append(e)
+
+    terminals = [
+        e
+        for e in events
+        if e.kind in TERMINAL_KINDS
+        and canonical_pr(e.payload.get("pr")) == pr_key
+        and canonical_repo(e.payload.get("repo")) in (None, repo_key)
+    ]
+
+    base = Verdict(
+        verdict="",
+        exit_code=0,
+        pr=pr_key,
+        repo=repo if isinstance(repo, str) else repo_key,
+        task_id=task_id,
+        baseline=_baseline_summary(baseline) if baseline else None,
+        watcher_count=len(watchers),
+        ignored_unknown_repo=ignored_unknown_repo,
+    )
+
+    def finish(verdict: str, reason: str) -> Verdict:
+        base.verdict = verdict
+        base.exit_code = VERDICT_EXIT_CODES[verdict]
+        base.reason = reason
+        if verdict in TRIPPING_VERDICTS:
+            base.remediation = remediation_text(base.pr, base.repo)
+        return base
+
+    if not watchers:
+        return finish(
+            "missing",
+            f"no {WATCHER_KIND} event recorded for this PR at all",
+        )
+
+    newest_watcher = max(watchers, key=_sort_key)
+    base.watcher = _watcher_summary(newest_watcher)
+
+    if baseline is not None and _sort_key(newest_watcher) <= _sort_key(baseline):
+        return finish(
+            "stale",
+            "the newest watcher started at or before the last push "
+            f"({newest_watcher.occurred_at} <= {baseline.occurred_at}); a live "
+            "pane proves nothing, the watch it belongs to predates the push",
+        )
+
+    after = [e for e in terminals if _sort_key(e) >= _sort_key(newest_watcher)]
+    if not after:
+        return finish(
+            "live",
+            "a watcher started after the last push and no terminal event has "
+            "arrived since",
+        )
+
+    terminal = max(after, key=_sort_key)
+    base.terminal = _terminal_summary(terminal)
+
+    if terminal.kind in MERGE_TERMINAL_KINDS:
+        return finish(
+            "completed",
+            f"the PR is merged ({terminal.kind}); there is nothing left to watch",
+        )
+
+    # Did the watch end with an ANSWER, or did it just stop? This question
+    # comes before the head comparison, because a watch that stopped without
+    # a verdict leaves the current head unwatched no matter which head it was
+    # looking at.
+    if terminal.kind in ABORT_TERMINAL_KINDS:
+        return finish(
+            "ended_inconclusive",
+            f"the watch ended with {terminal.kind}, which carries no CI "
+            "verdict for any head; nothing is watching the current head",
+        )
+
+    status = _ci_status(terminal.payload)
+    if status not in CONCLUSIVE_CI_STATUSES:
+        shown = status if status is not None else "unrecorded"
+        return finish(
+            "ended_inconclusive",
+            f"the watch ended with {terminal.kind} status {shown!r}, which is "
+            "not a CI verdict (checks still pending, unreadable probe, or "
+            "canceled); the watch stopped without answering for the current "
+            "head",
+        )
+
+    # A verdict was reached. From here the head is a DEMOTER, not a
+    # requirement: it can prove the answer belongs to an older push, but a
+    # head that either side failed to record proves nothing either way, and
+    # tripping on that absence would fire on the ~36% of ci_completed rows
+    # that carry no head at all.
+    baseline_commit, _key = _baseline_sha(baseline.payload) if baseline else (None, None)
+    terminal_head = terminal.payload.get("head")
+    both_known = (
+        isinstance(baseline_commit, str)
+        and baseline_commit.strip() != ""
+        and isinstance(terminal_head, str)
+        and terminal_head.strip() != ""
+    )
+    if both_known and not head_corroborates(baseline_commit, terminal_head):
+        return finish(
+            "ended_stale_head",
+            f"the watch ended with {terminal.kind} status {status!r} on head "
+            f"{terminal_head!r}, which does not correspond to the pushed "
+            f"commit {baseline_commit!r}; the verdict belongs to an older "
+            "push and the current head is unwatched",
+        )
+    if both_known:
+        return finish(
+            "completed",
+            f"{terminal.kind} reported {status!r} on head {terminal_head!r}, "
+            f"which corresponds to the pushed commit {baseline_commit!r}",
+        )
+    return finish(
+        "completed",
+        f"a watcher started after the last push and ended with "
+        f"{terminal.kind} status {status!r}; the heads could not be compared "
+        f"(pushed commit {baseline_commit!r}, verdict head {terminal_head!r}), "
+        "so the verdict is taken to be this push's",
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR / repo resolution
+# ---------------------------------------------------------------------------
+
+
+# ``runs.pr_url`` holds a PR web URL, not a git remote, so the shared
+# remote-URL matcher in ``tools.resolve_run_repo`` (anchored at end of
+# string) does not apply to it. Port handling mirrors that pattern's
+# ``:\d+`` allowance so an enterprise-style host with an explicit port
+# still parses.
+_PR_URL_RE = re.compile(
+    r"github\.com(?::\d+)?[:/]([^/:\s]+)/([^/:\s]+?)(?:\.git)?"
+    r"/pulls?/(\d+)",
+    re.IGNORECASE,
+)
+
+
+def _split_pr_url(url: Any) -> "tuple[Optional[str], Optional[str]]":
+    """Return ``(OWNER/REPO, pr)`` for a GitHub PR URL, else ``(None, None)``.
+
+    Case is preserved for the repo -- it is echoed back in the remediation
+    line an operator copies -- while matching itself is case-insensitive.
+    """
+    if not isinstance(url, str):
+        return (None, None)
+    m = _PR_URL_RE.search(url.strip())
+    if not m:
+        return (None, None)
+    return (f"{m.group(1)}/{m.group(2)}", canonical_pr(m.group(3)))
+
+
+def _pr_number_from_url(url: Any) -> Optional[str]:
+    return _split_pr_url(url)[1]
+
+
+def _owner_repo_from_url(url: Any) -> Optional[str]:
+    """``OWNER/REPO`` from a PR URL, falling back to the git-remote matcher."""
+    repo, _pr = _split_pr_url(url)
+    if repo is not None:
+        return repo
+    try:
+        from tools.resolve_run_repo import owner_repo_from_url
+    except Exception:  # pragma: no cover - bare checkout without the seam
+        return None
+    try:
+        return owner_repo_from_url(url)
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+@dataclass(frozen=True)
+class Resolution:
+    pr: Optional[str]
+    repo: Optional[str]
+    source: str
+    error: Optional[str] = None
+
+
+def resolve_for_task(conn: sqlite3.Connection, task_id: str) -> Resolution:
+    """Resolve ``(pr, repo)`` for ``task_id`` from the run row, then events.
+
+    ``runs.pr_url`` is the primary source because it is written by the
+    PR-opening helpers in the same transaction as ``pr_state``. The
+    fallback is the newest ``pr_opened`` event carrying the task, which
+    covers runs whose row was never updated.
+    """
+    try:
+        row = conn.execute(
+            "SELECT pr_url FROM runs WHERE task_id = ?", (task_id,)
+        ).fetchone()
+    except sqlite3.DatabaseError as exc:
+        return Resolution(None, None, "error", f"runs lookup failed: {exc}")
+
+    if row is not None:
+        pr_url = row["pr_url"] if isinstance(row, sqlite3.Row) else row[0]
+        pr = _pr_number_from_url(pr_url)
+        repo = _owner_repo_from_url(pr_url)
+        if pr is not None:
+            return Resolution(pr, repo, "runs.pr_url")
+
+    events = _load_events(conn, ("pr_opened",))
+    candidates = [e for e in events if e.payload.get("task") == task_id]
+    for e in sorted(candidates, key=_sort_key, reverse=True):
+        url = e.payload.get("url")
+        pr = _pr_number_from_url(url) or canonical_pr(e.payload.get("pr"))
+        repo = _owner_repo_from_url(url) or (
+            e.payload.get("repo") if isinstance(e.payload.get("repo"), str) else None
+        )
+        if pr is not None:
+            return Resolution(pr, repo, "pr_opened event")
+
+    return Resolution(
+        None,
+        None,
+        "none",
+        f"no pr_url on run {task_id!r} and no pr_opened event for it",
+    )
+
+
+def task_for_pr(
+    conn: sqlite3.Connection, pr: Any, repo: Any
+) -> Optional[str]:
+    """The task_id of the run holding this PR, for the ``--pr`` form.
+
+    Without this the ``--pr`` form has no ``fix_pushed`` baseline, the
+    ``stale`` branch is unreachable, and the tool answers exit 0 on the
+    exact incident it exists to catch -- while the module docstring and
+    ``--help`` both advertise ``--pr`` as an equal way in. So the baseline
+    is recovered from the run row rather than left absent.
+    """
+    pr_key = canonical_pr(pr)
+    repo_key = canonical_repo(repo)
+    if pr_key is None:
+        return None
+    try:
+        rows = conn.execute(
+            "SELECT task_id, pr_url FROM runs "
+            "WHERE pr_url IS NOT NULL AND TRIM(pr_url) != '' "
+            "ORDER BY id DESC"
+        ).fetchall()
+    except sqlite3.DatabaseError:
+        return None
+    for row in rows:
+        task_id = row["task_id"] if isinstance(row, sqlite3.Row) else row[0]
+        pr_url = row["pr_url"] if isinstance(row, sqlite3.Row) else row[1]
+        row_repo, row_pr = _split_pr_url(pr_url)
+        if row_pr != pr_key:
+            continue
+        # Same asymmetry as the watcher match: a run whose repo cannot be
+        # read is not proof that this PR is that run's.
+        if repo_key is not None and canonical_repo(row_repo) != repo_key:
+            continue
+        if isinstance(task_id, str) and task_id.strip():
+            return task_id
+    return None
+
+
+def _home_repo() -> Optional[str]:
+    """``OWNER/REPO`` of this checkout's own origin, or None.
+
+    Used only as the last fallback for ``check --pr N`` with no ``--repo``
+    and no task: the operator is standing in a repo and asking about a PR
+    number, so that repo is the only defensible default. It is never used
+    to match "any repo" -- when it cannot be derived the tool exits 2
+    rather than guessing.
+    """
+    try:
+        from tools.resolve_worker_layout import _git_origin_url
+    except Exception:  # pragma: no cover - bare checkout without the seam
+        return None
+    try:
+        return _owner_repo_from_url(_git_origin_url(_REPO_ROOT))
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+def audit(conn: sqlite3.Connection) -> list[Verdict]:
+    """Evaluate every run whose PR is still open (or of unknown state).
+
+    Terminal runs and merged / closed PRs are excluded: an unwatched PR
+    that is already finished is not an incident, and listing it would train
+    the reader to skim past the ones that are.
+    """
+    placeholders = ",".join("?" for _ in TERMINAL_STATUSES)
+    rows = conn.execute(
+        "SELECT task_id, pr_url FROM runs "
+        "WHERE pr_url IS NOT NULL AND TRIM(pr_url) != '' "
+        "AND (pr_state IN ('draft','open') OR pr_state IS NULL) "
+        f"AND status NOT IN ({placeholders}) "
+        "ORDER BY task_id",
+        TERMINAL_STATUSES,
+    ).fetchall()
+
+    results: list[Verdict] = []
+    for row in rows:
+        task_id = row["task_id"] if isinstance(row, sqlite3.Row) else row[0]
+        pr_url = row["pr_url"] if isinstance(row, sqlite3.Row) else row[1]
+        pr = _pr_number_from_url(pr_url)
+        repo = _owner_repo_from_url(pr_url)
+        if pr is None:
+            results.append(
+                Verdict(
+                    verdict="unresolved",
+                    exit_code=VERDICT_EXIT_CODES["unresolved"],
+                    task_id=task_id,
+                    reason=f"pr_url {pr_url!r} is not a recognisable PR URL",
+                )
+            )
+            continue
+        results.append(evaluate(conn, pr, repo, task_id=task_id))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_verdict(v: Verdict) -> str:
+    lines = [
+        f"verdict: {v.verdict} (exit {v.exit_code})",
+        f"  pr: {v.pr}  repo: {v.repo}  task: {v.task_id}",
+    ]
+    if v.baseline:
+        lines.append(
+            "  baseline push: {occurred_at} commit={commit} "
+            "(from payload key {commit_key}, event {event_id})".format(**v.baseline)
+        )
+    else:
+        lines.append("  baseline push: null (no fix_pushed recorded for this task)")
+    if v.watcher:
+        lines.append(
+            "  newest watcher: {occurred_at} pane={pane_id} "
+            "(event {event_id})".format(**v.watcher)
+        )
+    else:
+        lines.append("  newest watcher: null")
+    if v.terminal:
+        lines.append(
+            "  terminal: {kind} at {occurred_at} head={head} status={status} "
+            "(event {event_id})".format(**v.terminal)
+        )
+    else:
+        lines.append("  terminal: null")
+    lines.append(f"  watchers matched: {v.watcher_count}")
+    if v.ignored_unknown_repo:
+        lines.append(
+            f"  ignored_unknown_repo: {len(v.ignored_unknown_repo)} "
+            f"{WATCHER_KIND} row(s) matched the PR number but carried no repo, "
+            "so they were not counted as proof of monitoring"
+        )
+    if v.reason:
+        lines.append(f"  why: {v.reason}")
+    if v.remediation:
+        for line in v.remediation.splitlines():
+            lines.append(f"  {line}")
+    return "\n".join(lines)
+
+
+def render_audit(results: list[Verdict]) -> str:
+    if not results:
+        return "no open-PR runs to check."
+    lines = []
+    for v in results:
+        lines.append(render_verdict(v))
+        lines.append("")
+    counts: dict[str, int] = {}
+    for v in results:
+        counts[v.verdict] = counts.get(v.verdict, 0) + 1
+    lines.append(
+        "summary: " + ", ".join(f"{k}={counts[k]}" for k in sorted(counts))
+    )
+    return "\n".join(lines)
+
+
+def _verdict_counts(results: list[Verdict]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for v in results:
+        counts[v.verdict] = counts.get(v.verdict, 0) + 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="tools/watcher_restart_guard.py",
+        description=(
+            "Decide whether a PR has a CI watcher that started AFTER the last "
+            "push, from the events table. A live pr-watch pane is not proof: "
+            "watcher panes do not self-close on every transport (Refs #978)."
+        ),
+    )
+    p.add_argument(
+        "--db-path",
+        default=None,
+        help=(
+            "override the resolved state.db path "
+            "(--db-path > $STATE_DB_PATH > discovery)."
+        ),
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    check = sub.add_parser(
+        "check",
+        help="check one PR (by number or by task id).",
+        description=(
+            "Check one PR. Exit 0 when monitoring is accounted for (live / "
+            "completed), 3 when it is not (stale / missing / "
+            "ended_stale_head / ended_inconclusive), 2 when the PR could not "
+            "be resolved."
+        ),
+    )
+    check.add_argument(
+        "--pr",
+        default=None,
+        help=(
+            "PR number, e.g. 73. The fix_pushed baseline is recovered from "
+            "the run row that holds this PR."
+        ),
+    )
+    check.add_argument(
+        "--task",
+        default=None,
+        help=(
+            "task id; resolves the PR from runs.pr_url (or the newest "
+            "pr_opened event) and selects the fix_pushed baseline."
+        ),
+    )
+    check.add_argument(
+        "--repo",
+        default=None,
+        help=(
+            "OWNER/REPO. On the --task path it defaults to the repo named by "
+            "the run row and never to another one; with --pr alone it falls "
+            "back to this checkout's own origin."
+        ),
+    )
+    check.add_argument(
+        "--json", action="store_true", help="emit one JSON object instead of text."
+    )
+
+    aud = sub.add_parser(
+        "audit",
+        help="check every run with an open PR.",
+        description=(
+            "Check every run holding a non-terminal PR. Exit 3 if any run "
+            "trips, 0 otherwise."
+        ),
+    )
+    aud.add_argument(
+        "--json", action="store_true", help="emit one JSON object instead of text."
+    )
+    return p
+
+
+def _open_conn(db_path_arg: Optional[str]) -> "tuple[sqlite3.Connection, Path]":
+    from tools.state_db import connect
+    from tools.state_db.discover import (
+        StateDbSchemaError,
+        resolve_state_db_path,
+        verify_state_db_schema,
+    )
+
+    db_path = resolve_state_db_path(Path(db_path_arg) if db_path_arg else None)
+    conn = connect(db_path)
+    try:
+        verify_state_db_schema(db_path, conn=conn)
+    except StateDbSchemaError:
+        conn.close()
+        raise
+    return conn, db_path
+
+
+def main(argv: Optional[list] = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.command == "check":
+        if bool(args.pr) == bool(args.task):
+            print(
+                "watcher_restart_guard: check requires exactly one of --pr / "
+                "--task.",
+                file=sys.stderr,
+            )
+            return EXIT_ERROR
+
+    from tools.state_db.discover import StateDbSchemaError
+
+    try:
+        conn, _db_path = _open_conn(args.db_path)
+    except StateDbSchemaError as exc:
+        print(f"watcher_restart_guard: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+    except sqlite3.DatabaseError as exc:
+        print(f"watcher_restart_guard: cannot open state.db: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    try:
+        if args.command == "audit":
+            results = audit(conn)
+            if args.json:
+                print(
+                    json.dumps(
+                        {
+                            "results": [v.to_jsonable() for v in results],
+                            "verdict_counts": _verdict_counts(results),
+                        },
+                        indent=2,
+                        ensure_ascii=False,
+                    )
+                )
+            else:
+                print(render_audit(results))
+            return EXIT_TRIPPED if any(v.tripped for v in results) else EXIT_OK
+
+        pr = args.pr
+        repo = args.repo
+        task_id = args.task
+        if task_id:
+            resolved = resolve_for_task(conn, task_id)
+            if resolved.pr is None:
+                v = Verdict(
+                    verdict="unresolved",
+                    exit_code=VERDICT_EXIT_CODES["unresolved"],
+                    task_id=task_id,
+                    reason=resolved.error or "no PR could be resolved",
+                )
+                print(
+                    json.dumps(v.to_jsonable(), indent=2, ensure_ascii=False)
+                    if args.json
+                    else render_verdict(v),
+                    file=sys.stdout,
+                )
+                return EXIT_UNRESOLVED
+            pr = resolved.pr
+            repo = repo or resolved.repo
+        elif not repo:
+            # Only the no-task form may fall back to this checkout's own
+            # origin: the operator is standing in a repo asking about a bare
+            # PR number, so that repo is the one defensible reading. On the
+            # task path the run row names the repo, and substituting a
+            # different one there would let another repo's watcher certify
+            # this PR as watched (PR numbers collide across repos).
+            repo = _home_repo()
+        if not repo:
+            print(
+                "watcher_restart_guard: could not determine OWNER/REPO for PR "
+                f"{pr}; pass --repo OWNER/REPO. (PR numbers collide across "
+                "repos, so matching any repo would be a guess.)",
+                file=sys.stderr,
+            )
+            return EXIT_UNRESOLVED
+
+        if task_id is None:
+            # Recover the baseline the --task form would have used, so both
+            # documented entry points answer the same question.
+            task_id = task_for_pr(conn, pr, repo)
+
+        verdict = evaluate(conn, pr, repo, task_id=task_id)
+        if args.json:
+            print(json.dumps(verdict.to_jsonable(), indent=2, ensure_ascii=False))
+        else:
+            print(render_verdict(verdict))
+        return verdict.exit_code
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# journal_append post-check
+# ---------------------------------------------------------------------------
+
+_GUARD_OFF_VALUES = ("off", "0", "false")
+
+
+def guard_disabled(env: Optional[dict] = None) -> bool:
+    """True when $ORG_WATCHER_GUARD switches the post-check off."""
+    source = os.environ if env is None else env
+    return str(source.get("ORG_WATCHER_GUARD", "")).strip().lower() in _GUARD_OFF_VALUES
+
+
+def format_post_push_notice(v: Verdict) -> str:
+    """The stderr block printed after a ``fix_pushed`` row is committed.
+
+    At this point a tripping verdict is the NORMAL state -- the restart
+    happens after the push, by definition -- so the text has to read as the
+    next required action rather than as an alarm. An alarm that fires on
+    every push is an alarm the reader learns to skip, which is how the
+    Issue #978 incident happened in the first place.
+    """
+    if not v.tripped:
+        return (
+            f"[watcher-guard] PR #{v.pr} ({v.repo}): {v.verdict} - a watcher "
+            "started after this push is already on record."
+        )
+    lines = [
+        f"[watcher-guard] NEXT ACTION: PR #{v.pr} ({v.repo}) has no CI watcher "
+        "for the commit you just pushed.",
+        f"[watcher-guard] evidence: {v.verdict} - {v.reason}",
+    ]
+    if v.watcher:
+        lines.append(
+            "[watcher-guard] a pr-watch pane may still be on screen (pane "
+            f"{v.watcher.get('pane_id')}); watcher panes do not self-close on "
+            "every transport, so a visible pane is not proof of monitoring."
+        )
+    for line in remediation_text(v.pr, v.repo).splitlines():
+        lines.append(f"[watcher-guard] {line}")
+    return "\n".join(lines)
+
+
+def post_push_check(
+    conn: sqlite3.Connection,
+    payload: dict,
+    stream=None,
+) -> Optional[Verdict]:
+    """Evaluate the guard for a just-committed ``fix_pushed`` payload.
+
+    Returns the verdict (for tests) or None when nothing could be checked.
+    Callers must treat every exception as non-fatal: see
+    :mod:`tools.journal_append`.
+    """
+    if stream is None:
+        stream = sys.stderr
+    task_id = payload.get("task")
+    if not isinstance(task_id, str) or not task_id.strip():
+        return None
+    task_id = task_id.strip()
+
+    resolved = resolve_for_task(conn, task_id)
+    if resolved.pr is None:
+        return None
+    # No _home_repo() fallback here: on this path the task IS known, so
+    # substituting this checkout's origin could match a same-numbered PR in
+    # another repo and report someone else's watcher as this push's. An
+    # unreadable repo is not evidence of monitoring, so say so rather than
+    # going quiet -- silence is what the guard exists to remove.
+    repo = resolved.repo
+    if not repo:
+        lines = [
+            f"[watcher-guard] NEXT ACTION: could not determine OWNER/REPO for "
+            f"PR #{resolved.pr} (task {task_id}), so the watcher state could "
+            "not be checked.",
+        ]
+        for line in remediation_text(resolved.pr, None).splitlines():
+            lines.append(f"[watcher-guard] {line}")
+        stream.write("\n".join(lines) + "\n")
+        return None
+
+    verdict = evaluate(conn, resolved.pr, repo, task_id=task_id)
+    stream.write(format_post_push_notice(verdict) + "\n")
+    return verdict
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #978.

修正の再 push 後に watcher を立て直し忘れると、CI を誰も見ていない時間ができる。2026-08-30 に実際に起き、ペインが `list_panes` に残っていたため窓口は「監視中」と誤って報告し続けた。判定を **ペインの存在から、events の時系列へ** 移す。

## 採用した設計

Issue の 2 案（`fix_pushed` 経路への後置検査 / 独立ツール + exit code）は排他ではないと判断し、**1 つの判定式を 2 面で出す**構成にした。

- **独立ツール** — 監査できる半分。exit code と判定根拠の行を出力に載せるので、後から「本当に見張られていたか」を検証できる。
- **`fix_pushed` への後置検査** — 忘れられない半分。窓口は push ごとに `fix_pushed` を打つ契約なので、別ツールの実行を忘れる経路が消える。非致命的で exit code は変えず、`fix_pushed` 以外では走らない。

独立ツール単体では「実行し忘れ」という本 Issue の失敗モードがそのまま残り、後置検査単体では事後監査ができない。

## 実測が決めた判定順序

本番 state.db に当てて測った 2 つの数字が設計を決めている。

1. **`ci_completed` の約 7%（27/392）は決着しないまま終わっている**（`incomplete` / `indeterminate` / `canceled` / 未記録）。そこで「その watch は答えを出したか」を head の一致より **先に** 見る。head だけ見る実装は「CI 走行中・ペイン消滅」を exit 0 で「判定済み」と誤答していた。
2. **`ci_completed` の 36% は head を持たない**。よって head は必須条件にせず、両方読めて食い違うときだけ `ended_stale_head` に降格させる。head 必須にすると健全な watch で誤報が出て、警告を読み飛ばす習慣 — 本インシデントの原因そのもの — を再生産する。

その他の判定上の要点:

- watch はその起動行が journal に書かれる **前に** 終わりうる（skill は spawn → 起動確認 → 記録の順）。watcher と terminal を時系列で貪欲にペアリングし、終了済みの watch を live と誤答しない。
- repo 欠落行の扱いは非対称。watcher 側（監視の存在証明）は repo 一致必須、terminal 側（終了の証拠）は欠落も採用するが結論には使わない。どちらの向きでも警告に倒れる。

## 副産物

audit を本番データのコピーに実行したところ、**PR #794（workers-guard-layer-design）で watcher が一度も起動されていない**ことを検出した（真陽性）。本 PR のスコープ外なので何も変更していない。

## 既知の限界

terminal イベントは pane 識別子を名乗らないため、現在の語彙では特定 watcher との対応を厳密には判別できない。誤検知は「再起動が 1 回増える」方向にのみ倒れるため、docstring と docs に明記して退出した（Codex P2 1 件）。

## 変更

9 files, +2516/-5

- `tools/watcher_restart_guard.py`（新規）/ `tools/test_watcher_restart_guard.py`（新規 76 tests）
- `tools/journal_append.py`（post-check 配線）、`tools/state_db/queries.py`
- `docs/journal-events.md` — `fix_pushed` 行の sha キー名を catalog の `commit` から実態の `head` へ訂正（実 DB 69 行中 `commit`=0 / `head`=47）
- `.claude/skills/{pr-watch-pane,org-pull-request}/SKILL.md`（+ `.md.in`）

## 検証

- `python3 -m unittest discover -s tools -p 'test_*.py'` → Ran 1186, OK
- `python3 -m unittest discover -s tests` → Ran 1018, OK
- CLI `--help` の cp932 安全性 / ASCII 検査 OK
- Codex ゲート 3 round（各 succeeded ≥ 9 / failed 0 / exit 0）。P1 2 件を検出し修正、round 3 は P1 ゼロ
