### PR TITLE
fix(tools): Group B チェッカーがネストした別チェックアウトへ降りないようにする

### DIFF
--- a/tools/check_group_b_selectors.py
+++ b/tools/check_group_b_selectors.py
@@ -68,6 +68,9 @@ allowlist エントリがどの違反にも一致しなくなった場合（pros
 * ``tmp/`` — 作業スクラッチ
 * ``*.local.md`` — operator 私物の machine-local ドキュメント（``.gitignore``
   の ``.local.md`` 規約。ワーカー brief ``CLAUDE.local.md`` を含む）
+* ネストした別チェックアウト（走査ルート以外で直下に ``.git`` を持つ
+  ディレクトリ = worktree / clone）— このリポジトリの正準手順ではない。
+  ディレクトリ名は任意なので名前ではなく構造で判定する
 
 ## 終了コード
 
@@ -90,6 +93,9 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 #: 検査対象の拡張子（長い方を先に判定する）。
 SCAN_SUFFIXES = (".md.in", ".md")
+
+#: 別チェックアウトのルートを指す印（worktree ではファイル、clone ではディレクトリ）。
+CHECKOUT_MARKER = ".git"
 
 #: どの階層でも降りないディレクトリ名。
 SKIP_DIR_NAMES = frozenset(
@@ -400,10 +406,29 @@ def _scan_suffix(name: str) -> str | None:
     return None
 
 
+def _is_nested_checkout(path: Path) -> bool:
+    """``path`` 自身が別チェックアウトのルートか（直下に ``.git`` を持つか）。
+
+    判定できないとき（読めないディレクトリ等）は ``False`` を返し、枝刈りは
+    ``os.walk`` 側の既存挙動に委ねる（降りられない枝は walk が黙って飛ばす）。
+    """
+    try:
+        return (path / CHECKOUT_MARKER).exists()
+    except OSError:
+        return False
+
+
 def iter_scan_files(root: Path) -> Iterator[Path]:
     """検査対象のファイルを列挙する（canonical source 側だけ）。"""
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIR_NAMES)
+        # 別チェックアウト（worktree / clone）はこのリポジトリの正準手順ではない。
+        # ディレクトリ名は任意なので、``.git`` の有無で構造的に判定する。
+        dirnames[:] = sorted(
+            d
+            for d in dirnames
+            if d not in SKIP_DIR_NAMES
+            and not _is_nested_checkout(Path(dirpath) / d)
+        )
         here = Path(dirpath)
         for name in sorted(filenames):
             if _scan_suffix(name) is None:

--- a/tools/test_check_group_b_selectors.py
+++ b/tools/test_check_group_b_selectors.py
@@ -28,6 +28,7 @@ bare name). It must:
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import tempfile
@@ -437,6 +438,49 @@ class ExclusionTest(TmpRootTestCase):
     def test_git_directory_is_not_walked(self) -> None:
         _write(self.root, ".git/hooks/note.md", 'close_pane(target="curator")\n')
         self.assertEqual(self.scan().violations, [])
+
+    def test_nested_worktree_is_not_walked(self) -> None:
+        # worktree の .git は gitdir ポインタ *ファイル*、ディレクトリ名は任意。
+        _write(self.root, ".worktrees/ja-848/.git", "gitdir: /elsewhere\n")
+        _write(
+            self.root,
+            ".worktrees/ja-848/docs/procedure.md",
+            'close_pane(target="curator")\n',
+        )
+        self.assertEqual(self.scan().violations, [])
+
+    def test_nested_clone_is_not_walked(self) -> None:
+        # clone の .git は *ディレクトリ*。こちらも同じく降りない。
+        (self.root / "vendor" / "dep" / ".git").mkdir(parents=True)
+        _write(
+            self.root,
+            "vendor/dep/docs/procedure.md",
+            'close_pane(target="curator")\n',
+        )
+        self.assertEqual(self.scan().violations, [])
+
+    @unittest.skipIf(os.name == "nt", "POSIX permission bits only")
+    @unittest.skipIf(
+        getattr(os, "geteuid", lambda: -1)() == 0,
+        "root bypasses permission bits",
+    )
+    def test_unreadable_directory_does_not_abort_the_scan(self) -> None:
+        # 読めないディレクトリは判定不能。walk 側の既存挙動（黙って飛ばす）に
+        # 委ね、marker の probe が例外で走査全体を落とさないこと。
+        _write(self.root, "docs/procedure.md", 'close_pane(target=3)\n')
+        blocked = self.root / "blocked"
+        blocked.mkdir()
+        blocked.chmod(0o000)
+        self.addCleanup(blocked.chmod, 0o755)
+        self.assertEqual(self.scan().violations, [])
+
+    def test_scan_root_with_a_git_marker_is_still_walked(self) -> None:
+        # 走査ルート自身は「別チェックアウト」ではない（枝刈りの対象外）。
+        (self.root / ".git").mkdir()
+        _write(self.root, "docs/procedure.md", 'close_pane(target="curator")\n')
+        self.assertEqual(
+            [f.path for f in self.scan().violations], ["docs/procedure.md"]
+        )
 
 
 class AllowlistTest(TmpRootTestCase):


### PR DESCRIPTION
## 問題

`tools/check_group_b_selectors.py` のリポジトリ走査が、ネストした git worktree の中まで降りていた。その結果 `RepositoryRegressionTest` の 2 テスト (`test_cli_exits_0_on_the_repository` / `test_repository_is_clean`) が、ローカルに worktree がある環境で必ず fail していた。

チェッカーの検査対象は「このリポジトリの正準手順」であり、ネストしたチェックアウトは同じリポジトリの別リビジョンであって追加のリポジトリ内容ではない。実際の失敗出力には 6 つの worktree 由来の Finding が並んでいた。

枝刈りは `SKIP_DIR_NAMES` によるディレクトリ名判定しか無く、worktree のディレクトリ名は任意なので名前ベースでは枝刈りできなかった。`.claude/worktrees/` は `.git/info/exclude` で無視されているが `.worktrees/` は無視されておらず、gitignore に頼る枝刈りでも不十分だった。

## 修正

走査ルート自身を除き、直下に `.git` エントリ (ファイルでもディレクトリでもよい) を持つディレクトリには降りないようにした。ネストした worktree は gitdir ポインタの `.git` ファイルを、ネストした clone は `.git` ディレクトリを持つので、どちらも構造的に判定できる。

除外リスト (`EXCLUDED_DIRS` / `EXCLUDED_FILES`) へのパス追記による回避はしていない。

## テスト

`ExclusionTest` に 4 件追加した。

- `.git` がファイルの場合 (worktree) / ディレクトリの場合 (clone) の双方で枝刈りされること
- 走査ルート自身は枝刈りされないこと (過剰枝刈りの回帰止め)
- 読めないディレクトリで走査全体が落ちないこと

枝刈りが効いていることは、修正前のチェッカーを同じ tmp 構造にかけて違反が報告されることで確認した (全体 green のみを根拠にしていない)。

- `tools/test_check_group_b_selectors.py`: 47 passed
- 全体: 2205 passed, 6 skipped, 307 subtests passed (修正前は 2 failed)

## レビュー

Codex 2 ラウンド。R1 で Major 1 件 (`Path.exists()` が `PermissionError` を送出しうる点) を修正し、R2 は Blocker 0 / Major 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXZRnN344fdTBn5YnTEqQj