### PR TITLE
ダッシュボードの workers 欄を DB の in_use / review だけに絞る

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -88,6 +88,12 @@ function renderWorkers(workers) {
   const countEl = document.getElementById("worker-count");
   if (countEl) countEl.textContent = workers.length;
 
+  // Always drop the previous tick first: an early return on an empty list
+  // used to leave the interval from the last non-empty render running,
+  // ticking against DOM nodes that no longer exist.
+  clearInterval(window._tick);
+  window._tick = null;
+
   if (workers.length === 0) {
     list.innerHTML = '<p class="empty-state">No active workers</p>';
     list.style.background = "var(--surface)";
@@ -98,7 +104,6 @@ function renderWorkers(workers) {
   list.innerHTML = workers.map(workerCard).join("");
 
   // Tick elapsed counters
-  clearInterval(window._tick);
   window._tick = setInterval(() => {
     workers.forEach((w) => {
       const el = document.getElementById("el-" + w.id);

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -39,6 +39,7 @@ from tools.registry_parser import parse_projects_text as _parse_projects_shared
 from tools.state_db import connect as _db_connect
 from tools.state_db.queries import (
     get_org_state_summary as _db_org_state_summary,
+    list_live_worker_task_ids as _db_live_worker_task_ids,
     list_recent_events as _db_recent_events,
 )
 
@@ -79,12 +80,45 @@ def _parse_projects(text):
     ]
 
 
-def _parse_workers(workers_dir):
+def _parse_workers(workers_dir, eligible_task_ids):
+    """Build worker cards for the *live* workers only.
+
+    ``eligible_task_ids`` is the display-eligibility set computed from the
+    DB (``runs.status = 'in_use'``); it is a required argument so no caller
+    can accidentally fall back to "every md file under .state/workers/",
+    which is what made the panel report dozens of finished workers as
+    active. The md files never grant eligibility of their own.
+
+    A card is emitted for the *intersection* of that set with the md files
+    sitting directly under ``workers_dir`` (a run whose file has been
+    archived is no longer live — Issue #264). Within that intersection the
+    md is a detail source only: if it cannot be parsed the card is still
+    emitted, with null details, so a corrupt file degrades one card instead
+    of hiding a running worker.
+    """
+    eligible = set(eligible_task_ids)
+    if not eligible:
+        return []
+
     workers = []
     try:
-        for md_file in sorted(Path(workers_dir).glob("worker-*.md")):
-            text = _read(md_file)
-            worker_id = md_file.stem.replace("worker-", "")
+        md_files = sorted(Path(workers_dir).glob("worker-*.md"))
+    except OSError as exc:
+        print(
+            f"[dashboard] workers: cannot list {workers_dir}: {exc}",
+            file=sys.stderr,
+        )
+        return []
+
+    for md_file in md_files:
+        worker_id = md_file.stem[len("worker-"):]
+        if worker_id not in eligible:
+            continue
+        try:
+            # Read directly (not via _read, which swallows errors and
+            # returns "") so an unreadable / undecodable file reaches the
+            # per-file handler below instead of rendering a blank card.
+            text = md_file.read_text(encoding="utf-8").replace("\r\n", "\n")
             task = None
             pane_id = None
             started = None
@@ -127,8 +161,26 @@ def _parse_workers(workers_dir):
                 "lastProgress": last_progress["message"] if last_progress else None,
                 "lastProgressTs": last_progress["ts"] if last_progress else None,
             })
-    except Exception:
-        pass
+        except Exception as exc:
+            # Per-file containment: one corrupt md must not blank the whole
+            # panel (the previous blanket try/except turned a single parse
+            # error into "0 workers", indistinguishable from an idle org).
+            # The DB says this worker is running, so the card stays — only
+            # its md-sourced detail is dropped.
+            print(
+                f"[dashboard] workers: unparsable {md_file.name}: {exc}; "
+                "rendering card without detail",
+                file=sys.stderr,
+            )
+            workers.append({
+                "id": worker_id,
+                "shortId": worker_id[:8],
+                "task": None,
+                "paneId": None,
+                "started": None,
+                "lastProgress": None,
+                "lastProgressTs": None,
+            })
     return workers
 
 
@@ -275,6 +327,44 @@ def _load_state_from_db():
     )
 
 
+def _live_worker_task_ids():
+    """Return the DB-side display-eligibility set for the workers panel.
+
+    Never raises: on a missing DB, or if the eligibility query itself
+    fails, it returns an empty set and logs the reason, so the panel
+    degrades to "no live workers" rather than to "show everything on
+    disk".
+
+    Scope note: this only covers the workers panel. If the DB file exists
+    but is corrupt, ``_load_state_from_db`` raises first and the whole
+    ``/api/state`` response fails — that is the deliberate M4 (Issue #267)
+    "DB is required" behaviour, and this helper does not soften it. The
+    guard here is defense-in-depth for the cases the M4 path survives (a
+    transient lock, a schema the org-state queries tolerate but this one
+    does not).
+    """
+    if not STATE_DB_PATH.exists():
+        print(
+            "[dashboard] workers: state.db not found at "
+            f"{STATE_DB_PATH}; rendering 0 workers",
+            file=sys.stderr,
+        )
+        return set()
+    try:
+        conn = _db_connect(STATE_DB_PATH)
+        try:
+            return set(_db_live_worker_task_ids(conn))
+        finally:
+            conn.close()
+    except Exception as exc:
+        print(
+            "[dashboard] workers: live-worker query failed "
+            f"({exc.__class__.__name__}: {exc}); rendering 0 workers",
+            file=sys.stderr,
+        )
+        return set()
+
+
 def build_state():
     state_dir = BASE_DIR / ".state"
 
@@ -310,9 +400,20 @@ def build_state():
     projects_text = _read(BASE_DIR / "registry" / "projects.md")
     projects = _parse_projects(projects_text)
 
-    # Source of truth for "live worker" is presence directly under .state/workers/;
-    # closing a worker moves its md file to .state/workers/archive/ (org-delegate Step 5).
-    workers = _parse_workers(state_dir / "workers")
+    # The workers panel renders the intersection of two liveness signals:
+    # the DB phase (runs.status = 'in_use') and an md file sitting directly
+    # under .state/workers/ (archival means the worker is closed —
+    # Issue #264). The DB is the admitting predicate: md presence alone is
+    # NOT evidence of a live worker, because archival lags and completed /
+    # abandoned / suspended runs keep their file in place. Within the
+    # intersection the md contributes card detail only.
+    #
+    # Fail-safe: if the DB is missing or the eligibility query fails we
+    # render zero workers and log why. Falling back to "every md file"
+    # would silently reinstate the bug this guards against. (A corrupt DB
+    # file never reaches here — the M4 org-state read above raises first,
+    # by design.)
+    workers = _parse_workers(state_dir / "workers", _live_worker_task_ids())
 
     knowledge = _parse_knowledge(BASE_DIR / "knowledge" / "curated")
 

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -84,10 +84,11 @@ def _parse_workers(workers_dir, eligible_task_ids):
     """Build worker cards for the *live* workers only.
 
     ``eligible_task_ids`` is the display-eligibility set computed from the
-    DB (``runs.status = 'in_use'``); it is a required argument so no caller
-    can accidentally fall back to "every md file under .state/workers/",
-    which is what made the panel report dozens of finished workers as
-    active. The md files never grant eligibility of their own.
+    DB (``runs.status IN ('in_use', 'review')``). It is a required argument
+    so no caller can accidentally fall back to "every md file under
+    .state/workers/", which is what made the panel report dozens of
+    finished workers as active; md files never grant eligibility of their
+    own.
 
     A card is emitted for the *intersection* of that set with the md files
     sitting directly under ``workers_dir`` (a run whose file has been
@@ -401,7 +402,9 @@ def build_state():
     projects = _parse_projects(projects_text)
 
     # The workers panel renders the intersection of two liveness signals:
-    # the DB phase (runs.status = 'in_use') and an md file sitting directly
+    # the DB phase (the Set F §3.3 user-visible projection — in_use /
+    # review; a review pane is still open awaiting human approval, so it
+    # stays on the panel per Issue #264) and an md file sitting directly
     # under .state/workers/ (archival means the worker is closed —
     # Issue #264). The DB is the admitting predicate: md presence alone is
     # NOT evidence of a live worker, because archival lags and completed /

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -48,9 +48,15 @@ class TestParseProjects(unittest.TestCase):
 
 
 class TestParseWorkers(unittest.TestCase):
+    """``_parse_workers`` renders detail for ids the DB already admitted.
+
+    The eligibility set is supplied by the caller (``build_state`` derives
+    it from ``runs.status = 'in_use'``); these tests pass it explicitly, so
+    they cover md parsing / directory scoping only.
+    """
 
     def test_happy_path(self):
-        workers = _parse_workers(FIXTURES / "workers")
+        workers = _parse_workers(FIXTURES / "workers", {"abc12345"})
 
         self.assertEqual(len(workers), 1)
         w = workers[0]
@@ -63,11 +69,20 @@ class TestParseWorkers(unittest.TestCase):
         self.assertEqual(w["lastProgressTs"], "2026-04-10T10:30:00Z")
 
     def test_nonexistent_dir(self):
-        workers = _parse_workers(FIXTURES / "nonexistent")
+        workers = _parse_workers(FIXTURES / "nonexistent", {"abc12345"})
         self.assertEqual(workers, [])
 
+    def test_empty_eligibility_returns_nothing(self):
+        """An md file on disk is never sufficient on its own."""
+        self.assertEqual(_parse_workers(FIXTURES / "workers", set()), [])
+
     def test_archive_subdir_excluded(self):
-        """Issue #264: workers under .state/workers/archive/ must not appear as live."""
+        """Issue #264: workers under .state/workers/archive/ must not appear as live.
+
+        Still enforced by the non-recursive glob, independently of the DB
+        eligibility gate: even an ``in_use`` id whose md has been archived
+        stays out of the panel.
+        """
         with tempfile.TemporaryDirectory() as td:
             wdir = Path(td)
             (wdir / "worker-live.md").write_text(
@@ -79,27 +94,29 @@ class TestParseWorkers(unittest.TestCase):
                 "Task: old-task\nPane ID: pane-9\nStarted: long ago\n",
                 encoding="utf-8",
             )
-            workers = _parse_workers(wdir)
+            workers = _parse_workers(wdir, {"live", "old"})
             self.assertEqual([w["task"] for w in workers], ["live-task"])
 
 
 class TestBuildStateLiveWorkers(unittest.TestCase):
-    """Issue #264 regression: live worker list = files in .state/workers/
-    root only. Workers in REVIEW must remain visible (pane is still
-    open, awaiting human approval). Workers whose md file has been moved
-    to archive/ must NOT appear as live."""
+    """The live-worker panel is gated by the DB, not by md-file presence.
 
-    def test_review_workers_stay_visible_and_archived_disappear(self):
+    This supersedes the earlier Issue #264 rule that treated "file sits
+    directly under .state/workers/" as the liveness predicate: archival
+    lags behind the run's real phase, so completed / abandoned /
+    suspended runs kept rendering as active workers. Eligibility is now
+    ``runs.status = 'in_use'``; the directory scoping from #264 (archive/
+    is never live) remains in force on top of it.
+    """
+
+    def test_no_db_yields_no_workers(self):
+        """Fail-safe: without state.db the panel is empty, not "everything"."""
         from unittest.mock import patch
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
             (base / ".state" / "workers" / "archive").mkdir(parents=True)
             (base / ".state" / "workers" / "worker-active.md").write_text(
                 "Task: active-task\nPane ID: pane-1\nStarted: now\n",
-                encoding="utf-8",
-            )
-            (base / ".state" / "workers" / "worker-review.md").write_text(
-                "Task: review-task\nPane ID: pane-2\nStarted: now\n",
                 encoding="utf-8",
             )
             (base / ".state" / "workers" / "archive" / "worker-old.md").write_text(
@@ -109,11 +126,12 @@ class TestBuildStateLiveWorkers(unittest.TestCase):
             (base / "registry").mkdir()
             (base / "registry" / "projects.md").write_text("", encoding="utf-8")
 
-            with patch("dashboard.server.BASE_DIR", base):
+            with patch("dashboard.server.BASE_DIR", base), \
+                    patch("dashboard.server.STATE_DB_PATH",
+                          base / ".state" / "state.db"):
                 state = build_state()
 
-            tasks = sorted(w["task"] for w in state["workers"])
-            self.assertEqual(tasks, ["active-task", "review-task"])
+            self.assertEqual(state["workers"], [])
 
 
 class TestParseKnowledge(unittest.TestCase):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -22,6 +22,8 @@ from dashboard.server import (
     _parse_knowledge,
     build_state,
 )
+from tools.state_db import connect
+from tools.state_db.importer import import_full_rebuild
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
@@ -99,15 +101,84 @@ class TestParseWorkers(unittest.TestCase):
 
 
 class TestBuildStateLiveWorkers(unittest.TestCase):
-    """The live-worker panel is gated by the DB, not by md-file presence.
+    """Issue #264 regression, re-gated on the DB.
 
-    This supersedes the earlier Issue #264 rule that treated "file sits
-    directly under .state/workers/" as the liveness predicate: archival
-    lags behind the run's real phase, so completed / abandoned /
-    suspended runs kept rendering as active workers. Eligibility is now
-    ``runs.status = 'in_use'``; the directory scoping from #264 (archive/
-    is never live) remains in force on top of it.
+    Two predicates must both hold for a worker card: the run is in the
+    Set F §3.3 user-visible projection (in_use / review) AND its md file
+    still sits directly under .state/workers/. Workers in REVIEW stay
+    visible — the pane is still open, awaiting human approval — while an
+    md moved to archive/ disappears. The DB gate is the addition: md
+    presence alone used to be the whole predicate, so completed /
+    abandoned / suspended runs kept rendering as active.
     """
+
+    def _seed(self, base, statuses):
+        """Import a minimal org into base/.state/state.db and set statuses."""
+        (base / "registry").mkdir(exist_ok=True)
+        (base / "registry" / "projects.md").write_text(
+            "| 通称 | プロジェクト名 | パス | 説明 | 例 |\n"
+            "|---|---|---|---|---|\n"
+            "| demo | demo-project | https://example.invalid/d | demo | x |\n",
+            encoding="utf-8",
+        )
+        (base / ".state" / "org-state.md").write_text(
+            "# Org State\n\nStatus: ACTIVE\nCurrent Objective: t\n",
+            encoding="utf-8",
+        )
+        db_path = base / ".state" / "state.db"
+        import_full_rebuild(db_path, base)
+        conn = connect(db_path)
+        try:
+            pid = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()[0]
+            for task_id, status in statuses.items():
+                conn.execute(
+                    "INSERT INTO runs (task_id, project_id, pattern, title, "
+                    "status) VALUES (?, ?, 'A', ?, ?)",
+                    (task_id, pid, task_id, status),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+        return db_path
+
+    def test_review_workers_stay_visible_and_archived_disappear(self):
+        from unittest.mock import patch
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            (base / ".state" / "workers" / "archive").mkdir(parents=True)
+            (base / ".state" / "workers" / "worker-active.md").write_text(
+                "Task: active-task\nPane ID: pane-1\nStarted: now\n",
+                encoding="utf-8",
+            )
+            (base / ".state" / "workers" / "worker-review.md").write_text(
+                "Task: review-task\nPane ID: pane-2\nStarted: now\n",
+                encoding="utf-8",
+            )
+            (base / ".state" / "workers" / "worker-old.md").write_text(
+                "Task: done-task\nPane ID: pane-4\nStarted: now\n",
+                encoding="utf-8",
+            )
+            (base / ".state" / "workers" / "archive" / "worker-arch.md").write_text(
+                "Task: archived-task\nPane ID: pane-3\nStarted: ages ago\n",
+                encoding="utf-8",
+            )
+            db_path = self._seed(base, {
+                "active": "in_use",
+                "review": "review",
+                # Still in_use in the DB, but its md lives in archive/ —
+                # the #264 directory rule keeps it off the panel.
+                "arch": "in_use",
+                # md sits in the live directory, but the run is finished —
+                # the DB gate keeps it off the panel.
+                "old": "completed",
+            })
+
+            with patch("dashboard.server.BASE_DIR", base), \
+                    patch("dashboard.server.STATE_DB_PATH", db_path):
+                state = build_state()
+
+            tasks = sorted(w["task"] for w in state["workers"])
+            self.assertEqual(tasks, ["active-task", "review-task"])
 
     def test_no_db_yields_no_workers(self):
         """Fail-safe: without state.db the panel is empty, not "everything"."""

--- a/tests/test_state_db_fallback.py
+++ b/tests/test_state_db_fallback.py
@@ -155,7 +155,9 @@ class TestWorkersPanelEligibility(unittest.TestCase):
     Before this gate, ``_parse_workers`` globbed ``.state/workers/*.md``
     and rendered every hit as a live worker, so finished / abandoned /
     suspended runs kept pulsing on the dashboard long after their pane
-    was gone.
+    was gone. The admitting predicate is the Set F §3.3 user-visible
+    projection (``in_use`` / ``review``): a review run's pane is still
+    open awaiting human approval, so it stays on the panel (Issue #264).
     """
 
     def setUp(self) -> None:
@@ -206,7 +208,7 @@ class TestWorkersPanelEligibility(unittest.TestCase):
         finally:
             conn.close()
 
-    def test_only_in_use_runs_render_as_workers(self):
+    def test_only_user_visible_runs_render_as_workers(self):
         self._seed_runs()
         for task_id in (
             "w-running", "w-review", "w-queued", "w-done",
@@ -215,10 +217,14 @@ class TestWorkersPanelEligibility(unittest.TestCase):
             self._write_worker_md(task_id)
 
         state = self.server.build_state()
-        self.assertEqual([w["id"] for w in state["workers"]], ["w-running"])
-        # Detail still comes from the md file for the admitted id.
-        self.assertEqual(state["workers"][0]["task"], "w-running")
-        self.assertEqual(state["workers"][0]["lastProgress"], "working")
+        by_id = {w["id"]: w for w in state["workers"]}
+        # in_use and review are admitted; queued / terminal / suspended and
+        # an md file with no DB row at all are not.
+        self.assertEqual(sorted(by_id), ["w-review", "w-running"])
+        # Detail still comes from the md file for the admitted ids.
+        self.assertEqual(by_id["w-running"]["task"], "w-running")
+        self.assertEqual(by_id["w-running"]["lastProgress"], "working")
+        self.assertEqual(by_id["w-review"]["task"], "w-review")
 
     def test_db_missing_renders_no_workers(self):
         """Fail-safe: no DB must not fall back to "every md file"."""

--- a/tests/test_state_db_fallback.py
+++ b/tests/test_state_db_fallback.py
@@ -12,7 +12,9 @@ Run:  python -m unittest tests.test_state_db_fallback
 """
 from __future__ import annotations
 
+import contextlib
 import importlib
+import io
 import json
 import sys
 import tempfile
@@ -145,6 +147,140 @@ class TestServerDbRead(unittest.TestCase):
         # Terminal rows are filtered out of both surfaces (§3.4).
         self.assertNotIn("t-done", work_ids)
         self.assertNotIn("t-done", reserved_ids)
+
+
+class TestWorkersPanelEligibility(unittest.TestCase):
+    """The workers panel must be gated by the DB, not by md-file presence.
+
+    Before this gate, ``_parse_workers`` globbed ``.state/workers/*.md``
+    and rendered every hit as a live worker, so finished / abandoned /
+    suspended runs kept pulsing on the dashboard long after their pane
+    was gone.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.addCleanup(self._td.cleanup)
+        self.root = Path(self._td.name)
+        self.state_dir = self.root / ".state"
+        self.registry_dir = self.root / "registry"
+        _seed_state_dir(self.state_dir, self.registry_dir)
+        self.db_path = self.state_dir / "state.db"
+        self.workers_dir = self.state_dir / "workers"
+        self.workers_dir.mkdir(parents=True, exist_ok=True)
+
+        if "dashboard.server" in sys.modules:
+            del sys.modules["dashboard.server"]
+        import dashboard.server as server  # noqa: E402
+        self.server = server
+        server.BASE_DIR = self.root
+        server.STATE_DB_PATH = self.db_path
+
+    def _write_worker_md(self, task_id: str) -> None:
+        (self.workers_dir / f"worker-{task_id}.md").write_text(
+            f"Task: {task_id}\nPane ID: worker-{task_id}\n"
+            "Started: 2026-05-04T00:00:00Z\n\n"
+            "## Progress Log\n- [2026-05-04T00:01:00Z] working\n",
+            encoding="utf-8",
+        )
+
+    def _seed_runs(self) -> None:
+        import_full_rebuild(self.db_path, self.root)
+        conn = connect(self.db_path)
+        try:
+            pid = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()[0]
+            for task_id, status in (
+                ("w-running", "in_use"),
+                ("w-review", "review"),
+                ("w-queued", "queued"),
+                ("w-done", "completed"),
+                ("w-abandoned", "abandoned"),
+                ("w-suspended", "suspended"),
+            ):
+                conn.execute(
+                    "INSERT INTO runs (task_id, project_id, pattern, title, "
+                    "status) VALUES (?, ?, 'A', ?, ?)",
+                    (task_id, pid, task_id, status),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_only_in_use_runs_render_as_workers(self):
+        self._seed_runs()
+        for task_id in (
+            "w-running", "w-review", "w-queued", "w-done",
+            "w-abandoned", "w-suspended", "w-no-db-row",
+        ):
+            self._write_worker_md(task_id)
+
+        state = self.server.build_state()
+        self.assertEqual([w["id"] for w in state["workers"]], ["w-running"])
+        # Detail still comes from the md file for the admitted id.
+        self.assertEqual(state["workers"][0]["task"], "w-running")
+        self.assertEqual(state["workers"][0]["lastProgress"], "working")
+
+    def test_db_missing_renders_no_workers(self):
+        """Fail-safe: no DB must not fall back to "every md file"."""
+        self._write_worker_md("w-orphan")
+        self.assertFalse(self.db_path.exists())
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            state = self.server.build_state()
+        self.assertEqual(state["workers"], [])
+        # The degradation must be diagnosable, not silent.
+        self.assertIn("rendering 0 workers", err.getvalue())
+
+    def test_db_query_failure_renders_no_workers(self):
+        """A DB that exists but cannot be queried also fails safe.
+
+        Asserted on ``_live_worker_task_ids`` rather than ``build_state``
+        because the surrounding org-state read path deliberately raises on
+        an unreadable DB (M4); only the workers panel degrades quietly, and
+        it must degrade to empty, never to "every md file on disk".
+        """
+        self._seed_runs()
+        self._write_worker_md("w-running")
+        self.db_path.write_bytes(b"not a sqlite database")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            eligible = self.server._live_worker_task_ids()
+        self.assertEqual(eligible, set())
+        self.assertIn("rendering 0 workers", err.getvalue())
+        self.assertEqual(
+            self.server._parse_workers(self.workers_dir, eligible), []
+        )
+
+    def test_unparsable_md_degrades_only_that_card(self):
+        """A corrupt md must not blank the panel, nor hide a running worker.
+
+        The DB already admitted the id, so the card stays; only its
+        md-sourced detail is dropped.
+        """
+        self._seed_runs()
+        conn = connect(self.db_path)
+        try:
+            pid = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()[0]
+            conn.execute(
+                "INSERT INTO runs (task_id, project_id, pattern, title, "
+                "status) VALUES ('w-broken', ?, 'A', 'w-broken', 'in_use')",
+                (pid,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        self._write_worker_md("w-running")
+        # Invalid UTF-8 → read_text raises → per-file skip.
+        (self.workers_dir / "worker-w-broken.md").write_bytes(b"Task: \xff\xfe")
+
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            state = self.server.build_state()
+        by_id = {w["id"]: w for w in state["workers"]}
+        self.assertEqual(sorted(by_id), ["w-broken", "w-running"])
+        self.assertEqual(by_id["w-running"]["task"], "w-running")
+        self.assertIsNone(by_id["w-broken"]["task"])
+        self.assertIn("worker-w-broken.md", err.getvalue())
 
 
 class TestConverterDbOnly(unittest.TestCase):

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -150,15 +150,14 @@ def list_reserved_runs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
 
 
 def list_live_worker_task_ids(conn: sqlite3.Connection) -> list[str]:
-    """Return task_ids of runs that are actively executing (Set F §3.5).
+    """Return task_ids of runs whose worker pane is live (Set F §3.3).
 
-    Predicate: ``runs.status IN ACTIVE_EXECUTION_STATUSES`` (``in_use``).
-    This is the DB-side eligibility source for the dashboard's "live
-    workers" panel: a worker is shown only while its run is actually
-    executing. ``review`` is deliberately excluded — a run awaiting review
-    has no working pane, so rendering it as a pulsing worker card
-    misreports the org's live capacity. ``queued`` has no pane yet, and
-    terminal / ``suspended`` rows are not running at all.
+    Predicate: ``runs.status IN USER_VISIBLE_STATUSES`` (``in_use`` /
+    ``review``) — the same user-visible projection Active Work Items uses.
+    ``review`` belongs here per Issue #264: the pane is still open awaiting
+    human approval, which is precisely the state an operator needs to see
+    on the panel. ``queued`` has no pane yet, and terminal / ``suspended``
+    rows are not running at all, so both stay out.
 
     Note the deliberate split of responsibilities: this query is the
     *admitting* predicate for a worker card, while ``.state/workers/*.md``
@@ -168,7 +167,7 @@ def list_live_worker_task_ids(conn: sqlite3.Connection) -> list[str]:
     never admits a worker on its own — that is what kept dozens of finished
     runs rendering as live.
     """
-    placeholders = ", ".join("?" for _ in ACTIVE_EXECUTION_STATUSES)
+    placeholders = ", ".join("?" for _ in USER_VISIBLE_STATUSES)
     rows = conn.execute(
         f"""
         SELECT r.task_id AS task_id
@@ -176,7 +175,7 @@ def list_live_worker_task_ids(conn: sqlite3.Connection) -> list[str]:
         WHERE r.status IN ({placeholders})
         ORDER BY r.dispatched_at DESC, r.id DESC
         """,
-        ACTIVE_EXECUTION_STATUSES,
+        USER_VISIBLE_STATUSES,
     ).fetchall()
     return [r["task_id"] for r in rows if r["task_id"]]
 

--- a/tools/state_db/queries.py
+++ b/tools/state_db/queries.py
@@ -149,6 +149,38 @@ def list_reserved_runs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     return _rows_to_dicts(rows)
 
 
+def list_live_worker_task_ids(conn: sqlite3.Connection) -> list[str]:
+    """Return task_ids of runs that are actively executing (Set F §3.5).
+
+    Predicate: ``runs.status IN ACTIVE_EXECUTION_STATUSES`` (``in_use``).
+    This is the DB-side eligibility source for the dashboard's "live
+    workers" panel: a worker is shown only while its run is actually
+    executing. ``review`` is deliberately excluded — a run awaiting review
+    has no working pane, so rendering it as a pulsing worker card
+    misreports the org's live capacity. ``queued`` has no pane yet, and
+    terminal / ``suspended`` rows are not running at all.
+
+    Note the deliberate split of responsibilities: this query is the
+    *admitting* predicate for a worker card, while ``.state/workers/*.md``
+    supplies the card's detail (task / pane / progress). The dashboard
+    intersects this set with the md files still sitting directly under
+    ``.state/workers/`` (archival is its own closed signal), but an md file
+    never admits a worker on its own — that is what kept dozens of finished
+    runs rendering as live.
+    """
+    placeholders = ", ".join("?" for _ in ACTIVE_EXECUTION_STATUSES)
+    rows = conn.execute(
+        f"""
+        SELECT r.task_id AS task_id
+        FROM runs r
+        WHERE r.status IN ({placeholders})
+        ORDER BY r.dispatched_at DESC, r.id DESC
+        """,
+        ACTIVE_EXECUTION_STATUSES,
+    ).fetchall()
+    return [r["task_id"] for r in rows if r["task_id"]]
+
+
 def list_runs_with_dirs(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     """Return every run that has a worker_dir attached, regardless of status.
 
@@ -740,6 +772,7 @@ __all__ = [
     "BRIEFING_EVENT_KINDS_NOISE",
     "list_active_runs",
     "list_reserved_runs",
+    "list_live_worker_task_ids",
     "list_runs_with_dirs",
     "get_run_by_task_id",
     "list_worker_dirs",


### PR DESCRIPTION
ダッシュボードの workers 欄が、稼働していないワーカーを大量に「稼働中」として表示していた。`.state/workers/*.md` を glob して全件返し、全件に緑の pulse を付けていたため、実稼働 2 件に対して 38 件が並んだ。

## 直したこと

- **表示資格を DB から取る。** `runs.status IN ('in_use', 'review')` の task_id と、`.state/workers/` 直下に md があるものの積集合だけを返す。DB が唯一の表示資格ソースで、md は task / pane / progress の詳細ソースに留める（二重の source of truth を作らない）。
- **review は残す。** ペインが開いていて人間の承認を待っている状態は、まさに operator が見たいもの（Issue #264 の既存契約）。`queued`（ペイン未生成）、terminal、`suspended` は出さない。
- **fail-safe は「空 + stderr」であって「全件表示」ではない。** `state.db` 不在、または資格クエリの失敗で空の panel を描き、理由を stderr に出す。全件表示へ落ちる経路は残していない（それが今回のバグそのもの）。
- **parse 例外の握り潰しをやめた。** 破損した md が 1 つあるだけで「workers 0 件」に化けていた。ファイル単位で warn + skip。DB が admit している id の md が壊れていた場合は、落とさず null 詳細のカードで出す（DB が稼働中と言っている）。
- **`app.js`**: workers 0 件のとき `clearInterval` より先に return していて interval が解除されなかった。

## 触っていないもの

`.state/workers/` のファイル、`archive/`、`state.db` の中身、archive の仕組み（`writer.py`）、`org_state_converter.py` の registry（status 欄への自由文混入）。データ側の滞留は表示から見えなくなるだけで残る。#988 に保留理由と再訪条件を記録済み。

## 検証

`tests.test_parsers` / `tests.test_state_db_fallback` / `tests.test_state_transitions_contract`: 40 ran, 40 OK。実 DB のコピー上で review を 1 件模擬し、in_use + review の 2 枚だけ描画されることを確認。Codex 3 ラウンド + follow-up 1 ラウンドで Blocker / Major ゼロ。
