### PR TITLE
worker brief: workflow 内の Bash は cd + 相対パスを使わず絶対パスで書く規約を追加

### DIFF
--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -36,6 +36,20 @@ org-delegate の Step 1.5 でワーカー専用ディレクトリ（`{workers_di
 - Python 実行時は `py -3` または `python` を使用すること（Windows では `python` がストアアプリにリダイレクトされる場合があり、`py -3` も py launcher が別の Python 環境を指す場合がある。起動直後に `--version` で意図したバージョンか確認し、動作する方を使うこと）
 - 日本語を含むファイルを扱う場合は `encoding="utf-8"` を明示すること
 
+### Bash コマンドのパス指定（絶対パス必須。ultracode の `agent()` プロンプト内も同じ）
+- grep / find / sed / テスト実行などの対象は、**常に `{worker_dir}/...` の絶対パスで書く**。`cd <dir>; <相対パスのコマンド>` の形と、ワークツリー root での `grep -r ... .` は使わない
+- ultracode（Workflow tool）で書く**各 `agent()` プロンプト内の Bash 指示にも同じ規約を適用する**（subagent が発行するコマンドは worker 本体の permissions で判定される）
+- 理由: Claude Code の auto-mode 分類器は `cd` 後の相対パスを静的に解決できない。worker の permissions には `Read(.env)` 等の deny 規則（[`tools/org_extension_schema.json`](../../../../tools/org_extension_schema.json) の `layer2Fallback`）が入っているため、対象を解決できない検索は「deny 対象を含むかもしれない」として毎回人間承認プロンプトに落ちる。2026-09-04 の continuo-110-lease-renewal では workflow subagent がこの形の grep を繰り返し、1 タスクで 6 回の手動承認が必要になった。対処は deny 規則の緩和ではなく書き方の統一である
+
+```bash
+# NG: cd 後の相対パス / root での再帰 grep（分類器が対象を判定できず承認待ちになる）
+cd {worker_dir}; grep -n "renewLease" test/lap/root.test.ts
+grep -rln "lease" . --include=*.json
+# OK: 絶対パスで対象を明示する
+grep -n "renewLease" {worker_dir}/test/lap/root.test.ts
+grep -rln "lease" {worker_dir}/test --include=*.json
+```
+
 ## プロジェクト情報
 - プロジェクト名: {project_name}
 - 説明: {project_description}

--- a/.dispatcher/references/spawn-flow.md
+++ b/.dispatcher/references/spawn-flow.md
@@ -295,7 +295,7 @@ worker brief に **ultracode 使用許可**があるタスクでは、kickoff �
 2. **send_keys は 2 段で打つ**（text と Enter を別呼び出しに分ける。同時送は draft 残りになりやすい — 既存の承認ハンドシェイク規律と同型）。`ultracode` は **語境界付きの単独トークン**として置く（行頭に単独で置くのを推奨。`ultracode-arming-fix` のような **slug 内 substring では武装しなかった**＝実走確認済。harness の検出方式の内部仕様には依存せず「語境界付き単独トークンなら武装／slug 内 substring なら非武装」という実走事実で運用する）。`send_keys` は **1 行**（埋め込み改行を入れない。生 `\n` は Claude Code 入力欄で途中 submit になる）:
    ```
    send_keys(target="worker-{task_id}",
-     text="ultracode で本タスクに着手してください。詳細は worker brief の通り。まず pwd で作業ディレクトリを確認。",
+     text="ultracode で本タスクに着手してください。詳細は worker brief の通り。まず pwd で作業ディレクトリを確認。workflow の agent() 内の grep/find 等は cd せず絶対パスで。",
      enter=false)
    # inspect_pane で text が入力欄に乗ったことを確認後、別呼び出しで Enter:
    send_keys(target="worker-{task_id}", enter=true)
