### PR TITLE
spawn_gate verify が worker md の Pane ID / Started / 派遣完了 を副作用で書く

### DIFF
--- a/.dispatcher/references/spawn-flow.md
+++ b/.dispatcher/references/spawn-flow.md
@@ -339,6 +339,8 @@ worker brief に **ultracode 使用許可**があるタスクでは、kickoff �
    - [{time}] 派遣完了、作業開始
    ```
 
+   > **本項の `Status: active` flip / `Pane ID:` / `Started:` / Progress Log「派遣完了」行は、[`tools/spawn_gate.py`](../../tools/spawn_gate.py) `verify` が成功時（`worker_spawn_verified` 記帳と同じ流れ）に副作用として書く。** dispatcher は手で書かず、`verify` 出力の `worker_record.status`（`updated` / `unchanged` が正常）を確認するだけでよい。`missing` / `error`（stderr に 1 行出る。gate の exit code は変わらない）のときだけ、上記を手で補う。
+
    > **`Status:` 行は省略不可**（Refs #835）。runtime はこの行を overflow 予約台帳として機械的に読む（`_seed_status`、`claude_org_runtime/dispatcher/runner.py:1265-1286`）。行が無いと `None` が返り、`count_unbound_reservations` が mtime クロック（`WORKER_BIND_WINDOW_SECONDS = 45`、`runner.py:305`）へ**黙って**フォールバックするため、この Step 4 で既に active になった worker が最長 45 秒 pending 予約として枠を占有し、直後の overflow spawn が `split_capacity_exceeded` で不当に拒否されうる（`runner.py:1253-1260` / `runner.py:2796-2832`）。書式契約（bullet 前置き `- Status:` は**パースされない**等）は [`docs/contracts/state-schema-contract.md`](../../docs/contracts/state-schema-contract.md) §7、回帰検出は [`tests/test_worker_seed_status_contract.py`](../../tests/test_worker_seed_status_contract.py)。
 
 2. **DB 経由で run と Active Work Items を登録する**（`.state/org-state.md` 直接編集は禁止。`StateWriter.transaction()` 経由、post-commit hook が再生成）:

--- a/tools/spawn_gate.py
+++ b/tools/spawn_gate.py
@@ -122,8 +122,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sqlite3
 import sys
+import tempfile
 from pathlib import Path
 
 # Make `tools.state_db.*` importable when invoked directly (no prior
@@ -374,6 +376,273 @@ def _append_verified_event(payload: dict, db_override: "str | None") -> None:
         conn.close()
 
 
+#: Marker the Progress Log bullet carries; a bullet in the `## Progress Log`
+#: section holding it is the idempotency key for the side effect below.
+DISPATCHED_MARK = "派遣完了"
+
+
+def _workers_dir_for(db_path: Path) -> Path:
+    """`.state/workers/` sits beside `state.db` (`.state/state.db`)."""
+    return db_path.parent / "workers"
+
+
+def _utc_now_iso() -> str:
+    """Same shape as `events.occurred_at` (`%Y-%m-%dT%H:%M:%fZ`)."""
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+#: Level-2 markdown heading (CommonMark allows up to 3 leading spaces).
+#: The one detector used for header end, section start and section end,
+#: so the three never disagree about where a section is.
+_H2_RE = re.compile(r"^\s{0,3}##\s+(?P<title>.*?)\s*#*\s*$")
+#: `Status: planned` with the value isolated; only the value is rewritten
+#: so indentation / capitalisation / trailing whitespace stay intact.
+_STATUS_PLANNED_RE = re.compile(
+    r"^(?P<lead>\s*status\s*:\s*)planned(?P<tail>\s*)$", re.IGNORECASE
+)
+
+
+#: Fenced code block delimiter (``` or ~~~, up to 3 leading spaces).
+_FENCE_RE = re.compile(r"^\s{0,3}(?P<run>`{3,}|~{3,})(?P<rest>.*)$")
+
+
+def _fenced_lines(lines: "list[str]") -> "list[bool]":
+    """Per-line flag: inside (or delimiting) a fenced code block.
+
+    CommonMark closing rule: same character, a run at least as long as the
+    opener, nothing but whitespace after it. So a ```` fence is not closed
+    by ```, and ```py (an info string) cannot close anything.
+    """
+    flags: "list[bool]" = []
+    fence: "str | None" = None  # the opening run, e.g. "````"
+    for ln in lines:
+        fm = _FENCE_RE.match(ln)
+        if fm:
+            run, rest = fm.group("run"), fm.group("rest")
+            if fence is None:
+                fence = run
+                flags.append(True)
+                continue
+            if (
+                run[0] == fence[0]
+                and len(run) >= len(fence)
+                and rest.strip() == ""
+            ):
+                fence = None
+                flags.append(True)
+                continue
+        flags.append(fence is not None)
+    return flags
+
+
+def _h2_titles(lines: "list[str]") -> "list[str | None]":
+    """Per-line lowercase H2 title, or None. Lines inside a fenced code
+    block are never headings, so a ``## `` quoted in an example cannot
+    end the header or a section."""
+    titles: "list[str | None]" = []
+    for ln, fenced in zip(lines, _fenced_lines(lines)):
+        m = None if fenced else _H2_RE.match(ln)
+        titles.append(m.group("title").strip().lower() if m else None)
+    return titles
+
+
+def _has_dispatch_bullet(lines: "list[str]", start: int, end: int) -> bool:
+    """A real bullet carrying the marker in ``lines[start:end]``; fenced
+    example text does not count."""
+    fenced = _fenced_lines(lines)
+    return any(
+        not fenced[i]
+        and lines[i].lstrip().startswith("- ")
+        and DISPATCHED_MARK in lines[i]
+        for i in range(start, end)
+    )
+
+
+def _replace_file_atomically(path: Path, data: bytes) -> None:
+    """Same-directory temp file + ``os.replace`` so a failed write leaves
+    the original record intact rather than truncated."""
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+        # mkstemp creates 0600; keep the record's own mode across the swap.
+        os.chmod(tmp, path.stat().st_mode & 0o7777)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _rewrite_worker_md(
+    text: str, pane_id: int, started_at: str
+) -> "tuple[str, list[str]]":
+    """Pure edit of one worker record; returns (new_text, changes).
+
+    ``changes`` is empty when nothing needed doing (then ``new_text`` is
+    ``text`` unchanged). See :func:`_record_dispatch_in_worker_md` for
+    what is written and why.
+    """
+    newline = "\r\n" if "\r\n" in text else "\n"
+    lines = text.replace("\r\n", "\n").split("\n")
+    trailing_newline = text.endswith("\n")
+    if trailing_newline:
+        lines.pop()  # split() leaves an empty tail after the final newline
+    changes: "list[str]" = []
+
+    # Header = everything before the first `## ` section. Only lines there
+    # count as fields, so a `Pane ID:` quoted inside prose is not mistaken
+    # for the header field.
+    titles = _h2_titles(lines)
+    header_end = next(
+        (i for i, t in enumerate(titles) if t is not None), len(lines)
+    )
+    header = lines[:header_end]
+
+    def _has_field(name: str) -> bool:
+        return any(
+            ln.lstrip().lower().startswith(name.lower() + ":") for ln in header
+        )
+
+    def _anchor() -> int:
+        """After `Pane Name:` (its natural neighbour); else before
+        `Status:` (the spawn-flow template order); else after the last
+        `Key: value` header line; else right after the title line."""
+        for i, ln in enumerate(header):
+            if ln.lstrip().lower().startswith("pane name:"):
+                return i + 1
+        for i, ln in enumerate(header):
+            if ln.lstrip().lower().startswith("status:"):
+                return i
+        last_field = -1
+        for i, ln in enumerate(header):
+            stripped = ln.lstrip()
+            if stripped and stripped[0].isalpha() and ":" in stripped:
+                last_field = i
+        return last_field + 1 if last_field >= 0 else min(1, len(header))
+
+    insert_at = _anchor()
+    if not _has_field("Pane ID"):
+        header.insert(insert_at, f"Pane ID: {pane_id}")
+        insert_at += 1
+        changes.append("pane_id")
+    if not _has_field("Started"):
+        header.insert(insert_at, f"Started: {started_at}")
+        changes.append("started")
+    lines[:header_end] = header
+    titles = _h2_titles(lines)  # indices shifted by the header inserts
+
+    # Status: first `status:` line top-to-bottom, exactly how the runtime
+    # reads it (state-schema-contract §7). planned -> active only, and
+    # only the value is rewritten.
+    for i, ln in enumerate(lines):
+        if ln.strip().lower().startswith("status:"):
+            m = _STATUS_PLANNED_RE.match(ln)
+            if m:
+                lines[i] = f"{m.group('lead')}active{m.group('tail')}"
+                changes.append("status")
+            break
+
+    log_start = next(
+        (i for i, t in enumerate(titles) if t == "progress log"), None
+    )
+    bullet = f"- [{started_at}] {DISPATCHED_MARK}、作業開始（pane id={pane_id}）"
+    if log_start is None:
+        if lines and lines[-1] != "":
+            lines.append("")
+        lines.extend(["## Progress Log", bullet])
+        changes.append("progress_log")
+    else:
+        # Section ends at the next `## ` heading or EOF. The bullet goes
+        # after the last non-blank line so the blank separator before the
+        # following section survives.
+        section_end = next(
+            (
+                i
+                for i in range(log_start + 1, len(lines))
+                if titles[i] is not None
+            ),
+            len(lines),
+        )
+        if not _has_dispatch_bullet(lines, log_start + 1, section_end):
+            insert = section_end
+            while insert > log_start + 1 and lines[insert - 1] == "":
+                insert -= 1
+            lines.insert(insert, bullet)
+            changes.append("progress_log")
+
+    if not changes:
+        return text, changes
+    return newline.join(lines) + (newline if trailing_newline else ""), changes
+
+
+#: Read-modify-replace attempts before giving up on a record that keeps
+#: changing underneath us (the secretary also appends to Progress Log).
+_WORKER_MD_ATTEMPTS = 3
+
+
+def _record_dispatch_in_worker_md(
+    workers_dir: Path, task_id: str, pane_id: int, started_at: str
+) -> dict:
+    """Write spawn-flow Step 4 items (b)/(c) into the worker record.
+
+    A side effect of ``verify``, not a gate check. The dispatcher used to
+    do this by hand right after ``spawn_claude_pane`` and, on 2026-09-03,
+    flipped ``Status`` only — leaving five live workers rendered as
+    "pane not yet spawned" on the dashboard (which reads ``Pane ID:`` /
+    ``Started:`` / the last Progress Log bullet from this file). Since the
+    dispatcher cannot produce ``DELEGATE_COMPLETE`` without running
+    ``verify``, doing the writes here makes them unforgettable.
+
+    Idempotent per item: existing ``Pane ID:`` / ``Started:`` headers are
+    kept as they are, the progress bullet is added only when the
+    ``## Progress Log`` section has no bullet carrying ``派遣完了``, and
+    ``Status`` moves ``planned`` -> ``active`` only (value-only rewrite of
+    the line the runtime reads, state-schema-contract §7). Nothing else in
+    the file is touched: line endings and the presence/absence of a
+    trailing newline are preserved, ``## `` inside fenced code is not a
+    heading, and the file is replaced atomically only if its bytes are
+    still what was read (retried a few times; a record that keeps moving
+    is reported as ``status: error`` rather than clobbered). A missing
+    file is reported (``status: missing``), never raised: a bookkeeping
+    side effect must not withhold the gate result.
+    """
+    path = workers_dir / f"worker-{task_id}.md"
+    result: "dict[str, object]" = {"path": str(path), "changes": []}
+    if not path.is_file():
+        result["status"] = "missing"
+        return result
+
+    for _ in range(_WORKER_MD_ATTEMPTS):
+        # Bytes, not read_text(): universal-newline decoding would hide CRLF.
+        before = path.read_bytes()
+        new_text, changes = _rewrite_worker_md(
+            before.decode("utf-8"), pane_id, started_at
+        )
+        if not changes:
+            result["status"] = "unchanged"
+            return result
+        # Lost-update guard: another writer (secretary Progress Log append)
+        # may have landed between the read and now. Re-read and redo the
+        # edit on the fresh content instead of overwriting it.
+        if path.read_bytes() != before:
+            continue
+        _replace_file_atomically(path, new_text.encode("utf-8"))
+        result["status"] = "updated"
+        result["changes"] = changes
+        return result
+
+    result["status"] = "error"
+    result["error"] = (
+        f"record changed concurrently {_WORKER_MD_ATTEMPTS} times; not written"
+    )
+    return result
+
+
 def _delegate_complete_body(
     task_id: str, worker: str, pane_id: int, peer_id: "int | None", evidence: str
 ) -> str:
