### PR TITLE
docs(worker): sandbox 書き込み境界の着手前 preflight を worker brief 雛形に焼き込む

### DIFF
--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -50,6 +50,29 @@ grep -n "renewLease" {worker_dir}/test/lap/root.test.ts
 grep -rln "lease" {worker_dir}/test --include=*.json
 ```
 
+### 着手前 preflight（sandbox 書き込み境界・非対話 alias・hook 拒否）
+着手前に以下を 1 回読み、該当する準備を済ませてから作業に入ること。同型の失敗が 2026-08-31 / 2026-09-05 / 2026-09-06 に独立した複数タスクで再発しており、いずれもエラー文面が原因を指していない（ネットワーク障害・権限エラー・ハングに見える）
+- **作業ファイルを置ける場所は `{worker_dir}` 配下と `$TMPDIR` だけ**（git が内部で触る Pattern B の `.git` メタデータ（worktree admin / objects / 当該 branch ref / packed-refs）は別枠で、作業ファイルの置き場ではない。`default` ロールはこれに `knowledge/raw/` の振り返り記録が加わる。監査ロール `doc-audit` は書き込み面が無く、`.worker-scratch` を含めどこにもファイルを作らず成果は報告本文で返す）。作業メモ・中間生成物はハーネスの scratchpad（`/tmp/claude-<uid>/.../scratchpad`）に置かない。Write / Edit ツールで `{worker_dir}` 外に書くと [`.hooks/check-worker-boundary.sh`](../../../../.hooks/check-worker-boundary.sh)（許可パスは `{worker_dir}` 内 / `~/.claude/plans/` / `knowledge/raw/` の 3 つ。113-136 行）が deny する。Bash が作る一時ファイルは `$TMPDIR` へ、Write / Edit で作る作業メモは `{worker_dir}/.worker-scratch/` へ置く（下記コマンド）。`.worker-scratch/` は commit に含めないこと（staging は `git add -u` と明示 `git add <path>` のみ。`git add -A` / `git add .` を使わない）
+- **`/tmp/claude-<uid>` は並走中のワーカー間で共有される**。`foo.bak` のような一般名のバックアップは別ワーカーのものと衝突しうる。バックアップは `.worker-scratch/` に置くか名前に task_id を入れ、復元前に中身を照合する（同名ファイルの存在は、それが**自分の**バックアップである証拠にならない）
+- **npm は cache 読みは通り、cache 書きだけ落ちる**。`~/.npm/_cacache` が read-only なので、warm cache から reify するだけの `npm ci` は成功し、`npm pack` / `npm install` / 未インストールのツールへの `npx <tool>`、および内部で `npm pack` を呼ぶ検査（publint / attw / package check）だけが `EROFS ... path ~/.npm/_cacache/tmp/...` で落ちる。文面は `Invalid response body while trying to fetch` とネットワーク障害の顔をしている。対処は sandbox 解除ではなく cache の移動（`npm_config_cache` 環境変数またはコマンド単位の `--cache <dir>`。cache の場所は tarball / lockfile の内容に影響しない）。着手時にリポジトリが指定する install 行（例: `npm ci --ignore-scripts`）を 1 回打ち、ツールは `npx <tool>` でなく `npm run <script>` で呼ぶ
+- **`cp` / `mv` / `rm` は `-i` alias 化されている前提で書く**。既存ファイルへの上書きは画面に出ない確認プロンプトで tool timeout まで無言停止する（退避側は成功し、復元側だけ止まる）。上書きは `command cp -f`（`\cp` / `/bin/cp` でも可）か `cat backup > dest` を既定にする。`rm -rf` / `rm -r` は permissions.deny でブロックされる（ワークツリー破壊防止。Node 等で再帰削除を迂回しない）ので、掃除が要るときは新しい名前のディレクトリを掘る
+- **git 側の退避／復元コマンドは使えない**。`git stash` 変更系（禁止事項 4）に加え、パス指定の `git checkout -- <path>` と `git restore --source=<ref>`（`--staged` 単独の index-only を除く）も [`.hooks/block-dangerous-git.sh`](../../../../.hooks/block-dangerous-git.sh) が deny する（484-487 行 / 491-505 行）。mutation testing 等で一時的に壊して戻す手順は **`cp` バックアップ（書き戻しは `command cp -f` / `cat >`）か一時 commit の 2 択**。復元後は `git diff` で戻ったことを確認してから次の変異を入れる（復元が無音で効かず変異が二重に入ったまま RED を観測した事故あり）
+- **`read-only file system` / `Permission denied` が出ても `dangerouslyDisableSandbox` を反復要求しない**（安全分類器のセッションロックアウトで作業不能になる）。出力先を上記の書ける場所へ変えて再試行する。`sh: <tool>: Permission denied` は `node_modules/.bin/<tool>` が存在しないだけのことが多い（`ls {worker_dir}/node_modules/.bin/<tool>` で実体を確認）
+
+```bash
+# スクラッチはワーカーディレクトリ内。exclude 登録は best effort（自前 clone の Pattern A では通る。
+# linked worktree の Pattern B では共通 .git/info/exclude を指し sandbox 外で失敗するが、上記のとおり
+# .worker-scratch/ を git add しなければ commit に混入しないので、失敗しても先へ進んでよい）
+mkdir -p {worker_dir}/.worker-scratch
+EXCLUDE="$(git -C {worker_dir} rev-parse --path-format=absolute --git-path info/exclude)"
+grep -qxF '.worker-scratch/' "$EXCLUDE" 2>/dev/null || echo '.worker-scratch/' >> "$EXCLUDE" || true
+# npm の cache をワーカーディレクトリ内（または $TMPDIR）へ向けてから install / pack する
+export npm_config_cache={worker_dir}/.worker-scratch/npm-cache
+npm ci --ignore-scripts
+PKG_DIR={worker_dir}/packages/example   # pack 対象のフォルダは positional 引数で渡す
+npm pack "$PKG_DIR" --pack-destination {worker_dir}/.worker-scratch
+```
+
 ## プロジェクト情報
 - プロジェクト名: {project_name}
 - 説明: {project_description}

--- a/tests/fixtures/transport_seam/worker_brief_normal_full.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_normal_full.golden.md
@@ -34,6 +34,29 @@ grep -n "renewLease" /tmp/workers/demo-task/test/lap/root.test.ts
 grep -rln "lease" /tmp/workers/demo-task/test --include=*.json
 ```
 