@@ -308,6 +308,8 @@ worker brief に **ultracode 使用許可**があるタスクでは、kickoff �
 
 5. **強い権限の事前許可文言を workflow の agent プロンプトに書かせない（重要）**: ultracode を許可しても、`dangerouslyDisableSandbox` / `--dangerously-skip-permissions` 等の**強い権限を事前に許可する文言**を workflow の `agent()` プロンプト本文に書き込ませない（kickoff / brief でもそう促す）。安全分類器が該当 agent 呼び出しを **silent block** し、workflow が原因不明のまま停滞する事故になる。どうしても強い権限が要る段がある場合は、その agent の**成否を明示確認**（戻り値 / 失敗検知でブロックを検出）し、**block 時のリカバリ手段**（当該段を通常権限で再実行 / worker 本体で手動実行等）を workflow に組み込むよう促す。これは worker brief（[`.claude/skills/org-delegate/SKILL.md`](../../.claude/skills/org-delegate/SKILL.md) の「重量レーンの brief 強化（ultracode）」）と**同じ意味の制約**であり、両所に置くことで kickoff 導線から危険例が再発しないようにする。
    - **既存の args[] 規約とは別レイヤ**: 3-2 / 上記 `[invalid-params]` の「`spawn_claude_pane` の `args[]` に `--permission-mode` / `--dangerously-load-development-channels` 等の flag を入れない」は **pane 起動 CLI 引数**の話。本項は **worker が書く workflow script の `agent()` プロンプト本文**に強権限の事前許可文言を書かない話で、対象レイヤが異なる（混同しない）。
+
+6. **workflow の `agent()` プロンプト内の Bash は絶対パスで書かせる**: `cd <dir>; <相対パス>` や worktree root での `grep -r ... .` は auto-mode 分類器が対象を静的に解決できず、worker の `Read(.env)` deny 規則と組み合わさって毎回人間承認プロンプトに落ちる（2026-09-04 continuo-110-lease-renewal で 1 タスク 6 回の手動承認）。規約本体は worker brief の「Bash コマンドのパス指定（絶対パス必須）」節（[`.claude/skills/org-delegate/references/worker-claude-template.md`](../../.claude/skills/org-delegate/references/worker-claude-template.md)、実体は `tools/templates/worker_brief_*.md`）にあり、kickoff の send_keys 行でも「grep 等は絶対パスで」と一言添えて思い出させる。
 
 > **検証状況メモ**: 「send_keys の単独 `ultracode` トークンで武装」「armed turn の応答全体（多数 tool 呼び出し）にわたり武装継続」は本タスクで broker 実走確認済。手順 1 の「send_message をリファレンス配信し worker が send_keys turn で着手する」待ち合わせは、上記実走事実から導いた by-design の推奨手順（race を構造的に避ける）。最もシンプルな保険は **ultracode タスクで actionable な send_message kickoff を送らず、send_keys を唯一の着手トリガにする**こと（worker brief = 既定 `CLAUDE.md` / self-edit は `CLAUDE.local.md` が brief 全文を持つため成立する）。
 

--- a/tests/fixtures/transport_seam/worker_brief_normal_full.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_normal_full.golden.md
@@ -20,6 +20,20 @@
 - 日本語を含むファイルを扱う場合は `encoding="utf-8"` を明示すること
 - CLI / 標準出力を持つツールを実装する場合、CLI へ出力される文字列（argparse の `help=` / `print()` など）には ASCII の `-` を使い、em-dash（`—` U+2014）等 cp932 で encode できない文字を含めないこと。含めると cp932 コンソールでの `--help` 実行時に `UnicodeEncodeError` でクラッシュする（pytest は `redirect_stdout` で UTF-8 キャプチャするため検出できず、実端末でのみ落ちる）。実装後は `--help` を実端末で 1 回スモークすること
 
+### Bash コマンドのパス指定（絶対パス必須。ultracode の `agent()` プロンプト内も同じ）
+- grep / find / sed / テスト実行などの対象は、**常に `/tmp/workers/demo-task/...` の絶対パスで書く**。`cd <dir>; <相対パスのコマンド>` の形と、ワークツリー root での `grep -r ... .` は使わない
+- ultracode（Workflow tool）で書く**各 `agent()` プロンプト内の Bash 指示にも同じ規約を適用する**（subagent が発行するコマンドは worker 本体の permissions で判定される）
+- 理由: Claude Code の auto-mode 分類器は `cd` 後の相対パスを静的に解決できない。worker の permissions には `Read(.env)` 等の deny 規則（[`tools/org_extension_schema.json`](/home/user/work/claude-org/tools/org_extension_schema.json) の `layer2Fallback`）が入っているため、対象を解決できない検索は「deny 対象を含むかもしれない」として毎回人間承認プロンプトに落ちる。2026-09-04 の continuo-110-lease-renewal では workflow subagent がこの形の grep を繰り返し、1 タスクで 6 回の手動承認が必要になった。対処は deny 規則の緩和ではなく書き方の統一である
+
+```bash
+# NG: cd 後の相対パス / root での再帰 grep（分類器が対象を判定できず承認待ちになる）
+cd /tmp/workers/demo-task; grep -n "renewLease" test/lap/root.test.ts
+grep -rln "lease" . --include=*.json
+# OK: 絶対パスで対象を明示する
+grep -n "renewLease" /tmp/workers/demo-task/test/lap/root.test.ts
+grep -rln "lease" /tmp/workers/demo-task/test --include=*.json
+```
+
 ## プロジェクト情報
 - プロジェクト名: claude-org-ja
 - 説明: テスト用説明