@@ -547,6 +816,34 @@ def cmd_verify(args) -> int:
     else:
         status = "already_verified"
 
+    # Spawn-flow Step 4 (b)/(c) as a side effect of the gate the dispatcher
+    # cannot skip. Runs on the re-verify path too (idempotent), so a record
+    # the helper wrote late still gets its fields. Never alters the exit
+    # code or the event above: a failed write is reported on stderr and in
+    # the JSON, and the gate result stands.
+    try:
+        worker_record = _record_dispatch_in_worker_md(
+            _workers_dir_for(db_path),
+            task_id,
+            pane_id,
+            spawned_at or _utc_now_iso(),
+        )
+    except Exception as exc:  # noqa: BLE001 - bookkeeping must not fail the gate
+        worker_record = {
+            "path": str(_workers_dir_for(db_path) / f"worker-{task_id}.md"),
+            "status": "error",
+            "error": str(exc),
+            "changes": [],
+        }
+    if worker_record["status"] in ("missing", "error"):
+        detail = worker_record.get("error", "file not found")
+        print(
+            f"spawn_gate: worker record not updated ({detail}): "
+            f"{worker_record['path']} — dispatcher must write Pane ID / "
+            "Started / 派遣完了 by hand (spawn-flow Step 4)",
+            file=sys.stderr,
+        )
+
     print(
         json.dumps(
             {
@@ -554,6 +851,7 @@ def cmd_verify(args) -> int:
                 "task": task_id,
                 "worker": worker,
                 "recorded": payload,
+                "worker_record": worker_record,
                 "checks": checks,
                 "limitations": _ATTESTED_ONLY,
                 "delegate_complete": _delegate_complete_body(

--- a/tools/test_spawn_gate.py
+++ b/tools/test_spawn_gate.py
@@ -23,7 +23,7 @@ import sqlite3
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -32,7 +32,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import spawn_gate  # noqa: E402
 
 WORKER_DIR = "/tmp/org/workers/login-fix"
-#: Seeded spawn time for VerifyTests. Must be in the past relative to the
+#: Seeded spawn time for the `verify` fixture. Must be in the past relative to the
 #: real clock, because `verify` compares the verification it writes (stamped
 #: `now` by SQLite) against the latest `worker_spawned`.
 _PAST = "2000-01-01T00:00:00.000Z"
@@ -90,14 +90,21 @@ def _seed_event(db: Path, kind: str, payload: dict, occurred_at: str) -> None:
         conn.close()
 
 
-def _run(argv: "list[str]") -> "tuple[int, dict]":
+def _run(
+    argv: "list[str]", stderr: "io.StringIO | None" = None
+) -> "tuple[int, dict]":
+    """Run `main`, parse its stdout JSON. stderr is captured into `stderr`
+    when given, otherwise swallowed (the worker-record side effect prints
+    one line there whenever no `.state/workers/` record exists)."""
     buf = io.StringIO()
-    with redirect_stdout(buf):
+    with redirect_stdout(buf), redirect_stderr(stderr or io.StringIO()):
         code = spawn_gate.main(argv)
     return code, json.loads(buf.getvalue())
 
 
-class VerifyTests(unittest.TestCase):
+class _VerifyFixture(unittest.TestCase):
+    """Seeded state.db + `verify` argv shared by the `verify` test classes."""
+
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
         self.db = Path(self._tmp.name) / "state.db"
@@ -129,6 +136,8 @@ class VerifyTests(unittest.TestCase):
             argv += [key, val]
         return argv
 
+
+class VerifyTests(_VerifyFixture):
     def test_happy_path_records_event_and_emits_report(self) -> None:
         code, out = _run(self._argv())
         self.assertEqual(code, spawn_gate.EXIT_OK)
@@ -339,6 +348,385 @@ class VerifyTests(unittest.TestCase):
         finally:
             conn.close()
         self.assertEqual(count, 1)
+
+
+#: What the delegate-plan helper leaves in `.state/workers/` before spawn
+#: (mirrors a real record: no Pane ID / Started, Status planned, and the
+#: runner's "pane not yet spawned" bullet that the dashboard surfaces).
+_PLANNED_MD = (
+    f"# Worker: worker-{TASK}\n"
+    f"Task: {TASK}\n"
+    f"Directory: {WORKER_DIR}\n"
+    f"Pane Name: worker-{TASK}\n"
+    "Status: planned\n"
+    "\n"
+    "## Assignment\n"
+    "Fix the login form.\n"
+    "\n"
+    "## Progress Log\n"
+    "- [planned by dispatcher_runner] pane not yet spawned\n"
+    "\n"
+    "## Notes\n"
+    "Status: keep this literal; it is prose, not the header field.\n"
+)
+
+
+class WorkerRecordSideEffectTests(_VerifyFixture):
+    """spawn-flow Step 4 (b)/(c) are written by `verify`, not by hand.
+
+    Observed 2026-09-03: the dispatcher flipped `Status` only, so the
+    dashboard showed every live worker as "pane not yet spawned". The
+    gate is the one step a dispatch cannot skip, so the record is written
+    there. The exit-code / event contract of `verify` must not move.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.workers = self.db.parent / "workers"
+        self.workers.mkdir()
+        self.md = self.workers / f"worker-{TASK}.md"
+
+    def _lines(self) -> "list[str]":
+        return self.md.read_text(encoding="utf-8").split("\n")
+
+    def test_planned_record_becomes_active_with_pane_and_started(self) -> None:
+        self.md.write_text(_PLANNED_MD, encoding="utf-8")
+        code, out = _run(self._argv())
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(out["status"], "verified")
+        self.assertEqual(out["worker_record"]["status"], "updated")
+        self.assertEqual(
+            out["worker_record"]["changes"],
+            ["pane_id", "started", "status", "progress_log"],
+        )
+
+        lines = self._lines()
+        # Header fields land right after `Pane Name:`; Started comes from
+        # the seeded `worker_spawned.occurred_at`, not the wall clock.
+        i = lines.index(f"Pane Name: worker-{TASK}")
+        self.assertEqual(lines[i + 1], "Pane ID: 5")
+        self.assertEqual(lines[i + 2], f"Started: {_PAST}")
+        self.assertEqual(lines[i + 3], "Status: active")
+        # The bullet is appended inside `## Progress Log`, before `## Notes`.
+        log = lines.index("## Progress Log")
+        notes = lines.index("## Notes")
+        self.assertEqual(
+            lines[log + 1 : notes],
+            [
+                "- [planned by dispatcher_runner] pane not yet spawned",
+                f"- [{_PAST}] 派遣完了、作業開始（pane id=5）",
+                "",
+            ],
+        )
+        # The prose `Status:` under `## Notes` is not the header field.
+        self.assertEqual(
+            lines[notes + 1],
+            "Status: keep this literal; it is prose, not the header field.",
+        )
+        # Nothing else moved.
+        self.assertEqual(lines[0], f"# Worker: worker-{TASK}")
+        self.assertIn("Fix the login form.", lines)
+        self.assertEqual(lines[-1], "")
+
+    def test_second_verify_is_idempotent(self) -> None:
+        self.md.write_text(_PLANNED_MD, encoding="utf-8")
+        _run(self._argv())
+        first = self.md.read_text(encoding="utf-8")
+        code, out = _run(self._argv())
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(out["status"], "already_verified")
+        self.assertEqual(out["worker_record"]["status"], "unchanged")
+        self.assertEqual(out["worker_record"]["changes"], [])
+        self.assertEqual(self.md.read_text(encoding="utf-8"), first)
+        self.assertEqual(first.count("派遣完了"), 1)
+        self.assertEqual(first.count("Pane ID:"), 1)
+
+    def test_existing_fields_are_kept_not_overwritten(self) -> None:
+        text = _PLANNED_MD.replace(
+            "Status: planned\n",
+            "Pane ID: 77\nStarted: 1999-12-31T23:59:59.000Z\nStatus: active\n",
+        ).replace(
+            "- [planned by dispatcher_runner] pane not yet spawned\n",
+            "- [1999-12-31T23:59:59.000Z] 派遣完了、作業開始\n",
+        )
+        self.md.write_text(text, encoding="utf-8")
+        code, out = _run(self._argv())
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(out["worker_record"]["status"], "unchanged")
+        self.assertEqual(self.md.read_text(encoding="utf-8"), text)
+
+    def test_crlf_and_missing_trailing_newline_are_preserved(self) -> None:
+        text = _PLANNED_MD.replace("\n", "\r\n").rstrip("\r\n")
+        self.md.write_bytes(text.encode("utf-8"))
+        code, out = _run(self._argv())
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(out["worker_record"]["status"], "updated")
+        raw = self.md.read_bytes().decode("utf-8")
+        self.assertNotIn("\n", raw.replace("\r\n", ""))  # only CRLF endings
+        self.assertFalse(raw.endswith("\n"))
+        self.assertIn("\r\nPane ID: 5\r\nStarted: ", raw)
+        self.assertIn("派遣完了", raw)
+
+    def test_marker_in_prose_does_not_suppress_the_bullet(self) -> None:
+        """Idempotency is keyed on a bullet inside `## Progress Log`, not
+        on the phrase appearing anywhere in the file."""
+        text = _PLANNED_MD.replace(
+            "Fix the login form.", "Fix the login form. 派遣完了後に着手。"
+        )
+        self.md.write_text(text, encoding="utf-8")
+        _, out = _run(self._argv())
+        self.assertIn("progress_log", out["worker_record"]["changes"])
+        lines = self._lines()
+        log = lines.index("## Progress Log")
+        self.assertIn("派遣完了、作業開始", lines[log + 2])
+
+    def test_lookalike_and_indented_headings(self) -> None:
+        """`## Progress Logger` is not the section; an indented `## ` still
+        ends the header and the section."""
+        text = (
+            f"# Worker: worker-{TASK}\n"
+            "Status: planned\n"
+            "\n"
+            "## Progress Logger\n"
+            "Pane ID: not-a-header\n"
+            "\n"
+            "  ## Progress Log\n"
+            "- [x] first\n"
+            "\n"
+            "  ## Notes\n"
+            "n\n"
+        )
+        self.md.write_text(text, encoding="utf-8")
+        code, _ = _run(self._argv())
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(
+            self._lines(),
+            [
+                f"# Worker: worker-{TASK}",
+                "Pane ID: 5",
+                f"Started: {_PAST}",
+                "Status: active",
+                "",
+                "## Progress Logger",
+                "Pane ID: not-a-header",
+                "",
+                "  ## Progress Log",
+                "- [x] first",
+                f"- [{_PAST}] 派遣完了、作業開始（pane id=5）",
+                "",
+                "  ## Notes",
+                "n",
+                "",
+            ],
+        )
+
+    def test_indented_existing_headers_count_as_present(self) -> None:
+        text = _PLANNED_MD.replace(
+            "Status: planned\n",
+            "  Pane ID: 77\n  Started: 1999-12-31T23:59:59.000Z\nStatus: planned\n",
+        )
+        self.md.write_text(text, encoding="utf-8")
+        _, out = _run(self._argv())
+        self.assertEqual(out["worker_record"]["changes"], ["status", "progress_log"])
+        raw = self.md.read_text(encoding="utf-8")
+        self.assertEqual(raw.count("Pane ID:"), 1)
+        self.assertEqual(raw.count("Started:"), 1)
+
+    def test_file_mode_survives_the_atomic_replace(self) -> None:
+        self.md.write_text(_PLANNED_MD, encoding="utf-8")
+        self.md.chmod(0o664)
+        _run(self._argv())
+        self.assertEqual(self.md.stat().st_mode & 0o777, 0o664)
+
+    def test_fenced_headings_do_not_end_the_section(self) -> None:
+        """A `## ` quoted inside a code fence is not a heading, so the
+        bullet lands after the fence, not inside it."""
+        text = _PLANNED_MD.replace(
+            "- [planned by dispatcher_runner] pane not yet spawned\n",
+            "- [planned by dispatcher_runner] pane not yet spawned\n"
+            "  ```markdown\n"
+            "  ## Notes\n"
+            "  - 派遣完了 (example, not a bullet)\n"
+            "  ```\n",
+        )
+        self.md.write_text(text, encoding="utf-8")
+        _, out = _run(self._argv())
+        self.assertIn("progress_log", out["worker_record"]["changes"])
+        lines = self._lines()
+        fence_close = lines.index("  ```")
+        self.assertIn("派遣完了、作業開始", lines[fence_close + 1])
+        self.assertEqual(lines[fence_close + 2], "")
+        self.assertEqual(lines[fence_close + 3], "## Notes")
+        # And a second run sees that bullet, not the fenced example.
+        _, out = _run(self._argv())
+        self.assertEqual(out["worker_record"]["status"], "unchanged")
+
+    def test_fence_closing_follows_commonmark_lengths(self) -> None:
+        """A ```` fence is not closed by ``` (nor by ```py), so everything
+        up to the real closer stays fenced."""
+        text = _PLANNED_MD.replace(
+            "- [planned by dispatcher_runner] pane not yet spawned\n",
+            "- [planned by dispatcher_runner] pane not yet spawned\n"
+            "````\n"
+            "```\n"
+            "```md\n"
+            "## Notes\n"
+            "- 派遣完了 (still fenced)\n"
+            "````\n",
+        )
+        self.md.write_text(text, encoding="utf-8")
+        _, out = _run(self._argv())
+        self.assertIn("progress_log", out["worker_record"]["changes"])
+        lines = self._lines()
+        closer = len(lines) - 1 - lines[::-1].index("````")
+        self.assertIn("派遣完了、作業開始", lines[closer + 1])
+        self.assertEqual(lines[closer + 3], "## Notes")
+
+    def test_concurrent_append_is_not_lost(self) -> None:
+        """A write that lands between read and replace is re-applied on
+        top of the fresh content instead of being overwritten."""
+        self.md.write_text(_PLANNED_MD, encoding="utf-8")
+        original = spawn_gate._rewrite_worker_md
+        calls = {"n": 0}
+
+        def racing(text, pane_id, started_at):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Secretary appends while we hold the stale copy.
+                with self.md.open("a", encoding="utf-8") as fh:
+                    fh.write("- [x] secretary note\n")
+            return original(text, pane_id, started_at)
+
+        spawn_gate._rewrite_worker_md = racing
+        try:
+            code, out = _run(self._argv())
+        finally:
+            spawn_gate._rewrite_worker_md = original
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(out["worker_record"]["status"], "updated")
+        self.assertEqual(calls["n"], 2)
+        raw = self.md.read_text(encoding="utf-8")
+        self.assertIn("- [x] secretary note", raw)
+        self.assertEqual(raw.count("派遣完了"), 1)
+
+    def test_record_that_keeps_moving_is_reported_not_clobbered(self) -> None:
+        self.md.write_text(_PLANNED_MD, encoding="utf-8")
+        original = spawn_gate._rewrite_worker_md
+        calls = {"n": 0}
+
+        def always_racing(text, pane_id, started_at):
+            calls["n"] += 1
+            with self.md.open("a", encoding="utf-8") as fh:
+                fh.write(f"- [x] note {calls['n']}\n")
+            return original(text, pane_id, started_at)
+
+        spawn_gate._rewrite_worker_md = always_racing
+        try:
+            err = io.StringIO()
+            code, out = _run(self._argv(), stderr=err)
+        finally:
+            spawn_gate._rewrite_worker_md = original
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(out["worker_record"]["status"], "error")
+        self.assertIn("concurrently", err.getvalue())
+        raw = self.md.read_text(encoding="utf-8")
+        self.assertNotIn("派遣完了", raw)
+        self.assertEqual(raw.count("- [x] note"), spawn_gate._WORKER_MD_ATTEMPTS)
+
+    def test_status_flip_rewrites_only_the_value(self) -> None:
+        text = _PLANNED_MD.replace("Status: planned\n", "  STATUS:  planned  \n")
+        self.md.write_text(text, encoding="utf-8")
+        _run(self._argv())
+        self.assertIn("  STATUS:  active  ", self._lines())
+
+    def test_failed_write_keeps_the_original_record(self) -> None:
+        """Atomic replace: a write that dies mid-way must not truncate."""
+        self.md.write_text(_PLANNED_MD, encoding="utf-8")
+        original = spawn_gate._replace_file_atomically
+
+        def boom(path, data):
+            raise OSError("disk full")
+
+        spawn_gate._replace_file_atomically = boom
+        try:
+            err = io.StringIO()
+            code, out = _run(self._argv(), stderr=err)
+        finally:
+            spawn_gate._replace_file_atomically = original
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(out["worker_record"]["status"], "error")
+        self.assertEqual(self.md.read_text(encoding="utf-8"), _PLANNED_MD)
+        # No temp file left behind beside the record.
+        self.assertEqual(sorted(p.name for p in self.workers.iterdir()), [self.md.name])
+
+    def test_missing_record_does_not_fail_the_gate(self) -> None:
+        err = io.StringIO()
+        code, out = _run(self._argv(), stderr=err)
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(out["status"], "verified")
+        self.assertIn("DELEGATE_COMPLETE", out["delegate_complete"])
+        self.assertEqual(out["worker_record"]["status"], "missing")
+        stderr_lines = [ln for ln in err.getvalue().splitlines() if ln]
+        self.assertEqual(len(stderr_lines), 1)
+        self.assertIn(str(self.md), stderr_lines[0])
+        # The event was still recorded: the side effect is downstream of it.
+        conn = sqlite3.connect(self.db)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM events WHERE kind = ?",
+                (spawn_gate.VERIFIED_EVENT,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        self.assertEqual(count, 1)
+
+    def test_write_error_does_not_fail_the_gate(self) -> None:
+        self.md.write_text(_PLANNED_MD, encoding="utf-8")
+        original = spawn_gate._record_dispatch_in_worker_md
+
+        def boom(*_a, **_k):
+            raise OSError("disk full")
+
+        spawn_gate._record_dispatch_in_worker_md = boom
+        try:
+            err = io.StringIO()
+            code, out = _run(self._argv(), stderr=err)
+        finally:
+            spawn_gate._record_dispatch_in_worker_md = original
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(out["worker_record"]["status"], "error")
+        self.assertIn("disk full", err.getvalue())
+
+    def test_gate_failure_leaves_the_record_untouched(self) -> None:
+        """No event, no side effect: the md must not claim a dispatch that
+        the gate refused to certify."""
+        self.md.write_text(_PLANNED_MD, encoding="utf-8")
+        code, out = _run(self._argv(**{"--peer-cwd": "/tmp/org/workers/other"}))
+        self.assertEqual(code, spawn_gate.EXIT_FIRE)
+        self.assertNotIn("worker_record", out)
+        self.assertEqual(self.md.read_text(encoding="utf-8"), _PLANNED_MD)
+
+    def test_record_without_progress_log_gets_one(self) -> None:
+        self.md.write_text(
+            f"# Worker: worker-{TASK}\nTask: {TASK}\nStatus: planned\n",
+            encoding="utf-8",
+        )
+        code, _ = _run(self._argv())
+        self.assertEqual(code, spawn_gate.EXIT_OK)
+        self.assertEqual(
+            self._lines(),
+            [
+                f"# Worker: worker-{TASK}",
+                f"Task: {TASK}",
+                "Pane ID: 5",
+                f"Started: {_PAST}",
+                "Status: active",
+                "",
+                "## Progress Log",
+                f"- [{_PAST}] 派遣完了、作業開始（pane id=5）",
+                "",
+            ],
+        )
 
 
 class AuditTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

spawn-flow Step 4 項 1（worker md の `Status` flip / `Pane ID:` / `Started:` / 「派遣完了」Progress Log 行）は dispatcher の手順として書かれていたが、2026-09-02 に半実行で落ちた。手順で守られなかったものを機構化する: `tools/spawn_gate.py verify` が `worker_spawn_verified` を記帳した直後（`already_verified` 経路でも）に `.state/workers/worker-<task_id>.md` へ副作用として書く。

- `tools/spawn_gate.py`: `_record_dispatch_in_worker_md` を追加。`Pane ID:` / `Started:`（`worker_spawned.occurred_at` 由来）を `Pane Name:` 直後に挿入、`Status: planned` → `active` は値のみ置換、`## Progress Log` 末尾に `- [<ts>] 派遣完了、作業開始（pane id=N）` を追記。冪等・原子的書込（mkstemp + rename、mode 保持）・CRLF / 末尾改行保全・fenced code 内 `##` を見出しと誤認しない。stdout JSON に `worker_record: {path, status: updated|unchanged|missing|error, changes[]}` を追加。event payload / exit code は不変。md 不在・書込失敗は stderr 1 行 + `worker_record.status` で、gate 自体は成功のまま
- `tools/test_spawn_gate.py`: `WorkerRecordSideEffectTests` 15 件（planned→active、2 回目冪等、md 不在、gate 失敗時 md 無傷、CRLF 保全、fence 規則、並行 append の lost-update 防止、書込失敗時原本無傷、mode 保持 ほか）
- `.dispatcher/references/spawn-flow.md` Step 4 項 1: (b)(c) は verify が書く旨の注記。dispatcher は `worker_record.status` を確認し、`missing` / `error` のときだけ手で補う

受容した限界: CRLF/LF 混在ファイルは CRLF に正規化。compare-then-replace の窓はゼロではない（これらの md 用のプロセス間ロックは本 repo に無い）。

## Test plan

- `python3 -m unittest tools.test_spawn_gate tests.test_worker_seed_status_contract` → 52 tests OK
- `git diff --check` clean
- Codex review 5 rounds → 0 blocker / 0 major / 0 minor

Refs #990（同日の「手順は守られない前提で機構化する」系列）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014a76tE5ck4cbjg2Ar7QSZb
