### PR TITLE
gen_skill_prose は --transport 未指定時に ORG_TRANSPORT を見ず DEFAULT_TRANSPORT で render する

### DIFF
--- a/notes/broker-skill-generator-design.md
+++ b/notes/broker-skill-generator-design.md
@@ -88,7 +88,9 @@ SoT を作るのではなく既存 seam を延伸する（§論点 6）。
 > 得られる」= rollback byte 安定性**を意味する（§0.3 の恒等核と同じ）。
 >
 > **rollback の運用（§3.3）**: 既定 broker からの切戻しは `ORG_TRANSPORT=renga` + **再生成**（org-setup が
-> generator を renga で再走）で、frontmatter・settings・本文すべてが byte 安定な renga 面に戻る。これは settings.
+> generator を **`--transport renga` 明示**で再走。generator は `--transport` 未指定時に `ORG_TRANSPORT` env を
+> 見ず `DEFAULT_TRANSPORT` 面で render するため、env flip だけでは render 面は変わらない — 2026-09-04 に worker
+> pane の継承 env で committed 面が renga に引きずられ偽 diff を出した事故を受けた固定）で、frontmatter・settings・本文すべてが byte 安定な renga 面に戻る。これは settings.
 > local.json が既に取っている per-transport 再生成モデルと**完全に同型**で、新たな運用負担を足さない（promotion-plan
 > §5.6 の「コード変更なし」は満たす — 再生成はコード変更ではなく機械的な regen ステップ）。
 >
@@ -289,7 +291,7 @@ literal 面が renga→broker に替わるだけ。よって:
   renga 運用時も読解可能（renga ユーザーは併記の機械置換指示で読み替え）。
 - **frontmatter `allowed-tools` は本文と同じ broker 面で render**（renga ツールは broker 面に出さない、§0.4）。
   これにより broker 既定でツール認可が本文と一致し、renga 面の auth 迂回も生じない。
-- **rollback は再生成**: `ORG_TRANSPORT=renga` に倒すと org-setup が generator を renga で再走し、frontmatter・
+- **rollback は再生成**: `ORG_TRANSPORT=renga` に倒すと org-setup が generator を `--transport renga` 明示で再走し、frontmatter・
   settings・本文すべてが byte 安定な renga 面に戻る（settings.local.json と同型の per-transport 再生成。renga 恒等
   基底で byte 安定）。git-committed 面は broker 1 枚、rollback 時の renga 面は再生成で得る（transient）。
 
@@ -299,7 +301,7 @@ literal 面が renga→broker に替わるだけ。よって:
 > できない）。選べるのは 2 モデル:
 >
 > - **モデル 1（per-transport + 再生成。本設計の推奨）**: frontmatter も settings.local.json も broker 単一面。
->   切戻しは `ORG_TRANSPORT=renga` + **org-setup 再生成**。auth クリーン（迂回なし）。**この再生成は settings.
+>   切戻しは `ORG_TRANSPORT=renga` + **org-setup 再生成**（generator へは `--transport renga` を明示して渡す）。auth クリーン（迂回なし）。**この再生成は settings.
 >   local.json が既に取っている per-transport 生成と同型**で新規負担を足さない。promotion-plan §5.6 の「コード変更
 >   なし」は満たす（再生成 ≠ コード変更）が、§5.6 の「**再生成なし**」の語感は「env flip + org-setup 再生成」へ
 >   読み替える必要がある。

--- a/tools/gen_skill_prose.py
+++ b/tools/gen_skill_prose.py
@@ -88,7 +88,16 @@ per-skill 認可の過剰拡大)。
   (``surface("renga").tools_for_role(role)``) で **明示展開** -> per-tool リネーム
   + descriptor 検証にかけ、broker 側は「source 集合の像」の明示リストとして出力。
 - renga 面 (TEMPLATE_TRANSPORT) は **恒等** (source をそのまま返す)。
-  ``ORG_TRANSPORT=renga`` 再生成が byte 等価になる rollback byte 安定の根拠 (§3.2)。
+  ``--transport renga`` 再生成が byte 等価になる rollback byte 安定の根拠 (§3.2)。
+
+## render transport の解決順 (generator 固有)
+
+``--transport`` 明示 > ``DEFAULT_TRANSPORT``。**``ORG_TRANSPORT`` env は見ない**
+(``transport.resolve`` の explicit > env > 既定 とは意図的に異なる)。committed 生成物は
+常に ``DEFAULT_TRANSPORT`` 面 (§3.2) で、pane が継承する運用 env に render 面が
+引きずられると無関係な生成 SKILL.md に偽 diff が出る (2026-09-04 実測)。rollback
+再生成 (設計 §3.3) は ``--transport renga`` を明示して呼ぶ。env が設定されていて
+無視したときは stderr に 1 行明示する。
 
 ``permissions.md`` (org-setup) のみ機構が異なり ``rewrite_allow_entries``
 (role-tier 置換) を使う (``identity-anchor`` モード, §4.2(2))。