+### 着手前 preflight（sandbox 書き込み境界・非対話 alias・hook 拒否）
+着手前に以下を 1 回読み、該当する準備を済ませてから作業に入ること。同型の失敗が 2026-08-31 / 2026-09-05 / 2026-09-06 に独立した複数タスクで再発しており、いずれもエラー文面が原因を指していない（ネットワーク障害・権限エラー・ハングに見える）
+- **作業ファイルを置ける場所は `/tmp/workers/demo-task` 配下と `$TMPDIR` だけ**（git が内部で触る Pattern B の `.git` メタデータ（worktree admin / objects / 当該 branch ref / packed-refs）は別枠で、作業ファイルの置き場ではない。`default` ロールはこれに `knowledge/raw/` の振り返り記録が加わる。監査ロール `doc-audit` は書き込み面が無く、`.worker-scratch` を含めどこにもファイルを作らず成果は報告本文で返す）。作業メモ・中間生成物はハーネスの scratchpad（`/tmp/claude-<uid>/.../scratchpad`）に置かない。Write / Edit ツールで `/tmp/workers/demo-task` 外に書くと [`.hooks/check-worker-boundary.sh`](/home/user/work/claude-org/.hooks/check-worker-boundary.sh)（許可パスは `/tmp/workers/demo-task` 内 / `~/.claude/plans/` / `knowledge/raw/` の 3 つ。113-136 行）が deny する。Bash が作る一時ファイルは `$TMPDIR` へ、Write / Edit で作る作業メモは `/tmp/workers/demo-task/.worker-scratch/` へ置く（下記コマンド）。`.worker-scratch/` は commit に含めないこと（staging は `git add -u` と明示 `git add <path>` のみ。`git add -A` / `git add .` を使わない）
+- **`/tmp/claude-<uid>` は並走中のワーカー間で共有される**。`foo.bak` のような一般名のバックアップは別ワーカーのものと衝突しうる。バックアップは `.worker-scratch/` に置くか名前に task_id を入れ、復元前に中身を照合する（同名ファイルの存在は、それが**自分の**バックアップである証拠にならない）
+- **npm は cache 読みは通り、cache 書きだけ落ちる**。`~/.npm/_cacache` が read-only なので、warm cache から reify するだけの `npm ci` は成功し、`npm pack` / `npm install` / 未インストールのツールへの `npx <tool>`、および内部で `npm pack` を呼ぶ検査（publint / attw / package check）だけが `EROFS ... path ~/.npm/_cacache/tmp/...` で落ちる。文面は `Invalid response body while trying to fetch` とネットワーク障害の顔をしている。対処は sandbox 解除ではなく cache の移動（`npm_config_cache` 環境変数またはコマンド単位の `--cache <dir>`。cache の場所は tarball / lockfile の内容に影響しない）。着手時にリポジトリが指定する install 行（例: `npm ci --ignore-scripts`）を 1 回打ち、ツールは `npx <tool>` でなく `npm run <script>` で呼ぶ
+- **`cp` / `mv` / `rm` は `-i` alias 化されている前提で書く**。既存ファイルへの上書きは画面に出ない確認プロンプトで tool timeout まで無言停止する（退避側は成功し、復元側だけ止まる）。上書きは `command cp -f`（`\cp` / `/bin/cp` でも可）か `cat backup > dest` を既定にする。`rm -rf` / `rm -r` は permissions.deny でブロックされる（ワークツリー破壊防止。Node 等で再帰削除を迂回しない）ので、掃除が要るときは新しい名前のディレクトリを掘る
+- **git 側の退避／復元コマンドは使えない**。`git stash` 変更系（禁止事項 4）に加え、パス指定の `git checkout -- <path>` と `git restore --source=<ref>`（`--staged` 単独の index-only を除く）も [`.hooks/block-dangerous-git.sh`](/home/user/work/claude-org/.hooks/block-dangerous-git.sh) が deny する（484-487 行 / 491-505 行）。mutation testing 等で一時的に壊して戻す手順は **`cp` バックアップ（書き戻しは `command cp -f` / `cat >`）か一時 commit の 2 択**。復元後は `git diff` で戻ったことを確認してから次の変異を入れる（復元が無音で効かず変異が二重に入ったまま RED を観測した事故あり）
+- **`read-only file system` / `Permission denied` が出ても `dangerouslyDisableSandbox` を反復要求しない**（安全分類器のセッションロックアウトで作業不能になる）。出力先を上記の書ける場所へ変えて再試行する。`sh: <tool>: Permission denied` は `node_modules/.bin/<tool>` が存在しないだけのことが多い（`ls /tmp/workers/demo-task/node_modules/.bin/<tool>` で実体を確認）
+
+```bash
+# スクラッチはワーカーディレクトリ内。exclude 登録は best effort（自前 clone の Pattern A では通る。
+# linked worktree の Pattern B では共通 .git/info/exclude を指し sandbox 外で失敗するが、上記のとおり
+# .worker-scratch/ を git add しなければ commit に混入しないので、失敗しても先へ進んでよい）
+mkdir -p /tmp/workers/demo-task/.worker-scratch
+EXCLUDE="$(git -C /tmp/workers/demo-task rev-parse --path-format=absolute --git-path info/exclude)"
+grep -qxF '.worker-scratch/' "$EXCLUDE" 2>/dev/null || echo '.worker-scratch/' >> "$EXCLUDE" || true
+# npm の cache をワーカーディレクトリ内（または $TMPDIR）へ向けてから install / pack する
+export npm_config_cache=/tmp/workers/demo-task/.worker-scratch/npm-cache
+npm ci --ignore-scripts
+PKG_DIR=/tmp/workers/demo-task/packages/example   # pack 対象のフォルダは positional 引数で渡す
+npm pack "$PKG_DIR" --pack-destination /tmp/workers/demo-task/.worker-scratch
+```
+
 ## プロジェクト情報
 - プロジェクト名: claude-org-ja
 - 説明: テスト用説明