--- a/tests/fixtures/transport_seam/worker_brief_normal_minimal.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_normal_minimal.golden.md
@@ -20,6 +20,20 @@
 - 日本語を含むファイルを扱う場合は `encoding="utf-8"` を明示すること
 - CLI / 標準出力を持つツールを実装する場合、CLI へ出力される文字列（argparse の `help=` / `print()` など）には ASCII の `-` を使い、em-dash（`—` U+2014）等 cp932 で encode できない文字を含めないこと。含めると cp932 コンソールでの `--help` 実行時に `UnicodeEncodeError` でクラッシュする（pytest は `redirect_stdout` で UTF-8 キャプチャするため検出できず、実端末でのみ落ちる）。実装後は `--help` を実端末で 1 回スモークすること
 
+### Bash コマンドのパス指定（絶対パス必須。ultracode の `agent()` プロンプト内も同じ）
+- grep / find / sed / テスト実行などの対象は、**常に `/tmp/workers/demo-task/...` の絶対パスで書く**。`cd <dir>; <相対パスのコマンド>` の形と、ワークツリー root での `grep -r ... .` は使わない
+- ultracode（Workflow tool）で書く**各 `agent()` プロンプト内の Bash 指示にも同じ規約を適用する**（subagent が発行するコマンドは worker 本体の permissions で判定される）
+- 理由: Claude Code の auto-mode 分類器は `cd` 後の相対パスを静的に解決できない。worker の permissions には `Read(.env)` 等の deny 規則（[`tools/org_extension_schema.json`](/home/user/work/claude-org/tools/org_extension_schema.json) の `layer2Fallback`）が入っているため、対象を解決できない検索は「deny 対象を含むかもしれない」として毎回人間承認プロンプトに落ちる。2026-09-04 の continuo-110-lease-renewal では workflow subagent がこの形の grep を繰り返し、1 タスクで 6 回の手動承認が必要になった。対処は deny 規則の緩和ではなく書き方の統一である
+
+```bash
+# NG: cd 後の相対パス / root での再帰 grep（分類器が対象を判定できず承認待ちになる）
+cd /tmp/workers/demo-task; grep -n "renewLease" test/lap/root.test.ts
+grep -rln "lease" . --include=*.json
+# OK: 絶対パスで対象を明示する
+grep -n "renewLease" /tmp/workers/demo-task/test/lap/root.test.ts
+grep -rln "lease" /tmp/workers/demo-task/test --include=*.json
+```
+
 ## プロジェクト情報
 - プロジェクト名: claude-org-ja
 - 説明: テスト用説明

--- a/tests/fixtures/transport_seam/worker_brief_self_edit_full.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_self_edit_full.golden.md
@@ -19,6 +19,11 @@
 - 日本語ファイル: `encoding="utf-8"` 明示
 - CLI 出力文字列（argparse `help=` / `print()`）は ASCII の `-` を使う（em-dash 等 cp932 非対応文字は cp932 コンソールでの `--help` を `UnicodeEncodeError` でクラッシュさせる。pytest の `redirect_stdout` では検出できず実端末でのみ落ちる）。実装後 `--help` を実端末で 1 回スモーク
 