@@ -835,7 +844,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--transport",
         choices=list(transport.TRANSPORTS),
         default=None,
-        help="render transport flag (default: resolve via ORG_TRANSPORT / DEFAULT_TRANSPORT).",
+        help=(
+            "render transport flag (default: DEFAULT_TRANSPORT; ORG_TRANSPORT in the "
+            "environment is NOT consulted -- committed outputs are always on the "
+            "DEFAULT_TRANSPORT face)."
+        ),
     )
     p.add_argument(
         "--fragments-dir",
@@ -856,6 +869,38 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _resolve_render_transport(
+    explicit: Optional[str],
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    err=None,
+) -> str:
+    """render transport を決める (generator 専用の解決順)。
+
+    ``transport.resolve`` の解決順 (explicit > ``ORG_TRANSPORT`` env > 既定) と
+    **意図的に異なり**、``ORG_TRANSPORT`` env は見ない: explicit > 既定
+    ``DEFAULT_TRANSPORT``。committed な生成物は常に ``DEFAULT_TRANSPORT`` 面
+    (設計 §3.2) なので、ペインが継承する運用 env (worker pane の
+    ``ORG_TRANSPORT=renga`` 等) に render 面が引きずられると、無関係な生成
+    SKILL.md に renga 面の偽 diff が大量に出る。env を無視するときは silent に
+    せず stderr へ 1 行で明示する (``--transport`` 明示時は出さない)。
+    """
+    if err is None:
+        err = sys.stderr
+    if explicit is not None:
+        return transport.resolve(explicit, env=env)
+    flag = transport.DEFAULT_TRANSPORT
+    environ = os.environ if env is None else env
+    env_value = environ.get("ORG_TRANSPORT")
+    if env_value is not None:
+        print(
+            f"gen_skill_prose: ORG_TRANSPORT={env_value!r} in environment ignored "
+            f"(--transport not given); rendering transport {flag!r} (DEFAULT_TRANSPORT).",
+            file=err,
+        )
+    return flag
+
+
 def main(argv: Optional[list] = None) -> int:
     args = _build_parser().parse_args(argv)
 
@@ -863,7 +908,7 @@ def main(argv: Optional[list] = None) -> int:
         print(json.dumps(load_manifest_schema(), indent=2, ensure_ascii=False))
         return 0
 
-    flag = transport.resolve(args.transport)
+    flag = _resolve_render_transport(args.transport)
     fragments_dir = args.fragments_dir or (Path(__file__).resolve().parent / "skill_src" / "fragments")
 
     if not args.manifest:

--- a/tools/test_gen_skill_prose.py
+++ b/tools/test_gen_skill_prose.py
@@ -707,5 +707,112 @@ class RootTokenCliWiringTest(unittest.TestCase):
             self.assertEqual(rc_check, 0)
 
 
+class RenderTransportResolutionTest(unittest.TestCase):
+    """--transport 未指定時は ORG_TRANSPORT env を見ず DEFAULT_TRANSPORT で render する。
+
+    worker pane が継承する ``ORG_TRANSPORT=renga`` の下で flag なし実行すると、
+    manifest 全体が renga 面で render され無関係な生成 SKILL.md に偽 diff が出た
+    (2026-09-04 実測)。committed 生成物は常に DEFAULT_TRANSPORT 面 (設計 §3.2)
+    なので、generator の解決順は explicit > 既定 (env は無視 + stderr 明示) に固定する。
+    """
+
+    _SRC = (
+        "---\nname: t\nallowed-tools:\n  - Read\n---\n\n"
+        "# t\n\n本文 {{FQ}}send_message\n"
+    )
+
+    def _write_fixture(self, base: Path) -> tuple[Path, Path]:
+        (base / "SKILL.md.in").write_text(self._SRC, encoding="utf-8")
+        manifest = base / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "entries": [
+                        {
+                            "source": "SKILL.md.in",
+                            "output": "SKILL.md",
+                            "mode": "template",
+                            "allowlist": "none",
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        return manifest, base / "SKILL.md"
+
+    def _run_cli(self, *args, env_transport):
+        import os
+
+        env = dict(os.environ)
+        env.pop("ORG_TRANSPORT", None)
+        if env_transport is not None:
+            env["ORG_TRANSPORT"] = env_transport
+        return subprocess.run(
+            [sys.executable, str(_CLI), *args],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_env_renga_without_flag_renders_default_transport(self):
+        import tempfile
+
+        self.assertEqual(_DEFAULT, "broker", "test assumes the code default is broker")
+        with tempfile.TemporaryDirectory() as d:
+            manifest, out = self._write_fixture(Path(d))
+            proc = self._run_cli("--manifest", str(manifest), env_transport="renga")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            rendered = out.read_text(encoding="utf-8")
+            self.assertIn("mcp__org-broker__send_message", rendered)
+            self.assertNotIn("mcp__renga-peers__", rendered)
+            # (c) env を無視したことが stderr に 1 行で見える (silent ignore にしない)。
+            note_lines = [ln for ln in proc.stderr.splitlines() if "ORG_TRANSPORT" in ln]
+            self.assertEqual(len(note_lines), 1, proc.stderr)
+            self.assertIn("'renga'", note_lines[0])
+            self.assertIn("ignored", note_lines[0])
+            self.assertIn(f"rendering transport '{_DEFAULT}'", note_lines[0])
+
+    def test_explicit_transport_renga_renders_renga(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            manifest, out = self._write_fixture(Path(d))
+            # env が broker を指していても explicit --transport renga が勝つ。
+            proc = self._run_cli(
+                "--manifest", str(manifest), "--transport", "renga", env_transport="broker"
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            rendered = out.read_text(encoding="utf-8")
+            self.assertIn("mcp__renga-peers__send_message", rendered)
+            self.assertNotIn("mcp__org-broker__", rendered)
+            # explicit 指定時は env を無視した旨の note を出さない。
+            self.assertNotIn("ORG_TRANSPORT", proc.stderr)
+
+    def test_no_env_no_flag_is_silent(self):
+        import io
+
+        err = io.StringIO()
+        flag = g._resolve_render_transport(None, env={}, err=err)
+        self.assertEqual(flag, _DEFAULT)
+        self.assertEqual(err.getvalue(), "")
+
+    def test_helper_ignores_env_and_notes_it(self):
+        import io
+
+        err = io.StringIO()
+        flag = g._resolve_render_transport(None, env={"ORG_TRANSPORT": "renga"}, err=err)
+        self.assertEqual(flag, _DEFAULT)
+        self.assertEqual(err.getvalue().count("\n"), 1)
+        self.assertIn("ORG_TRANSPORT='renga'", err.getvalue())
+        # explicit は env より優先し、note も出さない。
+        err = io.StringIO()
+        self.assertEqual(
+            g._resolve_render_transport("renga", env={"ORG_TRANSPORT": "broker"}, err=err), "renga"
+        )
+        self.assertEqual(err.getvalue(), "")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 何を直したか

`tools/gen_skill_prose.py` は `--transport` 未指定時に `transport.resolve()` 経由で `ORG_TRANSPORT` を継承していた。worker ペインは `ORG_TRANSPORT=renga` を継承しているため、素の `python3 tools/gen_skill_prose.py` を叩くと manifest 全件が renga 面で render され、無関係な SKILL.md 16 本に差分が出た（2026-09-04、relay-scan-cycle-955 で実発生。キュレーター提案・人間承認済み）。

- `--transport` 未指定時は `ORG_TRANSPORT` を見ず `DEFAULT_TRANSPORT`（broker）で render する。明示 `--transport` は従来どおり効く
- `ORG_TRANSPORT` が環境に在るのに `--transport` が無い場合は stderr に 1 行注記（`... ignored (--transport not given); rendering transport 'broker' (DEFAULT_TRANSPORT).`）を出し、無視を可視化する
- `notes/broker-skill-generator-design.md` §3.3 の切り戻し記述を「`--transport renga` を明示して再生成」に揃えた（環境変数経由で再生成する呼び出し元は実在しない。grep で確認）

## 検証

- `python3 -m pytest tools/test_gen_skill_prose.py -q` → 66 passed（`RenderTransportResolutionTest` 4 本追加: env renga + flag なし → broker render + 注記 1 行 / 明示 renga → renga render・注記なし / helper 単体 2 本）
- `python -m unittest discover -s tools -p 'test_*.py'`（CI の drift gate 相当）→ 1228 tests OK
- `ORG_TRANSPORT=renga` の shell で `--check` → exit 0、生成物に差分なし
- Codex `exec review` 2 round（r1: 設計ノートの切り戻し記述との矛盾 → ノート側を修正 / r2: clean）

Refs: knowledge/raw/2026-09-04-gen-skill-prose-transport-flag.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvaCvo3WhWgxMmCiUKPaqL
