### PR TITLE
fix(dispatcher): relay scan の --list を audit の exit に依らず毎サイクル実行すると明記する

### DIFF
--- a/.dispatcher/references/worker-monitoring.md
+++ b/.dispatcher/references/worker-monitoring.md
@@ -1204,6 +1204,8 @@ bash ../tools/journal_append.sh anomaly_observed source={面} worker=worker-{tas
       python3 ../tools/relay_scan.py --recipient secretary --list
       ```
 
+      **0. の exit code に関わらず毎サイクル実行する**（0. の exit 0 は「是正措置は不要」の意であって、本ステップを省いてよいという意味ではない）。
+
       出力は JSON 配列。各要素は `{source_event_id, kind, occurred_at, attempt, message, payload}`。空配列 (`[]`) なら本ステップは何もせず終了。DB 不在時も `[]` (エラーにしない)。
 
       **`[]` と「出力が無い」を同一視しない (Refs #941)**: 判定は **exit code 0 かつ stdout が JSON としてパースできること**の両方で行う。exit != 0 / stdout が空 / JSON でない場合は「配送対象なし」ではなく **ツールが走っていない**（`command not found`・import エラー・DB 破損等）ので、**本ステップを完了扱いにせず窓口へ `RELAY_SCAN_BROKEN: <exit code> <stderr 1 行>` を送る**。2026-07-30 〜 2026-08-19 の 20 日間、runbook の綴りが `python`（この環境には `python3` しか無い）だったため毎サイクル `command not found` で stdout が空になり、それが `[]` と区別されずに「配送対象なし」と読まれ続けた。終端イベント 134 件がその間に滞留している。

--- a/.dispatcher/references/worker-monitoring.md.in
+++ b/.dispatcher/references/worker-monitoring.md.in
@@ -1200,6 +1200,8 @@ bash ../tools/journal_append.sh anomaly_observed source={面} worker=worker-{tas
       python3 ../tools/relay_scan.py --recipient secretary --list
       ```
 
+      **0. の exit code に関わらず毎サイクル実行する**（0. の exit 0 は「是正措置は不要」の意であって、本ステップを省いてよいという意味ではない）。
+
       出力は JSON 配列。各要素は `{source_event_id, kind, occurred_at, attempt, message, payload}`。空配列 (`[]`) なら本ステップは何もせず終了。DB 不在時も `[]` (エラーにしない)。
 
       **`[]` と「出力が無い」を同一視しない (Refs #941)**: 判定は **exit code 0 かつ stdout が JSON としてパースできること**の両方で行う。exit != 0 / stdout が空 / JSON でない場合は「配送対象なし」ではなく **ツールが走っていない**（`command not found`・import エラー・DB 破損等）ので、**本ステップを完了扱いにせず窓口へ `RELAY_SCAN_BROKEN: <exit code> <stderr 1 行>` を送る**。2026-07-30 〜 2026-08-19 の 20 日間、runbook の綴りが `python`（この環境には `python3` しか無い）だったため毎サイクル `command not found` で stdout が空になり、それが `[]` と区別されずに「配送対象なし」と読まれ続けた。終端イベント 134 件がその間に滞留している。


### PR DESCRIPTION
## 問題

Step 5.25 の relay scan は段 0 (`--audit`、診断) と段 1 (`--list`、本体) の 2 段構成で、段 0 が exit 0 のときは「何もせず 1. へ進む」と書かれている。これは「是正措置は不要、そのまま 1. へ進め」の意味だが、「本ステップを省いてよい」と読み違えることができる。

実際にディスパッチャーがそう読み違え、`--list` が 1 時間以上一度も走らない状態になった。終端イベント (`ci_completed` / `pr_merged`) の窓口への配送が 13 分以上遅延し、同日中に 2 回発生している。

この誤りは無症状のまま続く。`--audit` は「trace 欠落 かつ backlog 実在」でしか鳴らないので (偽陽性を避けるための意図的な絞り込み)、配送すべきイベントが溜まるまで誰も気づかない。

## 修正

段 1 の `--list` に、audit の exit に依らず毎サイクル実行することを 1 行明記した。

> **0. の exit code に関わらず毎サイクル実行する**（0. の exit 0 は「是正措置は不要」の意であって、本ステップを省いてよいという意味ではない）。

段 0 の記述、検出条件の絞り込み、`--list` が heartbeat を無条件に残すという説明はいずれも変えていない。それらは既に正しく、理由も書かれている。足したのは「何をするか」だけで、理由の重複は増やしていない。

`tools/relay_scan.py` は変更していない。検出条件を緩めると、夜間停止後の起動のたびに偽 `RELAY_SCAN_STALE` が出て alert が無視されるように学習される。これは手順書自身が説明している設計判断で、今回の誤読とは別の問題である。

## 生成物ではなく `.in` を編集している

`.dispatcher/references/worker-monitoring.md` は `tools/skill_src/manifest.json` に `template+fragment` として登録された生成物だった。SoT である `.md.in` を編集し `tools/gen_skill_prose.py` で再生成している。差分は `.md.in` と `.md` の 2 ファイル各 2 行のみで、他の生成物に副次差分はない。

## 検証

`pytest -q` 全通過 (2205 passed, 6 skipped, 307 subtests passed)。drift チェック (`ProductionManifestTest::test_production_manifest_no_drift`) も通っている。Codex レビュー 2 ラウンドで Blocker / Major / P1 いずれもゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXZRnN344fdTBn5YnTEqQj