--- a/tests/fixtures/transport_seam/worker_brief_normal_minimal.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_normal_minimal.golden.md
@@ -34,6 +34,29 @@ grep -n "renewLease" /tmp/workers/demo-task/test/lap/root.test.ts
 grep -rln "lease" /tmp/workers/demo-task/test --include=*.json
 ```
 
+### 着手前 preflight（sandbox 書き込み境界・非対話 alias・hook 拒否）
+着手前に以下を 1 回読み、該当する準備を済ませてから作業に入ること。同型の失敗が 2026-08-31 / 2026-09-05 / 2026-09-06 に独立した複数タスクで再発しており、いずれもエラー文面が原因を指していない（ネットワーク障害・権限エラー・ハングに見える）
+- **作業ファイルを置ける場所は `/tmp/workers/demo-task` 配下と `$TMPDIR` だけ**（git が内部で触る Pattern B の `.git` メタデータ（worktree admin / objects / 当該 branch ref / packed-refs）は別枠で、作業ファイルの置き場ではない。`default` ロールはこれに `knowledge/raw/` の振り返り記録が加わる。監査ロール `doc-audit` は書き込み面が無く、`.worker-scratch` を含めどこにもファイルを作らず成果は報告本文で返す）。作業メモ・中間生成物はハーネスの scratchpad（`/tmp/claude-<uid>/.../scratchpad`）に置かない。Write / Edit ツールで `/tmp/workers/demo-task` 外に書くと [`.hooks/check-worker-boundary.sh`](/home/user/work/claude-org/.hooks/check-worker-boundary.sh)（許可パスは `/tmp/workers/demo-task` 内 / `~/.claude/plans/` / `knowledge/raw/` の 3 つ。113-136 行）が deny する。Bash が作る一時ファイルは `$TMPDIR` へ、Write / Edit で作る作業メモは `/tmp/workers/demo-task/.worker-scratch/` へ置く（下記コマンド）。`.worker-scratch/` は commit に含めないこと（staging は `git add -u` と明示 `git add <path>` のみ。`git add -A` / `git add .` を使わない）
+- **`/tmp/claude-<uid>` は並走中のワーカー間で共有される**。`foo.bak` のような一般名のバックアップは別ワーカーのものと衝突しうる。バックアップは `.worker-scratch/` に置くか名前に task_id を入れ、復元前に中身を照合する（同名ファイルの存在は、それが**自分の**バックアップである証拠にならない）
+- **npm は cache 読みは通り、cache 書きだけ落ちる**。`~/.npm/_cacache` が read-only なので、warm cache から reify するだけの `npm ci` は成功し、`npm pack` / `npm install` / 未インストールのツールへの `npx <tool>`、および内部で `npm pack` を呼ぶ検査（publint / attw / package check）だけが `EROFS ... path ~/.npm/_cacache/tmp/...` で落ちる。文面は `Invalid response body while trying to fetch` とネットワーク障害の顔をしている。対処は sandbox 解除ではなく cache の移動（`npm_config_cache` 環境変数またはコマンド単位の `--cache <dir>`。cache の場所は tarball / lockfile の内容に影響しない）。着手時にリポジトリが指定する install 行（例: `npm ci --ignore-scripts`）を 1 回打ち、ツールは `npx <tool>` でなく `npm run <script>` で呼ぶ
+- **`cp` / `mv` / `rm` は `-i` alias 化されている前提で書く**。既存ファイルへの上書きは画面に出ない確認プロンプトで tool timeout まで無言停止する（退避側は成功し、復元側だけ止まる）。上書きは `command cp -f`（`\cp` / `/bin/cp` でも可）か `cat backup > dest` を既定にする。`rm -rf` / `rm -r` は permissions.deny でブロックされる（ワークツリー破壊防止。Node 等で再帰削除を迂回しない）ので、掃除が要るときは新しい名前のディレクトリを掘る
+- **git 側の退避／復元コマンドは使えない**。`git stash` 変更系（禁止事項 4）に加え、パス指定の `git checkout -- <path>` と `git restore --source=<ref>`（`--staged` 単独の index-only を除く）も [`.hooks/block-dangerous-git.sh`](/home/user/work/claude-org/.hooks/block-dangerous-git.sh) が deny する（484-487 行 / 491-505 行）。mutation testing 等で一時的に壊して戻す手順は **`cp` バックアップ（書き戻しは `command cp -f` / `cat >`）か一時 commit の 2 択**。復元後は `git diff` で戻ったことを確認してから次の変異を入れる（復元が無音で効かず変異が二重に入ったまま RED を観測した事故あり）
+- **`read-only file system` / `Permission denied` が出ても `dangerouslyDisableSandbox` を反復要求しない**（安全分類器のセッションロックアウトで作業不能になる）。出力先を上記の書ける場所へ変えて再試行する。`sh: <tool>: Permission denied` は `node_modules/.bin/<tool>` が存在しないだけのことが多い（`ls /tmp/workers/demo-task/node_modules/.bin/<tool>` で実体を確認）
+
+```bash
+# スクラッチはワーカーディレクトリ内。exclude 登録は best effort（自前 clone の Pattern A では通る。
+# linked worktree の Pattern B では共通 .git/info/exclude を指し sandbox 外で失敗するが、上記のとおり
+# .worker-scratch/ を git add しなければ commit に混入しないので、失敗しても先へ進んでよい）
+mkdir -p /tmp/workers/demo-task/.worker-scratch
+EXCLUDE="$(git -C /tmp/workers/demo-task rev-parse --path-format=absolute --git-path info/exclude)"
+grep -qxF '.worker-scratch/' "$EXCLUDE" 2>/dev/null || echo '.worker-scratch/' >> "$EXCLUDE" || true
+# npm の cache をワーカーディレクトリ内（または $TMPDIR）へ向けてから install / pack する
+export npm_config_cache=/tmp/workers/demo-task/.worker-scratch/npm-cache
+npm ci --ignore-scripts
+PKG_DIR=/tmp/workers/demo-task/packages/example   # pack 対象のフォルダは positional 引数で渡す
+npm pack "$PKG_DIR" --pack-destination /tmp/workers/demo-task/.worker-scratch
+```
+
 ## プロジェクト情報
 - プロジェクト名: claude-org-ja
 - 説明: テスト用説明

--- a/tests/fixtures/transport_seam/worker_brief_self_edit_full.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_self_edit_full.golden.md
@@ -24,6 +24,12 @@
 - 理由: auto-mode 分類器は `cd` 後の相対パスを解決できず、`Read(.env)` 等の deny 規則（`tools/org_extension_schema.json` の `layer2Fallback`）と組み合わさって毎回人間承認に落ちる（2026-09-04 continuo-110-lease-renewal で 1 タスク 6 回）。deny 規則は緩めず書き方で回避する
 - NG: `cd /tmp/workers/demo-task; grep -n "renewLease" test/lap/root.test.ts` / `grep -rln "lease" . --include=*.json` → OK: `grep -n "renewLease" /tmp/workers/demo-task/test/lap/root.test.ts` / `grep -rln "lease" /tmp/workers/demo-task/test --include=*.json`
 
+### 着手前 preflight（sandbox 書き込み境界・非対話 alias・hook 拒否）
+- 作業ファイルを置けるのは `/tmp/workers/demo-task` 配下と `$TMPDIR` だけ（git が内部で触る Pattern B の `.git` メタデータは別枠で、作業ファイルの置き場ではない）。ハーネスの scratchpad（`/tmp/claude-<uid>/.../scratchpad`）は `/tmp/workers/demo-task` 外なので Write / Edit が `.hooks/check-worker-boundary.sh`（許可パスは worker dir / `~/.claude/plans/` / `knowledge/raw/` の 3 つ。113-136 行）で deny される。Bash の一時ファイルは `$TMPDIR` へ、Write / Edit の作業メモは `mkdir -p /tmp/workers/demo-task/.worker-scratch` へ。linked worktree（Pattern B）では `.git/info/exclude` が共通 clone 側（sandbox 外）にあり登録できないので、禁止事項 5 のとおり `git add -u` + 明示 add で staging し `.worker-scratch/` を commit に混入させない。`/tmp/claude-<uid>` は並走ワーカーと共有なので一般名のバックアップは衝突する（`.worker-scratch/` に置くか task_id を名前に入れる）
+- `cp` / `mv` / `rm` は `-i` alias 前提で書く（既存ファイルへの上書きが無言の確認待ちで timeout まで止まる）。上書きは `command cp -f` か `cat backup > dest`。`rm -rf` / `rm -r` は permissions.deny（Node 等で再帰削除を迂回しない。掃除は新しい名前のディレクトリを掘る）
+- git 側の退避／復元は使えない: `git stash` 変更系（禁止事項 4）に加え、パス指定の `git checkout -- <path>` / `git restore --source=<ref>`（`--staged` 単独の index-only を除く）も `.hooks/block-dangerous-git.sh` が deny（484-487 行 / 491-505 行）。壊して戻す手順は `cp` バックアップ（書き戻しは `command cp -f` / `cat >`）か一時 commit の 2 択。復元後は `git diff` で戻ったことを確認してから次に進む
+- `read-only file system` / `Permission denied` でも `dangerouslyDisableSandbox` を反復要求しない（安全分類器のロックアウトで作業不能になる）。出力先を書ける場所へ変えて再試行する
+
 ## プロジェクト
 - claude-org-ja: テスト用説明
 

--- a/tests/fixtures/transport_seam/worker_brief_self_edit_minimal.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_self_edit_minimal.golden.md
@@ -24,6 +24,12 @@
 - 理由: auto-mode 分類器は `cd` 後の相対パスを解決できず、`Read(.env)` 等の deny 規則（`tools/org_extension_schema.json` の `layer2Fallback`）と組み合わさって毎回人間承認に落ちる（2026-09-04 continuo-110-lease-renewal で 1 タスク 6 回）。deny 規則は緩めず書き方で回避する
 - NG: `cd /tmp/workers/demo-task; grep -n "renewLease" test/lap/root.test.ts` / `grep -rln "lease" . --include=*.json` → OK: `grep -n "renewLease" /tmp/workers/demo-task/test/lap/root.test.ts` / `grep -rln "lease" /tmp/workers/demo-task/test --include=*.json`
 
+### 着手前 preflight（sandbox 書き込み境界・非対話 alias・hook 拒否）
+- 作業ファイルを置けるのは `/tmp/workers/demo-task` 配下と `$TMPDIR` だけ（git が内部で触る Pattern B の `.git` メタデータは別枠で、作業ファイルの置き場ではない）。ハーネスの scratchpad（`/tmp/claude-<uid>/.../scratchpad`）は `/tmp/workers/demo-task` 外なので Write / Edit が `.hooks/check-worker-boundary.sh`（許可パスは worker dir / `~/.claude/plans/` / `knowledge/raw/` の 3 つ。113-136 行）で deny される。Bash の一時ファイルは `$TMPDIR` へ、Write / Edit の作業メモは `mkdir -p /tmp/workers/demo-task/.worker-scratch` へ。linked worktree（Pattern B）では `.git/info/exclude` が共通 clone 側（sandbox 外）にあり登録できないので、禁止事項 5 のとおり `git add -u` + 明示 add で staging し `.worker-scratch/` を commit に混入させない。`/tmp/claude-<uid>` は並走ワーカーと共有なので一般名のバックアップは衝突する（`.worker-scratch/` に置くか task_id を名前に入れる）
+- `cp` / `mv` / `rm` は `-i` alias 前提で書く（既存ファイルへの上書きが無言の確認待ちで timeout まで止まる）。上書きは `command cp -f` か `cat backup > dest`。`rm -rf` / `rm -r` は permissions.deny（Node 等で再帰削除を迂回しない。掃除は新しい名前のディレクトリを掘る）
+- git 側の退避／復元は使えない: `git stash` 変更系（禁止事項 4）に加え、パス指定の `git checkout -- <path>` / `git restore --source=<ref>`（`--staged` 単独の index-only を除く）も `.hooks/block-dangerous-git.sh` が deny（484-487 行 / 491-505 行）。壊して戻す手順は `cp` バックアップ（書き戻しは `command cp -f` / `cat >`）か一時 commit の 2 択。復元後は `git diff` で戻ったことを確認してから次に進む
+- `read-only file system` / `Permission denied` でも `dangerouslyDisableSandbox` を反復要求しない（安全分類器のロックアウトで作業不能になる）。出力先を書ける場所へ変えて再試行する
+
 ## プロジェクト
 - claude-org-ja: テスト用説明
 

--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -34,6 +34,29 @@ grep -n "renewLease" ${worker_dir}/test/lap/root.test.ts
 grep -rln "lease" ${worker_dir}/test --include=*.json
 ```
 