+### Bash のパス指定（絶対パス必須。ultracode の `agent()` プロンプト内も同じ）
+- grep / find / sed / テスト対象は**常に `/tmp/workers/demo-task/...` の絶対パス**。`cd <dir>; <相対パス>` と root での `grep -r ... .` は使わない。ultracode の各 `agent()` プロンプト内の Bash 指示にも同じ規約を適用（subagent のコマンドは worker 本体の permissions で判定される）
+- 理由: auto-mode 分類器は `cd` 後の相対パスを解決できず、`Read(.env)` 等の deny 規則（`tools/org_extension_schema.json` の `layer2Fallback`）と組み合わさって毎回人間承認に落ちる（2026-09-04 continuo-110-lease-renewal で 1 タスク 6 回）。deny 規則は緩めず書き方で回避する
+- NG: `cd /tmp/workers/demo-task; grep -n "renewLease" test/lap/root.test.ts` / `grep -rln "lease" . --include=*.json` → OK: `grep -n "renewLease" /tmp/workers/demo-task/test/lap/root.test.ts` / `grep -rln "lease" /tmp/workers/demo-task/test --include=*.json`
+
 ## プロジェクト
 - claude-org-ja: テスト用説明
 

--- a/tests/fixtures/transport_seam/worker_brief_self_edit_minimal.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_self_edit_minimal.golden.md
@@ -19,6 +19,11 @@
 - 日本語ファイル: `encoding="utf-8"` 明示
 - CLI 出力文字列（argparse `help=` / `print()`）は ASCII の `-` を使う（em-dash 等 cp932 非対応文字は cp932 コンソールでの `--help` を `UnicodeEncodeError` でクラッシュさせる。pytest の `redirect_stdout` では検出できず実端末でのみ落ちる）。実装後 `--help` を実端末で 1 回スモーク
 
+### Bash のパス指定（絶対パス必須。ultracode の `agent()` プロンプト内も同じ）
+- grep / find / sed / テスト対象は**常に `/tmp/workers/demo-task/...` の絶対パス**。`cd <dir>; <相対パス>` と root での `grep -r ... .` は使わない。ultracode の各 `agent()` プロンプト内の Bash 指示にも同じ規約を適用（subagent のコマンドは worker 本体の permissions で判定される）
+- 理由: auto-mode 分類器は `cd` 後の相対パスを解決できず、`Read(.env)` 等の deny 規則（`tools/org_extension_schema.json` の `layer2Fallback`）と組み合わさって毎回人間承認に落ちる（2026-09-04 continuo-110-lease-renewal で 1 タスク 6 回）。deny 規則は緩めず書き方で回避する
+- NG: `cd /tmp/workers/demo-task; grep -n "renewLease" test/lap/root.test.ts` / `grep -rln "lease" . --include=*.json` → OK: `grep -n "renewLease" /tmp/workers/demo-task/test/lap/root.test.ts` / `grep -rln "lease" /tmp/workers/demo-task/test --include=*.json`
+
 ## プロジェクト
 - claude-org-ja: テスト用説明
 

--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -20,6 +20,20 @@
 - 日本語を含むファイルを扱う場合は `encoding="utf-8"` を明示すること
 - CLI / 標準出力を持つツールを実装する場合、CLI へ出力される文字列（argparse の `help=` / `print()` など）には ASCII の `-` を使い、em-dash（`—` U+2014）等 cp932 で encode できない文字を含めないこと。含めると cp932 コンソールでの `--help` 実行時に `UnicodeEncodeError` でクラッシュする（pytest は `redirect_stdout` で UTF-8 キャプチャするため検出できず、実端末でのみ落ちる）。実装後は `--help` を実端末で 1 回スモークすること
 
+### Bash コマンドのパス指定（絶対パス必須。ultracode の `agent()` プロンプト内も同じ）
+- grep / find / sed / テスト実行などの対象は、**常に `${worker_dir}/...` の絶対パスで書く**。`cd <dir>; <相対パスのコマンド>` の形と、ワークツリー root での `grep -r ... .` は使わない
+- ultracode（Workflow tool）で書く**各 `agent()` プロンプト内の Bash 指示にも同じ規約を適用する**（subagent が発行するコマンドは worker 本体の permissions で判定される）
+- 理由: Claude Code の auto-mode 分類器は `cd` 後の相対パスを静的に解決できない。worker の permissions には `Read(.env)` 等の deny 規則（[`tools/org_extension_schema.json`](${claude_org_path}/tools/org_extension_schema.json) の `layer2Fallback`）が入っているため、対象を解決できない検索は「deny 対象を含むかもしれない」として毎回人間承認プロンプトに落ちる。2026-09-04 の continuo-110-lease-renewal では workflow subagent がこの形の grep を繰り返し、1 タスクで 6 回の手動承認が必要になった。対処は deny 規則の緩和ではなく書き方の統一である
+
+```bash
+# NG: cd 後の相対パス / root での再帰 grep（分類器が対象を判定できず承認待ちになる）
+cd ${worker_dir}; grep -n "renewLease" test/lap/root.test.ts
+grep -rln "lease" . --include=*.json
+# OK: 絶対パスで対象を明示する
+grep -n "renewLease" ${worker_dir}/test/lap/root.test.ts
+grep -rln "lease" ${worker_dir}/test --include=*.json
+```
+
 ## プロジェクト情報
 - プロジェクト名: ${project_name}
 - 説明: ${project_description}

--- a/tools/templates/worker_brief_self_edit.md
+++ b/tools/templates/worker_brief_self_edit.md
@@ -19,6 +19,11 @@
 - 日本語ファイル: `encoding="utf-8"` 明示
 - CLI 出力文字列（argparse `help=` / `print()`）は ASCII の `-` を使う（em-dash 等 cp932 非対応文字は cp932 コンソールでの `--help` を `UnicodeEncodeError` でクラッシュさせる。pytest の `redirect_stdout` では検出できず実端末でのみ落ちる）。実装後 `--help` を実端末で 1 回スモーク
 
+### Bash のパス指定（絶対パス必須。ultracode の `agent()` プロンプト内も同じ）
+- grep / find / sed / テスト対象は**常に `${worker_dir}/...` の絶対パス**。`cd <dir>; <相対パス>` と root での `grep -r ... .` は使わない。ultracode の各 `agent()` プロンプト内の Bash 指示にも同じ規約を適用（subagent のコマンドは worker 本体の permissions で判定される）
+- 理由: auto-mode 分類器は `cd` 後の相対パスを解決できず、`Read(.env)` 等の deny 規則（`tools/org_extension_schema.json` の `layer2Fallback`）と組み合わさって毎回人間承認に落ちる（2026-09-04 continuo-110-lease-renewal で 1 タスク 6 回）。deny 規則は緩めず書き方で回避する
+- NG: `cd ${worker_dir}; grep -n "renewLease" test/lap/root.test.ts` / `grep -rln "lease" . --include=*.json` → OK: `grep -n "renewLease" ${worker_dir}/test/lap/root.test.ts` / `grep -rln "lease" ${worker_dir}/test --include=*.json`
+
 ## プロジェクト
 - ${project_name}: ${project_description}
 


### PR DESCRIPTION
## 何を直したか

worker（および ultracode workflow 内の各 `agent()` プロンプト）が書く Bash について、「`cd` + 相対パス」「worktree root での `grep -r .`」を禁止し、grep / find / sed / テスト対象は `{worker_dir}/...` の絶対パスで書く規約を追加した。

背景（2026-09-04 実測、continuo-110-lease-renewal）: ultracode の understand 段で subagent が `cd <worktree>; grep -n ... test/lap/root.test.ts` の形を繰り返し、auto-mode 分類器が `cd` 後の相対パスを静的に解決できず、worker settings の `Read(.env)` deny に触れる可能性があるとして人間承認に落ちた。窓口が 1 タスクで 10 回手動解除した。2026-09-03 の suspend 申し送りにも「worker-claude-template.md への規約追加が未着手」として残っていた項目。deny の緩和ではなく書き方の規約で直す。

- `tools/templates/worker_brief_normal.md` / `worker_brief_self_edit.md`（worker が実際に読む brief の雛形。`tools/gen_worker_brief.py:415` が選択）に規約 + 理由 + NG/OK 例を追加
- `.claude/skills/org-delegate/references/worker-claude-template.md`（手保守の参照文書）に同節を追加
- `.dispatcher/references/spawn-flow.md` 3-5a（ultracode 武装）に相互参照を追加し、kickoff の `send_keys` 例文末尾に「workflow の agent() 内の grep/find 等は cd せず絶対パスで。」を追加
- `tests/fixtures/transport_seam/worker_brief_*.golden.md` 4 本を再生成（純追加）

## 検証

- `python3 -m unittest discover -s tools -p 'test_*.py'` → 1228 OK
- `python3 -m unittest discover -s tests`（CI の suite）→ 1024 OK
- `gen_worker_brief.py` の render スモーク（normal / self-edit）で `${...}` の残留なし
- Codex `exec review` 2 round（r1: golden 未再生成の P1 → 修正 / r2: clean）

Refs: notes/2026-08-03 以降の suspend 申し送り「worker-claude-template.md への規約追加」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvaCvo3WhWgxMmCiUKPaqL