+### 着手前 preflight（sandbox 書き込み境界・非対話 alias・hook 拒否）
+着手前に以下を 1 回読み、該当する準備を済ませてから作業に入ること。同型の失敗が 2026-08-31 / 2026-09-05 / 2026-09-06 に独立した複数タスクで再発しており、いずれもエラー文面が原因を指していない（ネットワーク障害・権限エラー・ハングに見える）
+- **作業ファイルを置ける場所は `${worker_dir}` 配下と `$TMPDIR` だけ**（git が内部で触る Pattern B の `.git` メタデータ（worktree admin / objects / 当該 branch ref / packed-refs）は別枠で、作業ファイルの置き場ではない。`default` ロールはこれに `knowledge/raw/` の振り返り記録が加わる。監査ロール `doc-audit` は書き込み面が無く、`.worker-scratch` を含めどこにもファイルを作らず成果は報告本文で返す）。作業メモ・中間生成物はハーネスの scratchpad（`/tmp/claude-<uid>/.../scratchpad`）に置かない。Write / Edit ツールで `${worker_dir}` 外に書くと [`.hooks/check-worker-boundary.sh`](${claude_org_path}/.hooks/check-worker-boundary.sh)（許可パスは `${worker_dir}` 内 / `~/.claude/plans/` / `knowledge/raw/` の 3 つ。113-136 行）が deny する。Bash が作る一時ファイルは `$TMPDIR` へ、Write / Edit で作る作業メモは `${worker_dir}/.worker-scratch/` へ置く（下記コマンド）。`.worker-scratch/` は commit に含めないこと（staging は `git add -u` と明示 `git add <path>` のみ。`git add -A` / `git add .` を使わない）
+- **`/tmp/claude-<uid>` は並走中のワーカー間で共有される**。`foo.bak` のような一般名のバックアップは別ワーカーのものと衝突しうる。バックアップは `.worker-scratch/` に置くか名前に task_id を入れ、復元前に中身を照合する（同名ファイルの存在は、それが**自分の**バックアップである証拠にならない）
+- **npm は cache 読みは通り、cache 書きだけ落ちる**。`~/.npm/_cacache` が read-only なので、warm cache から reify するだけの `npm ci` は成功し、`npm pack` / `npm install` / 未インストールのツールへの `npx <tool>`、および内部で `npm pack` を呼ぶ検査（publint / attw / package check）だけが `EROFS ... path ~/.npm/_cacache/tmp/...` で落ちる。文面は `Invalid response body while trying to fetch` とネットワーク障害の顔をしている。対処は sandbox 解除ではなく cache の移動（`npm_config_cache` 環境変数またはコマンド単位の `--cache <dir>`。cache の場所は tarball / lockfile の内容に影響しない）。着手時にリポジトリが指定する install 行（例: `npm ci --ignore-scripts`）を 1 回打ち、ツールは `npx <tool>` でなく `npm run <script>` で呼ぶ
+- **`cp` / `mv` / `rm` は `-i` alias 化されている前提で書く**。既存ファイルへの上書きは画面に出ない確認プロンプトで tool timeout まで無言停止する（退避側は成功し、復元側だけ止まる）。上書きは `command cp -f`（`\cp` / `/bin/cp` でも可）か `cat backup > dest` を既定にする。`rm -rf` / `rm -r` は permissions.deny でブロックされる（ワークツリー破壊防止。Node 等で再帰削除を迂回しない）ので、掃除が要るときは新しい名前のディレクトリを掘る
+- **git 側の退避／復元コマンドは使えない**。`git stash` 変更系（禁止事項 4）に加え、パス指定の `git checkout -- <path>` と `git restore --source=<ref>`（`--staged` 単独の index-only を除く）も [`.hooks/block-dangerous-git.sh`](${claude_org_path}/.hooks/block-dangerous-git.sh) が deny する（484-487 行 / 491-505 行）。mutation testing 等で一時的に壊して戻す手順は **`cp` バックアップ（書き戻しは `command cp -f` / `cat >`）か一時 commit の 2 択**。復元後は `git diff` で戻ったことを確認してから次の変異を入れる（復元が無音で効かず変異が二重に入ったまま RED を観測した事故あり）
+- **`read-only file system` / `Permission denied` が出ても `dangerouslyDisableSandbox` を反復要求しない**（安全分類器のセッションロックアウトで作業不能になる）。出力先を上記の書ける場所へ変えて再試行する。`sh: <tool>: Permission denied` は `node_modules/.bin/<tool>` が存在しないだけのことが多い（`ls ${worker_dir}/node_modules/.bin/<tool>` で実体を確認）
+
+```bash
+# スクラッチはワーカーディレクトリ内。exclude 登録は best effort（自前 clone の Pattern A では通る。
+# linked worktree の Pattern B では共通 .git/info/exclude を指し sandbox 外で失敗するが、上記のとおり
+# .worker-scratch/ を git add しなければ commit に混入しないので、失敗しても先へ進んでよい）
+mkdir -p ${worker_dir}/.worker-scratch
+EXCLUDE="$(git -C ${worker_dir} rev-parse --path-format=absolute --git-path info/exclude)"
+grep -qxF '.worker-scratch/' "$EXCLUDE" 2>/dev/null || echo '.worker-scratch/' >> "$EXCLUDE" || true
+# npm の cache をワーカーディレクトリ内（または $TMPDIR）へ向けてから install / pack する
+export npm_config_cache=${worker_dir}/.worker-scratch/npm-cache
+npm ci --ignore-scripts
+PKG_DIR=${worker_dir}/packages/example   # pack 対象のフォルダは positional 引数で渡す
+npm pack "$PKG_DIR" --pack-destination ${worker_dir}/.worker-scratch
+```
+
 ## プロジェクト情報
 - プロジェクト名: ${project_name}
 - 説明: ${project_description}

--- a/tools/templates/worker_brief_self_edit.md
+++ b/tools/templates/worker_brief_self_edit.md
@@ -24,6 +24,12 @@
 - 理由: auto-mode 分類器は `cd` 後の相対パスを解決できず、`Read(.env)` 等の deny 規則（`tools/org_extension_schema.json` の `layer2Fallback`）と組み合わさって毎回人間承認に落ちる（2026-09-04 continuo-110-lease-renewal で 1 タスク 6 回）。deny 規則は緩めず書き方で回避する
 - NG: `cd ${worker_dir}; grep -n "renewLease" test/lap/root.test.ts` / `grep -rln "lease" . --include=*.json` → OK: `grep -n "renewLease" ${worker_dir}/test/lap/root.test.ts` / `grep -rln "lease" ${worker_dir}/test --include=*.json`
 
+### 着手前 preflight（sandbox 書き込み境界・非対話 alias・hook 拒否）
+- 作業ファイルを置けるのは `${worker_dir}` 配下と `$TMPDIR` だけ（git が内部で触る Pattern B の `.git` メタデータは別枠で、作業ファイルの置き場ではない）。ハーネスの scratchpad（`/tmp/claude-<uid>/.../scratchpad`）は `${worker_dir}` 外なので Write / Edit が `.hooks/check-worker-boundary.sh`（許可パスは worker dir / `~/.claude/plans/` / `knowledge/raw/` の 3 つ。113-136 行）で deny される。Bash の一時ファイルは `$TMPDIR` へ、Write / Edit の作業メモは `mkdir -p ${worker_dir}/.worker-scratch` へ。linked worktree（Pattern B）では `.git/info/exclude` が共通 clone 側（sandbox 外）にあり登録できないので、禁止事項 5 のとおり `git add -u` + 明示 add で staging し `.worker-scratch/` を commit に混入させない。`/tmp/claude-<uid>` は並走ワーカーと共有なので一般名のバックアップは衝突する（`.worker-scratch/` に置くか task_id を名前に入れる）
+- `cp` / `mv` / `rm` は `-i` alias 前提で書く（既存ファイルへの上書きが無言の確認待ちで timeout まで止まる）。上書きは `command cp -f` か `cat backup > dest`。`rm -rf` / `rm -r` は permissions.deny（Node 等で再帰削除を迂回しない。掃除は新しい名前のディレクトリを掘る）
+- git 側の退避／復元は使えない: `git stash` 変更系（禁止事項 4）に加え、パス指定の `git checkout -- <path>` / `git restore --source=<ref>`（`--staged` 単独の index-only を除く）も `.hooks/block-dangerous-git.sh` が deny（484-487 行 / 491-505 行）。壊して戻す手順は `cp` バックアップ（書き戻しは `command cp -f` / `cat >`）か一時 commit の 2 択。復元後は `git diff` で戻ったことを確認してから次に進む
+- `read-only file system` / `Permission denied` でも `dangerouslyDisableSandbox` を反復要求しない（安全分類器のロックアウトで作業不能になる）。出力先を書ける場所へ変えて再試行する
+
 ## プロジェクト
 - ${project_name}: ${project_description}
 


### PR DESCRIPTION
## 概要

worker brief 雛形（`tools/templates/worker_brief_normal.md` / `worker_brief_self_edit.md` と参照テンプレ `.claude/skills/org-delegate/references/worker-claude-template.md`）の「Bash コマンドのパス指定」節の直後に「着手前 preflight（sandbox 書き込み境界・非対話 alias・hook 拒否）」節を追加する。

2026-08-31 / 09-05 / 09-06 に独立した複数ワーカー（continuo-159-gate-close-json / rondo-cadenza-seam / cadenza-agent-type-record ほか）で同型の失敗が再発し、curator が skill 候補 `worker-sandbox-write-boundary-diagnosis`（5/5）へ統合していた。ユーザー判断で skill 化せず brief 側へ焼き込む。

## 内容（3 軸）

- **書き込み範囲**: 作業ファイルは worker_dir と `$TMPDIR` のみ。ハーネス scratchpad は `.hooks/check-worker-boundary.sh` に deny されるので `.worker-scratch/` を使う。`/tmp/claude-<uid>` は並走ワーカー間で共有されバックアップ名が衝突する。npm は cache 読み（`npm ci`）は通るが cache 書き（`npm pack` / `npm install` / `npx`）だけ EROFS になる非対称なので、`npm_config_cache` を worktree 内へ向ける
- **非対話 alias**: `cp` / `mv` / `rm` の `-i` alias は非対話で黙って止まるので `command cp -f` 等で迂回する。`rm -r` 系は deny で、Node 経由の迂回もしない
- **hook 拒否**: stash 系とパス指定の checkout / restore は `.hooks/block-dangerous-git.sh` で deny されるので、退避／復元は `cp` バックアップか一時 commit の 2 択

golden fixture（`tests/fixtures/transport_seam/*.golden.md`）を再生成。`tests/test_transport_seam.py` / `tests/test_gen_delegate_payload.py` 188 passed。Codex レビュー 3 round で Blocker / Major ゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHfEnMEFqUs9sAEJVn7TM5
